### PR TITLE
refactor(remote-config): migrate rcservice component to v2

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -157,7 +157,7 @@ import (
 	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
 	remoteconfig "github.com/DataDog/datadog-agent/comp/remote-config"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice/rcserviceimpl"
+	rcservicefx "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/fx"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf/rcservicemrfimpl"
 	rctelemetryreporterfx "github.com/DataDog/datadog-agent/comp/remote-config/rctelemetryreporter/fx"
 	metricscompressorfx "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx"
@@ -470,7 +470,7 @@ func getSharedFxOption() fx.Option {
 		otelcol.Bundle(),
 		hostProfilerFlareFx.Module(),
 		rctelemetryreporterfx.Module(),
-		rcserviceimpl.Module(),
+		rcservicefx.Module(),
 		rcservicemrfimpl.Module(),
 		remoteconfig.Bundle(),
 		daemoncheckerfx.Module(),

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -77,8 +77,8 @@ import (
 	metadatarunner "github.com/DataDog/datadog-agent/comp/metadata/runner"
 	metadatarunnerimpl "github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/impl"
-	rccomp "github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice/rcserviceimpl"
+	rccomp "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/def"
+	rcservicefx "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/fx"
 	rcstatusfx "github.com/DataDog/datadog-agent/comp/remote-config/rcstatus/fx"
 	rctelemetryreporterfx "github.com/DataDog/datadog-agent/comp/remote-config/rctelemetryreporter/fx"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
@@ -207,7 +207,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					return option.None[serializer.MetricSerializer]()
 				}),
 				autodiscoveryimpl.Module(),
-				rcserviceimpl.Module(),
+				rcservicefx.Module(),
 				rcstatusfx.Module(),
 				rctelemetryreporterfx.Module(),
 				fx.Provide(func(config config.Component) healthprobe.Options {

--- a/cmd/installer/subcommands/daemon/run.go
+++ b/cmd/installer/subcommands/daemon/run.go
@@ -19,8 +19,8 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	pidimpl "github.com/DataDog/datadog-agent/comp/core/pid/impl"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice/rcserviceimpl"
+	rcservice "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/def"
+	rcservicefx "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/fx"
 	rctelemetryreporterfx "github.com/DataDog/datadog-agent/comp/remote-config/rctelemetryreporter/fx"
 	localapiimplFx "github.com/DataDog/datadog-agent/comp/updater/localapi/fx"
 	updatertelemetryfx "github.com/DataDog/datadog-agent/comp/updater/telemetry/fx"
@@ -58,7 +58,7 @@ func getCommonFxOption(global *command.GlobalParams) fx.Option {
 			},
 		}),
 		rctelemetryreporterfx.Module(),
-		rcserviceimpl.Module(),
+		rcservicefx.Module(),
 		updaterimpl.Module(),
 		localapiimplFx.Module(),
 		updatertelemetryfx.Module(),

--- a/cmd/privateactionrunner/subcommands/run/command.go
+++ b/cmd/privateactionrunner/subcommands/run/command.go
@@ -28,7 +28,7 @@ import (
 	privateactionrunnerfx "github.com/DataDog/datadog-agent/comp/privateactionrunner/fx"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient/rcclientimpl"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice/rcserviceimpl"
+	rcservicefx "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/fx"
 	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -68,7 +68,7 @@ func runPrivateActionRunner(ctx context.Context, confPath string, extraConfFiles
 		settingsimpl.Module(),
 		remotehostnameimpl.Module(),
 		ipcfx.ModuleReadWrite(),
-		rcserviceimpl.Module(),
+		rcservicefx.Module(),
 		rcclientimpl.Module(),
 		fx.Supply(rcclient.Params{AgentName: "private-action-runner", AgentVersion: version.AgentVersion}),
 		getTaggerModule(),

--- a/comp/api/grpcserver/impl-agent/grpc.go
+++ b/comp/api/grpcserver/impl-agent/grpc.go
@@ -30,7 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
+	rcservice "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/def"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"

--- a/comp/api/grpcserver/impl-agent/server.go
+++ b/comp/api/grpcserver/impl-agent/server.go
@@ -31,7 +31,7 @@ import (
 	dsdReplay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl/hosttags"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
+	rcservice "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/def"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/grpc"

--- a/comp/remote-config/rcservice/def/component.go
+++ b/comp/remote-config/rcservice/def/component.go
@@ -9,7 +9,7 @@ package rcservice
 import (
 	"context"
 
-	"github.com/DataDog/datadog-agent/pkg/config/remote/service"
+	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 )
 
@@ -18,7 +18,7 @@ import (
 // Params is the set of parameters required for the remote config service.
 type Params struct {
 	// Options is the set of options for the remote config service.
-	Options []service.Option
+	Options []remoteconfig.Option
 }
 
 // Component is the component type.

--- a/comp/remote-config/rcservice/fx/fx.go
+++ b/comp/remote-config/rcservice/fx/fx.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package fx provides the fx module for the rcservice component.
+package fx
+
+import (
+	rcserviceimpl "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module conditionally provides the remote config service.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(rcserviceimpl.NewRemoteConfigServiceOptional),
+	)
+}

--- a/comp/remote-config/rcservice/impl/rcservice.go
+++ b/comp/remote-config/rcservice/impl/rcservice.go
@@ -15,16 +15,14 @@ import (
 	cfgcomp "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl/hosttags"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
+	rcservice "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/def"
 	rctelemetryreporter "github.com/DataDog/datadog-agent/comp/remote-config/rctelemetryreporter/def"
 	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/version"
-
-	"go.uber.org/fx"
 )
 
 var (
@@ -37,17 +35,11 @@ func init() {
 	rcExpvars.Set("startupFailureReason", &rcStartupFailureReason)
 }
 
-// Module conditionally provides the remote config service.
-func Module() fxutil.Module {
-	return fxutil.Component(
-		fx.Provide(newRemoteConfigServiceOptional),
-	)
-}
+// Dependencies defines the dependencies for the rcservice component.
+type Dependencies struct {
+	compdef.In
 
-type dependencies struct {
-	fx.In
-
-	Lc fx.Lifecycle
+	Lc compdef.Lifecycle
 
 	Params                *rcservice.Params `optional:"true"`
 	DdRcTelemetryReporter rctelemetryreporter.Component
@@ -56,24 +48,31 @@ type dependencies struct {
 	Logger                log.Component
 }
 
-// newRemoteConfigServiceOptional conditionally creates and configures a new remote config service, based on whether RC is enabled.
-func newRemoteConfigServiceOptional(deps dependencies) option.Option[rcservice.Component] {
+// Provides defines the output of the rcservice component.
+type Provides struct {
+	compdef.Out
+
+	Comp option.Option[rcservice.Component]
+}
+
+// NewRemoteConfigServiceOptional conditionally creates and configures a new remote config service, based on whether RC is enabled.
+func NewRemoteConfigServiceOptional(deps Dependencies) Provides {
 	none := option.None[rcservice.Component]()
 	if !configUtils.IsRemoteConfigEnabled(deps.Cfg) {
-		return none
+		return Provides{Comp: none}
 	}
 
 	configService, err := newRemoteConfigService(deps)
 	if err != nil {
 		deps.Logger.Errorf("remote config service not initialized or started: %s", err)
-		return none
+		return Provides{Comp: none}
 	}
 
-	return option.New[rcservice.Component](configService)
+	return Provides{Comp: option.New[rcservice.Component](configService)}
 }
 
-// newRemoteConfigServiceOptional creates and configures a new remote config service
-func newRemoteConfigService(deps dependencies) (rcservice.Component, error) {
+// newRemoteConfigService creates and configures a new remote config service
+func newRemoteConfigService(deps Dependencies) (rcservice.Component, error) {
 	apiKey := deps.Cfg.GetString("api_key")
 	if deps.Cfg.IsSet("remote_configuration.api_key") {
 		apiKey = deps.Cfg.GetString("remote_configuration.api_key")
@@ -124,12 +123,12 @@ func newRemoteConfigService(deps dependencies) (rcservice.Component, error) {
 	}
 	rcStartupFailureReason.Set("")
 
-	deps.Lc.Append(fx.Hook{OnStart: func(_ context.Context) error {
+	deps.Lc.Append(compdef.Hook{OnStart: func(_ context.Context) error {
 		configService.Start()
 		deps.Logger.Info("remote config service started")
 		return nil
 	}})
-	deps.Lc.Append(fx.Hook{OnStop: func(_ context.Context) error {
+	deps.Lc.Append(compdef.Hook{OnStop: func(_ context.Context) error {
 		err = configService.Stop()
 		if err != nil {
 			deps.Logger.Errorf("unable to stop remote config service: %s", err)

--- a/comp/updater/updater/updaterimpl/updater.go
+++ b/comp/updater/updater/updaterimpl/updater.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
+	rcservice "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/def"
 	updatercomp "github.com/DataDog/datadog-agent/comp/updater/updater"
 	"github.com/DataDog/datadog-agent/pkg/fleet/daemon"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"

--- a/comp/updater/updater/updaterimpl/updater_test.go
+++ b/comp/updater/updater/updaterimpl/updater_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
+	rcservice "github.com/DataDog/datadog-agent/comp/remote-config/rcservice/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )


### PR DESCRIPTION
### What does this PR do?

Migrates `comp/remote-config/rcservice` from V1 component structure to V2, following the standard `def/impl/fx` layout.

- Moved `component.go` to `def/component.go` (interface + public types)
- Moved `rcserviceimpl/rcservice.go` to `impl/rcservice.go` with updated package and imports
- Created `fx/fx.go` with `Module()` helper
- Deleted old `component.go` and `rcserviceimpl/` directory
- Updated all callers to import from `comp/remote-config/rcservice/def`

### Motivation

Standardizes the component structure to V2, separating the interface definition from the implementation and fx wiring.

### Describe how you validated your changes

CI

### Additional Notes

None.