### PR TITLE
[PROF-14140] Add version baking in ci job

### DIFF
--- a/tasks/host_profiler.py
+++ b/tasks/host_profiler.py
@@ -55,7 +55,7 @@ def _get_profiler_agent_version(ctx):
         return f"{version}-nightly_git.{commits}.{git_sha}"
 
     branch = os.environ.get("CI_COMMIT_REF_SLUG") or get_current_branch(ctx)
-    pre_label = pre if pre else "devel"
+    pre_label = f"{pre}_devtest" if pre else "devtest"
     return f"{version}-{pre_label}_git.{commits}.{git_sha}.{branch}"
 
 

--- a/tasks/host_profiler.py
+++ b/tasks/host_profiler.py
@@ -13,6 +13,7 @@ from tasks.libs.common.constants import ALLOWED_REPO_NIGHTLY_BRANCHES
 from tasks.libs.common.git import get_current_branch
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import REPO_PATH, bin_name, get_version_ldflags
+from tasks.libs.releasing.json import get_current_milestone
 from tasks.libs.releasing.version import query_version
 
 EBPF_PROFILER_MODULE = "go.opentelemetry.io/ebpf-profiler"
@@ -47,7 +48,8 @@ def _get_profiler_agent_version(ctx):
     if not is_nightly and not is_dev:
         return None
 
-    version, pre, commits, git_sha, _ = query_version(ctx, major_version='7')
+    major_version = get_current_milestone().split('.')[0]
+    version, pre, commits, git_sha, _ = query_version(ctx, major_version=major_version)
 
     if is_nightly:
         return f"{version}-nightly_git.{commits}.{git_sha}"

--- a/tasks/host_profiler.py
+++ b/tasks/host_profiler.py
@@ -10,7 +10,6 @@ from invoke.exceptions import Exit
 from tasks.build_tags import get_default_build_tags
 from tasks.libs.common.color import color_message
 from tasks.libs.common.constants import ALLOWED_REPO_NIGHTLY_BRANCHES
-from tasks.libs.common.git import get_current_branch
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import REPO_PATH, bin_name, get_version_ldflags
 from tasks.libs.releasing.json import get_current_milestone
@@ -54,7 +53,7 @@ def _get_profiler_agent_version(ctx):
     if is_nightly:
         return f"{version}-nightly_git.{commits}.{git_sha}"
 
-    branch = os.environ.get("CI_COMMIT_REF_SLUG") or get_current_branch(ctx)
+    branch = os.environ.get("CI_COMMIT_REF_SLUG")
     pre_label = pre if pre else "devel"
     return f"{version}-{pre_label}_git.{commits}.{git_sha}.{branch}"
 

--- a/tasks/host_profiler.py
+++ b/tasks/host_profiler.py
@@ -55,7 +55,7 @@ def _get_profiler_agent_version(ctx):
         return f"{version}-nightly_git.{commits}.{git_sha}"
 
     branch = os.environ.get("CI_COMMIT_REF_SLUG") or get_current_branch(ctx)
-    pre_label = f"{pre}_devtest" if pre else "devtest"
+    pre_label = pre if pre else "devel"
     return f"{version}-{pre_label}_git.{commits}.{git_sha}.{branch}"
 
 

--- a/tasks/host_profiler.py
+++ b/tasks/host_profiler.py
@@ -9,8 +9,11 @@ from invoke.exceptions import Exit
 
 from tasks.build_tags import get_default_build_tags
 from tasks.libs.common.color import color_message
+from tasks.libs.common.constants import ALLOWED_REPO_NIGHTLY_BRANCHES
+from tasks.libs.common.git import get_current_branch
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import REPO_PATH, bin_name, get_version_ldflags
+from tasks.libs.releasing.version import query_version
 
 EBPF_PROFILER_MODULE = "go.opentelemetry.io/ebpf-profiler"
 CILIUM_EBPF_MODULE = "github.com/cilium/ebpf"
@@ -18,6 +21,40 @@ CILIUM_EBPF_MODULE = "github.com/cilium/ebpf"
 BIN_NAME = "host-profiler"
 BIN_DIR = os.path.join(".", "bin", "host-profiler")
 BIN_PATH = os.path.join(BIN_DIR, bin_name("host-profiler"))
+
+
+def _get_profiler_agent_version(ctx):
+    """Return a profiler-specific AgentVersion string, or None to use the default.
+
+    Two deployment contexts are handled:
+      - Nightly (same condition as nightly relenv trigger):
+          DDR_WORKFLOW_ID set + CI_COMMIT_BRANCH == "main" + BUCKET_BRANCH in nightly set
+          → "7.79.0-nightly_git.101.89faa04"
+      - Dev branch (BUCKET_BRANCH == "dev", covers both branch standalone and devtest):
+          → "7.79.0-devel_git.101.89faa04.<branch_slug>"
+
+    Returns None for stable/beta/release builds and local builds.
+    """
+    bucket_branch = os.environ.get("BUCKET_BRANCH", "")
+
+    is_nightly = (
+        bool(os.environ.get("DDR_WORKFLOW_ID"))
+        and os.environ.get("CI_COMMIT_BRANCH") == "main"
+        and bucket_branch in ALLOWED_REPO_NIGHTLY_BRANCHES
+    )
+    is_dev = bucket_branch == "dev"
+
+    if not is_nightly and not is_dev:
+        return None
+
+    version, pre, commits, git_sha, _ = query_version(ctx, major_version='7')
+
+    if is_nightly:
+        return f"{version}-nightly_git.{commits}.{git_sha}"
+
+    branch = os.environ.get("CI_COMMIT_REF_SLUG") or get_current_branch(ctx)
+    pre_label = pre if pre else "devel"
+    return f"{version}-{pre_label}_git.{commits}.{git_sha}.{branch}"
 
 
 @task
@@ -32,6 +69,8 @@ def build(ctx):
     env = {"GO111MODULE": "on"}
     build_tags = get_default_build_tags(build="host-profiler")
     ldflags = get_version_ldflags(ctx)
+    if profiler_version := _get_profiler_agent_version(ctx):
+        ldflags += f" -X {REPO_PATH}/pkg/version.AgentVersion={profiler_version}"
     if os.environ.get("DELVE"):
         gcflags = "all=-N -l"
     else:


### PR DESCRIPTION
### What does this PR do?

Adds dynamic version string generation for the host-profiler binary in `nightly` and `dev` branch CI builds.
`_get_profiler_agent_version` detects the build context from environment variables (`BUCKET_BRANCH`, `DDR_WORKFLOW_ID`, `CI_COMMIT_BRANCH`) and produces a version string injected via `-X` ldflags at build time:
  - **Nightly** (`BUCKET_BRANCH` in nightly set + `CI_COMMIT_BRANCH == main` + `DDR_WORKFLOW_ID` set): `7.x.y-nightly_git.<commits>.<sha>`
  - **Dev** branch (`BUCKET_BRANCH == dev`): `7.x.y-<pre>_devtest_git.<commits>.<sha>.<branch_slug>`

For stable/beta/release or local builds the function returns None and the default version string is used unchanged.

### Motivation

Host-profiler nightly and dev builds were previously labeled with the same version string as release builds, making it difficult to distinguish rel-env deployments and correlate a running profiler with the exact commit it was built from. 

### Describe how you validated your changes

https://ddstaging.datadoghq.com/profiling/explorer?query=datadog.host.name%3Ai-08243de1f4939ad80%20profiler_version%3A7.79.0-devel_devtest_git.229.1f14300.theomagellan-override-profiler-version-ci&agg_m=%40prof_core_cpu_cores&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=sum&fromUser=false&my_code=enabled&refresh_mode=sliding&top_n=100&top_o=top&viz=stream&x_missing=true&from_ts=1774871328214&to_ts=1774872228214&live=true
