### PR TITLE
[CWS-5964] Skip discarder partial evaluation when rate limiter is exhausted

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -49,6 +49,7 @@ type PlatformProbe interface {
 	FlushDiscarders() error
 	ApplyRuleSet(_ *rules.RuleSet) (*kfilters.FilterReport, bool, error)
 	OnNewRuleSetLoaded(_ *rules.RuleSet)
+	ShouldEvaluateDiscarders(_ *model.Event) bool
 	OnNewDiscarder(_ *rules.RuleSet, _ *model.Event, _ eval.Field, _ eval.EventType)
 	HandleActions(_ *eval.Context, _ *rules.Rule)
 	NewEvent() *model.Event
@@ -243,6 +244,14 @@ func (p *Probe) Snapshot() error {
 // Walk iterates through the entire tree and call the provided callback on each entry
 func (p *Probe) Walk(cb func(entry *model.ProcessCacheEntry)) {
 	p.PlatformProbe.Walk(cb)
+}
+
+// ShouldEvaluateDiscarders returns whether discarder evaluation should proceed for the given event
+func (p *Probe) ShouldEvaluateDiscarders(ev *model.Event) bool {
+	if p.PlatformProbe == nil {
+		return true
+	}
+	return p.PlatformProbe.ShouldEvaluateDiscarders(ev)
 }
 
 // OnNewDiscarder is called when a new discarder is found

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1948,20 +1948,23 @@ func (p *EBPFProbe) GetEventTags(containerID containerutils.ContainerID) []strin
 	return p.Resolvers.TagsResolver.Resolve(containerID)
 }
 
-// OnNewDiscarder handles new discarders
-func (p *EBPFProbe) OnNewDiscarder(rs *rules.RuleSet, ev *model.Event, field eval.Field, eventType eval.EventType) {
-	// discarders disabled
+// ShouldEvaluateDiscarders returns whether discarder evaluation should proceed for the given event.
+// It also handles rate limiter token consumption so that OnNewDiscarder does not need to re-check.
+func (p *EBPFProbe) ShouldEvaluateDiscarders(ev *model.Event) bool {
 	if !p.config.Probe.EnableDiscarders {
-		return
+		return false
 	}
-
 	if p.isRuntimeDiscarded {
 		fakeTime := time.Unix(0, int64(ev.TimestampRaw))
 		if !p.discarderRateLimiter.AllowN(fakeTime, 1) {
-			return
+			return false
 		}
 	}
+	return true
+}
 
+// OnNewDiscarder handles new discarders
+func (p *EBPFProbe) OnNewDiscarder(rs *rules.RuleSet, ev *model.Event, field eval.Field, eventType eval.EventType) {
 	seclog.Tracef("New discarder of type %s for field %s", eventType, field)
 
 	if handler, ok := allDiscarderHandlers[field]; ok {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1948,15 +1948,14 @@ func (p *EBPFProbe) GetEventTags(containerID containerutils.ContainerID) []strin
 	return p.Resolvers.TagsResolver.Resolve(containerID)
 }
 
-// ShouldEvaluateDiscarders returns whether discarder evaluation should proceed for the given event.
-// It also handles rate limiter token consumption so that OnNewDiscarder does not need to re-check.
+// ShouldEvaluateDiscarders returns whether discarder evaluation should proceed for the given event
 func (p *EBPFProbe) ShouldEvaluateDiscarders(ev *model.Event) bool {
 	if !p.config.Probe.EnableDiscarders {
 		return false
 	}
 	if p.isRuntimeDiscarded {
 		fakeTime := time.Unix(0, int64(ev.TimestampRaw))
-		if !p.discarderRateLimiter.AllowN(fakeTime, 1) {
+		if p.discarderRateLimiter.TokensAt(fakeTime) < 1 {
 			return false
 		}
 	}
@@ -1965,6 +1964,13 @@ func (p *EBPFProbe) ShouldEvaluateDiscarders(ev *model.Event) bool {
 
 // OnNewDiscarder handles new discarders
 func (p *EBPFProbe) OnNewDiscarder(rs *rules.RuleSet, ev *model.Event, field eval.Field, eventType eval.EventType) {
+	if p.isRuntimeDiscarded {
+		fakeTime := time.Unix(0, int64(ev.TimestampRaw))
+		if !p.discarderRateLimiter.AllowN(fakeTime, 1) {
+			return
+		}
+	}
+
 	seclog.Tracef("New discarder of type %s for field %s", eventType, field)
 
 	if handler, ok := allDiscarderHandlers[field]; ok {

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -608,6 +608,11 @@ func (p *EBPFLessProbe) Walk(callback func(*model.ProcessCacheEntry)) {
 	p.Resolvers.ProcessResolver.Walk(callback)
 }
 
+// ShouldEvaluateDiscarders returns whether discarder evaluation should proceed for the given event
+func (p *EBPFLessProbe) ShouldEvaluateDiscarders(_ *model.Event) bool {
+	return true
+}
+
 // OnNewDiscarder handles discarders
 func (p *EBPFLessProbe) OnNewDiscarder(_ *rules.RuleSet, _ *model.Event, _ eval.Field, _ eval.EventType) {
 }

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -610,7 +610,7 @@ func (p *EBPFLessProbe) Walk(callback func(*model.ProcessCacheEntry)) {
 
 // ShouldEvaluateDiscarders returns whether discarder evaluation should proceed for the given event
 func (p *EBPFLessProbe) ShouldEvaluateDiscarders(_ *model.Event) bool {
-	return true
+	return false
 }
 
 // OnNewDiscarder handles discarders

--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -61,6 +61,11 @@ func (p *Probe) ApplyRuleSet(_ *rules.RuleSet) (*kfilters.FilterReport, bool, er
 func (p *Probe) OnNewRuleSetLoaded(_ *rules.RuleSet) {
 }
 
+// ShouldEvaluateDiscarders returns whether discarder evaluation should proceed for the given event
+func (p *Probe) ShouldEvaluateDiscarders(_ *model.Event) bool {
+	return true
+}
+
 // OnNewDiscarder is called when a new discarder is found. We currently don't generate discarders on Windows.
 func (p *Probe) OnNewDiscarder(_ *rules.RuleSet, _ *model.Event, _ eval.Field, _ eval.EventType) {
 }

--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -63,7 +63,7 @@ func (p *Probe) OnNewRuleSetLoaded(_ *rules.RuleSet) {
 
 // ShouldEvaluateDiscarders returns whether discarder evaluation should proceed for the given event
 func (p *Probe) ShouldEvaluateDiscarders(_ *model.Event) bool {
-	return true
+	return false
 }
 
 // OnNewDiscarder is called when a new discarder is found. We currently don't generate discarders on Windows.

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -1503,6 +1503,11 @@ func (p *WindowsProbe) FlushDiscarders() error {
 	return nil
 }
 
+// ShouldEvaluateDiscarders returns whether discarder evaluation should proceed for the given event
+func (p *WindowsProbe) ShouldEvaluateDiscarders(_ *model.Event) bool {
+	return p.config.Probe.EnableDiscarders
+}
+
 // OnNewDiscarder handles discarders
 func (p *WindowsProbe) OnNewDiscarder(_ *rules.RuleSet, ev *model.Event, field eval.Field, evalType eval.EventType) {
 	if !p.config.Probe.EnableDiscarders {

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -718,7 +718,9 @@ func (e *RuleEngine) HandleEvent(event *model.Event) {
 			if evtType >= 0 && evtType < len(e.noMatchCounters) {
 				e.noMatchCounters[evtType].Inc()
 			}
-			ruleSet.EvaluateDiscarders(event)
+			if e.probe.ShouldEvaluateDiscarders(event) {
+				ruleSet.EvaluateDiscarders(event)
+			}
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Moves the discarder rate limiter check before partial evaluation in the event handling pipeline. Previously, the probe would evaluate all partials only to discard the result in `OnNewDiscarder` when the rate limiter was exhausted. Now, `ShouldEvaluateDiscarders` is called before `EvaluateDiscarders`.

### Motivation

Partial evaluation is expensive. When the discarder rate limiter is already exhausted, performing that work is wasted CPU since the resulting discarder would be dropped before reaching kernel space.

### Describe how you validated your changes

Existing tests.

### Additional Notes
