### PR TITLE
Migrate some of L1 modules to bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -322,7 +322,9 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/networkdevice/integrations
 # gazelle:exclude pkg/networkdevice/metadata
 # gazelle:exclude pkg/networkdevice/testutils
-# gazelle:exclude pkg/networkpath
+# gazelle:exclude pkg/networkpath/metricsender
+# gazelle:exclude pkg/networkpath/telemetry
+# gazelle:exclude pkg/networkpath/traceroute
 # gazelle:exclude pkg/opentelemetry-mapping-go/inframetadata
 # gazelle:exclude pkg/opentelemetry-mapping-go/otlp/attributes
 # gazelle:exclude pkg/opentelemetry-mapping-go/otlp/logs

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -129,7 +129,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/trace/status
 # gazelle:exclude comp/trace/compression/fx-gzip
 # gazelle:exclude comp/trace/compression/fx-zstd
-# gazelle:exclude comp/trace/compression/impl-gzip
 # gazelle:exclude comp/updater
 # gazelle:exclude comp/workloadselection
 # gazelle:exclude comp/core/agenttelemetry

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -130,7 +130,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/trace/compression/fx-gzip
 # gazelle:exclude comp/trace/compression/fx-zstd
 # gazelle:exclude comp/trace/compression/impl-gzip
-# gazelle:exclude comp/trace/compression/impl-zstd
 # gazelle:exclude comp/updater
 # gazelle:exclude comp/workloadselection
 # gazelle:exclude comp/core/agenttelemetry

--- a/comp/trace/compression/impl-gzip/BUILD.bazel
+++ b/comp/trace/compression/impl-gzip/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "impl-gzip",
+    srcs = ["gzip.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip",
+    visibility = ["//visibility:public"],
+    deps = ["//comp/trace/compression/def"],
+)

--- a/comp/trace/compression/impl-zstd/BUILD.bazel
+++ b/comp/trace/compression/impl-zstd/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+# TODO(ABLD-424): reconcile @com_github_datadog_zstd CGo build with @zstd//:libzstd cc_library
+
+go_library(
+    name = "impl-zstd",
+    srcs = ["zstd.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/trace/compression/def",
+        "@com_github_datadog_zstd//:zstd",
+    ],
+)

--- a/pkg/networkpath/payload/BUILD.bazel
+++ b/pkg/networkpath/payload/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "payload",
+    srcs = [
+        "pathevent.go",
+        "utils.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/networkpath/payload",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/network/payload"],
+)
+
+go_test(
+    name = "payload_test",
+    srcs = ["payload_test.go"],
+    embed = [":payload"],
+    deps = ["@com_github_stretchr_testify//require"],
+)


### PR DESCRIPTION
### What does this PR do?
This migrates the following list of modules to go:
- comp/trace/compression/impl-gzip
- comp/trace/compression/impl-zstd
- pkg/networkpath/payload

Only the last one contains a test target, the first 2 are CGo libraries. 

### Additional Notes
As a follow up (ABLD-424) we should take a closer look at `zstd` as we build it basically twice for different purposes (to ship .so and as a CGO library)