### PR TITLE
fix(renovate): Adjust minimum release age condition

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,13 +10,11 @@
       {
         "matchDepNames": ["integrations-core"],
         "changelogUrl": "https://github.com/DataDog/integrations-core/compare/{{currentDigest}}..{{newDigest}}",
-        "schedule": ["* 2-6 * * 1,3"],
-        "minimumReleaseAge": null
+        "schedule": ["* 2-6 * * 1,3"]
       },
       {
         "matchDepNames": ["omnibus-ruby"],
         "changelogUrl": "https://github.com/DataDog/omnibus-ruby/compare/{{currentDigest}}..{{newDigest}}",
-        "minimumReleaseAge": null,
         "matchUpdateTypes": ["major", "minor", "patch"],
         "enabled": false
       },
@@ -36,6 +34,14 @@
         "matchDepNames": ["DataDog/datadog-agent-dev"],
         "changelogUrl": "https://github.com/DataDog/datadog-agent-dev/releases/tag/v{{newValue}}",
         "schedule": ["* 1-4 5 6,12 *"]
+      },
+      {
+        "matchManagers": ["custom.regex"],
+        "minimumReleaseAge": null
+      },
+      {
+        "matchDepNames": ["protocolbuffers/protobuf"],
+        "minimumReleaseAge": "7 days"
       },
       {
         "matchManagers": ["github-actions"],
@@ -118,7 +124,8 @@
         "currentValueTemplate": "datadog-5.5.0",
         "depNameTemplate": "omnibus-ruby",
         "packageNameTemplate": "https://github.com/DataDog/omnibus-ruby",
-        "datasourceTemplate": "git-refs"
+        "datasourceTemplate": "git-refs",
+        "registryUrlTemplate": ""
       },
       {
         "customType": "regex",


### PR DESCRIPTION
### What does this PR do?
- Discard the `minimumReleaseAge` for all internal dependencies managed by the `regex` manager, which are all internal deps, except for `protocolBuffer`
- Add the `registryUrlTemplate` to "" to remove the warning on renovate console

### Motivation
Dependency management

### Describe how you validated your changes
Configuration changes only, will reflect in the [console](https://developer.mend.io/github/DataDog/datadog-agent)

### Additional Notes
