### PR TITLE
Migrate even more L1 go modules to bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -379,7 +379,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/status/systemprobe
 # gazelle:exclude pkg/status/types.go
 # gazelle:exclude pkg/system-probe
-# gazelle:exclude pkg/tagset
 # gazelle:exclude pkg/telemetry
 # gazelle:exclude pkg/trace/agent
 # gazelle:exclude pkg/trace/api

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -53,7 +53,7 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/core/remoteagent
 # gazelle:exclude comp/core/remoteagentregistry
 # gazelle:exclude comp/core/settings
-# gazelle:exclude comp/core/status
+# gazelle:exclude comp/core/status/statusimpl
 # gazelle:exclude comp/core/sysprobeconfig
 # gazelle:exclude comp/core/tagger
 # gazelle:exclude comp/core/telemetry
@@ -164,7 +164,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/core/secrets/impl
 # gazelle:exclude comp/core/secrets/noop-impl
 # gazelle:exclude comp/core/settings
-# gazelle:exclude comp/core/status
 # gazelle:exclude comp/core/sysprobeconfig
 # gazelle:exclude comp/core/telemetry
 # gazelle:exclude comp/core/workloadfilter

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -398,7 +398,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/trace/teststatsd
 # gazelle:exclude pkg/trace/testutil
 # gazelle:exclude pkg/trace/timing
-# gazelle:exclude pkg/trace/traceutil
 # gazelle:exclude pkg/trace/transform
 # gazelle:exclude pkg/trace/version
 # gazelle:exclude pkg/trace/watchdog

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -55,7 +55,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/core/settings
 # gazelle:exclude comp/core/status/statusimpl
 # gazelle:exclude comp/core/sysprobeconfig
-# gazelle:exclude comp/core/tagger
 # gazelle:exclude comp/core/telemetry
 # gazelle:exclude comp/core/workloadfilter
 # gazelle:exclude comp/core/workloadmeta
@@ -193,7 +192,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/core/tagger/taglist
 # gazelle:exclude comp/core/tagger/tagstore
 # gazelle:exclude comp/core/tagger/telemetry
-# gazelle:exclude comp/core/tagger/types
 # gazelle:exclude internal/remote-agent
 # gazelle:exclude internal/third_party
 # gazelle:exclude pkg/aggregator

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,7 +35,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/core/configsync
 # gazelle:exclude comp/core/delegatedauth
 # gazelle:exclude comp/core/diagnose
-# gazelle:exclude comp/core/flare
 # gazelle:exclude comp/core/fxinstrumentation
 # gazelle:exclude comp/core/gui
 # gazelle:exclude comp/core/healthprobe
@@ -139,7 +138,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/core/diagnose
 # gazelle:exclude comp/core/flare/flareimpl
 # gazelle:exclude comp/core/flare/helpers
-# gazelle:exclude comp/core/flare/types
 # gazelle:exclude comp/core/fxinstrumentation
 # gazelle:exclude comp/core/gui
 # gazelle:exclude comp/core/healthprobe

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -379,7 +379,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/status/systemprobe
 # gazelle:exclude pkg/status/types.go
 # gazelle:exclude pkg/system-probe
-# gazelle:exclude pkg/tagger
 # gazelle:exclude pkg/tagset
 # gazelle:exclude pkg/telemetry
 # gazelle:exclude pkg/trace/agent

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -322,7 +322,9 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/networkdevice/integrations
 # gazelle:exclude pkg/networkdevice/metadata
 # gazelle:exclude pkg/networkdevice/testutils
-# gazelle:exclude pkg/networkpath
+# gazelle:exclude pkg/networkpath/metricsender
+# gazelle:exclude pkg/networkpath/telemetry
+# gazelle:exclude pkg/networkpath/traceroute
 # gazelle:exclude pkg/opentelemetry-mapping-go/inframetadata
 # gazelle:exclude pkg/opentelemetry-mapping-go/otlp/attributes
 # gazelle:exclude pkg/opentelemetry-mapping-go/otlp/logs

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -129,7 +129,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/trace/status
 # gazelle:exclude comp/trace/compression/fx-gzip
 # gazelle:exclude comp/trace/compression/fx-zstd
-# gazelle:exclude comp/trace/compression/impl-gzip
 # gazelle:exclude comp/updater
 # gazelle:exclude comp/workloadselection
 # gazelle:exclude comp/core/agenttelemetry

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -159,11 +159,9 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/core/profiler
 # gazelle:exclude comp/core/remoteagent
 # gazelle:exclude comp/core/remoteagentregistry
-# gazelle:exclude comp/core/secrets/def
 # gazelle:exclude comp/core/secrets/fx-noop
 # gazelle:exclude comp/core/secrets/fx
 # gazelle:exclude comp/core/secrets/impl
-# gazelle:exclude comp/core/secrets/mock
 # gazelle:exclude comp/core/secrets/noop-impl
 # gazelle:exclude comp/core/settings
 # gazelle:exclude comp/core/status

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -130,7 +130,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/trace/compression/fx-gzip
 # gazelle:exclude comp/trace/compression/fx-zstd
 # gazelle:exclude comp/trace/compression/impl-gzip
-# gazelle:exclude comp/trace/compression/impl-zstd
 # gazelle:exclude comp/updater
 # gazelle:exclude comp/workloadselection
 # gazelle:exclude comp/core/agenttelemetry

--- a/comp/core/flare/BUILD.bazel
+++ b/comp/core/flare/BUILD.bazel
@@ -1,2 +1,1 @@
 # gazelle:ignore
-# Not yet migrated to Bazel. Only comp/core/flare/builder is migrated.

--- a/comp/core/flare/types/BUILD.bazel
+++ b/comp/core/flare/types/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "types",
+    srcs = ["types.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/core/flare/types",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/flare/builder",
+        "@org_uber_go_fx//:fx",
+    ],
+)

--- a/comp/core/secrets/mock/BUILD.bazel
+++ b/comp/core/secrets/mock/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "mock",
+    srcs = ["mock.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/core/secrets/mock",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/secrets/def",
+        "//comp/core/secrets/utils",
+        "@in_yaml_go_yaml_v2//:yaml",
+    ],
+)

--- a/comp/core/status/BUILD.bazel
+++ b/comp/core/status/BUILD.bazel
@@ -24,7 +24,6 @@ go_test(
     name = "status_test",
     srcs = ["render_helpers_test.go"],
     embed = [":status"],
-    gotags = ["test"],  # keep
     deps = [
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/core/status/BUILD.bazel
+++ b/comp/core/status/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "status",
+    srcs = [
+        "component.go",
+        "component_mock.go",
+        "render_helpers.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/core/status",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/template/html",
+        "//pkg/template/text",
+        "@com_github_dustin_go_humanize//:go-humanize",
+        "@com_github_fatih_color//:color",
+        "@com_github_spf13_cast//:cast",
+        "@org_golang_x_text//unicode/norm",
+        "@org_uber_go_fx//:fx",
+    ],
+)
+
+go_test(
+    name = "status_test",
+    srcs = ["render_helpers_test.go"],
+    embed = [":status"],
+    gotags = ["test"],  # keep
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/comp/core/tagger/types/BUILD.bazel
+++ b/comp/core/tagger/types/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "types",
+    srcs = [
+        "entity_id.go",
+        "filter_builder.go",
+        "filters.go",
+        "types.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/core/tagger/types",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/tagger/origindetection",
+        "//comp/core/tagger/utils",
+    ],
+)
+
+go_test(
+    name = "types_test",
+    srcs = [
+        "entity_id_test.go",
+        "filter_builder_test.go",
+        "filters_test.go",
+    ],
+    embed = [":types"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/comp/trace/compression/impl-gzip/BUILD.bazel
+++ b/comp/trace/compression/impl-gzip/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "impl-gzip",
+    srcs = ["gzip.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip",
+    visibility = ["//visibility:public"],
+    deps = ["//comp/trace/compression/def"],
+)

--- a/comp/trace/compression/impl-zstd/BUILD.bazel
+++ b/comp/trace/compression/impl-zstd/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+# TODO(ABLD-424): reconcile @com_github_datadog_zstd CGo build with @zstd//:libzstd cc_library
+
+go_library(
+    name = "impl-zstd",
+    srcs = ["zstd.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/trace/compression/def",
+        "@com_github_datadog_zstd//:zstd",
+    ],
+)

--- a/pkg/networkpath/payload/BUILD.bazel
+++ b/pkg/networkpath/payload/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "payload",
+    srcs = [
+        "pathevent.go",
+        "utils.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/networkpath/payload",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/network/payload"],
+)
+
+go_test(
+    name = "payload_test",
+    srcs = ["payload_test.go"],
+    embed = [":payload"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/tagger/BUILD.bazel
+++ b/pkg/tagger/BUILD.bazel
@@ -1,0 +1,1 @@
+# gazelle:ignore

--- a/pkg/tagger/types/BUILD.bazel
+++ b/pkg/tagger/types/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "types",
+    srcs = ["types.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/tagger/types",
+    visibility = ["//visibility:public"],
+    deps = ["//comp/core/tagger/origindetection"],
+)

--- a/pkg/tagset/BUILD.bazel
+++ b/pkg/tagset/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "tagset",
+    srcs = [
+        "composite_tags.go",
+        "docs.go",
+        "hash_generator.go",
+        "hashed_tags.go",
+        "hashed_tags_pvt.go",
+        "hashing_tags_accumulator.go",
+        "hashless_tags_accumulator.go",
+        "types.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/tagset",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/sort",
+        "@com_github_twmb_murmur3//:murmur3",
+    ],
+)
+
+go_test(
+    name = "tagset_test",
+    srcs = [
+        "composite_tags_test.go",
+        "hash_generator_test.go",
+        "hashed_tags_pvt_test.go",
+        "hashed_tags_test.go",
+        "hashing_tags_accumulator_test.go",
+        "hashless_tags_accumulator_test.go",
+    ],
+    embed = [":tagset"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@com_github_twmb_murmur3//:murmur3",
+    ],
+)

--- a/pkg/trace/traceutil/BUILD.bazel
+++ b/pkg/trace/traceutil/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "traceutil",
+    srcs = [
+        "azure.go",
+        "constants.go",
+        "doc.go",
+        "processed_trace.go",
+        "span.go",
+        "trace.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/trace/traceutil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/proto/pbgo/trace",
+        "//pkg/proto/pbgo/trace/idx",
+        "//pkg/trace/log",
+        "@com_github_tinylib_msgp//msgp",
+    ],
+)
+
+go_test(
+    name = "traceutil_test",
+    srcs = [
+        "azure_test.go",
+        "processed_trace_test.go",
+        "span_test.go",
+        "trace_test.go",
+    ],
+    embed = [":traceutil"],
+    deps = [
+        "//pkg/proto/pbgo/trace",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/pkg/trace/traceutil/normalize/BUILD.bazel
+++ b/pkg/trace/traceutil/normalize/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "normalize",
+    srcs = [
+        "normalize.go",
+        "truncate.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/trace/traceutil/normalize",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "normalize_test",
+    srcs = [
+        "fuzz_test.go",
+        "normalize_test.go",
+        "truncate_test.go",
+    ],
+    embed = [":normalize"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)


### PR DESCRIPTION
### What does this PR do?
This PR migrates the following go modules to bazel:
- pkg/tagger/types
- pkg/tagset
- pkg/trace/traceutil
