### PR TITLE
Stop ignoring `.bazelbsp` in REPO.bazel

### DIFF
--- a/REPO.bazel
+++ b/REPO.bazel
@@ -1,6 +1,12 @@
+# Do not ignore .bazelbsp: used by IDE BSP integration!
 ignore_directories([
     "**/build",  # avoid BUILD/build mess: https://github.com/docker/desktop-feedback/issues/251
-    ".*",  # hidden root directories: .cache, .claude, .cursor, .dda, .github, .gitlab, etc.
+    ".*_cache",  # .mypy_cache, .pytest_cache, .ruff_cache
+    ".c*",  # .cache, .claude, .cursor
+    ".d*",  # .dda, .ddqa
+    ".g*",  # .git, .github, .gitlab
+    ".i*",  # .idea, .ijwb
+    ".v*",  # .venv, .vscode
     "bazel-*",  # bazel convenience symlinks: suddenly caused issues inside arm64 Linux containers
     "target",  # cargo build creates it where Cargo.toml lives
 ])


### PR DESCRIPTION
### What does this PR do?
Replace the alas too broad `.*` pattern in `ignore_directories` (since #48525, my bad) with more fine-grained patterns (`.c*`, `.d*`, `.g*`, `.i*`, `.v*`, `.*_cache`) that cover the same hidden directories while leaving `.bazelbsp` visible to `bazel`.

### Motivation
IDE like IntelliJ IDEA and GoLand use the Bazel BSP (Build Server Protocol) integration, whose state lives in `.bazelbsp/`.
The `".*"` catch-all caused Bazel to skip that directory, so these IDEs stopped refreshing the project.

`ignore_directories` has no negation syntax, so enumerating more fine-grained patterns is the only available workaround.

### Describe how you validated your changes
Verified that `.bazelbsp` no longer appears in the ignored set and that all previously-ignored hidden directories still match at least one of the new patterns.

### Additional Notes
I'll file an issue upstream to request `ignore_directories` gets augmented with an `exclude=[]` arg, just like [`glob`](https://bazel.build/reference/be/functions#glob).