### PR TITLE
[CSPM] Add origin tag to compliance findings

### DIFF
--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -69,6 +69,7 @@ func NewLogReporter(hostname string, sourceName, sourceType string, endpoints *c
 	tags := []string{
 		common.QueryAccountIDTag(),
 		"host:" + hostname,
+		"origin:agent",
 	}
 
 	// merge tags from config


### PR DESCRIPTION
### What does this PR do?

This change adds an origin:compliance-agent tag to compliance findings.

The goal is to differentiate the compliance findings sent by the Datadog Agent from the findings sent by the Dataodg Agentless Scanner.

### Motivation

### Describe how you validated your changes

### Additional Notes
