### PR TITLE
Avoid redundant work in `bazel`-driven `go work sync`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -509,7 +509,7 @@ gazelle_binary(
 # bazel run //:go -- ...
 alias(
     name = "go",
-    actual = "@rules_go//go",
+    actual = "@go_fast",  #TODO(agent-build): move back to "@rules_go//go" when golang/go#77889 is addressed
 )
 
 # bazel run //:go_mod_tidy_all -- -x

--- a/bazel/rules/go_fast/avoid-redundant-work-in-go-work-sync.patch
+++ b/bazel/rules/go_fast/avoid-redundant-work-in-go-work-sync.patch
@@ -1,0 +1,27 @@
+diff --git a/src/cmd/go/internal/modload/buildlist.go b/src/cmd/go/internal/modload/buildlist.go
+--- src/cmd/go/internal/modload/buildlist.go
++++ src/cmd/go/internal/modload/buildlist.go
+@@ -307,2 +307,3 @@
+ 	buildList     []module.Version
++	checkPathsOnce sync.Once
+ }
+@@ -814,3 +815,7 @@
+ 	}
+-	return newRequirements(workspace, rs.rootModules, direct), nil
++	newRS := newRequirements(workspace, rs.rootModules, direct)
++	if cached := rs.graph.Load(); cached != nil {
++		newRS.graphOnce.Do(func() { newRS.graph.Store(cached) })
++	}
++	return newRS, nil
+ }
+diff --git a/src/cmd/go/internal/modload/load.go b/src/cmd/go/internal/modload/load.go
+--- src/cmd/go/internal/modload/load.go
++++ src/cmd/go/internal/modload/load.go
+@@ -2035,2 +2035,7 @@
+ 			mods = mg.BuildList()
++			var checkPaths bool
++			mg.checkPathsOnce.Do(func() { checkPaths = true })
++			if !checkPaths {
++				return
++			}
+ 		}

--- a/bazel/rules/go_fast/repo.bzl
+++ b/bazel/rules/go_fast/repo.bzl
@@ -1,0 +1,39 @@
+"""Repository rule for building a patched cmd/go binary."""
+
+load("@go_host_compatible_sdk_label//:defs.bzl", "HOST_COMPATIBLE_SDK")
+load("@rules_python//python/private:repo_utils.bzl", "repo_utils")  # buildifier: disable=bzl-visibility
+
+_PATCHED = [
+    "src/cmd/go/internal/modload/buildlist.go",
+    "src/cmd/go/internal/modload/load.go",
+]
+
+def _impl(rctx):
+    sdk = rctx.path(rctx.attr._go_sdk).dirname
+    replace = {}
+    for path in _PATCHED:
+        src = sdk.get_child(path)
+        rctx.file(path, rctx.read(src))
+        replace[str(src)] = path
+    rctx.file("overlay.json", json.encode({"Replace": replace}))
+    rctx.patch(rctx.attr.patch)
+    go = sdk.get_child("bin/go{}".format(".exe" if repo_utils.get_platforms_os_name(rctx) == "windows" else ""))
+    out = "{}.exe".format(rctx.original_name)  # like native_binary, since .exe is needed on Windows, otherwise harmless
+    repo_utils.execute_checked(
+        rctx,
+        arguments = [go, "build", "-overlay", "overlay.json", "-o", out, "cmd/go"],
+        environment = {"GOPATH": None, "GOROOT": str(sdk), "GOWORK": "off"},
+        op = "build {}".format(out),
+    )
+    rctx.file(
+        "BUILD.bazel",
+        'alias(name = "{}", actual = "{}", visibility = ["//visibility:public"])'.format(rctx.original_name, out),
+    )
+
+go_fast = repository_rule(
+    implementation = _impl,
+    attrs = {
+        "_go_sdk": attr.label(default = HOST_COMPATIBLE_SDK),
+        "patch": attr.label(default = "//bazel/rules/go_fast:avoid-redundant-work-in-go-work-sync.patch"),
+    },
+)

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -522,6 +522,8 @@ use_repo(
     "tools_gotest_gotestsum",
 )
 
+use_repo_rule("//bazel/rules/go_fast:repo.bzl", "go_fast")(name = "go_fast")
+
 use_repo_rule("//bazel/rules/go_sdk_overrides:repo.bzl", "go_sdk_overrides")(name = "go_sdk_overrides")
 
 use_repo_rule("//bazel/rules/go_stringer:repo.bzl", "go_stringer")(name = "go_stringer")


### PR DESCRIPTION
### What does this PR do?
Introduce a dedicated `go_fast` repository rule that builds a patched `cmd/go` binary from the hermetic Go SDK leading to a faster execution of `bazel run //:go work sync` (about 4 times faster on my machine).

The patch is a minimized backport of https://go-review.googlesource.com/c/go/+/750500 and stems from the upstream issue golang/go#77889.

The rule uses `-overlay` to substitute 2 patched source files without touching the SDK, and exports the resulting binary as `@go_fast`.

### Motivation
Users have been reporting that `dda inv tidy` takes time (with 180+ Go modules, we're in a quite rare setup).
To be clear, this _has nothing to do with the recent takeover by `bazel`_, but is nonetheless linked to it because contributors may use it more often.
Indeed, `bazel run //:go -- work sync` alone was taking about ~40s on machine.

Fortunately, @pgimalac did file:
- golang/go#77889.

We don't need to wait for it to be addressed upstream and instead benefit from a mimized patch from his upstream proposal:
- https://go-review.googlesource.com/c/go/+/750500

### Describe how you validated your changes
- `bazel run //:go work sync` succeeds,
- it still behaves exactly as the non-hermetic `go work sync`,
- its execution time decreases by a factor of 4+ compared to either `go work sync` or `bazel run @rules_go//go work sync`,
- `strings` on the produced binary confirms `checkPathsOnce` is present,
- also works on Windows by adopting `native_binary`'s systematic `.exe` extension for [`out`](https://github.com/bazelbuild/bazel-skylib/blob/main/docs/native_binary_doc.md#native_binary-out).

### Additional Notes
We'll of course remove this piece of infrastructure when addressed upstream.