### PR TITLE
Revert AGENTCFG-92 secret config layer

### DIFF
--- a/comp/core/settings/settingsimpl/settingsimpl.go
+++ b/comp/core/settings/settingsimpl/settingsimpl.go
@@ -108,9 +108,9 @@ func (s *settingsRegistry) getFullConfigHandler(includeDefaults bool, namespaces
 
 		var allSettings map[string]interface{}
 		if includeDefaults {
-			allSettings = s.config.AllSettingsWithoutSecrets()
+			allSettings = s.config.AllSettings()
 		} else {
-			allSettings = s.config.AllSettingsWithoutDefaultOrSecrets()
+			allSettings = s.config.AllSettingsWithoutDefault()
 		}
 
 		if !requiresAllNamespaces {

--- a/comp/core/settings/settingsimpl/settingsimpl_test.go
+++ b/comp/core/settings/settingsimpl/settingsimpl_test.go
@@ -311,7 +311,7 @@ func TestRuntimeSettings(t *testing.T) {
 				// simply compare strings.
 				expected := map[string]interface{}{}
 				actual := map[string]interface{}{}
-				json.Unmarshal([]byte("{\"value\":{\"Value\":\"\",\"Source\":\"\"},\"sources_value\":[{\"Source\":\"default\",\"Value\":null},{\"Source\":\"unknown\",\"Value\":null},{\"Source\":\"infra-mode\",\"Value\":null},{\"Source\":\"file\",\"Value\":null},{\"Source\":\"environment-variable\",\"Value\":null},{\"Source\":\"fleet-policies\",\"Value\":null},{\"Source\":\"agent-runtime\",\"Value\":null},{\"Source\":\"secret-backend\",\"Value\":null},{\"Source\":\"local-config-process\",\"Value\":null},{\"Source\":\"remote-config\",\"Value\":null},{\"Source\":\"cli\",\"Value\":null}]}"), &expected)
+				json.Unmarshal([]byte("{\"value\":{\"Value\":\"\",\"Source\":\"\"},\"sources_value\":[{\"Source\":\"default\",\"Value\":null},{\"Source\":\"unknown\",\"Value\":null},{\"Source\":\"infra-mode\",\"Value\":null},{\"Source\":\"file\",\"Value\":null},{\"Source\":\"environment-variable\",\"Value\":null},{\"Source\":\"fleet-policies\",\"Value\":null},{\"Source\":\"agent-runtime\",\"Value\":null},{\"Source\":\"local-config-process\",\"Value\":null},{\"Source\":\"remote-config\",\"Value\":null},{\"Source\":\"cli\",\"Value\":null}]}"), &expected)
 				err = json.Unmarshal(body, &actual)
 
 				require.NoError(t, err, fmt.Sprintf("error loading JSON body: %s", err))

--- a/comp/metadata/clusteragent/impl/cluster_agent.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent.go
@@ -180,7 +180,7 @@ func (dca *datadogclusteragent) getConfigs(data map[string]interface{}) {
 			}
 		}
 	}
-	if yaml, err := dca.marshalAndScrub(dca.conf.AllSettingsWithoutSecrets()); err == nil {
+	if yaml, err := dca.marshalAndScrub(dca.conf.AllSettings()); err == nil {
 		data["full_configuration"] = yaml
 	}
 }

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -497,7 +497,7 @@ func (ia *inventoryagent) getConfigs(data agentMetadata) {
 				}
 			}
 		}
-		if yaml, err := ia.marshalAndScrub(ia.conf.AllSettingsWithoutSecrets()); err == nil {
+		if yaml, err := ia.marshalAndScrub(ia.conf.AllSettings()); err == nil {
 			data["full_configuration"] = yaml
 		}
 	}

--- a/comp/trace/config/impl/config.go
+++ b/comp/trace/config/impl/config.go
@@ -188,7 +188,7 @@ func (c *cfg) GetConfigHandler() http.Handler {
 				return
 			}
 
-			runtimeConfig, err := yaml.Marshal(c.coreConfig.AllSettingsWithoutSecrets())
+			runtimeConfig, err := yaml.Marshal(c.coreConfig.AllSettings())
 			if err != nil {
 				log.Errorf("Unable to marshal runtime config response: %s", err)
 				body, _ := json.Marshal(map[string]string{"error": err.Error()})

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -40,9 +40,6 @@ const (
 	SourceFile Source = "file"
 	// SourceEnvVar are the values loaded from the environment variables.
 	SourceEnvVar Source = "environment-variable"
-	// SourceSecretBackend are the values resolved from a secret backend (replacing ENC[] placeholders).
-	// Stored as a separate layer so that config can be dumped without secrets to prevent leaks.
-	SourceSecretBackend Source = "secret-backend"
 	// SourceAgentRuntime are the values configured by the agent itself. The agent can dynamically compute the best
 	// value for some settings when not set by the user.
 	SourceAgentRuntime Source = "agent-runtime"
@@ -69,7 +66,6 @@ var Sources = []Source{
 	SourceEnvVar,
 	SourceFleetPolicies,
 	SourceAgentRuntime,
-	SourceSecretBackend,
 	SourceLocalConfigProcess,
 	SourceRC,
 	SourceCLI,
@@ -86,10 +82,9 @@ var sourcesPriority = map[Source]int{
 	SourceEnvVar:             4,
 	SourceFleetPolicies:      5,
 	SourceAgentRuntime:       6,
-	SourceSecretBackend:      7,
-	SourceLocalConfigProcess: 8,
-	SourceRC:                 9,
-	SourceCLI:                10,
+	SourceLocalConfigProcess: 7,
+	SourceRC:                 8,
+	SourceCLI:                9,
 }
 
 // ValueWithSource is a tuple for a source and a value, not necessarily the applied value in the main config
@@ -165,15 +160,6 @@ type Reader interface {
 	AllSettings() map[string]interface{}
 	AllSettingsWithoutDefault() map[string]interface{}
 	AllSettingsBySource() map[Source]interface{}
-	// AllSettingsWithoutSecrets returns all settings from the config, merging every layer except the
-	// secret backend layer. This provides a safe way to dump config without risking resolved secret leaks.
-	AllSettingsWithoutSecrets() map[string]interface{}
-	// AllSettingsWithoutDefaultOrSecrets returns all non-default settings, excluding the secret backend
-	// layer as well.
-	AllSettingsWithoutDefaultOrSecrets() map[string]interface{}
-	// GetSecretSettingPaths returns the flattened key path that exist in the secrets layer.
-	// This allows the scrubber to know exactly which settings contain secrets
-	GetSecretSettingPaths() []string
 	// AllKeysLowercased returns all config keys in the config, no matter how they are set.
 	// Note that it returns the keys lowercased.
 	AllKeysLowercased() []string

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -171,6 +171,9 @@ type Reader interface {
 	// AllSettingsWithoutDefaultOrSecrets returns all non-default settings, excluding the secret backend
 	// layer as well.
 	AllSettingsWithoutDefaultOrSecrets() map[string]interface{}
+	// GetSecretSettingPaths returns the flattened key path that exist in the secrets layer.
+	// This allows the scrubber to know exactly which settings contain secrets
+	GetSecretSettingPaths() []string
 	// AllKeysLowercased returns all config keys in the config, no matter how they are set.
 	// Note that it returns the keys lowercased.
 	AllKeysLowercased() []string

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -35,7 +35,6 @@ var sources = []model.Source{
 	model.SourceEnvVar,
 	model.SourceFleetPolicies,
 	model.SourceAgentRuntime,
-	model.SourceSecretBackend,
 	model.SourceLocalConfigProcess,
 	model.SourceRC,
 	model.SourceCLI,
@@ -78,8 +77,6 @@ type ntmConfig struct {
 	file *nodeImpl
 	// envs contains config settings created by environment variables
 	envs *nodeImpl
-	// secrets contains the settings resolved from secret backend
-	secrets *nodeImpl
 	// runtime contains the settings set from the agent code itself at runtime (self configured values).
 	runtime *nodeImpl
 	// localConfigProcess contains the settings pulled from the config process (process owning the source of truth
@@ -161,8 +158,6 @@ func (c *ntmConfig) getTreeBySource(source model.Source) (*nodeImpl, error) {
 		return c.file, nil
 	case model.SourceEnvVar:
 		return c.envs, nil
-	case model.SourceSecretBackend:
-		return c.secrets, nil
 	case model.SourceAgentRuntime:
 		return c.runtime, nil
 	case model.SourceLocalConfigProcess:
@@ -494,7 +489,6 @@ func (c *ntmConfig) mergeAllLayers() error {
 		c.envs,
 		c.fleetPolicies,
 		c.runtime,
-		c.secrets,
 		c.localConfigProcess,
 		c.remoteConfig,
 		c.cli,
@@ -926,82 +920,6 @@ func (c *ntmConfig) AllSettingsWithoutDefault() map[string]interface{} {
 	return c.root.dumpSettings(false)
 }
 
-// AllSettingsWithoutSecrets returns all settings from the config, merging all layers except the
-// secret backend layer. This allows dumping the full config without any risk of leaking resolved secrets.
-func (c *ntmConfig) AllSettingsWithoutSecrets() map[string]interface{} {
-	c.maybeRebuild()
-
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.mergeWithoutSecrets().dumpSettings(true)
-}
-
-// AllSettingsWithoutDefaultOrSecrets returns all non-default settings, excluding the secret backend
-func (c *ntmConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{} {
-	c.maybeRebuild()
-
-	c.RLock()
-	defer c.RUnlock()
-
-	return c.mergeWithoutSecrets().dumpSettings(false)
-}
-
-// mergeWithoutSecrets returns a merged tree of all layers except the secrets layer.
-func (c *ntmConfig) mergeWithoutSecrets() *nodeImpl {
-	treeList := []*nodeImpl{
-		c.defaults,
-		c.unknown,
-		c.file,
-		c.envs,
-		c.fleetPolicies,
-		// secrets layer excluded
-		c.runtime,
-		c.localConfigProcess,
-		c.remoteConfig,
-		c.cli,
-	}
-
-	merged := newInnerNode(nil)
-	for _, tree := range treeList {
-		next, err := merged.Merge(tree)
-		if err != nil {
-			log.Errorf("error merging config layers without secrets: %s", err)
-			return merged
-		}
-		merged = next
-	}
-
-	return merged
-}
-
-// GetSecretSettingPaths returns the flattened key paths that exist in the secrets layer.
-func (c *ntmConfig) GetSecretSettingPaths() []string {
-	c.RLock()
-	defer c.RUnlock()
-
-	var keys []string
-	collectFlattenedKeysFromNode(c.secrets, "", &keys)
-	return keys
-}
-
-// collectFlattenedKeysFromNode recursively walks a node tree and collects flattened dotted key paths
-// for all leaf nodes.
-func collectFlattenedKeysFromNode(node *nodeImpl, prefix string, keys *[]string) {
-	for _, name := range node.ChildrenKeys() {
-		child, err := node.GetChild(name)
-		if err != nil {
-			continue
-		}
-		fullKey := joinKey(prefix, name)
-		if child.IsLeafNode() {
-			*keys = append(*keys, fullKey)
-		} else if child.IsInnerNode() {
-			collectFlattenedKeysFromNode(child, fullKey, keys)
-		}
-	}
-}
-
 // AllSettingsBySource returns the settings from each source (file, env vars, ...)
 func (c *ntmConfig) AllSettingsBySource() map[model.Source]interface{} {
 	c.maybeRebuild()
@@ -1018,7 +936,6 @@ func (c *ntmConfig) AllSettingsBySource() map[model.Source]interface{} {
 		model.SourceEnvVar:             c.envs.dumpSettings(true),
 		model.SourceFleetPolicies:      c.fleetPolicies.dumpSettings(true),
 		model.SourceAgentRuntime:       c.runtime.dumpSettings(true),
-		model.SourceSecretBackend:      c.secrets.dumpSettings(true),
 		model.SourceLocalConfigProcess: c.localConfigProcess.dumpSettings(true),
 		model.SourceRC:                 c.remoteConfig.dumpSettings(true),
 		model.SourceCLI:                c.cli.dumpSettings(true),
@@ -1174,7 +1091,6 @@ func NewNodeTreeConfig(name string, envPrefix string, envKeyReplacer *strings.Re
 		unknown:            newInnerNode(nil),
 		infraMode:          newInnerNode(nil),
 		envs:               newInnerNode(nil),
-		secrets:            newInnerNode(nil),
 		runtime:            newInnerNode(nil),
 		localConfigProcess: newInnerNode(nil),
 		remoteConfig:       newInnerNode(nil),

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -486,8 +486,7 @@ func (c *ntmConfig) checkKnownKey(key string) {
 	log.Warnf("config key %v is unknown", key)
 }
 
-// mergeLayers merges all config layers in priority order. Layers passed as exclude are skipped.
-func (c *ntmConfig) mergeLayers(exclude ...*nodeImpl) (*nodeImpl, error) {
+func (c *ntmConfig) mergeAllLayers() error {
 	treeList := []*nodeImpl{
 		c.defaults,
 		c.unknown,
@@ -503,23 +502,13 @@ func (c *ntmConfig) mergeLayers(exclude ...*nodeImpl) (*nodeImpl, error) {
 
 	merged := newInnerNode(nil)
 	for _, tree := range treeList {
-		if slices.Contains(exclude, tree) {
-			continue
-		}
 		next, err := merged.Merge(tree)
 		if err != nil {
-			return merged, err
+			return err
 		}
 		merged = next
 	}
-	return merged, nil
-}
 
-func (c *ntmConfig) mergeAllLayers() error {
-	merged, err := c.mergeLayers()
-	if err != nil {
-		return err
-	}
 	c.root = merged
 	return nil
 }
@@ -960,11 +949,57 @@ func (c *ntmConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{} 
 
 // mergeWithoutSecrets returns a merged tree of all layers except the secrets layer.
 func (c *ntmConfig) mergeWithoutSecrets() *nodeImpl {
-	merged, err := c.mergeLayers(c.secrets)
-	if err != nil {
-		log.Errorf("error merging config layers without secrets: %s", err)
+	treeList := []*nodeImpl{
+		c.defaults,
+		c.unknown,
+		c.file,
+		c.envs,
+		c.fleetPolicies,
+		// secrets layer excluded
+		c.runtime,
+		c.localConfigProcess,
+		c.remoteConfig,
+		c.cli,
 	}
+
+	merged := newInnerNode(nil)
+	for _, tree := range treeList {
+		next, err := merged.Merge(tree)
+		if err != nil {
+			log.Errorf("error merging config layers without secrets: %s", err)
+			return merged
+		}
+		merged = next
+	}
+
 	return merged
+}
+
+// GetSecretSettingPaths returns the flattened key paths that exist in the secrets layer.
+func (c *ntmConfig) GetSecretSettingPaths() []string {
+	c.RLock()
+	defer c.RUnlock()
+
+	var keys []string
+	collectFlattenedKeysFromNode(c.secrets, "", &keys)
+	return keys
+}
+
+// collectFlattenedKeysFromNode recursively walks a node tree and collects flattened dotted key paths
+// for all leaf nodes.
+func collectFlattenedKeysFromNode(node *nodeImpl, prefix string, keys *[]string) {
+	for _, name := range node.ChildrenKeys() {
+		child, err := node.GetChild(name)
+		if err != nil {
+			continue
+		}
+		fullKey := joinKey(prefix, name)
+		if child.IsLeafNode() {
+			*keys = append(*keys, fullKey)
+		} else if child.IsInnerNode() {
+			collectFlattenedKeysFromNode(child, fullKey, keys)
+		}
+	}
 }
 
 // AllSettingsBySource returns the settings from each source (file, env vars, ...)

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -361,7 +361,6 @@ func TestAllSettingsBySource(t *testing.T) {
 				"c": 123,
 			},
 		},
-		model.SourceSecretBackend:      map[string]interface{}{},
 		model.SourceLocalConfigProcess: map[string]interface{}{},
 		model.SourceRC:                 map[string]interface{}{},
 		model.SourceCLI:                map[string]interface{}{},
@@ -373,63 +372,6 @@ func TestAllSettingsBySource(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, cfg.AllSettingsBySource())
-}
-
-func TestAllSettingsWithoutSecrets(t *testing.T) {
-	cfg := NewNodeTreeConfig("test", "TEST", nil)
-	cfg.SetDefault("a", 0)
-	cfg.SetDefault("b", 0)
-	cfg.BuildSchema()
-
-	cfg.Set("a", "file_value", model.SourceFile)
-	cfg.Set("a", "secret_value", model.SourceSecretBackend)
-	cfg.Set("b", 42, model.SourceAgentRuntime)
-
-	// includes secrets
-	all := cfg.AllSettings()
-	assert.Equal(t, "secret_value", all["a"])
-	assert.Equal(t, 42, all["b"])
-
-	// excludes secrets layer, "a" falls back to file layer value
-	withoutSecrets := cfg.AllSettingsWithoutSecrets()
-	assert.Equal(t, "file_value", withoutSecrets["a"])
-	assert.Equal(t, 42, withoutSecrets["b"])
-}
-
-func TestAllSettingsWithoutDefaultOrSecrets(t *testing.T) {
-	cfg := NewNodeTreeConfig("test", "TEST", nil)
-	cfg.SetDefault("a", 0)
-	cfg.SetDefault("b", 0)
-	cfg.SetDefault("c", 0)
-	cfg.BuildSchema()
-
-	cfg.Set("a", "file_value", model.SourceFile)
-	cfg.Set("a", "secret_value", model.SourceSecretBackend)
-	cfg.Set("b", 42, model.SourceAgentRuntime)
-
-	result := cfg.AllSettingsWithoutDefaultOrSecrets()
-	// "a" has a fallback file value
-	assert.Equal(t, "file_value", result["a"])
-	assert.Equal(t, 42, result["b"])
-	// "c" is only a default, excluded
-	_, found := result["c"]
-	assert.False(t, found)
-}
-
-func TestGetSecretSettingPaths(t *testing.T) {
-	cfg := NewNodeTreeConfig("test", "TEST", nil)
-	cfg.SetDefault("api_key", "")
-	cfg.SetDefault("proxy.https", "")
-	cfg.SetDefault("proxy.http", "")
-	cfg.BuildSchema()
-
-	assert.Empty(t, cfg.GetSecretSettingPaths())
-
-	cfg.Set("api_key", "resolved_key", model.SourceSecretBackend)
-	cfg.Set("proxy.https", "resolved_proxy", model.SourceSecretBackend)
-
-	paths := cfg.GetSecretSettingPaths()
-	assert.ElementsMatch(t, []string{"api_key", "proxy.https"}, paths)
 }
 
 func TestIsSet(t *testing.T) {

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -416,6 +416,22 @@ func TestAllSettingsWithoutDefaultOrSecrets(t *testing.T) {
 	assert.False(t, found)
 }
 
+func TestGetSecretSettingPaths(t *testing.T) {
+	cfg := NewNodeTreeConfig("test", "TEST", nil)
+	cfg.SetDefault("api_key", "")
+	cfg.SetDefault("proxy.https", "")
+	cfg.SetDefault("proxy.http", "")
+	cfg.BuildSchema()
+
+	assert.Empty(t, cfg.GetSecretSettingPaths())
+
+	cfg.Set("api_key", "resolved_key", model.SourceSecretBackend)
+	cfg.Set("proxy.https", "resolved_proxy", model.SourceSecretBackend)
+
+	paths := cfg.GetSecretSettingPaths()
+	assert.ElementsMatch(t, []string{"api_key", "proxy.https"}, paths)
+}
+
 func TestIsSet(t *testing.T) {
 	cfg := NewNodeTreeConfig("test", "TEST", nil)
 	cfg.SetDefault("a", 0)

--- a/pkg/config/nodetreemodel/getter_test.go
+++ b/pkg/config/nodetreemodel/getter_test.go
@@ -315,10 +315,9 @@ func TestGetAllSources(t *testing.T) {
 	cfg.Set("a", 3, model.SourceFile)
 	cfg.Set("a", 5, model.SourceFleetPolicies)
 	cfg.Set("a", 6, model.SourceAgentRuntime)
-	cfg.Set("a", 7, model.SourceSecretBackend)
-	cfg.Set("a", 8, model.SourceLocalConfigProcess)
-	cfg.Set("a", 9, model.SourceRC)
-	cfg.Set("a", 10, model.SourceCLI)
+	cfg.Set("a", 7, model.SourceLocalConfigProcess)
+	cfg.Set("a", 8, model.SourceRC)
+	cfg.Set("a", 9, model.SourceCLI)
 
 	res := cfg.GetAllSources("a")
 	assert.Equal(t,
@@ -330,10 +329,9 @@ func TestGetAllSources(t *testing.T) {
 			{Source: model.SourceEnvVar, Value: 4},
 			{Source: model.SourceFleetPolicies, Value: 5},
 			{Source: model.SourceAgentRuntime, Value: 6},
-			{Source: model.SourceSecretBackend, Value: 7},
-			{Source: model.SourceLocalConfigProcess, Value: 8},
-			{Source: model.SourceRC, Value: 9},
-			{Source: model.SourceCLI, Value: 10},
+			{Source: model.SourceLocalConfigProcess, Value: 7},
+			{Source: model.SourceRC, Value: 8},
+			{Source: model.SourceCLI, Value: 9},
 		},
 		res,
 	)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1033,7 +1033,7 @@ func resolveSecrets(config pkgconfigmodel.Config, secretResolver secrets.Compone
 func configAssignAtPath(config pkgconfigmodel.Config, settingPath []string, newValue any) error {
 	settingName := strings.Join(settingPath, ".")
 	if config.IsKnown(settingName) {
-		config.Set(settingName, newValue, pkgconfigmodel.SourceSecretBackend)
+		config.Set(settingName, newValue, pkgconfigmodel.SourceAgentRuntime)
 		return nil
 	}
 
@@ -1147,7 +1147,7 @@ func configAssignAtPath(config pkgconfigmodel.Config, settingPath []string, newV
 		}
 	}
 
-	config.Set(settingName, startingValue, pkgconfigmodel.SourceSecretBackend)
+	config.Set(settingName, startingValue, pkgconfigmodel.SourceAgentRuntime)
 	return nil
 }
 

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -508,27 +508,6 @@ func (t *teeConfig) AllSettingsBySource() map[model.Source]interface{} {
 
 }
 
-// AllSettingsWithoutSecrets returns all settings from the config without the secret backend layer
-func (t *teeConfig) AllSettingsWithoutSecrets() map[string]interface{} {
-	base := t.baseline.AllSettingsWithoutSecrets()
-	compare := t.compare.AllSettingsWithoutSecrets()
-	t.compareResult("", "AllSettingsWithoutSecrets", base, compare)
-	return base
-}
-
-// AllSettingsWithoutDefaultOrSecrets returns all non-default settings without the secret backend layer
-func (t *teeConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{} {
-	base := t.baseline.AllSettingsWithoutDefaultOrSecrets()
-	compare := t.compare.AllSettingsWithoutDefaultOrSecrets()
-	t.compareResult("", "AllSettingsWithoutDefaultOrSecrets", base, compare)
-	return base
-}
-
-// GetSecretSettingPaths returns the flattened key paths that exist in the secrets layer
-func (t *teeConfig) GetSecretSettingPaths() []string {
-	return t.baseline.GetSecretSettingPaths()
-}
-
 // AllFlattenedSettingsWithSequenceID returns all settings as a flattened map of schema leaf keys
 // along with the sequence ID.
 func (t *teeConfig) AllFlattenedSettingsWithSequenceID() (map[string]interface{}, uint64) {

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -524,6 +524,11 @@ func (t *teeConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{} 
 	return base
 }
 
+// GetSecretSettingPaths returns the flattened key paths that exist in the secrets layer
+func (t *teeConfig) GetSecretSettingPaths() []string {
+	return t.baseline.GetSecretSettingPaths()
+}
+
 // AllFlattenedSettingsWithSequenceID returns all settings as a flattened map of schema leaf keys
 // along with the sequence ID.
 func (t *teeConfig) AllFlattenedSettingsWithSequenceID() (map[string]interface{}, uint64) {

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -830,23 +830,6 @@ func (c *safeConfig) AllSettingsBySource() map[model.Source]interface{} {
 	return res
 }
 
-// AllSettingsWithoutSecrets returns all settings from the config without the secret backend layer.
-// In the viper implementation, secrets are not stored as a separate layer, so this falls back
-// to AllSettings which should still run the scrubber
-func (c *safeConfig) AllSettingsWithoutSecrets() map[string]interface{} {
-	return c.AllSettings()
-}
-
-// In the viper implementation, fall back to AllSettingsWithoutDefault
-func (c *safeConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{} {
-	return c.AllSettingsWithoutDefault()
-}
-
-// GetSecretSettingPaths does not exist in the viper impl
-func (c *safeConfig) GetSecretSettingPaths() []string {
-	return nil
-}
-
 // AllFlattenedSettingsWithSequenceID returns all settings as a flattened map of schema leaf keys
 // along with the sequence ID.
 // Keys are flattened (e.g., "logs_config.enabled" instead of nested {"logs_config": {"enabled": ...}}).

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -842,6 +842,11 @@ func (c *safeConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{}
 	return c.AllSettingsWithoutDefault()
 }
 
+// GetSecretSettingPaths does not exist in the viper impl
+func (c *safeConfig) GetSecretSettingPaths() []string {
+	return nil
+}
+
 // AllFlattenedSettingsWithSequenceID returns all settings as a flattened map of schema leaf keys
 // along with the sequence ID.
 // Keys are flattened (e.g., "logs_config.enabled" instead of nested {"logs_config": {"enabled": ...}}).

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -132,8 +132,8 @@ func (r *RemoteFlareProvider) provideRemoteConfig(fb flaretypes.FlareBuilder) er
 }
 
 func (r *RemoteFlareProvider) provideConfigDump(fb flaretypes.FlareBuilder) error {
-	fb.AddFileFromFunc("process_agent_runtime_config_dump.yaml", r.getProcessAgentFullConfig)                                                            //nolint:errcheck
-	fb.AddFileFromFunc("runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(pkgconfigsetup.Datadog().AllSettingsWithoutSecrets()) }) //nolint:errcheck
+	fb.AddFileFromFunc("process_agent_runtime_config_dump.yaml", r.getProcessAgentFullConfig)                                              //nolint:errcheck
+	fb.AddFileFromFunc("runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(pkgconfigsetup.Datadog().AllSettings()) }) //nolint:errcheck
 	return nil
 }
 
@@ -169,7 +169,7 @@ func provideSystemProbe(fb flaretypes.FlareBuilder) error {
 		_ = fb.AddFileFromFunc(filepath.Join("system-probe", "dyninst_symdb.json"), getSystemProbeDyninstSymDB)
 	} else {
 		// If system probe is disabled, we still want to include the system probe config file
-		_ = fb.AddFileFromFunc("system_probe_runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(pkgconfigsetup.SystemProbe().AllSettingsWithoutSecrets()) })
+		_ = fb.AddFileFromFunc("system_probe_runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(pkgconfigsetup.SystemProbe().AllSettings()) })
 	}
 	return nil
 }

--- a/pkg/flare/clusteragent/archive_dca.go
+++ b/pkg/flare/clusteragent/archive_dca.go
@@ -91,18 +91,18 @@ func createDCAArchive(fb flaretypes.FlareBuilder, confSearchPaths map[string]str
 	}
 	getClusterAgentClusterChecks(fb, client) //nolint:errcheck
 
-	fb.AddFileFromFunc("agent-daemonset.yaml", getAgentDaemonSet)                                                                                        //nolint:errcheck
-	fb.AddFileFromFunc("cluster-agent-deployment.yaml", getClusterAgentDeployment)                                                                       //nolint:errcheck
-	fb.AddFileFromFunc("helm-values.yaml", getHelmValues)                                                                                                //nolint:errcheck
-	fb.AddFileFromFunc("datadog-agent-cr.yaml", getDatadogAgentManifest)                                                                                 //nolint:errcheck
-	fb.AddFileFromFunc("envvars.log", flarecommon.GetEnvVars)                                                                                            //nolint:errcheck
-	fb.AddFileFromFunc("telemetry.log", QueryDCAMetrics)                                                                                                 //nolint:errcheck
-	fb.AddFileFromFunc("autoscaler-list.json", func() ([]byte, error) { return getDCAAutoscalerList(remote) })                                           //nolint:errcheck
-	fb.AddFileFromFunc("local-autoscaling-check.json", func() ([]byte, error) { return getDCALocalAutoscalingWorkloadList(remote) })                     //nolint:errcheck
-	fb.AddFileFromFunc("tagger-list.json", func() ([]byte, error) { return getDCATaggerList(remote) })                                                   //nolint:errcheck
-	fb.AddFileFromFunc("workload-list.log", func() ([]byte, error) { return getDCAWorkloadList(remote) })                                                //nolint:errcheck
-	fb.AddFileFromFunc("cluster-agent-metadata.json", func() ([]byte, error) { return getClusterAgentMetadataPayload(client) })                          //nolint:errcheck
-	fb.AddFileFromFunc("runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(pkgconfigsetup.Datadog().AllSettingsWithoutSecrets()) }) //nolint:errcheck
+	fb.AddFileFromFunc("agent-daemonset.yaml", getAgentDaemonSet)                                                                          //nolint:errcheck
+	fb.AddFileFromFunc("cluster-agent-deployment.yaml", getClusterAgentDeployment)                                                         //nolint:errcheck
+	fb.AddFileFromFunc("helm-values.yaml", getHelmValues)                                                                                  //nolint:errcheck
+	fb.AddFileFromFunc("datadog-agent-cr.yaml", getDatadogAgentManifest)                                                                   //nolint:errcheck
+	fb.AddFileFromFunc("envvars.log", flarecommon.GetEnvVars)                                                                              //nolint:errcheck
+	fb.AddFileFromFunc("telemetry.log", QueryDCAMetrics)                                                                                   //nolint:errcheck
+	fb.AddFileFromFunc("autoscaler-list.json", func() ([]byte, error) { return getDCAAutoscalerList(remote) })                             //nolint:errcheck
+	fb.AddFileFromFunc("local-autoscaling-check.json", func() ([]byte, error) { return getDCALocalAutoscalingWorkloadList(remote) })       //nolint:errcheck
+	fb.AddFileFromFunc("tagger-list.json", func() ([]byte, error) { return getDCATaggerList(remote) })                                     //nolint:errcheck
+	fb.AddFileFromFunc("workload-list.log", func() ([]byte, error) { return getDCAWorkloadList(remote) })                                  //nolint:errcheck
+	fb.AddFileFromFunc("cluster-agent-metadata.json", func() ([]byte, error) { return getClusterAgentMetadataPayload(client) })            //nolint:errcheck
+	fb.AddFileFromFunc("runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(pkgconfigsetup.Datadog().AllSettings()) }) //nolint:errcheck
 	fb.AddFileFromFunc("go-routine-dump.log", func() ([]byte, error) { return remote.GetGoRoutineDump() })
 	getPerformanceProfileDCA(fb, pdata)
 


### PR DESCRIPTION
### What does this PR do?

Reverts the following PRs:
- #46121 — [AGENTCFG-92] store secrets as their own config layer
- #48231 — remove unused `GetSecretSettingPaths` and add exclude node to `mergeLayers` (follow-up cleanup for #46121)

#48231 is reverted first since it modified the same files as #46121, allowing #46121 to revert cleanly.

### Motivation
To allow NTM to run on main and prod clusters as the secret layer PR changed some output which it relied on

### Describe how you validated your changes
CI, Unit Tests

### Additional Notes

[AGENTCFG-92]: https://datadoghq.atlassian.net/browse/AGENTCFG-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ