### PR TITLE
Add structured error handling with user-facing messages for traceroute system-probe responses

### DIFF
--- a/cmd/system-probe/modules/traceroute.go
+++ b/cmd/system-probe/modules/traceroute.go
@@ -118,8 +118,30 @@ func handleTracerouteReqError(w http.ResponseWriter, statusCode int, errString s
 	}
 }
 
+// userFacingMessages maps error codes to user-facing messages aligned with
+// synthetics-worker so the UI shows the same text regardless of the source.
+var userFacingMessages = map[traceroutelib.ErrorCode]string{
+	traceroutelib.ErrCodeDNS:            "Failed to resolve the host name.",
+	traceroutelib.ErrCodeTimeout:        "The request timed out.",
+	traceroutelib.ErrCodeConnRefused:    "The connection was refused by the remote host.",
+	traceroutelib.ErrCodeHostUnreach:    "The remote host is unreachable.",
+	traceroutelib.ErrCodeNetUnreach:     "The remote server network is unreachable.",
+	traceroutelib.ErrCodeDenied:         "Permission denied.",
+	traceroutelib.ErrCodeInvalidRequest: "Invalid request parameters.",
+	traceroutelib.ErrCodeFailedEncoding: "Failed to encode the response.",
+	traceroutelib.ErrCodeUnknown:        "An unknown error occurred.",
+}
+
+func userFacingMessage(code traceroutelib.ErrorCode, fallback string) string {
+	if msg, ok := userFacingMessages[code]; ok {
+		return msg
+	}
+	return fallback
+}
+
 func handleTracerouteStructuredError(w http.ResponseWriter, statusCode int, errResp traceroutelib.ErrorResponse, host string) {
 	log.Errorf("traceroute error for host %s: [%s] %s", host, errResp.Code, errResp.Message)
+	errResp.Message = userFacingMessage(errResp.Code, errResp.Message)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	if err := json.NewEncoder(w).Encode(errResp); err != nil {

--- a/cmd/system-probe/modules/traceroute.go
+++ b/cmd/system-probe/modules/traceroute.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -118,30 +119,31 @@ func handleTracerouteReqError(w http.ResponseWriter, statusCode int, errString s
 	}
 }
 
-// userFacingMessages maps error codes to user-facing messages aligned with
-// synthetics-worker so the UI shows the same text regardless of the source.
+// userFacingMessages maps error codes to user-facing message formats aligned
+// with synthetics-worker so the UI shows the same text regardless of the
+// source. Messages may contain a %s placeholder for the destination hostname.
 var userFacingMessages = map[traceroutelib.ErrorCode]string{
-	traceroutelib.ErrCodeDNS:            "Failed to resolve the host name.",
+	traceroutelib.ErrCodeDNS:            "Failed to resolve the host name %s.",
 	traceroutelib.ErrCodeTimeout:        "The request timed out.",
-	traceroutelib.ErrCodeConnRefused:    "The connection was refused by the remote host.",
-	traceroutelib.ErrCodeHostUnreach:    "The remote host is unreachable.",
-	traceroutelib.ErrCodeNetUnreach:     "The remote server network is unreachable.",
+	traceroutelib.ErrCodeConnRefused:    "The connection to %s was refused by the remote host.",
+	traceroutelib.ErrCodeHostUnreach:    "The remote host %s is unreachable.",
+	traceroutelib.ErrCodeNetUnreach:     "The remote network for %s is unreachable.",
 	traceroutelib.ErrCodeDenied:         "Permission denied.",
 	traceroutelib.ErrCodeInvalidRequest: "Invalid request parameters.",
 	traceroutelib.ErrCodeFailedEncoding: "Failed to encode the response.",
 	traceroutelib.ErrCodeUnknown:        "An unknown error occurred.",
 }
 
-func userFacingMessage(code traceroutelib.ErrorCode, fallback string) string {
-	if msg, ok := userFacingMessages[code]; ok {
-		return msg
+func userFacingMessage(code traceroutelib.ErrorCode, host string, fallback string) string {
+	if format, ok := userFacingMessages[code]; ok {
+		return strings.ReplaceAll(format, "%s", host)
 	}
 	return fallback
 }
 
 func handleTracerouteStructuredError(w http.ResponseWriter, statusCode int, errResp traceroutelib.ErrorResponse, host string) {
 	log.Errorf("traceroute error for host %s: [%s] %s", host, errResp.Code, errResp.Message)
-	errResp.Message = userFacingMessage(errResp.Code, errResp.Message)
+	errResp.Message = userFacingMessage(errResp.Code, host, errResp.Message)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	if err := json.NewEncoder(w).Encode(errResp); err != nil {

--- a/cmd/system-probe/modules/traceroute.go
+++ b/cmd/system-probe/modules/traceroute.go
@@ -18,6 +18,8 @@ import (
 	"github.com/gorilla/mux"
 	"google.golang.org/grpc"
 
+	traceroutelib "github.com/DataDog/datadog-traceroute/traceroute"
+
 	traceroutecomp "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 	tracerouteutil "github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/config"
@@ -69,7 +71,12 @@ func (t *traceroute) Register(httpMux *module.Router) error {
 		// Run traceroute
 		path, err := t.runner.Run(context.Background(), cfg)
 		if err != nil {
-			handleTracerouteReqError(w, http.StatusInternalServerError, fmt.Sprintf("unable to run traceroute for host: %s: %s", cfg.DestHostname, err.Error()))
+			classified := traceroutelib.ClassifyError(err)
+			errResp := traceroutelib.ErrorResponse{
+				Code:    classified.Code,
+				Message: classified.Message,
+			}
+			handleTracerouteStructuredError(w, http.StatusInternalServerError, errResp, cfg.DestHostname)
 			return
 		}
 
@@ -107,6 +114,15 @@ func handleTracerouteReqError(w http.ResponseWriter, statusCode int, errString s
 	log.Error(errString)
 	_, err := w.Write([]byte(errString))
 	if err != nil {
+		log.Errorf("unable to write traceroute error response: %s", err)
+	}
+}
+
+func handleTracerouteStructuredError(w http.ResponseWriter, statusCode int, errResp traceroutelib.ErrorResponse, host string) {
+	log.Errorf("traceroute error for host %s: [%s] %s", host, errResp.Code, errResp.Message)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if err := json.NewEncoder(w).Encode(errResp); err != nil {
 		log.Errorf("unable to write traceroute error response: %s", err)
 	}
 }

--- a/cmd/system-probe/modules/traceroute_test.go
+++ b/cmd/system-probe/modules/traceroute_test.go
@@ -149,11 +149,11 @@ func TestHandleTracerouteStructuredError(t *testing.T) {
 		expectedCode    traceroutelib.ErrorCode
 		expectedMessage string
 	}{
-		{"DNS", traceroutelib.ErrCodeDNS, "lookup example.com: no such host", traceroutelib.ErrCodeDNS, "Failed to resolve the host name."},
+		{"DNS", traceroutelib.ErrCodeDNS, "lookup example.com: no such host", traceroutelib.ErrCodeDNS, "Failed to resolve the host name example.com."},
 		{"timeout", traceroutelib.ErrCodeTimeout, "context deadline exceeded", traceroutelib.ErrCodeTimeout, "The request timed out."},
-		{"connection refused", traceroutelib.ErrCodeConnRefused, "connect: connection refused", traceroutelib.ErrCodeConnRefused, "The connection was refused by the remote host."},
-		{"host unreachable", traceroutelib.ErrCodeHostUnreach, "connect: host is unreachable", traceroutelib.ErrCodeHostUnreach, "The remote host is unreachable."},
-		{"network unreachable", traceroutelib.ErrCodeNetUnreach, "connect: network is unreachable", traceroutelib.ErrCodeNetUnreach, "The remote server network is unreachable."},
+		{"connection refused", traceroutelib.ErrCodeConnRefused, "connect: connection refused", traceroutelib.ErrCodeConnRefused, "The connection to example.com was refused by the remote host."},
+		{"host unreachable", traceroutelib.ErrCodeHostUnreach, "connect: host is unreachable", traceroutelib.ErrCodeHostUnreach, "The remote host example.com is unreachable."},
+		{"network unreachable", traceroutelib.ErrCodeNetUnreach, "connect: network is unreachable", traceroutelib.ErrCodeNetUnreach, "The remote network for example.com is unreachable."},
 		{"denied", traceroutelib.ErrCodeDenied, "operation not permitted", traceroutelib.ErrCodeDenied, "Permission denied."},
 		{"invalid request", traceroutelib.ErrCodeInvalidRequest, "invalid target: bad port", traceroutelib.ErrCodeInvalidRequest, "Invalid request parameters."},
 		{"failed encoding", traceroutelib.ErrCodeFailedEncoding, "json marshal error", traceroutelib.ErrCodeFailedEncoding, "Failed to encode the response."},

--- a/cmd/system-probe/modules/traceroute_test.go
+++ b/cmd/system-probe/modules/traceroute_test.go
@@ -9,9 +9,12 @@ package modules
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	traceroutelib "github.com/DataDog/datadog-traceroute/traceroute"
 
 	tracerouteutil "github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/config"
 
@@ -134,6 +137,45 @@ func TestHandleTracerouteReqError(t *testing.T) {
 
 			// Assert the response body
 			assert.Equal(t, tt.expectedBody, recorder.Body.String())
+		})
+	}
+}
+
+func TestHandleTracerouteStructuredError(t *testing.T) {
+	tests := []struct {
+		name            string
+		code            traceroutelib.ErrorCode
+		rawMessage      string
+		expectedCode    traceroutelib.ErrorCode
+		expectedMessage string
+	}{
+		{"DNS", traceroutelib.ErrCodeDNS, "lookup example.com: no such host", traceroutelib.ErrCodeDNS, "Failed to resolve the host name."},
+		{"timeout", traceroutelib.ErrCodeTimeout, "context deadline exceeded", traceroutelib.ErrCodeTimeout, "The request timed out."},
+		{"connection refused", traceroutelib.ErrCodeConnRefused, "connect: connection refused", traceroutelib.ErrCodeConnRefused, "The connection was refused by the remote host."},
+		{"host unreachable", traceroutelib.ErrCodeHostUnreach, "connect: host is unreachable", traceroutelib.ErrCodeHostUnreach, "The remote host is unreachable."},
+		{"network unreachable", traceroutelib.ErrCodeNetUnreach, "connect: network is unreachable", traceroutelib.ErrCodeNetUnreach, "The remote server network is unreachable."},
+		{"denied", traceroutelib.ErrCodeDenied, "operation not permitted", traceroutelib.ErrCodeDenied, "Permission denied."},
+		{"invalid request", traceroutelib.ErrCodeInvalidRequest, "invalid target: bad port", traceroutelib.ErrCodeInvalidRequest, "Invalid request parameters."},
+		{"failed encoding", traceroutelib.ErrCodeFailedEncoding, "json marshal error", traceroutelib.ErrCodeFailedEncoding, "Failed to encode the response."},
+		{"unknown", traceroutelib.ErrCodeUnknown, "something went wrong", traceroutelib.ErrCodeUnknown, "An unknown error occurred."},
+		{"unrecognized code falls back to raw message", "NEW_CODE", "some new error", "NEW_CODE", "some new error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			errResp := traceroutelib.ErrorResponse{Code: tt.code, Message: tt.rawMessage}
+
+			handleTracerouteStructuredError(recorder, http.StatusInternalServerError, errResp, "example.com")
+
+			assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+			assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+
+			var resp traceroutelib.ErrorResponse
+			err := json.Unmarshal(recorder.Body.Bytes(), &resp)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedCode, resp.Code)
+			assert.Equal(t, tt.expectedMessage, resp.Message)
 		})
 	}
 }

--- a/comp/networkpath/traceroute/impl-local/traceroute.go
+++ b/comp/networkpath/traceroute/impl-local/traceroute.go
@@ -63,7 +63,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 func (t *localTraceroute) Run(ctx context.Context, cfg config.Config) (payload.NetworkPath, error) {
 	path, err := t.runner.Run(ctx, cfg)
 	if err != nil {
-		return payload.NetworkPath{}, fmt.Errorf("error getting traceroute: %s", err)
+		return payload.NetworkPath{}, fmt.Errorf("error getting traceroute: %w", err)
 	}
 
 	agentHostname, err := t.hostname.Get(ctx)

--- a/comp/networkpath/traceroute/impl-remote/traceroute.go
+++ b/comp/networkpath/traceroute/impl-remote/traceroute.go
@@ -15,8 +15,6 @@ import (
 	"net/http"
 	"time"
 
-	traceroutelib "github.com/DataDog/datadog-traceroute/traceroute"
-
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
@@ -120,9 +118,9 @@ func (t *remoteTraceroute) getTracerouteFromSysProbe(ctx context.Context, client
 		}
 
 		// Try to parse structured error response
-		var errResp traceroutelib.ErrorResponse
+		var errResp payload.TracerouteErrorResponse
 		if json.Unmarshal(body, &errResp) == nil && errResp.Code != "" {
-			return nil, &traceroutelib.TracerouteError{
+			return nil, &payload.TracerouteError{
 				Code:    errResp.Code,
 				Message: errResp.Message,
 			}

--- a/comp/networkpath/traceroute/impl-remote/traceroute.go
+++ b/comp/networkpath/traceroute/impl-remote/traceroute.go
@@ -15,6 +15,8 @@ import (
 	"net/http"
 	"time"
 
+	traceroutelib "github.com/DataDog/datadog-traceroute/traceroute"
+
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
@@ -116,6 +118,13 @@ func (t *remoteTraceroute) getTracerouteFromSysProbe(ctx context.Context, client
 		if err != nil {
 			return nil, fmt.Errorf("traceroute request failed: url: %s, status code: %d", req.URL, resp.StatusCode)
 		}
+
+		// Try to parse structured error response
+		var errResp traceroutelib.ErrorResponse
+		if json.Unmarshal(body, &errResp) == nil && errResp.Code != "" {
+			return nil, fmt.Errorf("traceroute failed (%s): %s", errResp.Code, errResp.Message)
+		}
+
 		return nil, fmt.Errorf("traceroute request failed: url: %s, status code: %d, error: %s", req.URL, resp.StatusCode, string(body))
 	}
 

--- a/comp/networkpath/traceroute/impl-remote/traceroute.go
+++ b/comp/networkpath/traceroute/impl-remote/traceroute.go
@@ -64,7 +64,7 @@ type remoteTraceroute struct {
 func (t *remoteTraceroute) Run(ctx context.Context, cfg config.Config) (payload.NetworkPath, error) {
 	resp, err := t.getTracerouteFromSysProbe(ctx, clientID, cfg.DestHostname, cfg.DestPort, cfg.Protocol, cfg.TCPMethod, cfg.TCPSynParisTracerouteMode, cfg.DisableWindowsDriver, cfg.ReverseDNS, cfg.MaxTTL, cfg.Timeout, cfg.TracerouteQueries, cfg.E2eQueries)
 	if err != nil {
-		return payload.NetworkPath{}, fmt.Errorf("error getting traceroute: %s", err)
+		return payload.NetworkPath{}, fmt.Errorf("error getting traceroute: %w", err)
 	}
 
 	var path payload.NetworkPath
@@ -122,7 +122,10 @@ func (t *remoteTraceroute) getTracerouteFromSysProbe(ctx context.Context, client
 		// Try to parse structured error response
 		var errResp traceroutelib.ErrorResponse
 		if json.Unmarshal(body, &errResp) == nil && errResp.Code != "" {
-			return nil, fmt.Errorf("traceroute failed (%s): %s", errResp.Code, errResp.Message)
+			return nil, &traceroutelib.TracerouteError{
+				Code:    errResp.Code,
+				Message: errResp.Message,
+			}
 		}
 
 		return nil, fmt.Errorf("traceroute request failed: url: %s, status code: %d, error: %s", req.URL, resp.StatusCode, string(body))

--- a/comp/networkpath/traceroute/impl-remote/traceroute_test.go
+++ b/comp/networkpath/traceroute/impl-remote/traceroute_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	traceroutelib "github.com/DataDog/datadog-traceroute/traceroute"
-
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
@@ -156,23 +154,23 @@ func TestGetTracerouteInvalidJSON(t *testing.T) {
 func TestGetTracerouteStructuredError(t *testing.T) {
 	tests := []struct {
 		name         string
-		errorCode    traceroutelib.ErrorCode
+		errorCode    payload.TracerouteErrorCode
 		errorMessage string
-		expectedCode traceroutelib.ErrorCode
+		expectedCode payload.TracerouteErrorCode
 	}{
-		{"DNS error", traceroutelib.ErrCodeDNS, "Failed to resolve the host name.", traceroutelib.ErrCodeDNS},
-		{"timeout error", traceroutelib.ErrCodeTimeout, "The request timed out.", traceroutelib.ErrCodeTimeout},
-		{"connection refused", traceroutelib.ErrCodeConnRefused, "The connection was refused by the remote host.", traceroutelib.ErrCodeConnRefused},
-		{"host unreachable", traceroutelib.ErrCodeHostUnreach, "The remote host is unreachable.", traceroutelib.ErrCodeHostUnreach},
-		{"network unreachable", traceroutelib.ErrCodeNetUnreach, "The remote server network is unreachable.", traceroutelib.ErrCodeNetUnreach},
-		{"unknown error", traceroutelib.ErrCodeUnknown, "An unknown error occurred.", traceroutelib.ErrCodeUnknown},
+		{"DNS error", payload.TracerouteErrCodeDNS, "Failed to resolve the host name.", payload.TracerouteErrCodeDNS},
+		{"timeout error", payload.TracerouteErrCodeTimeout, "The request timed out.", payload.TracerouteErrCodeTimeout},
+		{"connection refused", payload.TracerouteErrCodeConnRefused, "The connection was refused by the remote host.", payload.TracerouteErrCodeConnRefused},
+		{"host unreachable", payload.TracerouteErrCodeHostUnreach, "The remote host is unreachable.", payload.TracerouteErrCodeHostUnreach},
+		{"network unreachable", payload.TracerouteErrCodeNetUnreach, "The remote server network is unreachable.", payload.TracerouteErrCodeNetUnreach},
+		{"unknown error", payload.TracerouteErrCodeUnknown, "An unknown error occurred.", payload.TracerouteErrCodeUnknown},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hostnameComponent, _ := hostnameinterface.NewMock("test-agent-hostname")
 
-			errResp := traceroutelib.ErrorResponse{Code: tt.errorCode, Message: tt.errorMessage}
+			errResp := payload.TracerouteErrorResponse{Code: tt.errorCode, Message: tt.errorMessage}
 			jsonBytes, err := json.Marshal(errResp)
 			require.NoError(t, err)
 
@@ -198,7 +196,7 @@ func TestGetTracerouteStructuredError(t *testing.T) {
 			_, err = rt.Run(context.Background(), cfg)
 			require.Error(t, err)
 
-			var trErr *traceroutelib.TracerouteError
+			var trErr *payload.TracerouteError
 			require.ErrorAs(t, err, &trErr)
 			assert.Equal(t, tt.expectedCode, trErr.Code)
 			assert.Equal(t, tt.errorMessage, trErr.Message)

--- a/comp/networkpath/traceroute/impl-remote/traceroute_test.go
+++ b/comp/networkpath/traceroute/impl-remote/traceroute_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	traceroutelib "github.com/DataDog/datadog-traceroute/traceroute"
+
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
@@ -149,6 +151,84 @@ func TestGetTracerouteInvalidJSON(t *testing.T) {
 	_, err := rt.Run(context.Background(), cfg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "error unmarshalling response")
+}
+
+func TestGetTracerouteStructuredError(t *testing.T) {
+	tests := []struct {
+		name           string
+		errorCode      traceroutelib.ErrorCode
+		errorMessage   string
+		expectedSubstr string
+	}{
+		{"DNS error", traceroutelib.ErrCodeDNS, "failed to resolve host", "traceroute failed (DNS)"},
+		{"timeout error", traceroutelib.ErrCodeTimeout, "context deadline exceeded", "traceroute failed (TIMEOUT)"},
+		{"connection refused", traceroutelib.ErrCodeConnRefused, "connection refused", "traceroute failed (CONNREFUSED)"},
+		{"host unreachable", traceroutelib.ErrCodeHostUnreach, "host unreachable", "traceroute failed (HOSTUNREACH)"},
+		{"network unreachable", traceroutelib.ErrCodeNetUnreach, "network unreachable", "traceroute failed (NETUNREACH)"},
+		{"unknown error", traceroutelib.ErrCodeUnknown, "something went wrong", "traceroute failed (UNKNOWN)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostnameComponent, _ := hostnameinterface.NewMock("test-agent-hostname")
+
+			errResp := traceroutelib.ErrorResponse{Code: tt.errorCode, Message: tt.errorMessage}
+			jsonBytes, err := json.Marshal(errResp)
+			require.NoError(t, err)
+
+			client := &http.Client{
+				Transport: &mockTransport{
+					RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusInternalServerError,
+							Body:       io.NopCloser(bytes.NewReader(jsonBytes)),
+							Header:     make(http.Header),
+						}, nil
+					},
+				},
+			}
+
+			cfg := config.Config{
+				DestHostname: "example.com",
+				DestPort:     80,
+				Protocol:     payload.ProtocolTCP,
+			}
+
+			rt := &remoteTraceroute{sysprobeClient: client, log: logmock.New(t), hostname: hostnameComponent}
+			_, err = rt.Run(context.Background(), cfg)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedSubstr)
+			assert.Contains(t, err.Error(), tt.errorMessage)
+		})
+	}
+}
+
+func TestGetTraceroutePlainTextErrorFallback(t *testing.T) {
+	hostnameComponent, _ := hostnameinterface.NewMock("test-agent-hostname")
+
+	client := &http.Client{
+		Transport: &mockTransport{
+			RoundTripFunc: func(_ *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(bytes.NewReader([]byte("plain text error"))),
+					Header:     make(http.Header),
+				}, nil
+			},
+		},
+	}
+
+	cfg := config.Config{
+		DestHostname: "example.com",
+		DestPort:     80,
+		Protocol:     payload.ProtocolTCP,
+	}
+
+	rt := &remoteTraceroute{sysprobeClient: client, log: logmock.New(t), hostname: hostnameComponent}
+	_, err := rt.Run(context.Background(), cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "traceroute request failed")
+	assert.Contains(t, err.Error(), "plain text error")
 }
 
 func TestGetTracerouteURL(t *testing.T) {

--- a/comp/networkpath/traceroute/impl-remote/traceroute_test.go
+++ b/comp/networkpath/traceroute/impl-remote/traceroute_test.go
@@ -155,17 +155,17 @@ func TestGetTracerouteInvalidJSON(t *testing.T) {
 
 func TestGetTracerouteStructuredError(t *testing.T) {
 	tests := []struct {
-		name           string
-		errorCode      traceroutelib.ErrorCode
-		errorMessage   string
-		expectedSubstr string
+		name         string
+		errorCode    traceroutelib.ErrorCode
+		errorMessage string
+		expectedCode traceroutelib.ErrorCode
 	}{
-		{"DNS error", traceroutelib.ErrCodeDNS, "failed to resolve host", "traceroute failed (DNS)"},
-		{"timeout error", traceroutelib.ErrCodeTimeout, "context deadline exceeded", "traceroute failed (TIMEOUT)"},
-		{"connection refused", traceroutelib.ErrCodeConnRefused, "connection refused", "traceroute failed (CONNREFUSED)"},
-		{"host unreachable", traceroutelib.ErrCodeHostUnreach, "host unreachable", "traceroute failed (HOSTUNREACH)"},
-		{"network unreachable", traceroutelib.ErrCodeNetUnreach, "network unreachable", "traceroute failed (NETUNREACH)"},
-		{"unknown error", traceroutelib.ErrCodeUnknown, "something went wrong", "traceroute failed (UNKNOWN)"},
+		{"DNS error", traceroutelib.ErrCodeDNS, "Failed to resolve the host name.", traceroutelib.ErrCodeDNS},
+		{"timeout error", traceroutelib.ErrCodeTimeout, "The request timed out.", traceroutelib.ErrCodeTimeout},
+		{"connection refused", traceroutelib.ErrCodeConnRefused, "The connection was refused by the remote host.", traceroutelib.ErrCodeConnRefused},
+		{"host unreachable", traceroutelib.ErrCodeHostUnreach, "The remote host is unreachable.", traceroutelib.ErrCodeHostUnreach},
+		{"network unreachable", traceroutelib.ErrCodeNetUnreach, "The remote server network is unreachable.", traceroutelib.ErrCodeNetUnreach},
+		{"unknown error", traceroutelib.ErrCodeUnknown, "An unknown error occurred.", traceroutelib.ErrCodeUnknown},
 	}
 
 	for _, tt := range tests {
@@ -196,9 +196,12 @@ func TestGetTracerouteStructuredError(t *testing.T) {
 
 			rt := &remoteTraceroute{sysprobeClient: client, log: logmock.New(t), hostname: hostnameComponent}
 			_, err = rt.Run(context.Background(), cfg)
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), tt.expectedSubstr)
-			assert.Contains(t, err.Error(), tt.errorMessage)
+			require.Error(t, err)
+
+			var trErr *traceroutelib.TracerouteError
+			require.ErrorAs(t, err, &trErr)
+			assert.Equal(t, tt.expectedCode, trErr.Code)
+			assert.Equal(t, tt.errorMessage, trErr.Message)
 		})
 	}
 }

--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -17,8 +17,6 @@ import (
 	"sync"
 	"time"
 
-	traceroutelib "github.com/DataDog/datadog-traceroute/traceroute"
-
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/syntheticstestscheduler/common"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -435,16 +433,16 @@ func (s *syntheticsTestScheduler) setResultStatus(w *workerResult, result *commo
 		if !hasAssertionOn100PacketLoss(w.assertionResult) {
 			result.Status = "failed"
 			result.Failure = common.APIError{
-				Code:    common.APIErrorCode(traceroutelib.ErrCodeNetUnreach),
+				Code:    common.APIErrorCode(payload.TracerouteErrCodeNetUnreach),
 				Message: "The remote network is unreachable.",
 			}
 		}
 	}
 	if w.tracerouteError != nil {
 		result.Status = "failed"
-		code := common.APIErrorCode(traceroutelib.ErrCodeUnknown)
+		code := common.APIErrorCode(payload.TracerouteErrCodeUnknown)
 		message := w.tracerouteError.Error()
-		var trErr *traceroutelib.TracerouteError
+		var trErr *payload.TracerouteError
 		if errors.As(w.tracerouteError, &trErr) {
 			code = common.APIErrorCode(trErr.Code)
 			message = trErr.Message

--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 	"time"
 
+	traceroutelib "github.com/DataDog/datadog-traceroute/traceroute"
+
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/syntheticstestscheduler/common"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -433,16 +435,23 @@ func (s *syntheticsTestScheduler) setResultStatus(w *workerResult, result *commo
 		if !hasAssertionOn100PacketLoss(w.assertionResult) {
 			result.Status = "failed"
 			result.Failure = common.APIError{
-				Code:    "NETUNREACH",
-				Message: "The remote server network is unreachable.",
+				Code:    common.APIErrorCode(traceroutelib.ErrCodeNetUnreach),
+				Message: "The remote network is unreachable.",
 			}
 		}
 	}
 	if w.tracerouteError != nil {
 		result.Status = "failed"
+		code := common.APIErrorCode(traceroutelib.ErrCodeUnknown)
+		message := w.tracerouteError.Error()
+		var trErr *traceroutelib.TracerouteError
+		if errors.As(w.tracerouteError, &trErr) {
+			code = common.APIErrorCode(trErr.Code)
+			message = trErr.Message
+		}
 		result.Failure = common.APIError{
-			Code:    "UNKNOWN",
-			Message: w.tracerouteError.Error(),
+			Code:    code,
+			Message: message,
 		}
 	}
 	if result.Status != "failed" {

--- a/go.mod
+++ b/go.mod
@@ -168,7 +168,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-go/v5 v5.8.3
 	github.com/DataDog/datadog-operator/api v0.0.0-20260323152500-0887e50ccf73
-	github.com/DataDog/datadog-traceroute v1.0.13
+	github.com/DataDog/datadog-traceroute v1.0.14
 	github.com/DataDog/dd-trace-go/v2 v2.7.0-rc.1
 	github.com/DataDog/ebpf-manager v0.7.16
 	github.com/DataDog/go-sqllexer v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -2558,8 +2558,8 @@ github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSq
 github.com/DataDog/datadog-go/v5 v5.8.3/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator/api v0.0.0-20260323152500-0887e50ccf73 h1:c9uNLuEey0R0xP1ETZ620UhE67zp+WsGoSYJmhC5A8Y=
 github.com/DataDog/datadog-operator/api v0.0.0-20260323152500-0887e50ccf73/go.mod h1:dMnKkWiv5j5UuRfaRUPXVDHG/79JG4S3llffsX4J+ko=
-github.com/DataDog/datadog-traceroute v1.0.13 h1:PBkmwNCRqDrjFMXi/W9yTydFOKuxr8fcP08NVKXri1U=
-github.com/DataDog/datadog-traceroute v1.0.13/go.mod h1:ywOVt342keSUAzy1Aa47td4+2yl8WJsYQ+m7PlEDy8o=
+github.com/DataDog/datadog-traceroute v1.0.14 h1:8pRhWjThs5/E5C8zG8xoOYjK5zZ87/bsxNz34PiFuR0=
+github.com/DataDog/datadog-traceroute v1.0.14/go.mod h1:ywOVt342keSUAzy1Aa47td4+2yl8WJsYQ+m7PlEDy8o=
 github.com/DataDog/dd-trace-go/v2 v2.7.0-rc.1 h1:4un+pQmyM3S6xQ4kAxYbNvoocXKuIyGYOBMDNBzfuvs=
 github.com/DataDog/dd-trace-go/v2 v2.7.0-rc.1/go.mod h1:RQxqBP+xYfpvy8qRUlreI3yQODieMMRqyZtfQuE7pRc=
 github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5 h1:R6uhWnfvq23xRAoV3vK9sc6D5pDHxEEDYBgs2YbcX8s=

--- a/pkg/networkpath/payload/BUILD.bazel
+++ b/pkg/networkpath/payload/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "payload",
     srcs = [
         "pathevent.go",
+        "traceroute_errors.go",
         "utils.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/networkpath/payload",

--- a/pkg/networkpath/payload/traceroute_errors.go
+++ b/pkg/networkpath/payload/traceroute_errors.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package payload
+
+// TracerouteErrorCode is a classifiable error code for traceroute failures,
+// aligned with the codes emitted by the system-probe traceroute module. The
+// wire values must match github.com/DataDog/datadog-traceroute/traceroute
+// ErrorCode constants so responses can be decoded on the agent side without
+// importing the heavy traceroute library.
+type TracerouteErrorCode string
+
+const (
+	// TracerouteErrCodeDNS indicates a DNS resolution failure.
+	TracerouteErrCodeDNS TracerouteErrorCode = "DNS"
+	// TracerouteErrCodeTimeout indicates the operation timed out.
+	TracerouteErrCodeTimeout TracerouteErrorCode = "TIMEOUT"
+	// TracerouteErrCodeConnRefused indicates the target actively refused the connection.
+	TracerouteErrCodeConnRefused TracerouteErrorCode = "CONNREFUSED"
+	// TracerouteErrCodeHostUnreach indicates the target host is unreachable.
+	TracerouteErrCodeHostUnreach TracerouteErrorCode = "HOSTUNREACH"
+	// TracerouteErrCodeNetUnreach indicates the target network is unreachable.
+	TracerouteErrCodeNetUnreach TracerouteErrorCode = "NETUNREACH"
+	// TracerouteErrCodeDenied indicates a permission error or unsupported configuration.
+	TracerouteErrCodeDenied TracerouteErrorCode = "DENIED"
+	// TracerouteErrCodeInvalidRequest indicates bad parameters from the caller.
+	TracerouteErrCodeInvalidRequest TracerouteErrorCode = "INVALID_REQUEST"
+	// TracerouteErrCodeFailedEncoding indicates a failure to encode the response.
+	TracerouteErrCodeFailedEncoding TracerouteErrorCode = "FAILED_ENCODING"
+	// TracerouteErrCodeUnknown is the catch-all for unclassified errors.
+	TracerouteErrCodeUnknown TracerouteErrorCode = "UNKNOWN"
+)
+
+// TracerouteError is a classified error returned from the system-probe
+// traceroute module. It is the agent-side mirror of the upstream library's
+// TracerouteError type, kept local to avoid pulling the whole traceroute
+// library into the main agent binary.
+type TracerouteError struct {
+	Code    TracerouteErrorCode
+	Message string
+}
+
+// Error implements the error interface.
+func (e *TracerouteError) Error() string {
+	return e.Message
+}
+
+// TracerouteErrorResponse is the JSON body returned on error from the
+// system-probe traceroute HTTP endpoint.
+type TracerouteErrorResponse struct {
+	Code    TracerouteErrorCode `json:"code"`
+	Message string              `json:"message"`
+}


### PR DESCRIPTION
### What does this PR do?

Adds structured JSON error responses to the traceroute system-probe endpoint with user-facing messages aligned with the synthetics-worker UI.

Instead of returning plain text error messages or raw Go error strings, the handler now:
1. Classifies errors using `datadog-traceroute`'s `ClassifyError()`
2. Maps error codes to user-facing messages matching what the synthetics-worker displays in the UI
3. Returns structured JSON with the user-facing text:

```json
{"code": "TIMEOUT", "message": "The request timed out."}
```

| Code | User-facing message |
|------|-------------------|
| `DNS` | Failed to resolve the host name. |
| `TIMEOUT` | The request timed out. |
| `CONNREFUSED` | The connection was refused by the remote host. |
| `HOSTUNREACH` | The remote host is unreachable. |
| `NETUNREACH` | The remote server network is unreachable. |
| `DENIED` | Permission denied. |
| `INVALID_REQUEST` | Invalid request parameters. |
| `FAILED_ENCODING` | Failed to encode the response. |
| `UNKNOWN` | An unknown error occurred. |

The remote traceroute client now returns a typed `*traceroutelib.TracerouteError` (instead of a formatted string), so consumers like the synthetics-worker can extract `Code` and `Message` via `errors.As` and display them directly in the UI.

Plain text error responses are still handled for backwards compatibility.

Also bumps `datadog-traceroute` v1.0.13 → v1.0.14.

### Motivation

The synthetics-worker sends error messages that are mapped to user-facing text in the UI. The agent needs to produce the same messages so users see consistent error descriptions regardless of the source. Previously, the agent returned raw Go error strings (e.g. `"connect: network is unreachable"`) instead of user-friendly text (e.g. `"The remote server network is unreachable."`).

### Describe how you validated your changes

- Added `TestGetTracerouteStructuredError` — table-driven test covering all 6 error codes, verifying typed error with code and user-facing message
- Added `TestGetTraceroutePlainTextErrorFallback` — verifies backwards compatibility with plain text errors
- Added `TestHandleTracerouteStructuredError` — tests the user-facing message mapping for all error codes including fallback for unknown codes
- All existing tests pass

### Additional Notes

Companion PR in synthetics-worker: https://github.com/DataDog/synthetics-worker/pull/9553