### PR TITLE
(Won't merge) Reduce binary by replacing Temporal Go SDK client

### DIFF
--- a/pkg/privateactionrunner/bundles/temporal/get_workflow_result.go
+++ b/pkg/privateactionrunner/bundles/temporal/get_workflow_result.go
@@ -7,9 +7,7 @@ package com_datadoghq_temporal
 
 import (
 	"context"
-	"errors"
 
-	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 )
@@ -50,13 +48,7 @@ func (h *GetWorkflowResultHandler) Run(
 	}
 	defer temporalClient.Close()
 
-	workflowRun := temporalClient.GetWorkflow(ctx, inputs.WorkflowId, inputs.RunId)
-	if workflowRun == nil {
-		log.FromContext(ctx).Warn("Unable to get workflow run.")
-		return nil, errors.New("unable to get workflow run")
-	}
-	var workflowResult string
-	err = workflowRun.Get(ctx, &workflowResult)
+	workflowResult, err := temporalClient.GetWorkflowResult(ctx, inputs.WorkflowId, inputs.RunId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/privateactionrunner/bundles/temporal/helpers.go
+++ b/pkg/privateactionrunner/bundles/temporal/helpers.go
@@ -11,85 +11,71 @@ import (
 	"crypto/x509"
 	"errors"
 
-	"go.temporal.io/sdk/client"
-
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 )
 
-func newTemporalClient(ctx context.Context, credentials *privateconnection.PrivateCredentials, namespace string) (client.Client, error) {
-	connectionOptions, err := getTemporalConnectionOptions(ctx, credentials, namespace)
-	if err != nil {
-		return nil, err
-	}
-	temporalClient, err := client.Dial(connectionOptions)
-	if err != nil {
-		return nil, err
-	}
-	return temporalClient, nil
+type temporalConnectionConfig struct {
+	apiKey   string
+	hostPort string
+	tls      *tls.Config
 }
 
-func getTemporalConnectionOptions(ctx context.Context, credentials *privateconnection.PrivateCredentials, namespace string) (client.Options, error) {
-	clientOptions := client.Options{
-		Namespace: namespace,
-	}
+func getTemporalConnectionConfig(
+	ctx context.Context,
+	credentials *privateconnection.PrivateCredentials,
+) (temporalConnectionConfig, error) {
 	credentialTokens := credentials.AsTokenMap()
-	// Simple address connection case
+
 	if address, ok := credentialTokens["address"]; ok {
-		clientOptions.HostPort = address
-		return clientOptions, nil
+		return temporalConnectionConfig{hostPort: address}, nil
 	}
-	// TLS and mTLS connection case
+
+	connectionConfig := temporalConnectionConfig{}
 	if serverAddress, ok := credentialTokens["serverAddress"]; ok {
-		clientOptions.HostPort = serverAddress
+		connectionConfig.hostPort = serverAddress
 	}
+
 	clientCertPairCrt, okCrt := credentialTokens["clientCertPairCrt"]
 	clientCertPairKey, okKey := credentialTokens["clientCertPairKey"]
 
-	// mTLS connection case
 	if okCrt && okKey {
 		cert, err := tls.X509KeyPair([]byte(clientCertPairCrt), []byte(clientCertPairKey))
 		if err != nil {
 			log.FromContext(ctx).Warn("Unable to parse client cert and key pair.")
-			return client.Options{}, err
+			return temporalConnectionConfig{}, err
 		}
-		clientOptions.ConnectionOptions = client.ConnectionOptions{
-			TLS: &tls.Config{
-				MinVersion:   tls.VersionTLS12,
-				Certificates: []tls.Certificate{cert},
-			},
+		connectionConfig.tls = &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{cert},
 		}
 	} else {
-		clientOptions.ConnectionOptions = client.ConnectionOptions{
-			TLS: &tls.Config{
-				MinVersion: tls.VersionTLS12,
-			},
+		connectionConfig.tls = &tls.Config{
+			MinVersion: tls.VersionTLS12,
 		}
 	}
 
 	if (okCrt && !okKey) || (!okCrt && okKey) {
-		return client.Options{}, errors.New("ensure both the client certificate and client key are provided")
+		return temporalConnectionConfig{}, errors.New("ensure both the client certificate and client key are provided")
 	}
 
-	// additional optional configuration for TLS and mTLS
 	if serverRootCACertificate, ok := credentialTokens["serverRootCACertificate"]; ok && serverRootCACertificate != "" {
 		rootCA, err := getCertPool(serverRootCACertificate)
 		if err != nil {
 			log.FromContext(ctx).Warn("Unable to parse root CA certificate.")
 		}
-		clientOptions.ConnectionOptions.TLS.RootCAs = rootCA
+		connectionConfig.tls.RootCAs = rootCA
 	}
 
 	if serverNameOverride, ok := credentialTokens["serverNameOverride"]; ok && serverNameOverride != "" {
-		clientOptions.ConnectionOptions.TLS.ServerName = serverNameOverride
+		connectionConfig.tls.ServerName = serverNameOverride
 	}
 
-	// apiKey case
 	if apiKey, ok := credentialTokens["apiKey"]; ok {
-		clientOptions.Credentials = client.NewAPIKeyStaticCredentials(apiKey)
+		connectionConfig.apiKey = apiKey
 	}
 
-	return clientOptions, nil
+	return connectionConfig, nil
 }
 
 func getCertPool(certString string) (*x509.CertPool, error) {

--- a/pkg/privateactionrunner/bundles/temporal/list_workflows.go
+++ b/pkg/privateactionrunner/bundles/temporal/list_workflows.go
@@ -9,7 +9,6 @@ import (
 	"context"
 
 	v112 "go.temporal.io/api/workflow/v1"
-	workflowService "go.temporal.io/api/workflowservice/v1"
 
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
@@ -51,21 +50,15 @@ func (h *ListWorkflowsHandler) Run(
 	}
 	defer temporalClient.Close()
 
-	request := &workflowService.ListWorkflowExecutionsRequest{
-		Namespace: namespace,
-		Query:     inputs.Query,
-	}
-
-	workflows, err := temporalClient.ListWorkflow(ctx, request)
+	workflows, err := temporalClient.ListWorkflowExecutions(ctx, inputs.Query)
 	if err != nil {
 		log.FromContext(ctx).Warn("Unable to list workflows.")
 		return nil, err
 	}
 
 	workflowsExecutions := []*v112.WorkflowExecutionInfo{}
-
 	if workflows != nil {
-		workflowsExecutions = workflows.Executions
+		workflowsExecutions = workflows
 	}
 
 	return &ListWorkflowsOutputs{

--- a/pkg/privateactionrunner/bundles/temporal/run_workflow.go
+++ b/pkg/privateactionrunner/bundles/temporal/run_workflow.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"errors"
 
-	"go.temporal.io/sdk/client"
-
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
@@ -54,22 +52,21 @@ func (h *RunWorkflowHandler) Run(
 	}
 	defer temporalClient.Close()
 
-	options := client.StartWorkflowOptions{
+	options := startWorkflowOptions{
 		ID:        inputs.WorkflowId,
 		TaskQueue: inputs.TaskQueue,
 	}
 
-	workflowExecution, err := temporalClient.ExecuteWorkflow(ctx, options, inputs.WorkFlowType, inputs.WorkflowArgs...)
+	runID, err := temporalClient.StartWorkflow(ctx, options, inputs.WorkFlowType, inputs.WorkflowArgs...)
 	if err != nil {
 		log.FromContext(ctx).Warn("Unable to run workflow.")
 		return nil, err
 	}
-	if workflowExecution == nil {
+	if runID == "" {
 		return nil, errors.New("workflow execution not found")
 	}
 
-	runId := workflowExecution.GetRunID()
 	return &RunWorkflowOutputs{
-		RunId: runId,
+		RunId: runID,
 	}, nil
 }

--- a/pkg/privateactionrunner/bundles/temporal/transport.go
+++ b/pkg/privateactionrunner/bundles/temporal/transport.go
@@ -1,0 +1,598 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_temporal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/converter"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/codes"
+	grpcCredentials "google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
+)
+
+const (
+	defaultClientNameHeaderValue             = "temporal-go"
+	defaultClientNameHeaderName              = "client-name"
+	defaultClientVersionHeaderName           = "client-version"
+	defaultGetHistoryTimeout                 = 65 * time.Second
+	defaultGetSystemInfoTimeout              = 5 * time.Second
+	defaultKeepAliveTime                     = 30 * time.Second
+	defaultKeepAliveTimeout                  = 15 * time.Second
+	defaultMaxPayloadSize                    = 128 * 1024 * 1024
+	defaultMaxRPCTimeout                     = 10 * time.Second
+	defaultMinRPCTimeout                     = 1 * time.Second
+	defaultRetryBackoffCoefficient           = 2.0
+	defaultRetryExpirationInterval           = 60 * time.Second
+	defaultRetryInitialInterval              = 200 * time.Millisecond
+	defaultSDKVersion                        = "1.39.0"
+	defaultSupportedServerVersionsHeaderName = "supported-server-versions"
+	defaultSupportedServerVersionsValue      = ">=1.0.0 <2.0.0"
+	defaultTemporalNamespaceHeaderKey        = "temporal-namespace"
+	defaultTemporalNamespace                 = "default"
+	maxConnectTimeout                        = 20 * time.Second
+	pollRetryBackoffMaxInterval              = 10 * time.Second
+)
+
+type startWorkflowOptions struct {
+	ID        string
+	TaskQueue string
+}
+
+type temporalTransport interface {
+	Close()
+	GetWorkflowResult(ctx context.Context, workflowID string, runID string) (string, error)
+	ListWorkflowExecutions(ctx context.Context, query string) ([]*workflowpb.WorkflowExecutionInfo, error)
+	StartWorkflow(ctx context.Context, options startWorkflowOptions, workflowType string, args ...any) (string, error)
+}
+
+type temporalWorkflowService interface {
+	DescribeWorkflowExecution(ctx context.Context, in *workflowservice.DescribeWorkflowExecutionRequest, opts ...grpc.CallOption) (*workflowservice.DescribeWorkflowExecutionResponse, error)
+	GetSystemInfo(ctx context.Context, in *workflowservice.GetSystemInfoRequest, opts ...grpc.CallOption) (*workflowservice.GetSystemInfoResponse, error)
+	GetWorkflowExecutionHistory(ctx context.Context, in *workflowservice.GetWorkflowExecutionHistoryRequest, opts ...grpc.CallOption) (*workflowservice.GetWorkflowExecutionHistoryResponse, error)
+	ListWorkflowExecutions(ctx context.Context, in *workflowservice.ListWorkflowExecutionsRequest, opts ...grpc.CallOption) (*workflowservice.ListWorkflowExecutionsResponse, error)
+	StartWorkflowExecution(ctx context.Context, in *workflowservice.StartWorkflowExecutionRequest, opts ...grpc.CallOption) (*workflowservice.StartWorkflowExecutionResponse, error)
+}
+
+type grpcTemporalTransport struct {
+	apiKey         string
+	conn           io.Closer
+	dataConverter  converter.DataConverter
+	identity       string
+	namespace      string
+	retryInternal  bool
+	workflowServer temporalWorkflowService
+}
+
+func newTemporalClient(
+	ctx context.Context,
+	credentials *privateconnection.PrivateCredentials,
+	namespace string,
+) (temporalTransport, error) {
+	connectionConfig, err := getTemporalConnectionConfig(ctx, credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	workflowServer, conn, retryInternal, err := dialTemporalTransport(ctx, connectionConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &grpcTemporalTransport{
+		apiKey:         connectionConfig.apiKey,
+		conn:           conn,
+		dataConverter:  converter.GetDefaultDataConverter(),
+		identity:       getTemporalIdentity(),
+		namespace:      namespace,
+		retryInternal:  retryInternal,
+		workflowServer: workflowServer,
+	}, nil
+}
+
+func dialTemporalTransport(
+	ctx context.Context,
+	connectionConfig temporalConnectionConfig,
+) (temporalWorkflowService, *grpc.ClientConn, bool, error) {
+	dialOptions := []grpc.DialOption{
+		grpc.WithConnectParams(grpc.ConnectParams{
+			Backoff:           newConnectBackoffConfig(),
+			MinConnectTimeout: maxConnectTimeout,
+		}),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(defaultMaxPayloadSize),
+			grpc.MaxCallSendMsgSize(defaultMaxPayloadSize),
+		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                defaultKeepAliveTime,
+			Timeout:             defaultKeepAliveTimeout,
+			PermitWithoutStream: true,
+		}),
+	}
+
+	if connectionConfig.tls != nil {
+		dialOptions = append(dialOptions, grpc.WithTransportCredentials(grpcCredentials.NewTLS(connectionConfig.tls)))
+	} else {
+		dialOptions = append(dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	conn, err := grpc.NewClient(connectionConfig.hostPort, dialOptions...)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	workflowServer := workflowservice.NewWorkflowServiceClient(conn)
+	retryInternal, err := loadRetryInternalCapability(ctx, workflowServer, connectionConfig.apiKey)
+	if err != nil {
+		_ = conn.Close()
+		return nil, nil, false, err
+	}
+
+	return workflowServer, conn, retryInternal, nil
+}
+
+func loadRetryInternalCapability(
+	ctx context.Context,
+	workflowServer temporalWorkflowService,
+	apiKey string,
+) (bool, error) {
+	callCtx, cancel := newTemporalRPCContext(ctx, "", apiKey, false, defaultGetSystemInfoTimeout)
+	defer cancel()
+
+	response, err := workflowServer.GetSystemInfo(callCtx, &workflowservice.GetSystemInfoRequest{})
+	if err != nil {
+		normalizedErr := normalizeTemporalError(err)
+		var unimplementedErr *serviceerror.Unimplemented
+		if errors.As(normalizedErr, &unimplementedErr) {
+			return true, nil
+		}
+		return false, fmt.Errorf("failed reaching server: %w", normalizedErr)
+	}
+
+	capabilities := response.GetCapabilities()
+	if capabilities == nil {
+		return true, nil
+	}
+	return !capabilities.GetInternalErrorDifferentiation(), nil
+}
+
+func newConnectBackoffConfig() backoff.Config {
+	backoffConfig := backoff.DefaultConfig
+	backoffConfig.BaseDelay = defaultRetryInitialInterval
+	backoffConfig.MaxDelay = pollRetryBackoffMaxInterval
+	return backoffConfig
+}
+
+func getTemporalIdentity() string {
+	hostName, err := os.Hostname()
+	if err != nil {
+		hostName = "Unknown"
+	}
+	return fmt.Sprintf("%d@%s@", os.Getpid(), hostName)
+}
+
+func (c *grpcTemporalTransport) StartWorkflow(
+	ctx context.Context,
+	options startWorkflowOptions,
+	workflowType string,
+	args ...any,
+) (string, error) {
+	workflowID := options.ID
+	if workflowID == "" {
+		workflowID = uuid.NewString()
+	}
+
+	input, err := c.dataConverter.ToPayloads(args...)
+	if err != nil {
+		return "", err
+	}
+
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		Identity:   c.identity,
+		Input:      input,
+		Namespace:  c.namespace,
+		RequestId:  uuid.NewString(),
+		TaskQueue:  &taskqueuepb.TaskQueue{Name: options.TaskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		WorkflowId: workflowID,
+		WorkflowType: &commonpb.WorkflowType{
+			Name: workflowType,
+		},
+	}
+
+	var response *workflowservice.StartWorkflowExecutionResponse
+	err = c.invokeWithRetry(ctx, false, func(callCtx context.Context) error {
+		var callErr error
+		response, callErr = c.workflowServer.StartWorkflowExecution(callCtx, request)
+		return callErr
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return response.GetRunId(), nil
+}
+
+func (c *grpcTemporalTransport) ListWorkflowExecutions(
+	ctx context.Context,
+	query string,
+) ([]*workflowpb.WorkflowExecutionInfo, error) {
+	request := &workflowservice.ListWorkflowExecutionsRequest{
+		Namespace: c.namespace,
+		Query:     query,
+	}
+
+	var response *workflowservice.ListWorkflowExecutionsResponse
+	err := c.invokeWithRetry(ctx, false, func(callCtx context.Context) error {
+		var callErr error
+		response, callErr = c.workflowServer.ListWorkflowExecutions(callCtx, request)
+		return callErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	if response == nil {
+		return nil, nil
+	}
+	return response.GetExecutions(), nil
+}
+
+func (c *grpcTemporalTransport) GetWorkflowResult(
+	ctx context.Context,
+	workflowID string,
+	runID string,
+) (string, error) {
+	currentRunID, err := c.resolveRunID(ctx, workflowID, runID)
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		closeEvent, err := c.getCloseEvent(ctx, workflowID, currentRunID)
+		if err != nil {
+			return "", err
+		}
+
+		switch closeEvent.GetEventType() {
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:
+			attributes := closeEvent.GetWorkflowExecutionCompletedEventAttributes()
+			if nextRunID := attributes.GetNewExecutionRunId(); nextRunID != "" {
+				currentRunID = nextRunID
+				continue
+			}
+
+			if attributes.GetResult() == nil {
+				return "", nil
+			}
+
+			var result string
+			if err := c.dataConverter.FromPayloads(attributes.GetResult(), &result); err != nil {
+				return "", err
+			}
+			return result, nil
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
+			attributes := closeEvent.GetWorkflowExecutionFailedEventAttributes()
+			if nextRunID := attributes.GetNewExecutionRunId(); nextRunID != "" {
+				currentRunID = nextRunID
+				continue
+			}
+			return "", fmt.Errorf("workflow execution failed: %s", attributes.GetFailure().GetMessage())
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
+			attributes := closeEvent.GetWorkflowExecutionTimedOutEventAttributes()
+			if nextRunID := attributes.GetNewExecutionRunId(); nextRunID != "" {
+				currentRunID = nextRunID
+				continue
+			}
+			return "", errors.New("workflow execution timed out")
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW:
+			nextRunID := closeEvent.GetWorkflowExecutionContinuedAsNewEventAttributes().GetNewExecutionRunId()
+			if nextRunID == "" {
+				return "", errors.New("workflow continued as new without a new run ID")
+			}
+			currentRunID = nextRunID
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
+			return "", errors.New("workflow execution canceled")
+		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
+			return "", errors.New("workflow execution terminated")
+		default:
+			return "", fmt.Errorf("unexpected event type %s when handling workflow execution result", closeEvent.GetEventType())
+		}
+	}
+}
+
+func (c *grpcTemporalTransport) Close() {
+	if c.conn != nil {
+		_ = c.conn.Close()
+	}
+}
+
+func (c *grpcTemporalTransport) resolveRunID(
+	ctx context.Context,
+	workflowID string,
+	runID string,
+) (string, error) {
+	if runID != "" {
+		return runID, nil
+	}
+
+	request := &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: c.namespace,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+	}
+
+	var response *workflowservice.DescribeWorkflowExecutionResponse
+	err := c.invokeWithRetry(ctx, false, func(callCtx context.Context) error {
+		var callErr error
+		response, callErr = c.workflowServer.DescribeWorkflowExecution(callCtx, request)
+		return callErr
+	})
+	if err != nil {
+		return "", err
+	}
+	if response.GetWorkflowExecutionInfo() == nil || response.GetWorkflowExecutionInfo().GetExecution() == nil {
+		return "", nil
+	}
+	return response.GetWorkflowExecutionInfo().GetExecution().GetRunId(), nil
+}
+
+func (c *grpcTemporalTransport) getCloseEvent(
+	ctx context.Context,
+	workflowID string,
+	runID string,
+) (*historypb.HistoryEvent, error) {
+	request := &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Execution: &commonpb.WorkflowExecution{
+			RunId:      runID,
+			WorkflowId: workflowID,
+		},
+		HistoryEventFilterType: enumspb.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT,
+		Namespace:              c.namespace,
+		SkipArchival:           true,
+		WaitNewEvent:           true,
+	}
+
+	for {
+		var response *workflowservice.GetWorkflowExecutionHistoryResponse
+		err := c.invokeWithRetry(ctx, true, func(callCtx context.Context) error {
+			var callErr error
+			response, callErr = c.workflowServer.GetWorkflowExecutionHistory(callCtx, request)
+			return callErr
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		history, err := getHistoryFromResponse(response, enumspb.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT)
+		if err != nil {
+			return nil, err
+		}
+		if len(history.GetEvents()) == 0 && len(response.GetNextPageToken()) != 0 {
+			request.NextPageToken = response.GetNextPageToken()
+			continue
+		}
+		if len(history.GetEvents()) == 0 {
+			return nil, errors.New("workflow close event not found")
+		}
+		return history.GetEvents()[len(history.GetEvents())-1], nil
+	}
+}
+
+func getHistoryFromResponse(
+	response *workflowservice.GetWorkflowExecutionHistoryResponse,
+	filterType enumspb.HistoryEventFilterType,
+) (*historypb.History, error) {
+	if response.GetRawHistory() != nil {
+		return deserializeBlobDataToHistoryEvents(response.GetRawHistory(), filterType)
+	}
+	if response.GetHistory() == nil {
+		return &historypb.History{}, nil
+	}
+	return response.GetHistory(), nil
+}
+
+func deserializeBlobDataToHistoryEvents(
+	dataBlobs []*commonpb.DataBlob,
+	filterType enumspb.HistoryEventFilterType,
+) (*historypb.History, error) {
+	var historyEvents []*historypb.HistoryEvent
+
+	for _, batch := range dataBlobs {
+		events, err := deserializeBatchEvents(batch)
+		if err != nil {
+			return nil, err
+		}
+		if len(events) == 0 {
+			return nil, serviceerror.NewInternal("corrupted history event batch, empty events")
+		}
+		historyEvents = append(historyEvents, events...)
+	}
+
+	if filterType == enumspb.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT && len(historyEvents) > 0 {
+		historyEvents = []*historypb.HistoryEvent{historyEvents[len(historyEvents)-1]}
+	}
+
+	return &historypb.History{Events: historyEvents}, nil
+}
+
+func deserializeBatchEvents(data *commonpb.DataBlob) ([]*historypb.HistoryEvent, error) {
+	if data == nil || len(data.GetData()) == 0 {
+		return nil, nil
+	}
+
+	events := &historypb.History{}
+	var err error
+	switch data.GetEncodingType() {
+	case enumspb.ENCODING_TYPE_JSON:
+		err = protojson.Unmarshal(data.GetData(), events)
+	case enumspb.ENCODING_TYPE_PROTO3:
+		err = proto.Unmarshal(data.GetData(), events)
+	default:
+		return nil, errors.New("DeserializeBatchEvents invalid encoding")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return events.GetEvents(), nil
+}
+
+func (c *grpcTemporalTransport) invokeWithRetry(
+	ctx context.Context,
+	isLongPoll bool,
+	call func(callCtx context.Context) error,
+) error {
+	retryCtx := ctx
+	var retryCancel context.CancelFunc
+	if _, hasDeadline := retryCtx.Deadline(); !hasDeadline {
+		retryCtx, retryCancel = context.WithDeadline(ctx, time.Now().Add(defaultRetryExpirationInterval))
+		defer retryCancel()
+	}
+
+	for attempt := 0; ; attempt++ {
+		callCtx, cancel := newTemporalRPCContext(retryCtx, c.namespace, c.apiKey, isLongPoll, 0)
+		err := call(callCtx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+
+		normalizedErr := normalizeTemporalError(err)
+		if !shouldRetry(normalizedErr, c.retryInternal) {
+			return normalizedErr
+		}
+
+		backoffDuration := getRetryBackoff(attempt, retryCtx)
+		timer := time.NewTimer(backoffDuration)
+		select {
+		case <-retryCtx.Done():
+			timer.Stop()
+			return retryCtx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func newTemporalRPCContext(
+	ctx context.Context,
+	namespace string,
+	apiKey string,
+	isLongPoll bool,
+	timeoutOverride time.Duration,
+) (context.Context, context.CancelFunc) {
+	timeout := getRPCTimeout(ctx)
+	if isLongPoll {
+		timeout = defaultGetHistoryTimeout
+	}
+	if timeoutOverride > 0 {
+		timeout = timeoutOverride
+	}
+
+	ctx = appendOutgoingMetadata(ctx, namespace, apiKey)
+	return context.WithTimeout(ctx, timeout)
+}
+
+func appendOutgoingMetadata(ctx context.Context, namespace string, apiKey string) context.Context {
+	existingMetadata, _ := metadata.FromOutgoingContext(ctx)
+	outgoingMetadata := existingMetadata.Copy()
+	if outgoingMetadata == nil {
+		outgoingMetadata = metadata.New(nil)
+	}
+
+	if len(outgoingMetadata.Get(defaultClientNameHeaderName)) == 0 {
+		outgoingMetadata.Set(defaultClientNameHeaderName, defaultClientNameHeaderValue)
+	}
+	if len(outgoingMetadata.Get(defaultClientVersionHeaderName)) == 0 {
+		outgoingMetadata.Set(defaultClientVersionHeaderName, defaultSDKVersion)
+	}
+	if len(outgoingMetadata.Get(defaultSupportedServerVersionsHeaderName)) == 0 {
+		outgoingMetadata.Set(defaultSupportedServerVersionsHeaderName, defaultSupportedServerVersionsValue)
+	}
+	if namespace != "" && len(outgoingMetadata.Get(defaultTemporalNamespaceHeaderKey)) == 0 {
+		outgoingMetadata.Set(defaultTemporalNamespaceHeaderKey, namespace)
+	}
+	if apiKey != "" && len(outgoingMetadata.Get("authorization")) == 0 {
+		outgoingMetadata.Set("authorization", "Bearer "+apiKey)
+	}
+
+	return metadata.NewOutgoingContext(ctx, outgoingMetadata)
+}
+
+func getRPCTimeout(ctx context.Context) time.Duration {
+	timeout := defaultMaxRPCTimeout
+	now := time.Now()
+	if deadline, hasDeadline := ctx.Deadline(); hasDeadline && deadline.After(now) {
+		timeout = deadline.Sub(now) / 2
+		if timeout < defaultMinRPCTimeout {
+			return defaultMinRPCTimeout
+		}
+		if timeout > defaultMaxRPCTimeout {
+			return defaultMaxRPCTimeout
+		}
+	}
+	return timeout
+}
+
+func getRetryBackoff(attempt int, ctx context.Context) time.Duration {
+	timeout := defaultRetryExpirationInterval
+	now := time.Now()
+	if deadline, hasDeadline := ctx.Deadline(); hasDeadline && deadline.After(now) {
+		timeout = deadline.Sub(now)
+	}
+
+	maximumInterval := timeout / 10
+	if maximumInterval < defaultRetryInitialInterval {
+		maximumInterval = defaultRetryInitialInterval
+	}
+
+	nextInterval := float64(defaultRetryInitialInterval) * math.Pow(defaultRetryBackoffCoefficient, float64(attempt))
+	return minDuration(time.Duration(nextInterval), maximumInterval)
+}
+
+func minDuration(a time.Duration, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func normalizeTemporalError(err error) error {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return serviceerror.FromStatus(status.Convert(err))
+}
+
+func shouldRetry(err error, retryInternal bool) bool {
+	switch status.Code(err) {
+	case codes.Aborted, codes.ResourceExhausted, codes.Unavailable, codes.Unknown:
+		return true
+	case codes.Internal:
+		return retryInternal
+	default:
+		return false
+	}
+}

--- a/pkg/privateactionrunner/bundles/temporal/transport_test.go
+++ b/pkg/privateactionrunner/bundles/temporal/transport_test.go
@@ -1,0 +1,329 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_temporal
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/converter"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
+)
+
+type fakeTemporalWorkflowService struct {
+	describeWorkflowExecutionFn func(context.Context, *workflowservice.DescribeWorkflowExecutionRequest, ...grpc.CallOption) (*workflowservice.DescribeWorkflowExecutionResponse, error)
+	getSystemInfoFn             func(context.Context, *workflowservice.GetSystemInfoRequest, ...grpc.CallOption) (*workflowservice.GetSystemInfoResponse, error)
+	getWorkflowExecutionFn      func(context.Context, *workflowservice.GetWorkflowExecutionHistoryRequest, ...grpc.CallOption) (*workflowservice.GetWorkflowExecutionHistoryResponse, error)
+	listWorkflowExecutionsFn    func(context.Context, *workflowservice.ListWorkflowExecutionsRequest, ...grpc.CallOption) (*workflowservice.ListWorkflowExecutionsResponse, error)
+	startWorkflowExecutionFn    func(context.Context, *workflowservice.StartWorkflowExecutionRequest, ...grpc.CallOption) (*workflowservice.StartWorkflowExecutionResponse, error)
+}
+
+func (f *fakeTemporalWorkflowService) DescribeWorkflowExecution(
+	ctx context.Context,
+	in *workflowservice.DescribeWorkflowExecutionRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+	if f.describeWorkflowExecutionFn == nil {
+		return &workflowservice.DescribeWorkflowExecutionResponse{}, nil
+	}
+	return f.describeWorkflowExecutionFn(ctx, in, opts...)
+}
+
+func (f *fakeTemporalWorkflowService) GetSystemInfo(
+	ctx context.Context,
+	in *workflowservice.GetSystemInfoRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetSystemInfoResponse, error) {
+	if f.getSystemInfoFn == nil {
+		return &workflowservice.GetSystemInfoResponse{}, nil
+	}
+	return f.getSystemInfoFn(ctx, in, opts...)
+}
+
+func (f *fakeTemporalWorkflowService) GetWorkflowExecutionHistory(
+	ctx context.Context,
+	in *workflowservice.GetWorkflowExecutionHistoryRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetWorkflowExecutionHistoryResponse, error) {
+	if f.getWorkflowExecutionFn == nil {
+		return &workflowservice.GetWorkflowExecutionHistoryResponse{}, nil
+	}
+	return f.getWorkflowExecutionFn(ctx, in, opts...)
+}
+
+func (f *fakeTemporalWorkflowService) ListWorkflowExecutions(
+	ctx context.Context,
+	in *workflowservice.ListWorkflowExecutionsRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.ListWorkflowExecutionsResponse, error) {
+	if f.listWorkflowExecutionsFn == nil {
+		return &workflowservice.ListWorkflowExecutionsResponse{}, nil
+	}
+	return f.listWorkflowExecutionsFn(ctx, in, opts...)
+}
+
+func (f *fakeTemporalWorkflowService) StartWorkflowExecution(
+	ctx context.Context,
+	in *workflowservice.StartWorkflowExecutionRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.StartWorkflowExecutionResponse, error) {
+	if f.startWorkflowExecutionFn == nil {
+		return &workflowservice.StartWorkflowExecutionResponse{}, nil
+	}
+	return f.startWorkflowExecutionFn(ctx, in, opts...)
+}
+
+func TestGetTemporalConnectionConfigAddressOnly(t *testing.T) {
+	credentials := &privateconnection.PrivateCredentials{
+		Tokens: []privateconnection.PrivateCredentialsToken{
+			{Name: "address", Value: "localhost:7233"},
+		},
+	}
+
+	config, err := getTemporalConnectionConfig(context.Background(), credentials)
+
+	require.NoError(t, err)
+	assert.Equal(t, "localhost:7233", config.hostPort)
+	assert.Empty(t, config.apiKey)
+	assert.Nil(t, config.tls)
+}
+
+func TestGetTemporalConnectionConfigTLSAndAPIKey(t *testing.T) {
+	rootCA := mustCreateCertificatePEM(t)
+	credentials := &privateconnection.PrivateCredentials{
+		Tokens: []privateconnection.PrivateCredentialsToken{
+			{Name: "serverAddress", Value: "temporal.example.com:7233"},
+			{Name: "serverNameOverride", Value: "temporal.internal"},
+			{Name: "serverRootCACertificate", Value: rootCA},
+			{Name: "apiKey", Value: "secret-key"},
+		},
+	}
+
+	config, err := getTemporalConnectionConfig(context.Background(), credentials)
+
+	require.NoError(t, err)
+	require.NotNil(t, config.tls)
+	assert.Equal(t, "temporal.example.com:7233", config.hostPort)
+	assert.Equal(t, "secret-key", config.apiKey)
+	assert.Equal(t, uint16(tls.VersionTLS12), config.tls.MinVersion)
+	assert.Equal(t, "temporal.internal", config.tls.ServerName)
+	assert.NotNil(t, config.tls.RootCAs)
+}
+
+func TestGetTemporalConnectionConfigMTLS(t *testing.T) {
+	certPEM, keyPEM := mustCreateCertificatePairPEM(t)
+	credentials := &privateconnection.PrivateCredentials{
+		Tokens: []privateconnection.PrivateCredentialsToken{
+			{Name: "serverAddress", Value: "temporal.example.com:7233"},
+			{Name: "clientCertPairCrt", Value: certPEM},
+			{Name: "clientCertPairKey", Value: keyPEM},
+		},
+	}
+
+	config, err := getTemporalConnectionConfig(context.Background(), credentials)
+
+	require.NoError(t, err)
+	require.NotNil(t, config.tls)
+	require.Len(t, config.tls.Certificates, 1)
+}
+
+func TestGetTemporalConnectionConfigMTLSRequiresKeyAndCert(t *testing.T) {
+	certPEM, _ := mustCreateCertificatePairPEM(t)
+	credentials := &privateconnection.PrivateCredentials{
+		Tokens: []privateconnection.PrivateCredentialsToken{
+			{Name: "serverAddress", Value: "temporal.example.com:7233"},
+			{Name: "clientCertPairCrt", Value: certPEM},
+		},
+	}
+
+	_, err := getTemporalConnectionConfig(context.Background(), credentials)
+
+	require.ErrorContains(t, err, "ensure both the client certificate and client key are provided")
+}
+
+func TestStartWorkflowBuildsRequestAndMetadata(t *testing.T) {
+	var capturedMetadata metadata.MD
+	var capturedRequest *workflowservice.StartWorkflowExecutionRequest
+	transport := &grpcTemporalTransport{
+		apiKey:        "secret-key",
+		dataConverter: converter.GetDefaultDataConverter(),
+		identity:      "test-identity",
+		namespace:     "test-namespace",
+		workflowServer: &fakeTemporalWorkflowService{
+			startWorkflowExecutionFn: func(ctx context.Context, in *workflowservice.StartWorkflowExecutionRequest, _ ...grpc.CallOption) (*workflowservice.StartWorkflowExecutionResponse, error) {
+				capturedRequest = in
+				capturedMetadata, _ = metadata.FromOutgoingContext(ctx)
+				return &workflowservice.StartWorkflowExecutionResponse{RunId: "run-123"}, nil
+			},
+		},
+	}
+
+	runID, err := transport.StartWorkflow(context.Background(), startWorkflowOptions{TaskQueue: "task-queue"}, "workflow-name", "arg-one", 42)
+
+	require.NoError(t, err)
+	assert.Equal(t, "run-123", runID)
+	require.NotNil(t, capturedRequest)
+	assert.Equal(t, "test-namespace", capturedRequest.GetNamespace())
+	assert.Equal(t, "workflow-name", capturedRequest.GetWorkflowType().GetName())
+	assert.Equal(t, "task-queue", capturedRequest.GetTaskQueue().GetName())
+	assert.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, capturedRequest.GetTaskQueue().GetKind())
+	assert.Equal(t, "test-identity", capturedRequest.GetIdentity())
+	assert.NotEmpty(t, capturedRequest.GetRequestId())
+	_, err = uuid.Parse(capturedRequest.GetWorkflowId())
+	require.NoError(t, err)
+	require.Len(t, capturedMetadata.Get("authorization"), 1)
+	assert.Equal(t, "Bearer secret-key", capturedMetadata.Get("authorization")[0])
+	require.Len(t, capturedMetadata.Get(defaultTemporalNamespaceHeaderKey), 1)
+	assert.Equal(t, "test-namespace", capturedMetadata.Get(defaultTemporalNamespaceHeaderKey)[0])
+	require.Len(t, capturedMetadata.Get(defaultClientNameHeaderName), 1)
+	assert.Equal(t, defaultClientNameHeaderValue, capturedMetadata.Get(defaultClientNameHeaderName)[0])
+
+	var argOne string
+	var argTwo int
+	err = transport.dataConverter.FromPayloads(capturedRequest.GetInput(), &argOne, &argTwo)
+	require.NoError(t, err)
+	assert.Equal(t, "arg-one", argOne)
+	assert.Equal(t, 42, argTwo)
+}
+
+func TestListWorkflowExecutionsBuildsRequest(t *testing.T) {
+	var capturedRequest *workflowservice.ListWorkflowExecutionsRequest
+	transport := &grpcTemporalTransport{
+		namespace: "test-namespace",
+		workflowServer: &fakeTemporalWorkflowService{
+			listWorkflowExecutionsFn: func(_ context.Context, in *workflowservice.ListWorkflowExecutionsRequest, _ ...grpc.CallOption) (*workflowservice.ListWorkflowExecutionsResponse, error) {
+				capturedRequest = in
+				return &workflowservice.ListWorkflowExecutionsResponse{
+					Executions: []*workflowpb.WorkflowExecutionInfo{{}},
+				}, nil
+			},
+		},
+	}
+
+	workflows, err := transport.ListWorkflowExecutions(context.Background(), "ExecutionStatus = 'Running'")
+
+	require.NoError(t, err)
+	require.Len(t, workflows, 1)
+	require.NotNil(t, capturedRequest)
+	assert.Equal(t, "test-namespace", capturedRequest.GetNamespace())
+	assert.Equal(t, "ExecutionStatus = 'Running'", capturedRequest.GetQuery())
+}
+
+func TestGetWorkflowResultResolvesRunIDAndFollowsContinueAsNew(t *testing.T) {
+	transport := &grpcTemporalTransport{
+		dataConverter: converter.GetDefaultDataConverter(),
+		namespace:     "test-namespace",
+		workflowServer: &fakeTemporalWorkflowService{
+			describeWorkflowExecutionFn: func(_ context.Context, in *workflowservice.DescribeWorkflowExecutionRequest, _ ...grpc.CallOption) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+				assert.Equal(t, "test-namespace", in.GetNamespace())
+				assert.Equal(t, "workflow-id", in.GetExecution().GetWorkflowId())
+				return &workflowservice.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
+						Execution: &commonpb.WorkflowExecution{RunId: "run-1"},
+					},
+				}, nil
+			},
+			getWorkflowExecutionFn: func(_ context.Context, in *workflowservice.GetWorkflowExecutionHistoryRequest, _ ...grpc.CallOption) (*workflowservice.GetWorkflowExecutionHistoryResponse, error) {
+				switch in.GetExecution().GetRunId() {
+				case "run-1":
+					return &workflowservice.GetWorkflowExecutionHistoryResponse{
+						History: &historypb.History{
+							Events: []*historypb.HistoryEvent{
+								{
+									EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW,
+									Attributes: &historypb.HistoryEvent_WorkflowExecutionContinuedAsNewEventAttributes{
+										WorkflowExecutionContinuedAsNewEventAttributes: &historypb.WorkflowExecutionContinuedAsNewEventAttributes{
+											NewExecutionRunId: "run-2",
+											TaskQueue:         &taskqueuepb.TaskQueue{Name: "queue"},
+											WorkflowType:      &commonpb.WorkflowType{Name: "workflow-name"},
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				case "run-2":
+					payloads, err := converter.GetDefaultDataConverter().ToPayloads("done")
+					require.NoError(t, err)
+					return &workflowservice.GetWorkflowExecutionHistoryResponse{
+						History: &historypb.History{
+							Events: []*historypb.HistoryEvent{
+								{
+									EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED,
+									Attributes: &historypb.HistoryEvent_WorkflowExecutionCompletedEventAttributes{
+										WorkflowExecutionCompletedEventAttributes: &historypb.WorkflowExecutionCompletedEventAttributes{
+											Result: payloads,
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				default:
+					t.Fatalf("unexpected run id %q", in.GetExecution().GetRunId())
+					return nil, nil
+				}
+			},
+		},
+	}
+
+	result, err := transport.GetWorkflowResult(context.Background(), "workflow-id", "")
+
+	require.NoError(t, err)
+	assert.Equal(t, "done", result)
+}
+
+func mustCreateCertificatePEM(t *testing.T) string {
+	certPEM, _ := mustCreateCertificatePairPEM(t)
+	return certPEM
+}
+
+func mustCreateCertificatePairPEM(t *testing.T) (string, string) {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	serialNumber, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		NotAfter:              time.Now().Add(time.Hour),
+		NotBefore:             time.Now().Add(-time.Minute),
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: "temporal-test"},
+	}
+
+	certificateDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+
+	certificatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificateDER})
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	return string(certificatePEM), string(privateKeyPEM)
+}


### PR DESCRIPTION
### What does this PR do?

This change reduces the privateactionrunner binary by replacing the Temporal Go SDK client with a small local gRPC transport that implements only the Temporal operations this bundle uses.

Will leave this in draft as I don't think a reduced 400Kib is worth the added complexity/vulnerabilities of having to maintain the inlined code.
### Motivation

Looking for ways to reduce the binary size to account for the exception granted for ADP. 

### Describe how you validated your changes

### Additional Notes
