### PR TITLE
[gensim-eks] Runner fixes + episode management skill

### DIFF
--- a/.claude/skills/gensim-episode-management/SKILL.md
+++ b/.claude/skills/gensim-episode-management/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: gensim-episode-management
+description: >
+  Manage gensim episodes on the gensim-eks EKS runner for observer anomaly detection
+  evaluation. Use this skill when the user wants to: add/run a gensim episode on EKS,
+  validate episode compatibility, debug a failed gensim-eks submit or run, check run
+  results, or troubleshoot Pulumi/helm/kubectl issues with the gensim cluster. Trigger
+  on mentions of gensim-eks, gensim submit, episode validation, observer evaluation,
+  or gensim infrastructure problems -- even if the user doesn't use these exact terms.
+---
+
+# Gensim Episode Management
+
+## When to use which sub-skill
+
+**Read `add-episode.md`** when the user wants to:
+- Run a new episode on gensim-eks for the first time
+- Validate an episode before submitting
+- Check results after a run completes (monitors, events, TP/FP metrics)
+- Batch-run multiple episodes
+
+**Read `debug-infra.md`** when the user is hitting:
+- Pulumi submit failures (state conflicts, stack locks, resource errors)
+- Helm install timeouts or conflicts
+- kubectl/auth connectivity issues
+- ImagePullBackOff, orchestrator Error state, or pod scheduling problems
+
+If unclear, start with the user's immediate problem. Infrastructure issues block
+everything else, so debug-infra takes priority when things are broken.
+
+## Shared Context
+
+### Repository Layout
+
+- **datadog-agent repo** (`alt-datadog-agent/`): contains the gensim-eks runner code
+  - `test/e2e-framework/scenarios/aws/gensim-eks/run.go` -- Pulumi program
+  - `test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl` -- orchestrator script
+  - `test/e2e-framework/scenarios/aws/gensim-eks/agent-values.yaml.tmpl` -- observer config
+  - `tasks/e2e_framework/aws/gensim_eks.py` -- `dda inv aws.eks.gensim.submit` task
+
+- **gensim-episodes repo** (sibling dir or `GENSIM_REPO_PATH`): episode definitions
+  - `synthetics/` -- hand-crafted scenarios (food-delivery, casino, ehr, timescaledb)
+  - `postmortems/` -- scenarios derived from real incident postmortems
+
+### Episode Anatomy
+
+```
+episode-name/
+├── play-episode.sh          # Phase functions sourced by orchestrator
+├── chart/                   # Helm chart for episode services
+├── docker-compose.yaml      # Service image definitions (triggers build VM)
+├── services/                # Source code for microservices
+├── episodes/*.yaml          # Scenario definitions (phases, durations)
+└── scenario.yaml            # Ground truth: true_positives, false_positives
+```
+
+### Observer Config (agent-values.yaml.tmpl)
+
+The observer's detector/correlator config for live runs:
+
+```yaml
+observer:
+  analysis:
+    enabled: true
+  event_reporter:
+    sending_enabled: true
+  components:
+    bocpd:
+      enabled: true        # streaming detector, works in live mode
+    scanwelch:
+      enabled: true        # batch detector, known eviction bug in live mode
+    rrcf:
+      enabled: false
+    time_cluster:
+      min_cluster_size: 1   # use 1 for eval (most clusters are size 1-2)
+```
+
+### Known Issues (affect all episodes)
+
+**Trace metric naming mismatch**: The observer stores `trace.hits{operation:redis.command}`
+while Datadog's backend shows `trace.redis.command.hits`. Same data, different naming.
+When validating TP/FP against scenario.yaml, translate: `trace.{operation}.{suffix}` in
+the backend maps to `trace.{suffix}{operation:{operation}}` in the observer.
+
+**BOCPD warmup**: Needs 120 data points. Virtual log metrics (~1s interval) warm up in
+2 min. Check/trace metrics (~10-15s interval) need 20-30 min -- longer than most baselines.
+Expect BOCPD to primarily detect on log-derived metrics for slow-interval scenarios.
+
+**ScanWelch eviction**: Batch detectors timestamp anomalies at the historical changepoint.
+TimeCluster's 120s window evicts them before EventReporter fires. Works in testbench,
+not in live mode. Known bug, pending fix.
+
+**Silent channel drops**: The observer's 1000-item observation channel drops data under
+load (non-blocking send). Affects live mode only; testbench bypasses the channel.
+
+### Useful pup Commands
+
+```bash
+pup events search --query 'source:agent-q-branch-observer' --from 1h
+pup metrics query --query 'avg:<metric>{env:<env-tag>}' --from '<start>' --to '<end>'
+pup monitors list --name 'gensim'
+pup logs search --query '"[observer]" cluster_name:gensim' --from 1h --limit 50
+```
+
+Note: `pup` auth expires frequently. Re-auth with `pup auth login`.

--- a/.claude/skills/gensim-episode-management/SKILL.md
+++ b/.claude/skills/gensim-episode-management/SKILL.md
@@ -56,42 +56,28 @@ episode-name/
 
 ### Observer Config (agent-values.yaml.tmpl)
 
-The observer's detector/correlator config for live runs:
+The observer's detector/correlator config lives in `agent-values.yaml.tmpl`. Each
+detector and correlator can be toggled via:
 
-```yaml
-observer:
-  analysis:
-    enabled: true
-  event_reporter:
-    sending_enabled: true
-  components:
-    bocpd:
-      enabled: true        # streaming detector, works in live mode
-    scanwelch:
-      enabled: true        # batch detector, known eviction bug in live mode
-    rrcf:
-      enabled: false
-    time_cluster:
-      min_cluster_size: 1   # use 1 for eval (most clusters are size 1-2)
 ```
+observer.components.<name>.enabled: true/false
+```
+
+Check the template for current detector names and defaults. For eval runs, ensure
+`time_cluster.min_cluster_size` is low enough (1-2) -- higher values filter out
+small anomaly clusters that are common in single-disruption scenarios.
 
 ### Known Issues (affect all episodes)
 
-**Trace metric naming mismatch**: The observer stores `trace.hits{operation:redis.command}`
-while Datadog's backend shows `trace.redis.command.hits`. Same data, different naming.
-When validating TP/FP against scenario.yaml, translate: `trace.{operation}.{suffix}` in
-the backend maps to `trace.{suffix}{operation:{operation}}` in the observer.
+**Trace metric naming mismatch** (structural, unlikely to change): The observer's
+`processStatsView` stores `trace.hits{operation:redis.command}` while Datadog's
+backend shows `trace.redis.command.hits`. Same data, different naming convention.
+When validating TP/FP against scenario.yaml, translate: `trace.{operation}.{suffix}`
+in the backend maps to `trace.{suffix}{operation:{operation}}` in the observer.
 
-**BOCPD warmup**: Needs 120 data points. Virtual log metrics (~1s interval) warm up in
-2 min. Check/trace metrics (~10-15s interval) need 20-30 min -- longer than most baselines.
-Expect BOCPD to primarily detect on log-derived metrics for slow-interval scenarios.
-
-**ScanWelch eviction**: Batch detectors timestamp anomalies at the historical changepoint.
-TimeCluster's 120s window evicts them before EventReporter fires. Works in testbench,
-not in live mode. Known bug, pending fix.
-
-**Silent channel drops**: The observer's 1000-item observation channel drops data under
-load (non-blocking send). Affects live mode only; testbench bypasses the channel.
+**Detector-specific issues**: See `references/current-detector-issues.md` for
+current detector warmup requirements, correlator eviction behavior, and known
+live-vs-testbench divergences. These change as the observer algorithms evolve.
 
 ### Useful pup Commands
 

--- a/.claude/skills/gensim-episode-management/add-episode.md
+++ b/.claude/skills/gensim-episode-management/add-episode.md
@@ -112,7 +112,7 @@ KUBECONFIG=<kubeconfig> kubectl --context aws \
 | +2-4 min | episode-running: warmup (2 min) |
 | +4-6 min | baseline (10 min) |
 | +14-16 min | disruption (10 min) |
-| +16-18 min | first observer events (BOCPD on virtual log metrics) |
+| +16-18 min | first observer anomaly events |
 | +24-26 min | cooldown (10 min) |
 | +34-36 min | episode done, parquet collection |
 

--- a/.claude/skills/gensim-episode-management/add-episode.md
+++ b/.claude/skills/gensim-episode-management/add-episode.md
@@ -1,0 +1,203 @@
+# Adding a Gensim Episode to gensim-eks
+
+Step-by-step process for taking an existing episode from the gensim-episodes repo
+and running it on the gensim-eks cluster with the observer agent.
+
+## Step 1: Locate and Validate the Episode
+
+### Find it
+
+Episodes live in `synthetics/` (hand-crafted) or `postmortems/` (incident-derived):
+
+```bash
+cd ~/dev/gensim-episodes
+ls synthetics/$EPISODE 2>/dev/null || ls postmortems/$EPISODE 2>/dev/null
+```
+
+If it was deleted, check git history:
+```bash
+git log --all --diff-filter=D --name-only -- "*$EPISODE*" | head -20
+```
+
+Recover with `git checkout <commit-before-deletion>~1 -- <path>`.
+
+### Find the scenario name
+
+```bash
+ls gensim-episodes/*/EPISODE/episodes/
+# filename without .yaml is the scenario name
+```
+
+### Run pre-flight checks
+
+Check all of these before submitting:
+
+| Check | Command | Fix |
+|-------|---------|-----|
+| Internal registry refs | `grep -rl "registry.ddbuild.io" */EPISODE/services/` | `sed -i '' 's\|registry.ddbuild.io/images/mirror/\|\|g'` |
+| Runtime docker build | `grep -E "docker.*build\|compose.*build\|kind load" */EPISODE/play-episode.sh` | **Blocker** -- needs refactoring |
+| Port-forward usage | `grep "port-forward" */EPISODE/play-episode.sh` | Works from orchestrator pod, just note it |
+| Python requests in exec | `grep "import requests" */EPISODE/play-episode.sh` | Target pod needs requests lib |
+| Dirty gensim checkout | `git status --porcelain` | Commit changes (push not required) |
+
+### Check the ground truth
+
+Read `scenario.yaml` for `true_positives` and `false_positives`. Note which metrics
+are expected to change and which should stay stable. You'll validate these after the
+run completes.
+
+Remember the trace naming mismatch: scenario.yaml uses backend names
+(`trace.redis.command.errors`) but the observer uses flat names
+(`trace.errors{operation:redis.command}`). See SKILL.md for the translation.
+
+## Step 2: Submit the Run
+
+### Basic command
+
+```bash
+dda inv aws.eks.gensim.submit \
+  --image=docker.io/datadog/agent-dev:<tag> \
+  --episodes=<episode>:<scenario> \
+  --mode=live-and-record \
+  --s3-bucket=qbranch-gensim-recordings
+```
+
+### With --skip-build (cached images)
+
+When images are already in ECR from a previous run, or when another user created
+the Pulumi stack:
+
+```bash
+dda inv aws.eks.gensim.submit \
+  --image=docker.io/datadog/agent-dev:<tag> \
+  --episodes=<episode>:<scenario> \
+  --mode=live-and-record \
+  --s3-bucket=qbranch-gensim-recordings \
+  --skip-build
+```
+
+`--skip-build` skips the build VM but still passes the ECR registry to helm charts.
+
+### Batch runs
+
+Comma-separate multiple `episode:scenario` pairs. They run sequentially, ~33 min each:
+
+```bash
+--episodes="ep1:scen1,ep2:scen2,ep3:scen3"
+```
+
+### Mode reference
+
+| Mode | Analysis | Recording | Use case |
+|------|----------|-----------|----------|
+| `record-parquet` | No | Yes | Offline testbench evaluation |
+| `live-anomaly-detection` | Yes | No | Live demo |
+| `live-and-record` | Yes | Yes | Evaluation (recommended) |
+
+## Step 3: Monitor the Run
+
+### Check status
+
+```bash
+KUBECONFIG=<kubeconfig> kubectl --context aws \
+  get configmap gensim-run-status -n default \
+  -o jsonpath='{.data.status}' | python3 -m json.tool
+```
+
+### Expected timeline (per episode)
+
+| Offset | Phase |
+|--------|-------|
+| +0 min | episode-install (helm chart + agent) |
+| +2-4 min | episode-running: warmup (2 min) |
+| +4-6 min | baseline (10 min) |
+| +14-16 min | disruption (10 min) |
+| +16-18 min | first observer events (BOCPD on virtual log metrics) |
+| +24-26 min | cooldown (10 min) |
+| +34-36 min | episode done, parquet collection |
+
+### Check events during the run
+
+```bash
+pup events search --query 'source:agent-q-branch-observer' --from 30m
+```
+
+If zero events 5+ minutes into disruption, check the orchestrator logs
+(see `debug-infra.md`).
+
+## Step 4: Validate Results
+
+### 4.1 Monitors
+
+Verify each episode's monitors transitioned OK -> Alert -> OK:
+
+```bash
+pup monitors list --name 'gensim'
+```
+
+Look for monitors tagged with the episode name. They should be in OK state
+(recovered after cooldown).
+
+### 4.2 Observer Events
+
+Count events and check which metrics were detected:
+
+```bash
+pup events search --query 'source:agent-q-branch-observer' --from '<start>' --to '<end>'
+```
+
+Parse the event messages to extract detected metric names. Cross-reference against
+the episode's `scenario.yaml` TP/FP lists, applying the trace metric name translation.
+
+### 4.3 Metric Signal Verification
+
+For each TP metric in scenario.yaml, query Datadog to confirm the disruption signal
+is actually present:
+
+```bash
+pup metrics query --query 'avg:<metric>{env:<episode-env-tag>}' \
+  --from '<baseline-start>' --to '<cooldown-end>'
+```
+
+The env tag follows the pattern `gensim-<episode-name-lowercased-hyphenated>`.
+
+Check that:
+- TP metrics show clear change during disruption window
+- FP metrics remain stable throughout
+
+### 4.4 Parquet Recordings
+
+If mode was `live-and-record` or `record-parquet`:
+
+```bash
+aws-vault exec sso-agent-sandbox-account-admin -- \
+  aws s3 ls s3://qbranch-gensim-recordings/ | grep <episode>
+```
+
+The zip contains four parquet types:
+- `observer-metrics-*.parquet` -- check metrics, DogStatsD (NOT trace-derived metrics)
+- `observer-trace-stats-*.parquet` -- pre-aggregated trace stats (source for trace metrics)
+- `observer-traces-*.parquet` -- raw spans
+- `observer-logs-*.parquet` -- log observations
+
+**Heads up**: Derived trace metrics (`trace.hits`, `trace.duration`, etc.) are NOT in
+the metrics parquet. They live in engine memory only, derived from trace-stats at
+runtime. The trace-stats parquet is the source of truth -- testbench replay re-derives
+them via `processStatsView`.
+
+## Checklist Summary
+
+Before submitting:
+- [ ] Episode exists with play-episode.sh, chart/, docker-compose.yaml
+- [ ] Scenario name identified from episodes/*.yaml
+- [ ] No `registry.ddbuild.io` refs in Dockerfiles
+- [ ] No runtime `docker compose build` in play-episode.sh
+- [ ] Gensim-episodes checkout is committed (not dirty)
+
+After completion:
+- [ ] Run status shows `done` for all episodes
+- [ ] Monitors created and transitioned OK -> Alert -> OK
+- [ ] Observer events fired during disruption window
+- [ ] TP metrics show expected signal in Datadog
+- [ ] FP metrics remain stable
+- [ ] Parquet uploaded to S3

--- a/.claude/skills/gensim-episode-management/debug-infra.md
+++ b/.claude/skills/gensim-episode-management/debug-infra.md
@@ -1,0 +1,232 @@
+# Debugging gensim-eks Infrastructure
+
+Troubleshooting guide for Pulumi, helm, kubectl, and cluster issues when running
+gensim episodes on EKS.
+
+## Diagnostic Flowchart
+
+Start here and follow the branch that matches the symptom:
+
+1. **Submit command fails** -> "Submit Failures" section
+2. **Run stuck in episode-install** -> "Orchestrator Failures" section
+3. **kubectl/pup commands fail** -> "Auth & Connectivity" section
+4. **Run completes but no events** -> "Detection Issues" section
+
+## Submit Failures
+
+### "Cluster already exists" (409 ResourceInUseException)
+
+Pulumi state lost track of the EKS cluster (usually from a cancelled `pulumi refresh`).
+Pulumi tries to CREATE it but AWS says it exists.
+
+**Fix**: Refresh state to rediscover the existing cluster:
+```bash
+cd test/e2e-framework/run
+pulumi refresh --stack <stack-name> --yes
+```
+
+If refresh doesn't help (the `aws:eks:Cluster` child resource was dropped), the
+nuclear option is destroy + recreate:
+```bash
+# 1. Delete the orphaned cluster from AWS
+aws-vault exec sso-agent-sandbox-account-admin -- \
+  aws eks delete-cluster --name <stack-name> --region us-east-1
+
+# 2. Wait for deletion (~3-5 min)
+watch -n 15 "aws-vault exec sso-agent-sandbox-account-admin -- \
+  aws eks describe-cluster --name <stack-name> --region us-east-1 \
+  --query 'cluster.status' --output text 2>&1"
+
+# 3. Destroy Pulumi state
+cd test/e2e-framework/run
+PULUMI_K8S_DELETE_UNREACHABLE=true pulumi destroy --stack <stack-name> --yes
+
+# 4. Resubmit (will create everything fresh, ~15 min)
+```
+
+### Stack lock
+
+Previous Pulumi run was interrupted or killed:
+```bash
+pulumi cancel --stack <stack-name> --yes
+```
+
+### "Scenario file not found"
+
+Wrong scenario name. List available scenarios:
+```bash
+ls gensim-episodes/*/<episode>/episodes/
+```
+
+### Build VM SSH timeout during refresh
+
+Pulumi refresh hangs trying to SSH into remote command resources on the build VM.
+Common after a weekend when the infra cleaner may have stopped instances.
+
+**Diagnose**: Check if the build VM exists and is reachable:
+```bash
+# Check EC2
+aws-vault exec sso-agent-sandbox-account-admin -- \
+  aws ec2 describe-instances --filters "Name=tag:Name,Values=*gensim-builder*" \
+  --query 'Reservations[].Instances[].{ID:InstanceId,State:State.Name,IP:PrivateIpAddress}' \
+  --region us-east-1 --output table
+
+# Test SSH connectivity (requires VPN/Appgate)
+nc -z -w 5 <private-ip> 22
+```
+
+If the VM exists and is reachable but Pulumi still hangs, it may be a pipe issue --
+don't pipe Pulumi output through `head` or `tail` as SIGPIPE kills the process.
+
+### Security group "DependencyViolation" during destroy
+
+The EKS cluster (which Pulumi doesn't know about) still references the security group.
+Delete the EKS cluster from AWS first (see "Cluster already exists" section above),
+then retry destroy.
+
+## Orchestrator Failures
+
+### "INSTALLATION FAILED: cannot re-use a name that is still in use"
+
+Stale helm release from a previous failed run. Helm tracks releases via secrets:
+
+```bash
+# List helm release secrets
+kubectl --context aws get secrets -n default -l owner=helm
+
+# Delete them
+kubectl --context aws delete secret -l owner=helm -n default
+
+# Delete the failed orchestrator job
+kubectl --context aws delete job gensim-orchestrator -n default
+
+# Resubmit
+```
+
+### "INSTALLATION FAILED: context deadline exceeded"
+
+Helm's `--wait` timed out. Usually NOT a resource issue. Check pod states:
+
+```bash
+kubectl --context aws get pods -n default -o wide
+```
+
+**ImagePullBackOff**: Pods are trying to pull from the wrong registry. If images
+reference `docker.io/gensim/<service>:latest` instead of
+`<ecr-registry>/gensim/<service>:latest`, the ECR registry wasn't passed to helm.
+This happens when `--skip-build` is used with the old code that didn't compute
+`imageRegistry`. The fix is in the `--skip-build` implementation (it now always
+resolves ECR).
+
+**Pending/Unschedulable**: Node is full. Check node resources:
+```bash
+kubectl --context aws describe node <node-name> | grep -A10 "Allocated resources"
+```
+
+### "invalid release name, must match regex... length must not be longer than 53"
+
+Episode name is too long for a helm release. The orchestrator truncates to
+`gensim-` + 46 chars. If you see this error, the truncation isn't working --
+check `orchestrator.sh.tmpl` line 142 for the `cut -c1-46`.
+
+### Orchestrator pod in Error state
+
+```bash
+kubectl --context aws logs -l job-name=gensim-orchestrator -n default --tail=30
+```
+
+The orchestrator is a Kubernetes Job with `restartPolicy: Never`. If it fails,
+you must delete the job before resubmitting:
+```bash
+kubectl --context aws delete job gensim-orchestrator -n default
+```
+
+## Auth & Connectivity
+
+### kubectl "Unauthorized" or "connection refused"
+
+**Stale kubeconfig**: After a cluster recreate, refresh:
+```bash
+aws-vault exec sso-agent-sandbox-account-admin -- \
+  aws eks update-kubeconfig --name <stack-name> --region us-east-1 \
+  --kubeconfig <kubeconfig-path>
+```
+
+**Wrong context**: The kubeconfig may have two contexts. Pulumi creates an `aws`
+context that works. The default context from `update-kubeconfig` may not:
+```bash
+kubectl --context aws get pods  # use this
+```
+
+**AWS STS expired**: kubectl shells out to `aws eks get-token` which needs valid
+AWS credentials:
+```bash
+aws-vault exec sso-agent-sandbox-account-admin -- aws sts get-caller-identity
+```
+
+### kubectl "no such host"
+
+The EKS cluster DNS was cleaned up (infra cleaner). The cluster needs to be
+recreated -- see "Submit Failures" section.
+
+### pup "authentication required"
+
+```bash
+pup auth login
+```
+
+This expires frequently (~30 min). Re-auth as needed.
+
+## Detection Issues
+
+### Zero events after disruption
+
+Checklist:
+1. **Is the episode actually in disruption?** Check run-status configmap phase.
+2. **Is analysis enabled?** Check deployed agent config:
+   ```bash
+   kubectl --context aws get configmap gensim-agent-values -n default -o yaml | grep -A5 "analysis"
+   ```
+3. **Is event_reporter.sending_enabled true?** Same configmap check.
+4. **Is min_cluster_size too high?** Most scenarios produce clusters of size 1-2.
+   If set to 3+, all events get filtered.
+5. **Is it just BOCPD warmup?** Virtual log metrics fire in ~2 min. Check/trace
+   metrics need 20-30 min of warmup. Be patient or check for log-based events.
+6. **Check pup auth** -- maybe events are firing but your query is failing silently.
+
+### Events fire but only on infrastructure metrics
+
+This is expected behavior. The observer detects on ALL metrics flowing through it,
+including container, coredns, and system metrics. The scenario-specific metrics
+(redis, trace, kafka) may not fire due to BOCPD warmup (see SKILL.md known issues).
+
+### ScanWelch fires in testbench but not live
+
+Known eviction bug. See SKILL.md "ScanWelch Eviction Bug" section. Use BOCPD for
+live evaluation. ScanWelch works for testbench/offline evaluation only.
+
+## Quick Recovery Playbook
+
+When everything is broken and you need a clean slate:
+
+```bash
+# 1. Cancel any Pulumi lock
+cd test/e2e-framework/run
+pulumi cancel --stack <stack-name> --yes 2>/dev/null
+
+# 2. Delete orphaned EKS cluster if it exists
+aws-vault exec sso-agent-sandbox-account-admin -- \
+  aws eks delete-cluster --name <stack-name> --region us-east-1 2>/dev/null
+
+# 3. Wait for deletion
+sleep 180  # or poll with aws eks describe-cluster
+
+# 4. Destroy Pulumi state
+PULUMI_K8S_DELETE_UNREACHABLE=true pulumi destroy --stack <stack-name> --yes
+
+# 5. Fresh submit
+cd <agent-repo>
+dda inv aws.eks.gensim.submit --image=<tag> --episodes=<ep:scen> --mode=live-and-record --s3-bucket=qbranch-gensim-recordings
+```
+
+Total time: ~20 min for clean-slate recovery.

--- a/.claude/skills/gensim-episode-management/debug-infra.md
+++ b/.claude/skills/gensim-episode-management/debug-infra.md
@@ -190,20 +190,27 @@ Checklist:
 3. **Is event_reporter.sending_enabled true?** Same configmap check.
 4. **Is min_cluster_size too high?** Most scenarios produce clusters of size 1-2.
    If set to 3+, all events get filtered.
-5. **Is it just BOCPD warmup?** Virtual log metrics fire in ~2 min. Check/trace
-   metrics need 20-30 min of warmup. Be patient or check for log-based events.
+5. **Have detectors completed warmup?** Detectors need a minimum number of data
+   points before they start detecting. High-frequency metrics (e.g. virtual logs
+   at ~1s) warm up fast; low-frequency metrics (e.g. check metrics at ~15s) may
+   need longer than the baseline phase. See `references/current-detector-issues.md`.
 6. **Check pup auth** -- maybe events are firing but your query is failing silently.
 
 ### Events fire but only on infrastructure metrics
 
-This is expected behavior. The observer detects on ALL metrics flowing through it,
-including container, coredns, and system metrics. The scenario-specific metrics
-(redis, trace, kafka) may not fire due to BOCPD warmup (see SKILL.md known issues).
+The observer detects on ALL metrics flowing through it, including container,
+coredns, and system metrics. Scenario-specific metrics (redis, trace, kafka) may
+not fire if the detector hasn't completed warmup for those slower-interval metrics.
+See `references/current-detector-issues.md` for current warmup requirements.
 
-### ScanWelch fires in testbench but not live
+### Detector works in testbench but not live
 
-Known eviction bug. See SKILL.md "ScanWelch Eviction Bug" section. Use BOCPD for
-live evaluation. ScanWelch works for testbench/offline evaluation only.
+Some detectors (e.g. batch/retrospective detectors like ScanWelch) may produce
+anomalies in testbench replay but not emit Datadog events in live mode. This can
+happen when the correlator's eviction window is shorter than the detector's
+detection delay. See `references/current-detector-issues.md` for details and
+check `engine.go` `runDetectorsAndCorrelatorsSnapshot()` for the current
+execution sequence.
 
 ## Quick Recovery Playbook
 

--- a/.claude/skills/gensim-episode-management/references/current-detector-issues.md
+++ b/.claude/skills/gensim-episode-management/references/current-detector-issues.md
@@ -1,0 +1,58 @@
+# Current Detector Issues (as of 2026-03)
+
+This file contains detector-specific known issues that change as the observer
+algorithms evolve. Verify these are still accurate before relying on them.
+
+## BOCPD Warmup
+
+BOCPD (Bayesian Online Changepoint Detection) needs `WarmupPoints` data points
+before it starts detecting. Check `DefaultBOCPDConfig()` in
+`comp/observer/impl/metrics_detector_bocpd.go` for the current value (120 as of
+this writing).
+
+Impact by metric frequency:
+
+| Metric type | Typical interval | Warmup time |
+|---|---|---|
+| Virtual log patterns | ~1s | ~2 min |
+| DogStatsD metrics | ~10s | ~20 min |
+| Check metrics (redis, pg) | ~15s | ~30 min |
+| Trace stats | ~10s | ~20 min |
+
+With a 10-minute baseline, only high-frequency metrics (virtual logs) complete
+warmup before disruption starts. Expect the observer to primarily fire on
+log-derived metrics for scenarios with slow-interval check/trace metrics.
+
+## ScanWelch / Batch Detector Eviction
+
+Batch detectors (ScanWelch, ScanMW) timestamp anomalies at the historical
+changepoint, not at detection time. The TimeCluster correlator's eviction window
+(`WindowSeconds`, default 120s in `DefaultTimeClusterConfig()`) can evict these
+anomalies before the EventReporter sees them.
+
+This means batch detectors work in testbench (which reads `rawAnomalies` directly)
+but may not produce Datadog events in live mode. The fix is to either:
+- Move `correlator.Advance()` before the detector loop in `engine.go`
+- Make `WindowSeconds` configurable and set it higher
+
+Check `comp/observer/impl/engine.go` `runDetectorsAndCorrelatorsSnapshot()` to
+see if this has been fixed.
+
+## Silent Observation Channel Drops
+
+The observer's observation channel (`observer.go` line ~235) has a fixed buffer
+with non-blocking sends. Under load, observations are silently dropped. This
+affects live mode only -- testbench replays bypass the channel entirely.
+
+Check `observer.go` for the current buffer size and whether drop metrics have
+been added.
+
+## min_cluster_size Filtering
+
+The TimeCluster correlator's `min_cluster_size` controls how many anomalies must
+cluster together (within `ProximitySeconds`) before an event is emitted. Most
+single-disruption scenarios produce clusters of size 1-2. Setting this to 3+
+filters out ALL events in many scenarios.
+
+For evaluation, use `min_cluster_size: 1`. For production noise reduction, tune
+based on observed cluster sizes in your specific scenarios.

--- a/q_branch/gensim-status.py
+++ b/q_branch/gensim-status.py
@@ -18,8 +18,8 @@ Usage:
     # 1. Submit an evaluation run
     dda inv aws.eks.gensim.submit --image=<agent-image> --episodes=<ep:scenario> --mode=record-parquet
 
-    # 2. Monitor it live with this TUI
-    uv run q_branch/gensim-status.py
+    # 2. Monitor it live with this TUI (run under aws-vault for EKS status)
+    aws-vault exec sso-agent-sandbox-account-admin -- uv run q_branch/gensim-status.py
 
     # Other useful commands
     dda inv aws.eks.gensim.status    # Quick non-interactive status check
@@ -53,8 +53,6 @@ _STACK_NAME = os.environ.get("GENSIM_STACK_NAME", f"{_USER}-gensim-eks")
 # All paths derived from stack name -- override via env vars if needed.
 KUBECONFIG = os.environ.get("KUBECONFIG", f"{_STACK_NAME}-kubeconfig.yaml")
 PULUMI_STATE = os.path.expanduser(os.environ.get("PULUMI_STATE", f"~/.pulumi/stacks/{_STACK_NAME}.json"))
-AWS_VAULT_PREFIX = os.environ.get("AWS_VAULT_PROFILE", "sso-agent-sandbox-account-admin").split()
-AWS_VAULT_PREFIX = ["aws-vault", "exec", *AWS_VAULT_PREFIX, "--"]
 EKS_CLUSTER_NAME = os.environ.get("EKS_CLUSTER_NAME", _STACK_NAME)
 EKS_REGION = os.environ.get("EKS_REGION", "us-east-1")
 
@@ -152,10 +150,12 @@ async def fetch_logs() -> str:
 
 
 async def fetch_eks_status() -> str:
-    """Fetch EKS cluster status via AWS CLI."""
+    """Fetch EKS cluster status via AWS CLI.
+
+    Expects AWS credentials in the environment (run the TUI under aws-vault exec).
+    """
     return await run_cmd(
         [
-            *AWS_VAULT_PREFIX,
             "aws",
             "eks",
             "describe-cluster",
@@ -715,6 +715,7 @@ class GensimStatusApp(App):
         self._node_counts: str = "?"
         self._pod_counts: str = "?"
         self._pod_list: list[dict[str, str]] = []
+        self._eks_failures: int = 0  # consecutive EKS poll failures for backoff
 
     # Minimum terminal height to show the pod logs panel
     _POD_LOGS_MIN_HEIGHT = 40
@@ -788,7 +789,25 @@ class GensimStatusApp(App):
         self.query_one(PodsWidget).content_text = build_pods_markup(self._pod_list)
 
     async def _poll_eks(self) -> None:
-        self._eks_status = await fetch_eks_status()
+        # Exponential backoff: skip polls after consecutive failures to avoid
+        # hammering AWS auth (which can open browser tabs on SSO expiry).
+        if self._eks_failures >= 3:
+            skip_rounds = min(2 ** (self._eks_failures - 3), 16)
+            if not hasattr(self, "_eks_skip_count"):
+                self._eks_skip_count = 0
+            self._eks_skip_count += 1
+            if self._eks_skip_count < skip_rounds:
+                return
+            self._eks_skip_count = 0
+
+        result = await fetch_eks_status()
+        if result:
+            self._eks_status = result
+            self._eks_failures = 0
+        else:
+            self._eks_failures += 1
+            if self._eks_failures == 3:
+                self._eks_status = "auth-error (backoff)"
         self._refresh_infra()
 
     def _refresh_episodes(self) -> None:

--- a/tasks/e2e_framework/aws/gensim_eks.py
+++ b/tasks/e2e_framework/aws/gensim_eks.py
@@ -191,15 +191,14 @@ def submit_gensim_eks(
 
     # ── 7. Compute ECR registry URL if any episode has docker-compose.yaml
     ecr_registry = ""
-    if skip_build:
-        tool.info("Skipping episode image build (--skip-build). Using cached ECR images.")
-    else:
-        for ep_name, _ in episode_pairs:
-            ep_dir = _find_episode_dir(gensim_repo_path, ep_name)
-            if (ep_dir / "docker-compose.yaml").exists():
-                ecr_registry, _ = _get_ecr_registry(ctx, aws_wrapper)
-                tool.info(f"ECR registry: {ecr_registry}")
-                break
+    for ep_name, _ in episode_pairs:
+        ep_dir = _find_episode_dir(gensim_repo_path, ep_name)
+        if (ep_dir / "docker-compose.yaml").exists():
+            ecr_registry, _ = _get_ecr_registry(ctx, aws_wrapper)
+            tool.info(f"ECR registry: {ecr_registry}")
+            if skip_build:
+                tool.info("Skipping episode image build (--skip-build). Using cached ECR images.")
+            break
 
     # ── 8. Deploy via Pulumi ──────────────────────────────────────────────
     extra_flags = {

--- a/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
@@ -139,7 +139,7 @@ for EP_SPEC in "${EP_LIST[@]}"; do
       CHART_DIR="/workspace/chart-$EPISODE"
     fi
 
-    EP_RELEASE="gensim-$(echo "$EPISODE" | tr '_' '-' | tr '[:upper:]' '[:lower:]')"
+    EP_RELEASE="gensim-$(echo "$EPISODE" | tr '_' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-46)"
 
     helm install "$EP_RELEASE" "$CHART_DIR" \
       --set agent.enabled=false \

--- a/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
@@ -177,7 +177,7 @@ for EP_SPEC in "${EP_LIST[@]}"; do
   # play-episode.sh requires DD_ENV, DD_API_KEY, DD_APP_KEY, KUBE_NAMESPACE.
   # DD_API_KEY, DD_APP_KEY, KUBE_NAMESPACE are set on the Job env. DD_ENV must
   # be set to the episode helm release name (used for monitor scoping).
-  export DD_ENV="gensim-$(echo "$EPISODE" | tr '_' '-' | tr '[:upper:]' '[:lower:]')"
+  export DD_ENV="$EP_RELEASE"
   EP_OUTCOME="success"
   bash /workspace/play-episode.sh run-episode "$SCENARIO" || EP_OUTCOME="failure"
   cd /


### PR DESCRIPTION
## Summary

- **Fix `--skip-build` ECR registry**: `--skip-build` was not passing the ECR registry URL to Pulumi, causing helm charts to reference Docker Hub instead of ECR (ImagePullBackOff). Now always computes ECR registry when episodes have docker-compose.yaml.
- **Fix helm release name length**: Long postmortem episode names exceeded helm's 53-char limit. Truncate episode portion to 46 chars.
- **Fix gensim-status TUI**: Remove inline aws-vault subprocess spawning (expects creds in env instead). Add exponential backoff for EKS status polling to avoid hammering auth on SSO expiry.
- **Add gensim episode management skill**: Structured skill for adding episodes to gensim-eks, split into add-episode workflow and infra debugging guide. Documents known issues (trace naming mismatch, BOCPD warmup, ScanWelch eviction, channel drops).

## Test plan

- [x] `--skip-build` fix validated: 3-episode batch run (Shopify, Cloudflare, Twilio) completed with 80 observer events
- [x] Helm name truncation validated: `546_cloudflare_october_2022_tiered_cache_outage` deployed successfully after fix
- [x] gensim-status TUI tested with aws-vault exec wrapper
- [ ] Skill reviewed by team for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)