### PR TITLE
[AGENTCFG-716] Give sgc to secret-manager with 550 perms

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -200,8 +200,8 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
   && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
   && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
   && chmod 755 /probe.sh /initlog.sh \
-  && chown root:secret-manager /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh \
-  && chmod 550 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh \
+  && chown root:secret-manager /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh /opt/datadog-agent/embedded/bin/secret-generic-connector \
+  && chmod 550 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh /opt/datadog-agent/embedded/bin/secret-generic-connector \
   # Keep the PAR config read-only, but group-readable so init containers can
   # copy it on OpenShift where containers run with a random UID in the root group.
   && chmod u=r,g=r,o= /etc/datadog-agent/private-action-runner/*


### PR DESCRIPTION
### What does this PR do?

To resolve [this issue](https://github.com/DataDog/datadog-agent/issues/48522), we want to follow the logic of the [cluster agent's docker file](https://github.com/DataDog/datadog-agent/blob/c60cac70b0eb2866788c5440f249ea8064cb8628/Dockerfiles/cluster-agent/Dockerfile#L83-L84), and give sgc 550 perms and ownership to the `secret-manager` user. We only want to make this change for containerized installs, and not host-based installs due to security concerns.

### Motivation

### Describe how you validated your changes

Ran the agent on docker with the reproduction steps described in the issue, and sgc works properly.

### Additional Notes
