### PR TITLE
Correct container host type for ECS MI when deployed as a daemon

### DIFF
--- a/pkg/process/checks/host_info.go
+++ b/pkg/process/checks/host_info.go
@@ -173,7 +173,10 @@ func getContainerHostType() model.ContainerHostType {
 	case fargate.EKS:
 		return model.ContainerHostType_fargateEKS
 	case fargate.ECSManagedInstances:
-		return model.ContainerHostType_sidecar
+		if fargate.IsSidecar() {
+			return model.ContainerHostType_sidecar
+		}
+		return model.ContainerHostType_notSpecified
 	}
 	return model.ContainerHostType_notSpecified
 }

--- a/pkg/process/checks/host_info_test.go
+++ b/pkg/process/checks/host_info_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	ipcclientmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
@@ -239,6 +240,66 @@ func TestGetHostnameShellCmd(t *testing.T) {
 	case "agent-empty_hostname":
 		assert.EqualValues(t, []string{"hostname"}, args)
 		fmt.Fprintf(os.Stdout, "")
+	}
+}
+
+func TestGetContainerHostType(t *testing.T) {
+	tests := []struct {
+		name         string
+		awsExecEnv   string
+		ecsExecEnv   string // ECS_FARGATE or empty
+		eksExecEnv   string // ECS_FARGATE for EKS
+		deployMode   string
+		features     []env.Feature
+		expectedType model.ContainerHostType
+	}{
+		{
+			name:         "not in a container environment",
+			expectedType: model.ContainerHostType_notSpecified,
+		},
+		{
+			name:         "ECS Fargate",
+			features:     []env.Feature{env.ECSFargate},
+			expectedType: model.ContainerHostType_fargateECS,
+		},
+		{
+			name:         "EKS Fargate",
+			features:     []env.Feature{env.EKSFargate},
+			expectedType: model.ContainerHostType_fargateEKS,
+		},
+		{
+			name:       "ECS Managed Instances sidecar mode",
+			awsExecEnv: "AWS_ECS_MANAGED_INSTANCES",
+			deployMode: "sidecar",
+			features:   []env.Feature{env.ECSManagedInstances},
+			// IsSidecar() reads IsECSManagedInstances() directly from env var, so t.Setenv is also needed
+			expectedType: model.ContainerHostType_sidecar,
+		},
+		{
+			name:         "ECS Managed Instances daemon mode reports a real host",
+			awsExecEnv:   "AWS_ECS_MANAGED_INSTANCES",
+			deployMode:   "daemon",
+			features:     []env.Feature{env.ECSManagedInstances},
+			expectedType: model.ContainerHostType_notSpecified,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.awsExecEnv != "" {
+				t.Setenv("AWS_EXECUTION_ENV", tc.awsExecEnv)
+			}
+			if tc.eksExecEnv != "" {
+				t.Setenv("EKS_FARGATE", tc.eksExecEnv)
+			}
+			if tc.deployMode != "" {
+				pkgconfigsetup.Datadog().SetWithoutSource("ecs_deployment_mode", tc.deployMode)
+				defer pkgconfigsetup.Datadog().SetWithoutSource("ecs_deployment_mode", "")
+			}
+			env.SetFeatures(t, tc.features...)
+
+			assert.Equal(t, tc.expectedType, getContainerHostType())
+		})
 	}
 }
 

--- a/releasenotes/notes/fix-ecs-managed-instances-daemon-host-type-f2c33d0b56980438.yaml
+++ b/releasenotes/notes/fix-ecs-managed-instances-daemon-host-type-f2c33d0b56980438.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The process check now reports the correct container host type on
+    ECS Managed Instances when the agent runs as a daemon.


### PR DESCRIPTION
### What does this PR do?

Fixes `getContainerHostType()` to correctly return `ContainerHostType_notSpecified` for ECS Managed Instances in **daemon mode**, rather than always returning `ContainerHostType_sidecar`.

Also adds a `TestGetContainerHostType` unit test covering all container host type cases (bare metal, ECS Fargate, EKS Fargate, ECS Managed Instances sidecar, ECS Managed Instances daemon).

### Motivation

On ECS Managed Instances in daemon mode, container check payloads were being sent with `ContainerHostType_sidecar`. This field is used to decide whether to associate containers and processes with a host — `sidecar` signals "no host identity" (Fargate-style), so containers were never tagged with the `host` tag even though a valid EC2 hostname was detected.

In daemon mode the agent runs once per instance, so `ContainerHostType_notSpecified` is correct and allows normal host association on the backend. In sidecar mode the task is the unit of identity (no host), so `ContainerHostType_sidecar` remains correct.


### Describe how you validated your changes

- Added `TestGetContainerHostType` unit test with 5 cases (no container env, ECS Fargate, EKS Fargate, ECS MI sidecar, ECS MI daemon) — all pass.
- Deployed agent with fix and verified that live process+containers are now tagged with host.

Before:
<img width="1048" height="325" alt="image" src="https://github.com/user-attachments/assets/471f45fa-c7ab-4a14-9d93-8e825c76ae54" />

After:
<img width="1044" height="335" alt="image" src="https://github.com/user-attachments/assets/78c27dc9-fbc0-465e-9d1a-f6de51b65f7a" />
