### PR TITLE
[ci] Allow oracle job to fail

### DIFF
--- a/.gitlab/test/functional_test/oracle.yml
+++ b/.gitlab/test/functional_test/oracle.yml
@@ -1,4 +1,5 @@
 oracle:
+  allow_failure: true #incident-51958
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   stage: functional_test


### PR DESCRIPTION
### What does this PR do?

Configure the oracle job as allowed to fail pre-emptively. 

### Motivation

#incident-51958

Related to: 
* https://github.com/DataDog/datadog-agent/pull/41527
* https://github.com/DataDog/datadog-agent/pull/41506

To be reverted once the job is happy and #incident-51958 is resolved

### Describe how you validated your changes

### Additional Notes
