### PR TITLE
Fix combined partial logs that go over the size limit

### DIFF
--- a/pkg/logs/internal/decoder/line_parser.go
+++ b/pkg/logs/internal/decoder/line_parser.go
@@ -69,9 +69,10 @@ type MultiLineParser struct {
 
 	// used to reconstruct the message
 
-	bufferedMsg *message.Message
-	buffer      *bytes.Buffer
-	rawDataLen  int
+	bufferedMsg       *message.Message
+	buffer            *bytes.Buffer
+	rawDataLen        int
+	bufferIsTruncated bool
 
 	// configuration attributes
 
@@ -125,6 +126,7 @@ func (p *MultiLineParser) process(input *message.Message, rawDataLen int) {
 	// track the raw data length and the timestamp so that the agent tails
 	// from the right place at restart
 	p.rawDataLen += rawDataLen
+	p.bufferIsTruncated = p.bufferIsTruncated || msg.ParsingExtra.IsTruncated
 	p.buffer.Write(msg.GetContent())
 	p.bufferedMsg = msg
 
@@ -148,16 +150,27 @@ func (p *MultiLineParser) sendLine() {
 		p.buffer.Reset()
 		p.bufferedMsg = nil
 		p.rawDataLen = 0
+		p.bufferIsTruncated = false
 	}()
 
 	if p.bufferedMsg == nil || p.buffer.Len() == 0 {
 		return
 	}
 
-	content := make([]byte, p.buffer.Len())
-	copy(content, p.buffer.Bytes())
+	bufferLen := p.buffer.Len()
+	contentLen := bufferLen
+	if contentLen > p.lineLimit {
+		contentLen = p.lineLimit
+	}
+
+	content := make([]byte, contentLen)
+	copy(content, p.buffer.Bytes()[:contentLen])
 	if len(content) > 0 || p.rawDataLen > 0 {
 		p.bufferedMsg.RawDataLen = p.rawDataLen
+		p.bufferedMsg.ParsingExtra.IsTruncated = p.bufferedMsg.ParsingExtra.IsTruncated ||
+			p.bufferIsTruncated ||
+			bufferLen > p.lineLimit ||
+			(p.bufferedMsg.ParsingExtra.IsPartial && bufferLen >= p.lineLimit)
 		p.bufferedMsg.SetContent(content)
 		p.lineHandler.process(p.bufferedMsg)
 	}

--- a/pkg/logs/internal/decoder/line_parser_test.go
+++ b/pkg/logs/internal/decoder/line_parser_test.go
@@ -201,6 +201,7 @@ func TestMultilineParserTruncatesReassembledKubernetesPartialLine(t *testing.T) 
 	firstChunk := strings.Repeat("a", 15)
 	secondChunk := strings.Repeat("b", 10)
 	combinedContent := firstChunk + secondChunk
+	t.Logf("combined message length: %d", len(combinedContent))
 
 	firstLine := []byte("2019-06-06T16:35:55.930852911Z stderr P " + firstChunk)
 	lineParser.process(message.NewMessage(firstLine, nil, "", 0), len(firstLine))
@@ -210,6 +211,7 @@ func TestMultilineParserTruncatesReassembledKubernetesPartialLine(t *testing.T) 
 	lineParser.process(message.NewMessage(secondLine, nil, "", 0), len(secondLine))
 
 	assert.NotNil(t, output)
+	t.Logf("emitted message length: %d", len(output.GetContent()))
 	assert.Equal(t, []byte(combinedContent+string(message.TruncatedFlag)), output.GetContent())
 	assert.Equal(t, len(firstLine)+len(secondLine), output.RawDataLen)
 	assert.Equal(t, message.StatusError, output.Status)

--- a/pkg/logs/internal/decoder/line_parser_test.go
+++ b/pkg/logs/internal/decoder/line_parser_test.go
@@ -8,6 +8,7 @@ package decoder
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -201,7 +202,7 @@ func TestMultilineParserTruncatesReassembledKubernetesPartialLine(t *testing.T) 
 	firstChunk := strings.Repeat("a", 15)
 	secondChunk := strings.Repeat("b", 10)
 	combinedContent := firstChunk + secondChunk
-	t.Logf("combined message length: %d", len(combinedContent))
+	fmt.Printf("combined message length: %d\n", len(combinedContent))
 
 	firstLine := []byte("2019-06-06T16:35:55.930852911Z stderr P " + firstChunk)
 	lineParser.process(message.NewMessage(firstLine, nil, "", 0), len(firstLine))
@@ -211,7 +212,7 @@ func TestMultilineParserTruncatesReassembledKubernetesPartialLine(t *testing.T) 
 	lineParser.process(message.NewMessage(secondLine, nil, "", 0), len(secondLine))
 
 	assert.NotNil(t, output)
-	t.Logf("emitted message length: %d", len(output.GetContent()))
+	fmt.Printf("emitted message length: %d\n", len(output.GetContent()))
 	assert.Equal(t, []byte(combinedContent+string(message.TruncatedFlag)), output.GetContent())
 	assert.Equal(t, len(firstLine)+len(secondLine), output.RawDataLen)
 	assert.Equal(t, message.StatusError, output.Status)

--- a/pkg/logs/internal/decoder/line_parser_test.go
+++ b/pkg/logs/internal/decoder/line_parser_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
@@ -185,4 +186,34 @@ func TestMultilineParserLimit(t *testing.T) {
 	message := <-lineHandler.ch
 	assert.Equal(t, "aaaa", string(message.GetContent()))
 	assert.Equal(t, message.RawDataLen, 13)
+}
+
+func TestMultilineParserTruncatesReassembledKubernetesPartialLine(t *testing.T) {
+	const contentLenLimit = 20
+
+	var output *message.Message
+
+	lineHandler := NewSingleLineHandler(func(msg *message.Message) {
+		output = msg
+	}, contentLenLimit)
+	lineParser := NewMultiLineParser(lineHandler, time.Second, kubernetes.New(), contentLenLimit)
+
+	firstChunk := strings.Repeat("a", 15)
+	secondChunk := strings.Repeat("b", 10)
+	combinedContent := firstChunk + secondChunk
+
+	firstLine := []byte("2019-06-06T16:35:55.930852911Z stderr P " + firstChunk)
+	lineParser.process(message.NewMessage(firstLine, nil, "", 0), len(firstLine))
+	assert.Nil(t, output)
+
+	secondLine := []byte("2019-06-06T16:35:55.930852912Z stderr F " + secondChunk)
+	lineParser.process(message.NewMessage(secondLine, nil, "", 0), len(secondLine))
+
+	assert.NotNil(t, output)
+	assert.Equal(t, []byte(combinedContent+string(message.TruncatedFlag)), output.GetContent())
+	assert.Equal(t, len(firstLine)+len(secondLine), output.RawDataLen)
+	assert.Equal(t, message.StatusError, output.Status)
+	assert.Equal(t, "2019-06-06T16:35:55.930852912Z", output.ParsingExtra.Timestamp)
+	assert.True(t, output.ParsingExtra.IsTruncated)
+	assert.Greater(t, len(output.GetContent()), contentLenLimit)
 }

--- a/pkg/logs/internal/decoder/line_parser_test.go
+++ b/pkg/logs/internal/decoder/line_parser_test.go
@@ -202,6 +202,7 @@ func TestMultilineParserTruncatesReassembledKubernetesPartialLine(t *testing.T) 
 	firstChunk := strings.Repeat("a", 15)
 	secondChunk := strings.Repeat("b", 10)
 	combinedContent := firstChunk + secondChunk
+	truncatedContent := combinedContent[:contentLenLimit]
 	fmt.Printf("combined message length: %d\n", len(combinedContent))
 
 	firstLine := []byte("2019-06-06T16:35:55.930852911Z stderr P " + firstChunk)
@@ -213,10 +214,10 @@ func TestMultilineParserTruncatesReassembledKubernetesPartialLine(t *testing.T) 
 
 	assert.NotNil(t, output)
 	fmt.Printf("emitted message length: %d\n", len(output.GetContent()))
-	assert.Equal(t, []byte(combinedContent+string(message.TruncatedFlag)), output.GetContent())
+	assert.Equal(t, []byte(truncatedContent+string(message.TruncatedFlag)), output.GetContent())
 	assert.Equal(t, len(firstLine)+len(secondLine), output.RawDataLen)
 	assert.Equal(t, message.StatusError, output.Status)
 	assert.Equal(t, "2019-06-06T16:35:55.930852912Z", output.ParsingExtra.Timestamp)
 	assert.True(t, output.ParsingExtra.IsTruncated)
-	assert.Greater(t, len(output.GetContent()), contentLenLimit)
+	assert.Equal(t, contentLenLimit+len(message.TruncatedFlag), len(output.GetContent()))
 }


### PR DESCRIPTION
### What does this PR do?
This pr truncates combined partial logs that go over the combined limit.
### Motivation
#incident-51914

https://dd.slack.com/archives/C0AQH2Q01S4/p1774899419366279?thread_ts=1774892247.956569&cid=C0AQH2Q01S4
### Describe how you validated your changes

### Additional Notes
