### PR TITLE
[AGNTLOG-570] Fix flaky TestADAnnotations in CCA off e2e test

### DIFF
--- a/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
@@ -77,7 +77,7 @@ func (v *k8sCCAOffSuite) TestADAnnotations() {
 		if assert.Contains(c, logsServiceNames, "ubuntu", "Ubuntu service not found") {
 			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("ubuntu")
 			assert.NoError(c, err, "Error filtering logs")
-			if assert.NotEmpty(v.T(), filteredLogs, "Fake Intake returned no logs even though log service name exists") {
+			if assert.NotEmpty(c, filteredLogs, "Fake Intake returned no logs even though log service name exists") {
 				assert.Equal(c, testLogMessage, filteredLogs[0].Message, "Test log doesn't match")
 			}
 		}


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `TestADAnnotations` where `assert.NotEmpty(v.T(), ...)` was used inside an `EventuallyWithT` callback instead of `assert.NotEmpty(c, ...)`. This caused the assertion to fail immediately on the test's `testing.T` rather than being collected by `assert.CollectT` for retry, defeating the purpose of `EventuallyWithT`.

## Motivation

The `TestK8sCCAOff/TestADAnnotations` E2E test has been intermittently failing on `main` (tracked by AGNTLOG-570). The failure occurs when FakeIntake has indexed the "ubuntu" service name but hasn't fully received the log payload yet. With `v.T()`, this transient state causes an immediate test failure instead of allowing `EventuallyWithT` to retry on the next 10-second poll.

The cascading effect is:
1. `TestADAnnotations` fails immediately via `v.T()`
2. The auto-retry mechanism re-runs `TestK8sCCAOff`, which calls `t.Parallel()` again, causing a panic
3. Sibling test `TestCCAOff` also fails as a result

## Describe how you validated your changes

- The fix matches the correct pattern already used in the companion test file `file_tailing_test.go` (line 82), which uses `c` (the `assert.CollectT`) for the same assertion and does not exhibit this flakiness.
- This is a single-character change (`v.T()` → `c`) with no behavioral change other than allowing proper retry semantics within `EventuallyWithT`.

## Additional Notes

- Only one file is changed: `test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go`
- No production code is affected; this is a test-only fix.
- A prior fix in commit `a88881ba188` (AGNTLOG-236) addressed a related issue by adding `sleep 10` to keep containers alive longer. This fix addresses the remaining assertion bug that was missed at that time.