### PR TITLE
[observer] Align trace stat metric names with backend convention

### DIFF
--- a/comp/observer/impl/stats_metrics.go
+++ b/comp/observer/impl/stats_metrics.go
@@ -72,7 +72,6 @@ func processStatsView(handle observerdef.Handle, stats observerdef.TraceStatsVie
 		handle.ObserveMetric(&statsMetricView{name: metricPrefix + ".hits", value: float64(row.GetHits()), tags: tags, timestampUnix: timestampUnix})
 		handle.ObserveMetric(&statsMetricView{name: metricPrefix + ".errors", value: float64(row.GetErrors()), tags: tags, timestampUnix: timestampUnix})
 		handle.ObserveMetric(&statsMetricView{name: metricPrefix + ".duration", value: float64(row.GetDurationNano()), tags: tags, timestampUnix: timestampUnix})
-		handle.ObserveMetric(&statsMetricView{name: metricPrefix + ".top_level_hits", value: float64(row.GetTopLevelHits()), tags: tags, timestampUnix: timestampUnix})
 
 		if okSummary := row.GetOkSummary(); len(okSummary) > 0 {
 			emitPercentiles(handle, metricPrefix, okSummary, tags, timestampUnix)

--- a/comp/observer/impl/stats_metrics.go
+++ b/comp/observer/impl/stats_metrics.go
@@ -40,6 +40,18 @@ var percentileQuantiles = []struct {
 }
 
 // processStatsView processes a TraceStatsView and emits derived metrics via ObserveMetric.
+//
+// Metric names follow the Datadog backend convention where the span operation
+// name is embedded in the metric name:
+//
+//	trace.{operation}.hits
+//	trace.{operation}.errors
+//	trace.{operation}.duration
+//	trace.{operation}.p50 … .p99       (ok latency percentiles)
+//	trace.{operation}.error.p50 … .p99 (error latency percentiles)
+//
+// The operation tag is intentionally omitted from the tag set because the
+// operation is already encoded in the metric name.
 func processStatsView(handle observerdef.Handle, stats observerdef.TraceStatsView) {
 	agentHostname := stats.GetAgentHostname()
 	agentEnv := stats.GetAgentEnv()
@@ -51,16 +63,22 @@ func processStatsView(handle observerdef.Handle, stats observerdef.TraceStatsVie
 		timestampUnix := int64(row.GetBucketStartUnixNano() / 1e9)
 		tags := buildStatsTagsFromRow(agentHostname, agentEnv, row)
 
-		handle.ObserveMetric(&statsMetricView{name: "trace.hits", value: float64(row.GetHits()), tags: tags, timestampUnix: timestampUnix})
-		handle.ObserveMetric(&statsMetricView{name: "trace.errors", value: float64(row.GetErrors()), tags: tags, timestampUnix: timestampUnix})
-		handle.ObserveMetric(&statsMetricView{name: "trace.duration", value: float64(row.GetDurationNano()), tags: tags, timestampUnix: timestampUnix})
-		handle.ObserveMetric(&statsMetricView{name: "trace.top_level_hits", value: float64(row.GetTopLevelHits()), tags: tags, timestampUnix: timestampUnix})
+		opName := row.GetName()
+		if opName == "" {
+			opName = "unknown"
+		}
+		metricPrefix := "trace." + opName
+
+		handle.ObserveMetric(&statsMetricView{name: metricPrefix + ".hits", value: float64(row.GetHits()), tags: tags, timestampUnix: timestampUnix})
+		handle.ObserveMetric(&statsMetricView{name: metricPrefix + ".errors", value: float64(row.GetErrors()), tags: tags, timestampUnix: timestampUnix})
+		handle.ObserveMetric(&statsMetricView{name: metricPrefix + ".duration", value: float64(row.GetDurationNano()), tags: tags, timestampUnix: timestampUnix})
+		handle.ObserveMetric(&statsMetricView{name: metricPrefix + ".top_level_hits", value: float64(row.GetTopLevelHits()), tags: tags, timestampUnix: timestampUnix})
 
 		if okSummary := row.GetOkSummary(); len(okSummary) > 0 {
-			emitPercentiles(handle, "trace.latency.ok", okSummary, tags, timestampUnix)
+			emitPercentiles(handle, metricPrefix, okSummary, tags, timestampUnix)
 		}
 		if errSummary := row.GetErrorSummary(); len(errSummary) > 0 {
-			emitPercentiles(handle, "trace.latency.error", errSummary, tags, timestampUnix)
+			emitPercentiles(handle, metricPrefix+".error", errSummary, tags, timestampUnix)
 		}
 	}
 }
@@ -114,9 +132,9 @@ func buildStatsTagsFromRow(agentHostname, agentEnv string, row observerdef.Trace
 	if row.GetService() != "" {
 		tags = append(tags, "service:"+row.GetService())
 	}
-	if row.GetName() != "" {
-		tags = append(tags, "operation:"+row.GetName())
-	}
+	// operation tag intentionally omitted: the operation name is embedded in
+	// the metric name (trace.{operation}.hits, etc.) matching the Datadog
+	// backend convention.
 	if row.GetResource() != "" {
 		tags = append(tags, "resource:"+quantizeResource(row.GetResource()))
 	}


### PR DESCRIPTION
### What does this PR do?

Expands the span operation name into trace stat metric names, matching the Datadog backend convention. Drops the now-redundant `operation:` tag from the metric tag set. Removes the `top_level_hits` metric which has no backend equivalent.

Before:
```
trace.hits      {service:billing, operation:redis.command, resource:SET}
trace.errors    {service:billing, operation:redis.command, resource:SET}
trace.duration  {service:billing, operation:redis.command, resource:SET}
trace.latency.ok.p95 {service:billing, operation:redis.command, ...}
```

After:
```
trace.redis.command.hits      {service:billing, resource:SET}
trace.redis.command.errors    {service:billing, resource:SET}
trace.redis.command.duration  {service:billing, resource:SET}
trace.redis.command.p95       {service:billing, resource:SET}
trace.redis.command.error.p95 {service:billing, resource:SET}
```

### Motivation

**User-facing correctness:** Observer anomaly events referenced flat metric names (`trace.hits`) that don't exist in Datadog. Users couldn't correlate these with what they see in Metrics Explorer or APM, where the real metrics are `trace.{operation}.hits`.

**Eval fidelity:** Ground truth scenarios (373/766 files, ~49%) use percentile queries like `p95:trace.http.request{...}` with `metric_name: trace.http.request`. The scoring pipeline's substring matcher (`score_tp.go:metricMatches`) matches `trace.http.request.p95` against ground truth `trace.http.request`. The old flat names (`trace.latency.ok.p95`) never matched, inflating unknown counts and deflating recall.

### Describe how you validated your changes

- `go build ./comp/observer/...` -- compiles clean
- `go test ./comp/observer/...` -- all tests pass
- Verified naming matches `dd-go/trace/intake/stats/converter.go` `makeMetricName()` which produces `trace.{name}.{measure}`, and `dd-go/trace/apps/trace-stats-counter/pipeline_test.go` which asserts metric names like `trace.a.hits`, `trace.b.hits`
- Confirmed via APM Stats Confluence (Metrics Origins table) that trace-stats-counter (TSC) is the canonical producer of these count metrics

### Additional Notes

- `top_level_hits` was removed entirely -- it has no backend equivalent and would cause false TP matches in eval scoring via the substring matcher.
- Percentile metrics (`trace.{op}.p50`..`.p99`) are observer-only derived metrics -- the backend stores DDSketches as distribution metrics and computes percentiles at query time. The expanded naming ensures the scoring substring matcher can link them back to ground truth entries.
- Falls back to `trace.unknown.{measure}` if the operation name is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)