### PR TITLE
fix(msi): Remove unused System.* NuGet polyfill packages from installer projects

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/CustomActions.Tests.csproj
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/CustomActions.Tests.csproj
@@ -133,20 +133,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http">
-      <Version>4.3.4</Version>
-    </PackageReference>
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.1</Version>
-    </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Algorithms">
-      <Version>4.3.1</Version>
-    </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.X509Certificates">
-      <Version>4.3.2</Version>
     </PackageReference>
     <!-- WiX 5 migration: Replaced WixSharp.bin with WixSharp_wix4 -->
     <PackageReference Include="WixSharp_wix4">

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/app.config
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/app.config
@@ -18,14 +18,6 @@
         <assemblyIdentity name="Fare" publicKeyToken="ea68d375bf33a7c8" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CustomActions.csproj
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CustomActions.csproj
@@ -116,12 +116,6 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
-    <PackageReference Include="System.Memory">
-      <Version>4.5.5</Version>
-    </PackageReference>
-    <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.5.4</Version>
-    </PackageReference>
     <PackageReference Include="YamlDotNet">
       <Version>13.0.1</Version>
     </PackageReference>

--- a/tools/windows/DatadogAgentInstaller/WixSetup.Tests/WixSetup.Tests.csproj
+++ b/tools/windows/DatadogAgentInstaller/WixSetup.Tests/WixSetup.Tests.csproj
@@ -80,20 +80,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http">
-      <Version>4.3.4</Version>
-    </PackageReference>
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.1</Version>
-    </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>6.0.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Algorithms">
-      <Version>4.3.1</Version>
-    </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.X509Certificates">
-      <Version>4.3.2</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Extensions">
       <Version>4.5.4</Version>

--- a/tools/windows/DatadogAgentInstaller/WixSetup.Tests/app.config
+++ b/tools/windows/DatadogAgentInstaller/WixSetup.Tests/app.config
@@ -15,14 +15,6 @@
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Fare" publicKeyToken="ea68d375bf33a7c8" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
       </dependentAssembly>


### PR DESCRIPTION
### What does this PR do?

Removes unused .NET polyfill NuGet packages and their binding redirects from the MSI installer projects.

**Install-time (CustomActions.csproj):**
- `System.Memory` 4.5.5
- `System.Threading.Tasks.Extensions` 4.5.4

**Test projects (CustomActions.Tests, WixSetup.Tests):**
- `System.Net.Http` 4.3.4
- `System.Runtime` 4.3.1
- `System.Security.Cryptography.Algorithms` 4.3.1
- `System.Security.Cryptography.X509Certificates` 4.3.2

**Binding redirects (test app.configs):**
- `System.Memory`
- `System.Buffers`

Packages confirmed needed were kept:
- `System.Threading.Tasks.Extensions` (WixSetup.Tests only) — required by Moq at runtime
- `System.Runtime.CompilerServices.Unsafe` — real transitive dependency, restored by MSBuild

### Motivation

These polyfill packages were added in #13459 and #15862 but were never actually used. They were **never bundled into the custom action cabinet** in any shipped MSI — verified by extracting and comparing the CA DLL contents across 7.50.3 (WiX 3), 7.76.3 (WiX 3), and 7.77.0 (WiX 5) using `7z`.

The CustomActions code uses `System.Net.WebClient` and `RNGCryptoServiceProvider` (from the .NET Framework GAC), not the NuGet polyfill versions of `System.Net.Http` or `System.Security.Cryptography.Algorithms`. No code references types from `System.Memory` or `System.Security.Cryptography.X509Certificates`.

Cleaning these up reduces confusion about what the custom actions actually depend on. See [WINA-2536](https://datadoghq.atlassian.net/browse/WINA-2536) for full investigation details. Related to [WINA-1313](https://datadoghq.atlassian.net/browse/WINA-1313).

### Describe how you validated your changes

1. `dda inv -e msi.build --debug` — builds successfully
2. `dda inv -e msi.test --debug` — all 104 unit tests pass
3. Deleted each removed DLL from build output, rebuilt — MSBuild did not restore them (confirming nothing in the dependency graph requires them)
4. Deleted DLLs from build output and re-ran tests without rebuilding — all 104 tests still pass (confirming no runtime dependency)
5. Verified these DLLs were never shipped in MSI versions 7.50.3, 7.76.3, or 7.77.0

### Additional Notes

The test projects still reference `System.Threading.Tasks.Extensions` and `System.Runtime.CompilerServices.Unsafe` — these are real transitive dependencies (Moq needs the former; MSBuild restores the latter during build). Removing them causes test failures.

[WINA-2536]: https://datadoghq.atlassian.net/browse/WINA-2536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ