### PR TITLE
[OTAGENT-825] Add E2E tests for dogtelextension in standalone mode 

### DIFF
--- a/test/new-e2e/tests/otel/otel-agent/config/dogtel-secrets.yml
+++ b/test/new-e2e/tests/otel/otel-agent/config/dogtel-secrets.yml
@@ -1,0 +1,60 @@
+extensions:
+  dogtel:
+    enable_tagger_server: true
+    tagger_server_port: 15555
+    tagger_server_addr: "0.0.0.0"
+    enable_metadata_collection: true
+  pprof:
+  health_check:
+  zpages:
+    endpoint: "localhost:55679"
+  ddflare:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  datadog:
+    metrics:
+      resource_attributes_as_tags: true
+    api:
+      key: ${env:DD_API_KEY}
+    sending_queue:
+      batch:
+
+processors:
+  infraattributes:
+    cardinality: 2
+    allow_hostname_override: true
+
+connectors:
+  datadog/connector:
+    traces:
+      compute_stats_by_span_kind: true
+      compute_top_level_by_span_kind: true
+      peer_tags_aggregation: true
+
+service:
+  extensions: [dogtel, pprof, health_check, zpages, ddflare]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [infraattributes]
+      exporters: [datadog/connector]
+    traces/send:
+      receivers: [otlp]
+      processors: [infraattributes]
+      exporters: [datadog]
+    metrics:
+      receivers: [otlp, datadog/connector]
+      processors: [infraattributes]
+      exporters: [datadog]
+    logs:
+      receivers: [otlp]
+      processors: [infraattributes]
+      exporters: [datadog]

--- a/test/new-e2e/tests/otel/otel-agent/config/dogtel-standalone.yml
+++ b/test/new-e2e/tests/otel/otel-agent/config/dogtel-standalone.yml
@@ -1,0 +1,59 @@
+extensions:
+  dogtel:
+    enable_tagger_server: true
+    tagger_server_port: 15555
+    tagger_server_addr: "0.0.0.0"
+    enable_metadata_collection: true
+  pprof:
+  health_check:
+  zpages:
+    endpoint: "localhost:55679"
+  ddflare:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  datadog:
+    metrics:
+      resource_attributes_as_tags: true
+    api:
+      key: ${env:DD_API_KEY}
+    sending_queue:
+      batch:
+
+processors:
+  infraattributes:
+    cardinality: 2
+
+connectors:
+  datadog/connector:
+    traces:
+      compute_stats_by_span_kind: true
+      compute_top_level_by_span_kind: true
+      peer_tags_aggregation: true
+
+service:
+  extensions: [dogtel, pprof, health_check, zpages, ddflare]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [infraattributes]
+      exporters: [datadog/connector]
+    traces/send:
+      receivers: [otlp]
+      processors: [infraattributes]
+      exporters: [datadog]
+    metrics:
+      receivers: [otlp, datadog/connector]
+      processors: [infraattributes]
+      exporters: [datadog]
+    logs:
+      receivers: [otlp]
+      processors: [infraattributes]
+      exporters: [datadog]

--- a/test/new-e2e/tests/otel/otel-agent/dogtel_secrets_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/dogtel_secrets_test.go
@@ -1,0 +1,159 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package otelagent contains e2e otel agent tests
+package otelagent
+
+import (
+	_ "embed"
+	"testing"
+	"time"
+
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent"
+	fakeintakeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
+	otelstandalone "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/otel-standalone"
+	scenkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
+	provkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
+	provlocal "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/local/kubernetes"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/otel/utils"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+)
+
+//go:embed config/dogtel-secrets.yml
+var dogtelSecretsConfig string
+
+const (
+	dogtelSecretsNamespace = "datadog"
+	dogtelSecretsName      = "dogtel-secrets"
+	// dogtelResolvedHostname is the hostname value stored in the K8s secret.
+	// If secretsfx.Module() is active the ENC[] handle resolves to this value;
+	// the noop impl would leave the raw "ENC[file@...]" literal unchanged.
+	dogtelResolvedHostname = "dogtel-secrets-test-host"
+)
+
+// dogtelSecretsTestSuite verifies that secretsfx.Module() (real secrets) is wired
+// when DD_OTEL_STANDALONE=true by confirming ENC[] handle resolution end-to-end.
+type dogtelSecretsTestSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+}
+
+// dogtelSecretsStandaloneProvisioner returns a provisioner that deploys the
+// otel-agent as a standalone DaemonSet (no core agent, no Helm chart) with:
+//   - A Kubernetes secret pre-created containing the resolved hostname
+//   - DD_SECRET_BACKEND_COMMAND pointing at the built-in multi-provider script
+//   - DD_HOSTNAME=ENC[file@...] referencing the secret
+//
+// Using the standalone DaemonSet avoids sidecar interference: in Helm sidecar
+// mode the core agent's hostname resolution can shadow the otel-agent container's
+// own DD_HOSTNAME env var.
+func dogtelSecretsStandaloneProvisioner() provisioners.TypedProvisioner[environments.Kubernetes] {
+	deployFn := func(e config.Env, kubeProvider *kubernetes.Provider, fi *fakeintakeComp.Fakeintake) (*agent.KubernetesAgent, error) {
+		return otelstandalone.K8sAppDefinition(
+			e, kubeProvider, dogtelSecretsNamespace, dogtelSecretsConfig, fi,
+			// Pre-create the K8s secret so it is mounted when the pod starts.
+			otelstandalone.WithK8sSecret(dogtelSecretsName, map[string]string{
+				"hostname": dogtelResolvedHostname,
+			}),
+			// Supply DD_HOSTNAME via ENC[] before the default downward-API entry.
+			// WithoutDefaultHostname() prevents the downward-API spec.nodeName
+			// entry from being added; Go's os.Getenv returns the first match, so
+			// the extra env vars must come first — which K8sAppDefinition guarantees.
+			otelstandalone.WithoutDefaultHostname(),
+			otelstandalone.WithExtraEnvVars(
+				&corev1.EnvVarArgs{
+					Name:  pulumi.String("DD_HOSTNAME"),
+					Value: pulumi.String("ENC[file@/etc/dogtel-secrets/hostname]"),
+				},
+				&corev1.EnvVarArgs{
+					Name:  pulumi.String("DD_SECRET_BACKEND_COMMAND"),
+					Value: pulumi.String("/readsecret_multiple_providers.sh"),
+				},
+			),
+			// Mount the K8s secret into the container.
+			otelstandalone.WithExtraVolumes(
+				&corev1.VolumeArgs{
+					Name: pulumi.String(dogtelSecretsName),
+					Secret: &corev1.SecretVolumeSourceArgs{
+						SecretName: pulumi.String(dogtelSecretsName),
+					},
+				},
+			),
+			otelstandalone.WithExtraVolumeMounts(
+				&corev1.VolumeMountArgs{
+					Name:      pulumi.String(dogtelSecretsName),
+					MountPath: pulumi.String("/etc/dogtel-secrets"),
+					ReadOnly:  pulumi.BoolPtr(true),
+				},
+			),
+		)
+	}
+
+	if isKindLocal() {
+		return provlocal.Provisioner(
+			provlocal.WithStandaloneOTelAgent(deployFn),
+		)
+	}
+	return provkindvm.Provisioner(
+		provkindvm.WithRunOptions(
+			scenkindvm.WithStandaloneOTelAgent(deployFn),
+		),
+	)
+}
+
+// TestOTelAgentDogtelSecretsStandalone is the entry point for the secrets suite.
+// It provisions a KindVM cluster and deploys the otel-agent as a standalone
+// DaemonSet pre-configured with ENC[] secrets resolution.
+func TestOTelAgentDogtelSecretsStandalone(t *testing.T) {
+	t.Parallel()
+	e2e.Run(t, &dogtelSecretsTestSuite{},
+		e2e.WithProvisioner(dogtelSecretsStandaloneProvisioner()),
+	)
+}
+
+func (s *dogtelSecretsTestSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure()
+	utils.TestCalendarApp(s, false, utils.CalendarService)
+}
+
+// TestDogtelSecretsResolution verifies that secretsfx.Module() (the real secrets
+// implementation) is active in standalone mode by confirming that an ENC[file@...]
+// handle in DD_HOSTNAME is resolved to the actual value at agent startup.
+//
+// The K8s secret and all secrets configuration are set up in the provisioner
+// (via WithK8sSecret and WithExtraEnvVars) so they are present when the agent
+// pod starts — no UpdateEnv mid-test is required.
+//
+// If the noop secrets impl were wired, os.Getenv("DD_HOSTNAME") would return
+// the raw "ENC[file@/etc/dogtel-secrets/hostname]" literal, the agent would
+// fall back to auto-detection, and tp.Hostname would be the node name.
+func (s *dogtelSecretsTestSuite) TestDogtelSecretsResolution() {
+	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	require.NoError(s.T(), err)
+
+	s.T().Logf("Waiting for traces with resolved hostname %q", dogtelResolvedHostname)
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		traces, err := s.Env().FakeIntake.Client().GetTraces()
+		assert.NoError(c, err)
+		assert.NotEmpty(c, traces)
+		for _, trace := range traces {
+			for _, tp := range trace.TracerPayloads {
+				assert.Equal(c, dogtelResolvedHostname, tp.Hostname,
+					"hostname should be the resolved ENC[] value, not the raw handle; "+
+						"raw value would indicate secretsnoopfx is wired instead of secretsfx")
+			}
+		}
+	}, 5*time.Minute, 10*time.Second)
+}

--- a/test/new-e2e/tests/otel/otel-agent/dogtel_standalone_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/dogtel_standalone_test.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package otelagent contains e2e otel agent tests
+package otelagent
+
+import (
+	_ "embed"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent"
+	fakeintakeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
+	otelstandalone "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/otel-standalone"
+	scenkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
+	provkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
+	provlocal "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/local/kubernetes"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner/parameters"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/otel/utils"
+)
+
+//go:embed config/dogtel-standalone.yml
+var dogtelStandaloneConfig string
+
+// dogtelStandaloneTestSuite tests the dogtelextension running in standalone mode
+// (DD_OTEL_STANDALONE=true). In this mode the extension starts its own workloadmeta
+// store, tagger, and tagger gRPC server, providing Kubernetes infrastructure
+// attribute enrichment independently of a co-located core Datadog Agent.
+type dogtelStandaloneTestSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+}
+
+// dogtelStandaloneProvisioner returns the appropriate provisioner based on the
+// E2E_DEV_LOCAL / E2E_PROVISIONER config, mirroring the SSI test pattern.
+// - kind-local (or E2E_DEV_LOCAL=true): uses a local KinD cluster
+// - default: uses KinD-on-EC2 (AWS)
+func dogtelStandaloneProvisioner() provisioners.TypedProvisioner[environments.Kubernetes] {
+	deployFn := func(e config.Env, kubeProvider *kubernetes.Provider, fi *fakeintakeComp.Fakeintake) (*agent.KubernetesAgent, error) {
+		return otelstandalone.K8sAppDefinition(e, kubeProvider, "datadog", dogtelStandaloneConfig, fi)
+	}
+	if isKindLocal() {
+		return provlocal.Provisioner(
+			provlocal.WithStandaloneOTelAgent(deployFn),
+		)
+	}
+	return provkindvm.Provisioner(
+		provkindvm.WithRunOptions(
+			scenkindvm.WithStandaloneOTelAgent(deployFn),
+		),
+	)
+}
+
+// isKindLocal returns true when E2E_DEV_LOCAL=true or E2E_PROVISIONER=kind-local.
+func isKindLocal() bool {
+	devLocal, err := runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.DevLocal, false)
+	if err == nil && devLocal {
+		return true
+	}
+	provisioner, err := runner.GetProfile().ParamStore().GetWithDefault(parameters.Provisioner, "")
+	return err == nil && strings.EqualFold(provisioner, "kind-local")
+}
+
+// TestDogtelStandalone is the entry point for the suite.
+// It provisions a KindVM cluster and deploys the otel-agent as a standalone
+// DaemonSet (no Helm chart, no core agent) with DD_OTEL_STANDALONE=true.
+// The dogtel-standalone OTel config enables the dogtelextension with a tagger
+// gRPC server on port 15555.
+//
+// The name is intentionally short (≤20 lowercase chars) to prevent Kubernetes
+// from truncating pod names: deployment name = "calendar-rest-go-" + lowercase(TestName).
+// Kubernetes truncates pod generateName at 57 chars, so RS names > 57 chars cause
+// pod names to omit part of the RS hash, breaking testInfraTags assertions.
+func TestDogtelStandalone(t *testing.T) {
+	t.Parallel()
+	e2e.Run(t, &dogtelStandaloneTestSuite{},
+		e2e.WithProvisioner(dogtelStandaloneProvisioner()),
+	)
+}
+
+var dogtelParams = utils.IAParams{
+	InfraAttributes: true,
+	EKS:             false,
+	Cardinality:     types.LowCardinality,
+}
+
+func (s *dogtelStandaloneTestSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure()
+	// Verify the liveness metric BEFORE TestCalendarApp flushes the aggregators.
+	// The metric is emitted once by dogtelextension.Start() at startup; it must be
+	// captured here before FlushServerAndResetAggregators() clears it.
+	s.T().Log("Waiting for dogtel liveness metric before aggregator flush")
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		metrics, err := s.Env().FakeIntake.Client().FilterMetrics(utils.DogtelLivenessMetricName)
+		assert.NoError(c, err)
+		assert.NotEmpty(c, metrics)
+	}, 5*time.Minute, 10*time.Second, "dogtel liveness metric not received after agent startup")
+	utils.TestCalendarApp(s, false, utils.CalendarService)
+}
+
+// TestDogtelAgentInstalled checks the otel-agent pod is running with the dogtelextension.
+func (s *dogtelStandaloneTestSuite) TestDogtelAgentInstalled() {
+	utils.TestOTelAgentInstalled(s)
+}
+
+// TestDogtelLivenessMetric verifies that the extension reports itself running.
+// The metric is checked in SetupSuite before the first aggregator flush.
+// If the binary emits the metric periodically (heartbeat), this test will also
+// catch a post-flush emission; otherwise it passes because SetupSuite already verified it.
+func (s *dogtelStandaloneTestSuite) TestDogtelLivenessMetric() {
+	metrics, err := s.Env().FakeIntake.Client().FilterMetrics(utils.DogtelLivenessMetricName)
+	require.NoError(s.T(), err)
+	if len(metrics) > 0 {
+		// Metric present (heartbeat or not yet flushed).
+		s.T().Log("Got dogtel liveness metric:", metrics[0])
+		require.NotEmpty(s.T(), metrics[0].Points)
+		assert.Equal(s.T(), 1.0, metrics[0].Points[0].Value, "otel.dogtel_extension.running should always be 1.0")
+	} else {
+		// Already flushed since SetupSuite; the metric was verified there.
+		s.T().Log("Liveness metric was verified in SetupSuite; not yet re-emitted since last flush (no heartbeat)")
+	}
+}
+
+// TestDogtelTaggerServerRunning confirms the tagger gRPC server is bound to
+// port 15555 inside the otel-agent container, as configured in dogtel-standalone.yml.
+// The server is started by dogtelextension.startTaggerServer() and exposes the
+// workloadmeta-backed tagger to remote clients over mTLS.
+func (s *dogtelStandaloneTestSuite) TestDogtelTaggerServerRunning() {
+	utils.TestDogtelTaggerServerRunning(s, 15555)
+}
+
+// TestDogtelOTLPTraces verifies OTLP traces are enriched with Kubernetes workloadmeta
+// tags (kube_deployment, pod_name, kube_namespace, etc.) via the infraattributes processor.
+// In standalone mode these tags come from the tagger started by dogtelextension, which
+// subscribes to the local workloadmeta store that watches the Kubernetes API.
+func (s *dogtelStandaloneTestSuite) TestDogtelOTLPTraces() {
+	utils.TestTraces(s, dogtelParams)
+}
+
+// TestDogtelOTLPMetrics verifies OTLP metrics carry Kubernetes workloadmeta tags.
+func (s *dogtelStandaloneTestSuite) TestDogtelOTLPMetrics() {
+	utils.TestMetrics(s, dogtelParams)
+}
+
+// TestDogtelOTLPLogs verifies OTLP logs carry Kubernetes workloadmeta tags.
+func (s *dogtelStandaloneTestSuite) TestDogtelOTLPLogs() {
+	utils.TestLogs(s, dogtelParams)
+}
+
+// TestDogtelHosts verifies that traces, metrics, and logs all report the same
+// hostname, which in standalone mode is resolved by dogtelextension's hostname
+// component (backed by the k8s node name from workloadmeta).
+func (s *dogtelStandaloneTestSuite) TestDogtelHosts() {
+	utils.TestHosts(s)
+}

--- a/test/new-e2e/tests/otel/utils/dogtel_utils.go
+++ b/test/new-e2e/tests/otel/utils/dogtel_utils.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package utils contains util functions for OTel e2e tests
+package utils
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+)
+
+const (
+	// DogtelLivenessMetricName is the metric emitted by the dogtelextension on every Start()
+	DogtelLivenessMetricName = "otel.dogtel_extension.running"
+)
+
+// TestDogtelLivenessMetric verifies that the dogtelextension emits its liveness gauge metric.
+// The metric is sent on Start() when otel_standalone=true and should appear in the fake intake.
+func TestDogtelLivenessMetric(s OTelTestSuite) {
+	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	require.NoError(s.T(), err)
+
+	s.T().Log("Waiting for dogtel liveness metric:", DogtelLivenessMetricName)
+	var metrics []*aggregator.MetricSeries
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		metrics, err = s.Env().FakeIntake.Client().FilterMetrics(DogtelLivenessMetricName)
+		assert.NoError(c, err)
+		assert.NotEmpty(c, metrics)
+	}, 5*time.Minute, 10*time.Second)
+
+	require.NotEmpty(s.T(), metrics)
+	s.T().Log("Got dogtel liveness metric:", metrics[0])
+
+	// The metric should be a gauge with value 1.0
+	m := metrics[0]
+	require.NotEmpty(s.T(), m.Points)
+	assert.Equal(s.T(), 1.0, m.Points[0].Value, "otel.dogtel_extension.running should always be 1.0")
+}
+
+// TestDogtelTaggerServerRunning verifies that the dogtel tagger gRPC server is listening
+// on the expected port inside the otel-agent container.
+func TestDogtelTaggerServerRunning(s OTelTestSuite, port int) {
+	agent := getAgentPod(s)
+	portHex := fmt.Sprintf("%04X", port)
+	// /proc/net/tcp6 lists listening sockets; the local address column is ADDR:PORT
+	// where PORT is the port in uppercase hex (big-endian).
+	cmd := []string{
+		"/bin/sh", "-c",
+		// /proc/net/tcp format: "XXXXXXXX:PPPP XXXXXXXX:PPPP STATE ..."
+		// The port appears as ":PPPP " (colon before, space after), not " PPPP ".
+		fmt.Sprintf("grep -i ':%s ' /proc/net/tcp6 /proc/net/tcp 2>/dev/null | grep ' 0A '", portHex),
+	}
+	s.T().Logf("Checking that tagger gRPC server is listening on port %d (0x%s)", port, portHex)
+	stdout, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", agent.Name, "otel-agent", cmd)
+	require.NoError(s.T(), err, "Tagger gRPC server should be listening on port %d", port)
+	require.NotEmpty(s.T(), stdout, "Expected a LISTEN entry for port %d in /proc/net/tcp", port)
+}


### PR DESCRIPTION
### What does this PR do?
Add E2E tests for dogtelextension in standalone mode 

New test suite TestOTelAgentDogtelExtensionStandalone verifies dogtelextension
behavior when DD_OTEL_STANDALONE=true in a KindVM Kubernetes environment:

- TestDogtelLivenessMetric: otel.dogtel_extension.running gauge (value=1)
  is received in fake intake, confirming the extension Start() lifecycle
- TestDogtelTaggerServerRunning: tagger gRPC server is listening on port 15555
  (checked via /proc/net/tcp inside the otel-agent container)
- TestDogtelOTLPTraces/Metrics/Logs: telemetry carries Kubernetes workloadmeta
  tags (kube_deployment, pod_name, kube_namespace, etc.) from the
  infraattributes processor backed by dogtelextension's local tagger
- TestDogtelHosts: hostname is consistent across traces, metrics, and logs
- TestDogtelSecretsResolution: secrets are resolved in standalone DaemonSet mode

### Motivation
[Standalone Dogtel Agent](http://docs.google.com/document/d/1JqX6qBUzF4QmWqjrO36EoMsXmyDHLxLEH1H2L2CDbmQ/edit?tab=t.qmhbvn69x67j#heading=h.og2yc74n1ngi)

### Describe how you validated your changes
new e2e tests

### Additional Notes
