### PR TITLE
Upgrade AWS Pulumi to v6.83.1

### DIFF
--- a/test/e2e-framework/go.mod
+++ b/test/e2e-framework/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.6.0
 	github.com/pkg/sftp v1.13.9
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.66.2
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.83.1
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.19.0
 	github.com/pulumi/pulumi-azure-native-sdk/authorization/v2 v2.81.0
 	github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.81.0

--- a/test/e2e-framework/go.sum
+++ b/test/e2e-framework/go.sum
@@ -397,8 +397,8 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.17.0 h1:oaVOIyFTENlYDuqc3pW75lQT9jb2cd6ie/4/Twxn66w=
 github.com/pulumi/esc v0.17.0/go.mod h1:XnSxlt5NkmuAj304l/gK4pRErFbtqq6XpfX1tYT9Jbc=
-github.com/pulumi/pulumi-aws/sdk/v6 v6.66.2 h1:mHiPVwdSQp5VjpvCdPy52FeMiNcscKvJP+len/mfqdU=
-github.com/pulumi/pulumi-aws/sdk/v6 v6.66.2/go.mod h1:C+L8LtajPSwGsZiGgknkCwClUzXk+ZXzSGkOZTQMp3U=
+github.com/pulumi/pulumi-aws/sdk/v6 v6.83.1 h1:46AF76KQV+1ER+Mg47Ke+0ONiNf1q0qKdIMVQcPmuPs=
+github.com/pulumi/pulumi-aws/sdk/v6 v6.83.1/go.mod h1:520DDoW2zBYVWwwAT8qt/9VhNoBcDIslDljzE8/O080=
 github.com/pulumi/pulumi-awsx/sdk/v2 v2.19.0 h1:jil2EBzZnKsRDrLfvx2gnAaq17HQLrTbpPsIb3h+98U=
 github.com/pulumi/pulumi-awsx/sdk/v2 v2.19.0/go.mod h1:r+K4M7jnLqvvQDeR/0mBRq2EPZaqsDg24Ciy3ml/thA=
 github.com/pulumi/pulumi-azure-native-sdk/authorization/v2 v2.81.0 h1:Njext/i2DuW6k9qMj7WJmIBuw7PLZ8ccTYEtU3PbX5s=

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -2,10 +2,6 @@ module github.com/DataDog/datadog-agent/test/new-e2e
 
 go 1.25.0
 
-// Do not upgrade Pulumi plugins to versions different from `test-infra-definitions`.
-// The plugin versions NEED to be aligned.
-// TODO: Implement hard check in CI
-
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.184
 	github.com/DataDog/datadog-agent/pkg/util/option v0.76.0-rc.4
@@ -30,7 +26,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/kr/pretty v0.3.1
 	github.com/pkg/sftp v1.13.9 // indirect
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.66.2
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.83.1
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.19.0
 	github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.23.0
 	github.com/pulumi/pulumi/sdk/v3 v3.190.0

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -500,8 +500,8 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.17.0 h1:oaVOIyFTENlYDuqc3pW75lQT9jb2cd6ie/4/Twxn66w=
 github.com/pulumi/esc v0.17.0/go.mod h1:XnSxlt5NkmuAj304l/gK4pRErFbtqq6XpfX1tYT9Jbc=
-github.com/pulumi/pulumi-aws/sdk/v6 v6.66.2 h1:mHiPVwdSQp5VjpvCdPy52FeMiNcscKvJP+len/mfqdU=
-github.com/pulumi/pulumi-aws/sdk/v6 v6.66.2/go.mod h1:C+L8LtajPSwGsZiGgknkCwClUzXk+ZXzSGkOZTQMp3U=
+github.com/pulumi/pulumi-aws/sdk/v6 v6.83.1 h1:46AF76KQV+1ER+Mg47Ke+0ONiNf1q0qKdIMVQcPmuPs=
+github.com/pulumi/pulumi-aws/sdk/v6 v6.83.1/go.mod h1:520DDoW2zBYVWwwAT8qt/9VhNoBcDIslDljzE8/O080=
 github.com/pulumi/pulumi-awsx/sdk/v2 v2.19.0 h1:jil2EBzZnKsRDrLfvx2gnAaq17HQLrTbpPsIb3h+98U=
 github.com/pulumi/pulumi-awsx/sdk/v2 v2.19.0/go.mod h1:r+K4M7jnLqvvQDeR/0mBRq2EPZaqsDg24Ciy3ml/thA=
 github.com/pulumi/pulumi-azure-native-sdk/authorization/v2 v2.81.0 h1:Njext/i2DuW6k9qMj7WJmIBuw7PLZ8ccTYEtU3PbX5s=


### PR DESCRIPTION
### What does this PR do?

Upgrade to latest AWS Pulumi v6 version to prepare for v7 bump. Require v7 for additionally exposed pulumi parameters to configure EC2s for NestedVirtualization testing.
