### PR TITLE
[AGNTLOG-577] Add Truncation Tag and Flag Truncated Logs as Truncated in the Detecting Aggregator

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_handler_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler_test.go
@@ -41,7 +41,7 @@ func newDetectingHandler(outputChan chan *message.Message, _ int, flushTimeout t
 	tok := preprocessor.NewTokenizer(1000)
 	sampler := preprocessor.NewNoopSampler()
 	labeler := buildAutoMultilineLabeler(nil, nil, tailerInfo)
-	aggregator := preprocessor.NewDetectingAggregator(tailerInfo, 1000, false)
+	aggregator := preprocessor.NewDetectingAggregator(tailerInfo, 1000, false, false)
 	return newPreprocessorHandler(aggregator, tok, labeler, sampler, outputChan, preprocessor.NewNoopJSONAggregator(), flushTimeout, 0)
 }
 

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -221,7 +221,9 @@ func buildLineHandler(source *sources.ReplaceableSource, multiLinePattern *regex
 		labeler := buildAutoMultilineLabeler(source.Config().AutoMultiLineOptions, source.Config().AutoMultiLineSamples, tailerInfo)
 		cfg := pkgconfigsetup.Datadog()
 		_, isDefaultPath := source.Config().AutoMultiLineStatus(cfg)
-		detectingAggregator := preprocessor.NewDetectingAggregator(tailerInfo, maxContentSize, isDefaultPath)
+		// JSON aggregation is disabled in detection mode — we don't want to combine JSON
+		// while only tagging everything else.
+		detectingAggregator := preprocessor.NewDetectingAggregator(tailerInfo, maxContentSize, pkgconfigsetup.Datadog().GetBool("logs_config.tag_truncated_logs"), isDefaultPath)
 		return newPreprocessorHandler(detectingAggregator, tok, labeler, sampler, outputChan, preprocessor.NewNoopJSONAggregator(), flushTimeout, labelerMaxBytes)
 	}
 	return newPreprocessorHandler(preprocessor.NewPassThroughAggregator(maxContentSize), tok, preprocessor.NewNoopLabeler(), sampler, outputChan, preprocessor.NewNoopJSONAggregator(), flushTimeout, 0)

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -6,7 +6,9 @@
 package decoder
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -398,4 +400,31 @@ func TestResolveTokenizerAndLabelerMaxInputBytes(t *testing.T) {
 			assert.Equal(t, tt.wantLabelerMax, gotLabelerMax)
 		})
 	}
+}
+
+func TestDecoderWithDockerJSONPartialLineDetectionOnlyMarksOversizedLogicalLineTruncated(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.Set("logs_config.max_message_size_bytes", 1000, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.tag_truncated_logs", true, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.auto_multi_line_detection_tagging", true, pkgconfigmodel.SourceAgentRuntime)
+
+	source := sources.NewLogSource("", &config.LogsConfig{})
+	d := InitializeDecoderForTest(source, dockerfile.New())
+	d.Start()
+	defer d.Stop()
+
+	part1 := strings.Repeat("a", 600)
+	part2 := strings.Repeat("b", 600)
+
+	line1 := []byte(fmt.Sprintf(`{"log":"%s","stream":"stdout","time":"2019-06-06T16:35:55.930852911Z"}`+"\n", part1))
+	line2 := []byte(fmt.Sprintf(`{"log":"%s\n","stream":"stdout","time":"2019-06-06T16:35:55.930852912Z"}`+"\n", part2))
+
+	d.InputChan() <- NewInput(line1)
+	d.InputChan() <- NewInput(line2)
+
+	output := <-d.OutputChan()
+	assert.Equal(t, part1+part2+string(message.TruncatedFlag), string(output.GetContent()))
+	assert.True(t, output.ParsingExtra.IsTruncated)
+	assert.Contains(t, output.ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
+	assert.Equal(t, len(line1)+len(line2), output.RawDataLen)
 }

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -724,20 +724,38 @@ func TestDetectingAggregator_TruncatesTaggedStartLineAndPrefixesContinuation(t *
 	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[1].ParsingExtra.Tags)
 }
 
-func TestDetectingAggregator_TruncationCarryResetsOnNoAggregate(t *testing.T) {
+func TestDetectingAggregator_NoAggregateInheritsTruncationCarry(t *testing.T) {
 	ag := NewDetectingAggregator(5, true, status.NewInfoRegistry())
 
-	require.Empty(t, processMsg(ag, newMessage("123456"), startGroup))
-
-	msgs := processMsg(ag, newMessage("abc"), aggregate)
-	require.Len(t, msgs, 2)
-	assert.Equal(t, "...TRUNCATED...abc", string(msgs[1].GetContent()))
+	msgs := processMsg(ag, newMessage("123456"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
 
 	msgs = processMsg(ag, newMessage("ok"), noAggregate)
 	require.Len(t, msgs, 1)
-	assert.Equal(t, "ok", string(msgs[0].GetContent()))
-	assert.False(t, msgs[0].ParsingExtra.IsTruncated)
-	assert.Empty(t, msgs[0].ParsingExtra.Tags)
+	assert.Equal(t, "...TRUNCATED...ok", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[0].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_StartGroupInheritsTruncationCarry(t *testing.T) {
+	ag := NewDetectingAggregator(5, true, status.NewInfoRegistry())
+
+	msgs := processMsg(ag, newMessage("123456"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
+
+	require.Empty(t, processMsg(ag, newMessage("abc"), startGroup))
+
+	msgs = processMsg(ag, newMessage("tail"), aggregate)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "...TRUNCATED...abc", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
+	assert.Equal(t, "tail", string(msgs[1].GetContent()))
+	assert.False(t, msgs[1].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[1].ParsingExtra.Tags)
 }
 
 func TestDetectingAggregator_TruncationDoesNotTagWhenDisabled(t *testing.T) {

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -494,7 +494,6 @@ func TestDetectingAggregator_IsEmpty(t *testing.T) {
 	require.Len(t, msgs, 1)
 	assert.True(t, ag.IsEmpty())
 }
-<<<<<<< HEAD
 
 func TestDetectingAggregator_TruncatesTaggedStartLineAndPrefixesContinuation(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true, false)
@@ -703,81 +702,3 @@ func TestDetectingAggregator_COATTelemetry_MultiGroupWithTruncation(t *testing.T
 	assert.Equal(t, float64(4), combineAfter-combineBefore) // group 1: startGroup + aggregate, group 2: startGroup + aggregate
 	assert.Equal(t, float64(2), truncAfter-truncBefore)     // group 2 (2 lines) would truncate
 }
-||||||| parent of 61235840f4b (Add detecting aggregator truncation tests)
-=======
-
-func TestDetectingAggregator_TruncatesTaggedStartLineAndPrefixesContinuation(t *testing.T) {
-	ag := NewDetectingAggregator(5, true, status.NewInfoRegistry())
-
-	require.Empty(t, processMsg(ag, newMessage("123456"), startGroup))
-
-	msgs := processMsg(ag, newMessage("abc"), aggregate)
-	require.Len(t, msgs, 2)
-
-	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
-	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
-	assert.Contains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
-	assert.Contains(t, msgs[0].ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
-
-	assert.Equal(t, "...TRUNCATED...abc", string(msgs[1].GetContent()))
-	assert.True(t, msgs[1].ParsingExtra.IsTruncated)
-	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[1].ParsingExtra.Tags)
-}
-
-func TestDetectingAggregator_NoAggregateInheritsTruncationCarry(t *testing.T) {
-	ag := NewDetectingAggregator(5, true, status.NewInfoRegistry())
-
-	msgs := processMsg(ag, newMessage("123456"), noAggregate)
-	require.Len(t, msgs, 1)
-	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
-
-	msgs = processMsg(ag, newMessage("ok"), noAggregate)
-	require.Len(t, msgs, 1)
-	assert.Equal(t, "...TRUNCATED...ok", string(msgs[0].GetContent()))
-	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
-	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[0].ParsingExtra.Tags)
-}
-
-func TestDetectingAggregator_StartGroupInheritsTruncationCarry(t *testing.T) {
-	ag := NewDetectingAggregator(5, true, status.NewInfoRegistry())
-
-	msgs := processMsg(ag, newMessage("123456"), noAggregate)
-	require.Len(t, msgs, 1)
-	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
-
-	require.Empty(t, processMsg(ag, newMessage("abc"), startGroup))
-
-	msgs = processMsg(ag, newMessage("tail"), aggregate)
-	require.Len(t, msgs, 2)
-	assert.Equal(t, "...TRUNCATED...abc", string(msgs[0].GetContent()))
-	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
-	assert.Contains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
-	assert.Contains(t, msgs[0].ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
-	assert.Equal(t, "tail", string(msgs[1].GetContent()))
-	assert.False(t, msgs[1].ParsingExtra.IsTruncated)
-	assert.Empty(t, msgs[1].ParsingExtra.Tags)
-}
-
-func TestDetectingAggregator_TruncationDoesNotTagWhenDisabled(t *testing.T) {
-	ag := NewDetectingAggregator(5, false, status.NewInfoRegistry())
-
-	msgs := processMsg(ag, newMessage("123456"), noAggregate)
-	require.Len(t, msgs, 1)
-	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
-	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
-	assert.Empty(t, msgs[0].ParsingExtra.Tags)
-}
-
-func TestDetectingAggregator_UsesExistingTruncatedFlag(t *testing.T) {
-	ag := NewDetectingAggregator(100, true, status.NewInfoRegistry())
-
-	msg := newMessage("already-truncated")
-	msg.ParsingExtra.IsTruncated = true
-
-	msgs := processMsg(ag, msg, noAggregate)
-	require.Len(t, msgs, 1)
-	assert.Equal(t, "already-truncated...TRUNCATED...", string(msgs[0].GetContent()))
-	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
-	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[0].ParsingExtra.Tags)
-}
->>>>>>> 61235840f4b (Add detecting aggregator truncation tests)

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -494,6 +494,7 @@ func TestDetectingAggregator_IsEmpty(t *testing.T) {
 	require.Len(t, msgs, 1)
 	assert.True(t, ag.IsEmpty())
 }
+<<<<<<< HEAD
 
 func TestDetectingAggregator_TruncatesTaggedStartLineAndPrefixesContinuation(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true, false)
@@ -702,3 +703,63 @@ func TestDetectingAggregator_COATTelemetry_MultiGroupWithTruncation(t *testing.T
 	assert.Equal(t, float64(4), combineAfter-combineBefore) // group 1: startGroup + aggregate, group 2: startGroup + aggregate
 	assert.Equal(t, float64(2), truncAfter-truncBefore)     // group 2 (2 lines) would truncate
 }
+||||||| parent of 61235840f4b (Add detecting aggregator truncation tests)
+=======
+
+func TestDetectingAggregator_TruncatesTaggedStartLineAndPrefixesContinuation(t *testing.T) {
+	ag := NewDetectingAggregator(5, true, status.NewInfoRegistry())
+
+	require.Empty(t, processMsg(ag, newMessage("123456"), startGroup))
+
+	msgs := processMsg(ag, newMessage("abc"), aggregate)
+	require.Len(t, msgs, 2)
+
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
+
+	assert.Equal(t, "...TRUNCATED...abc", string(msgs[1].GetContent()))
+	assert.True(t, msgs[1].ParsingExtra.IsTruncated)
+	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[1].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_TruncationCarryResetsOnNoAggregate(t *testing.T) {
+	ag := NewDetectingAggregator(5, true, status.NewInfoRegistry())
+
+	require.Empty(t, processMsg(ag, newMessage("123456"), startGroup))
+
+	msgs := processMsg(ag, newMessage("abc"), aggregate)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "...TRUNCATED...abc", string(msgs[1].GetContent()))
+
+	msgs = processMsg(ag, newMessage("ok"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "ok", string(msgs[0].GetContent()))
+	assert.False(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[0].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_TruncationDoesNotTagWhenDisabled(t *testing.T) {
+	ag := NewDetectingAggregator(5, false, status.NewInfoRegistry())
+
+	msgs := processMsg(ag, newMessage("123456"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[0].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_UsesExistingTruncatedFlag(t *testing.T) {
+	ag := NewDetectingAggregator(100, true, status.NewInfoRegistry())
+
+	msg := newMessage("already-truncated")
+	msg.ParsingExtra.IsTruncated = true
+
+	msgs := processMsg(ag, msg, noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "already-truncated...TRUNCATED...", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[0].ParsingExtra.Tags)
+}
+>>>>>>> 61235840f4b (Add detecting aggregator truncation tests)

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -385,7 +385,7 @@ func TestRegexAggregatorFirstLineMatchesWorksNormally(t *testing.T) {
 // Tests for detectingAggregator
 
 func TestDetectingAggregator_TagsMultilineStartOnly(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
 	// startGroup: stored as pending, nothing emitted
 	require.Empty(t, processMsg(ag, newMessage("Error: Exception"), startGroup))
@@ -406,7 +406,7 @@ func TestDetectingAggregator_TagsMultilineStartOnly(t *testing.T) {
 }
 
 func TestDetectingAggregator_SingleLineNotTagged(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
 	// startGroup: stored
 	require.Empty(t, processMsg(ag, newMessage("Single line 1"), startGroup))
@@ -425,7 +425,7 @@ func TestDetectingAggregator_SingleLineNotTagged(t *testing.T) {
 }
 
 func TestDetectingAggregator_NoAggregateOutputsImmediately(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
 	msgs := processMsg(ag, newMessage("No aggregate 1"), noAggregate)
 	require.Len(t, msgs, 1)
@@ -439,7 +439,7 @@ func TestDetectingAggregator_NoAggregateOutputsImmediately(t *testing.T) {
 }
 
 func TestDetectingAggregator_FlushPendingMessage(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
 	require.Empty(t, processMsg(ag, newMessage("Pending message"), startGroup))
 
@@ -450,7 +450,7 @@ func TestDetectingAggregator_FlushPendingMessage(t *testing.T) {
 }
 
 func TestDetectingAggregator_MixedSingleAndMultiLine(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
 	// Single line stored
 	require.Empty(t, processMsg(ag, newMessage("Single"), startGroup))
@@ -479,7 +479,7 @@ func TestDetectingAggregator_MixedSingleAndMultiLine(t *testing.T) {
 }
 
 func TestDetectingAggregator_IsEmpty(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
 	assert.True(t, ag.IsEmpty())
 
@@ -495,10 +495,86 @@ func TestDetectingAggregator_IsEmpty(t *testing.T) {
 	assert.True(t, ag.IsEmpty())
 }
 
+func TestDetectingAggregator_TruncatesTaggedStartLineAndPrefixesContinuation(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true, false)
+
+	require.Empty(t, processMsg(ag, newMessage("123456"), startGroup))
+
+	msgs := processMsg(ag, newMessage("abc"), aggregate)
+	require.Len(t, msgs, 2)
+
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
+
+	assert.Equal(t, "...TRUNCATED...abc", string(msgs[1].GetContent()))
+	assert.True(t, msgs[1].ParsingExtra.IsTruncated)
+	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[1].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_NoAggregateInheritsTruncationCarry(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true, false)
+
+	msgs := processMsg(ag, newMessage("123456"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
+
+	msgs = processMsg(ag, newMessage("ok"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "...TRUNCATED...ok", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[0].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_StartGroupInheritsTruncationCarry(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true, false)
+
+	msgs := processMsg(ag, newMessage("123456"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
+
+	require.Empty(t, processMsg(ag, newMessage("abc"), startGroup))
+
+	msgs = processMsg(ag, newMessage("tail"), aggregate)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "...TRUNCATED...abc", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
+
+	assert.Equal(t, "tail", string(msgs[1].GetContent()))
+	assert.False(t, msgs[1].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[1].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_TruncationDoesNotTagWhenDisabled(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, false, false)
+
+	msgs := processMsg(ag, newMessage("123456"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[0].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_UsesExistingTruncatedFlag(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, true, false)
+
+	msg := newMessage("already-truncated")
+	msg.ParsingExtra.IsTruncated = true
+
+	msgs := processMsg(ag, msg, noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "already-truncated...TRUNCATED...", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[0].ParsingExtra.Tags)
+}
+
 // COAT telemetry tests
 
 func TestDetectingAggregator_COATTelemetry_WouldCombine(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 1000, true)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 1000, false, true)
 
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
@@ -519,7 +595,7 @@ func TestDetectingAggregator_COATTelemetry_WouldCombine(t *testing.T) {
 }
 
 func TestDetectingAggregator_COATTelemetry_NoCombineForStandaloneAggregates(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 1000, true)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 1000, false, true)
 
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
@@ -539,7 +615,7 @@ func TestDetectingAggregator_COATTelemetry_NoCombineForStandaloneAggregates(t *t
 
 func TestDetectingAggregator_COATTelemetry_WouldTruncate(t *testing.T) {
 	// maxContentSize=20 so combining will overflow
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 20, true)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 20, false, true)
 
 	truncBefore := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
@@ -560,7 +636,7 @@ func TestDetectingAggregator_COATTelemetry_WouldTruncate(t *testing.T) {
 }
 
 func TestDetectingAggregator_COATTelemetry_NoTruncateForOversizedSingleLine(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, false, true)
 
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	truncBefore := metrics.TlmAutoMultilineWouldTruncate.WithValues().Get()
@@ -580,7 +656,7 @@ func TestDetectingAggregator_COATTelemetry_NoTruncateForOversizedSingleLine(t *t
 }
 
 func TestDetectingAggregator_COATTelemetry_NoCountsWhenNotDefaultPath(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 1000, false)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 1000, false, false)
 
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()
@@ -600,7 +676,7 @@ func TestDetectingAggregator_COATTelemetry_NoCountsWhenNotDefaultPath(t *testing
 
 func TestDetectingAggregator_COATTelemetry_MultiGroupWithTruncation(t *testing.T) {
 	// maxContentSize=15 to make the second group truncate
-	ag := NewDetectingAggregator(status.NewInfoRegistry(), 15, true)
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 15, false, true)
 
 	totalBefore := metrics.TlmAutoMultilineTotalLines.WithValues().Get()
 	combineBefore := metrics.TlmAutoMultilineWouldCombine.WithValues().Get()

--- a/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
+++ b/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
@@ -23,28 +23,28 @@ type detectingAggregator struct {
 	previousMsgTokens     []Token
 	previousWasStartGroup bool
 	multiLineMatchInfo    *status.CountInfo
-
+	shouldTruncate        bool
+	maxContentSize        int
+	tagTruncatedLogs      bool
 	// COAT simulation state
 	isDefaultPath       bool
-	maxContentSize      int
 	simulatedBufLen     int
 	linesInCurrentGroup int
 	inGroup             bool
 }
 
 // NewDetectingAggregator creates a new detecting aggregator.
-// maxContentSize is used to simulate truncation detection for COAT telemetry.
-// isDefaultPath should be true when the source relies on the default value of
-// auto_multi_line_detection (not explicitly configured), meaning these metrics
-// reflect the impact of changing that default.
-func NewDetectingAggregator(tailerInfo *status.InfoRegistry, maxContentSize int, isDefaultPath bool) Aggregator {
+// maxContentSize is used both for truncation handling and to simulate truncation
+// detection for COAT telemetry.
+func NewDetectingAggregator(tailerInfo *status.InfoRegistry, maxContentSize int, tagTruncatedLogs bool, isDefaultPath bool) Aggregator {
 	multiLineMatchInfo := status.NewCountInfo("MultiLine matches")
 	tailerInfo.Register(multiLineMatchInfo)
 
 	return &detectingAggregator{
 		multiLineMatchInfo: multiLineMatchInfo,
-		isDefaultPath:      isDefaultPath,
 		maxContentSize:     maxContentSize,
+		tagTruncatedLogs:   tagTruncatedLogs,
+		isDefaultPath:      isDefaultPath,
 	}
 }
 
@@ -61,7 +61,7 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label, tokens 
 		if d.previousMsg != nil && d.previousWasStartGroup {
 			// Tag the previous message as start of multiline group
 			d.previousMsg.ParsingExtra.Tags = append(d.previousMsg.ParsingExtra.Tags, "auto_multiline_detected:true")
-			d.collected = append(d.collected, AggregatedMessageWithTokens{Msg: d.previousMsg, Tokens: d.previousMsgTokens})
+			d.emit(d.previousMsg, d.previousMsgTokens)
 			// Track that we detected and tagged a multiline log
 			metrics.TlmAutoMultilineAggregatorFlush.Inc("false", "auto_multi_line_detected")
 			d.previousMsg = nil
@@ -69,13 +69,13 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label, tokens 
 			d.previousWasStartGroup = false
 		} else if d.previousMsg != nil {
 			// Previous message wasn't a startGroup, so just output it without tags
-			d.collected = append(d.collected, AggregatedMessageWithTokens{Msg: d.previousMsg, Tokens: d.previousMsgTokens})
+			d.emit(d.previousMsg, d.previousMsgTokens)
 			d.previousMsg = nil
 			d.previousMsgTokens = nil
 			d.previousWasStartGroup = false
 		}
 		// Output the current aggregate message immediately
-		d.collected = append(d.collected, AggregatedMessageWithTokens{Msg: msg, Tokens: tokens})
+		d.emit(msg, tokens)
 		d.processSimulatedAggregate(msg)
 		return d.collected
 	}
@@ -84,12 +84,12 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label, tokens 
 	if label == noAggregate {
 		// Flush any pending previous message first
 		if d.previousMsg != nil {
-			d.collected = append(d.collected, AggregatedMessageWithTokens{Msg: d.previousMsg, Tokens: d.previousMsgTokens})
+			d.emit(d.previousMsg, d.previousMsgTokens)
 			d.previousMsg = nil
 			d.previousMsgTokens = nil
 			d.previousWasStartGroup = false
 		}
-		d.collected = append(d.collected, AggregatedMessageWithTokens{Msg: msg, Tokens: tokens})
+		d.emit(msg, tokens)
 		d.resetSimulatedGroup()
 		return d.collected
 	}
@@ -97,7 +97,7 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label, tokens 
 	// Handle startGroup: flush previous and store current
 	if label == startGroup {
 		if d.previousMsg != nil {
-			d.collected = append(d.collected, AggregatedMessageWithTokens{Msg: d.previousMsg, Tokens: d.previousMsgTokens})
+			d.emit(d.previousMsg, d.previousMsgTokens)
 		}
 		d.multiLineMatchInfo.Add(1)
 		d.previousMsg = msg
@@ -114,7 +114,7 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label, tokens 
 func (d *detectingAggregator) Flush() []AggregatedMessageWithTokens {
 	d.collected = d.collected[:0]
 	if d.previousMsg != nil {
-		d.collected = append(d.collected, AggregatedMessageWithTokens{Msg: d.previousMsg, Tokens: d.previousMsgTokens})
+		d.emit(d.previousMsg, d.previousMsgTokens)
 		d.previousMsg = nil
 		d.previousMsgTokens = nil
 		d.previousWasStartGroup = false
@@ -185,4 +185,29 @@ func (d *detectingAggregator) resetSimulatedGroup() {
 	d.inGroup = false
 	d.simulatedBufLen = 0
 	d.linesInCurrentGroup = 0
+}
+
+func (d *detectingAggregator) emit(msg *message.Message, tokens []Token) {
+	lastWasTruncated := d.shouldTruncate
+	content := msg.GetContent()
+	d.shouldTruncate = len(content) > d.maxContentSize || msg.ParsingExtra.IsTruncated
+
+	if lastWasTruncated {
+		content = append(message.TruncatedFlag, content...)
+	}
+
+	if d.shouldTruncate {
+		content = append(content, message.TruncatedFlag...)
+		metrics.LogsTruncated.Add(1)
+	}
+
+	if lastWasTruncated || d.shouldTruncate {
+		msg.ParsingExtra.IsTruncated = true
+		if d.tagTruncatedLogs {
+			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
+		}
+	}
+
+	msg.SetContent(content)
+	d.collected = append(d.collected, AggregatedMessageWithTokens{Msg: msg, Tokens: tokens})
 }


### PR DESCRIPTION
### What does this PR do?

Adds truncated tags to truncated tags in the agent and appends/prepends `...TRUNCATED...` to truncated logs in the detecting aggregator. It fully mimics the behavior of the single line handler with regards to truncated logs.

### Motivation

This was a bug introduced in the detecting aggregator in #44030. 

### Describe how you validated your changes

Unit testing. I wrote an intentionally failing test to check if logs where tagged with the truncated flag and flagged with "TRUNCATED", then fixed the aggregator to pass the test.

Also ran a test locally to ensure the detector's output was the same as the single line handler. When a sample logs file was put through both the single line handler and the detecting aggregator, these were the results from stream logs.

Detecting aggregator:
<img width="1604" height="935" alt="image" src="https://github.com/user-attachments/assets/855ab685-f4e8-477c-b299-bca7991d4293" />

Single line handler:
<img width="1636" height="980" alt="image" src="https://github.com/user-attachments/assets/93bf06c6-a67f-40c1-9c54-6f3c44051722" />

Logs were truncated in the exact same manner, except the start group was tagged with auto multiline detected in the detecting aggregator.

### Additional Notes
