### PR TITLE
Add DDOT MSI upgrade E2E tests

### DIFF
--- a/.gitlab/windows/test/e2e_install_packages/windows.yml
+++ b/.gitlab/windows/test/e2e_install_packages/windows.yml
@@ -155,6 +155,12 @@ new-e2e-windows-ddot-package-a7-x86_64:
     - CURRENT_AGENT_ASSERT_VERSION=$(dda inv agent.version) || exit $?; export CURRENT_AGENT_ASSERT_VERSION
     - CURRENT_AGENT_ASSERT_PACKAGE_VERSION=$(dda inv agent.version --url-safe)-1 || exit $?; export CURRENT_AGENT_ASSERT_PACKAGE_VERSION
     - !reference [.new_e2e_template, before_script]
+  parallel:
+    matrix:
+      - EXTRA_PARAMS: --run "TestDDOTExtensionViaMSI$/TestInstallAndUninstallDDOTExtension$"
+      - EXTRA_PARAMS: --run "TestDDOTExtensionViaMSI$/TestUpgradeEnablesDDOTExtension$"
+      - EXTRA_PARAMS: --run "TestDDOTExtensionMSIUpgrade$/TestUpgradePreservesDDOTExtension$"
+      - EXTRA_PARAMS: --run "TestDDOTExtensionViaInstallScript$/TestInstallAndPurgeDDOTExtension$"
   rules:
     - !reference [.on_deploy]
     - !reference [.on_e2e_or_windows_installer_changes]

--- a/test/new-e2e/tests/installer/windows/ddot_msi_install_test.go
+++ b/test/new-e2e/tests/installer/windows/ddot_msi_install_test.go
@@ -18,6 +18,7 @@ import (
 	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
 	installer "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/unix"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
+	windowsagent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 )
 
 type testDDOTExtensionMSI struct {
@@ -67,6 +68,31 @@ func (s *testDDOTExtensionMSI) TestInstallAndUninstallDDOTExtension() {
 	s.Require().Host(s.Env().RemoteHost).HasNoService("datadog-otel-agent")
 }
 
+// TestUpgradeEnablesDDOTExtension verifies that upgrading from a stable Agent
+// to the current version with DD_OTELCOLLECTOR_ENABLED=true installs and starts
+// the DDOT extension.
+func (s *testDDOTExtensionMSI) TestUpgradeEnablesDDOTExtension() {
+	// Arrange: install a stable Agent without DDOT
+	s.installPreviousAgentVersion()
+
+	// Act: upgrade to current version with DDOT enabled
+	s.Require().NoError(s.Installer().Install(
+		WithOption(WithInstallerURL(s.CurrentAgentVersion().MSIPackage().URL)),
+		WithMSILogFile("upgrade-enable-ddot.log"),
+		WithMSIArg("DD_INSTALLER_REGISTRY_URL="+consts.PipelineOCIRegistry),
+		WithMSIArg("DD_OTELCOLLECTOR_ENABLED=true"),
+	))
+
+	// Assert: DDOT extension is installed and running
+	ddotExtDir := filepath.Join(consts.GetStableDirFor(consts.AgentPackage), "ext", "ddot")
+	s.Require().Host(s.Env().RemoteHost).DirExists(ddotExtDir, "ddot extension directory should exist")
+	s.Require().Host(s.Env().RemoteHost).FileExists(
+		filepath.Join(ddotExtDir, "embedded", "bin", "otel-agent.exe"),
+		"otel-agent.exe should be present in the ddot extension",
+	)
+	s.Require().NoError(s.WaitForServicesWithBackoff("Running", []string{"datadog-otel-agent"}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second))))
+}
+
 func (s *testDDOTExtensionMSI) installPreviousAgentVersion(opts ...MsiOption) {
 	agentVersion := s.StableAgentVersion().Version()
 	options := []MsiOption{
@@ -84,4 +110,75 @@ func (s *testDDOTExtensionMSI) installPreviousAgentVersion(opts ...MsiOption) {
 		WithVersionMatchPredicate(func(version string) {
 			s.Require().Contains(version, agentVersion)
 		})
+}
+
+const (
+	stableDDOTVersion      = "7.78.0-rc.4-1"
+	stableDDOTAgentVersion = "7.78.0-rc.4"
+)
+
+type testDDOTExtensionMSIUpgrade struct {
+	testDDOTExtensionMSI
+}
+
+// TestDDOTExtensionMSIUpgrade verifies that the DDOT extension persists
+// through an MSI upgrade from the previous stable version to the current pipeline version.
+func TestDDOTExtensionMSIUpgrade(t *testing.T) {
+	s := &testDDOTExtensionMSIUpgrade{}
+	s.CreateStableAgent = func() (*AgentVersionManager, error) {
+		oci, err := NewPackageConfig(
+			WithName(consts.AgentPackage),
+			WithVersion(stableDDOTVersion),
+			WithRegistry(consts.BetaS3OCIRegistry),
+		)
+		if err != nil {
+			return nil, err
+		}
+		msi, err := windowsagent.NewPackage(
+			windowsagent.WithProduct("datadog-agent"),
+			windowsagent.WithArch("x86_64"),
+			windowsagent.WithChannel("beta"),
+			windowsagent.WithVersion(stableDDOTVersion),
+		)
+		if err != nil {
+			return nil, err
+		}
+		return NewAgentVersionManager(stableDDOTAgentVersion, stableDDOTVersion, oci, msi)
+	}
+	e2e.Run(t, s,
+		e2e.WithProvisioner(
+			winawshost.ProvisionerNoAgentNoFakeIntake(),
+		))
+}
+
+// TestUpgradePreservesDDOTExtension installs the previous stable Agent with DDOT
+// enabled, then upgrades to the current pipeline version without passing
+// DD_OTELCOLLECTOR_ENABLED, and verifies the extension is still present and running.
+func (s *testDDOTExtensionMSIUpgrade) TestUpgradePreservesDDOTExtension() {
+	// Arrange: install previous stable Agent with DDOT enabled
+	s.installPreviousAgentVersion(
+		WithMSIArg("DD_INSTALLER_REGISTRY_URL="+consts.BetaS3OCIRegistry),
+		WithMSIArg("DD_OTELCOLLECTOR_ENABLED=true"),
+	)
+
+	// Sanity: DDOT is running after the initial install
+	ddotExtDir := filepath.Join(consts.GetStableDirFor(consts.AgentPackage), "ext", "ddot")
+	s.Require().Host(s.Env().RemoteHost).DirExists(ddotExtDir, "ddot extension directory should exist after initial install")
+	s.Require().NoError(s.WaitForServicesWithBackoff("Running", []string{"datadog-otel-agent"}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second))))
+
+	// Act: upgrade to current version without DD_OTELCOLLECTOR_ENABLED
+	s.Require().NoError(s.Installer().Install(
+		WithOption(WithInstallerURL(s.CurrentAgentVersion().MSIPackage().URL)),
+		WithMSILogFile("upgrade-to-current.log"),
+		WithMSIArg("DD_INSTALLER_REGISTRY_URL="+consts.PipelineOCIRegistry),
+	))
+
+	// Assert: DDOT extension persists through the upgrade
+	ddotExtDir = filepath.Join(consts.GetStableDirFor(consts.AgentPackage), "ext", "ddot")
+	s.Require().Host(s.Env().RemoteHost).DirExists(ddotExtDir, "ddot extension directory should exist after upgrade")
+	s.Require().Host(s.Env().RemoteHost).FileExists(
+		filepath.Join(ddotExtDir, "embedded", "bin", "otel-agent.exe"),
+		"otel-agent.exe should be present after upgrade",
+	)
+	s.Require().NoError(s.WaitForServicesWithBackoff("Running", []string{"datadog-otel-agent"}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second))))
 }


### PR DESCRIPTION
### What does this PR do?
Adds two new DDOT extension E2E tests exercising the MSI upgrade path, and parallelises the ddot-package CI job so each test runs independently.

- **TestUpgradeEnablesDDOTExtension**: install stable Agent, upgrade to current version with `DD_OTELCOLLECTOR_ENABLED=true`, verify DDOT is installed and running.
- **TestUpgradePreservesDDOTExtension**: install 7.78.0-rc.4 with DDOT enabled, upgrade to current pipeline version *without* `DD_OTELCOLLECTOR_ENABLED`, verify DDOT persists.

### Motivation
[WINA-2537](https://datadoghq.atlassian.net/browse/WINA-2537) — Ensure the DDOT extension is correctly installed and preserved through MSI upgrades via both code paths (enabling on upgrade, and preserving across upgrade).

[WINA-2537]: https://datadoghq.atlassian.net/browse/WINA-2537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ