### PR TITLE
fix(renovate): group prost/tonic crates and silence git-refs registry warning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,11 @@
         "labels": ["dependencies", "dependencies-cargo", "changelog/no-changelog", "qa/no-code-change"],
       },
       {
+        "matchManagers": ["cargo"],
+        "matchDepNames": ["prost", "prost-types", "prost-build", "tonic", "tonic-build", "tonic-reflection", "protoc-gen-prost", "protoc-gen-tonic"],
+        "groupName": "prost/tonic protobuf stack"
+      },
+      {
         "matchManagers": ["npm"],
         "enabled": false
       },
@@ -136,7 +141,8 @@
         "currentValueTemplate": "master",
         "depNameTemplate": "integrations-core",
         "packageNameTemplate": "https://github.com/DataDog/integrations-core",
-        "datasourceTemplate": "git-refs"
+        "datasourceTemplate": "git-refs",
+        "registryUrlTemplate": ""
       }
     ],
     "customDatasources": {


### PR DESCRIPTION
### What does this PR do?

Two fixes to the Renovate configuration:

1. **Group prost/tonic protobuf crates**: Adds a `packageRules` group so that `prost`, `prost-types`, `prost-build`, `tonic`, `tonic-build`, `tonic-reflection`, `protoc-gen-prost`, and `protoc-gen-tonic` are always bumped together in a single PR. This prevents version mismatches where one plugin generates code for a different prost version than the runtime.

2. **Silence git-refs registry warning**: Adds `registryUrlTemplate: ""` to the `integrations-core` custom manager, matching the pattern already used by `omnibus-ruby`. The `git-refs` datasource doesn't use registries, so the inherited default was causing a dashboard warning.

### Motivation

The `renovate/protoc-gen-prost-0.x` branch failed all CI jobs because `protoc-gen-prost` 0.5 was bumped in isolation. It generates code for prost 0.14, but the runtime `prost` (0.13), `tonic` (0.12), and `protoc-gen-tonic` (0.4) are incompatible. These crates must move as a unit.

The registry warning was noise on the Renovate dependency dashboard.

### Describe how you validated your changes

- Verified `renovate.json` is valid JSON
- Confirmed the `omnibus-ruby` manager already uses the same `registryUrlTemplate: ""` pattern
- Cross-referenced prost/tonic version compatibility via Cargo.lock and crates.io

### Additional Notes

After this merges, the existing `renovate/protoc-gen-prost-0.x` PR should be closed — Renovate will open a new grouped PR that bumps the full stack together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)