### PR TITLE
feat(host-profiler): add additional_http_headers config and fix env var config reading

### DIFF
--- a/cmd/host-profiler/README.md
+++ b/cmd/host-profiler/README.md
@@ -66,6 +66,7 @@ UID=1234 # required on Datadog workspace, set to the output of `id -u` on the wo
 GID=1234 # required on Datadog workspace, set to the output of `id -g` on the workspace
 DD_TAGS="key:value,key1:value2" # optional, defaults to workspace:${workspace-name} on a Datadog workspace
 DD_HOSTPROFILER_DEBUG='{"verbosity":"detailed"}' # optional, enable debug exporter (basic|normal|detailed|none)
+DD_HOSTPROFILER_ADDITIONAL_HTTP_HEADERS='{"x-custom-header":"value"}' # optional, additional HTTP headers on OTLP exporter requests; defaults to workspace metadata on Datadog workspaces
 ```
 
 Then run

--- a/cmd/host-profiler/README.md
+++ b/cmd/host-profiler/README.md
@@ -65,6 +65,7 @@ DD_SITE=datad0g.com # optional, defaults to "datadoghq.com"
 UID=1234 # required on Datadog workspace, set to the output of `id -u` on the workspace
 GID=1234 # required on Datadog workspace, set to the output of `id -g` on the workspace
 DD_TAGS="key:value,key1:value2" # optional, defaults to workspace:${workspace-name} on a Datadog workspace
+DD_HOSTPROFILER_DEBUG='{"verbosity":"detailed"}' # optional, enable debug exporter (basic|normal|detailed|none)
 ```
 
 Then run

--- a/cmd/host-profiler/docker-compose.yml
+++ b/cmd/host-profiler/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     environment:
       DD_SITE: ${DD_SITE:-datadoghq.com}
       DO_NOT_START_PROFILER:
+      DD_HOSTPROFILER_DEBUG:
     volumes:
       - ../..:/app
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/cmd/host-profiler/docker-compose.yml
+++ b/cmd/host-profiler/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       DD_SITE: ${DD_SITE:-datadoghq.com}
       DO_NOT_START_PROFILER:
       DD_HOSTPROFILER_DEBUG:
+      DD_HOSTPROFILER_ADDITIONAL_HTTP_HEADERS: ${DD_HOSTPROFILER_ADDITIONAL_HTTP_HEADERS:-${WORKSPACE_NAME:+{"x-datadog-profiling-metadata":"workspace:${WORKSPACE_NAME}"}}}
     volumes:
       - ../..:/app
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -53,14 +53,18 @@ func buildExporters(conf confMap, agent configManager) []any {
 	exporters := make(confMap)
 
 	createOtlpHTTPFromEndpoint := func(site, key string) confMap {
+		headers := make(confMap, 3+len(agent.hostProfilerConfig.AdditionalHTTPHeaders))
+		for k, v := range agent.hostProfilerConfig.AdditionalHTTPHeaders {
+			headers[k] = v
+		}
+		// Required headers set after additional headers to prevent overrides
+		headers["dd-api-key"] = key
+		headers["dd-evp-origin"] = version.ProfilerName
+		headers["dd-evp-origin-version"] = version.ProfilerVersion
 		return confMap{
 			"profiles_endpoint": fmt.Sprintf(profilesEndpointFormat, site),
 			"metrics_endpoint":  fmt.Sprintf(metricsEndpointFormat, site),
-			"headers": confMap{
-				"dd-api-key":            key,
-				"dd-evp-origin":         version.ProfilerName,
-				"dd-evp-origin-version": version.ProfilerVersion,
-			},
+			"headers":           headers,
 		}
 	}
 

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && test
+
+package agentprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildExportersAdditionalHTTPHeaders(t *testing.T) {
+	agent := configManager{
+		endpoints: []endpoint{{
+			site:    "datadoghq.com",
+			apiKeys: []string{"test_key"},
+		}},
+		endpointsTotalLength: 1,
+		hostProfilerConfig: hostProfilerConfig{
+			AdditionalHTTPHeaders: map[string]string{
+				"x-datadog-profiling-metadata": "workspace:peterg17,env:staging",
+				"x-custom-routing":             "some-value",
+			},
+		},
+	}
+	conf := make(confMap)
+	buildExporters(conf, agent)
+
+	exporters, ok := conf["exporters"].(confMap)
+	require.True(t, ok)
+	exporter, ok := exporters["otlphttp/datadoghq.com_0"].(confMap)
+	require.True(t, ok)
+	headers, ok := exporter["headers"].(confMap)
+	require.True(t, ok)
+
+	assert.Equal(t, "workspace:peterg17,env:staging", headers["x-datadog-profiling-metadata"])
+	assert.Equal(t, "some-value", headers["x-custom-routing"])
+	assert.Equal(t, "test_key", headers["dd-api-key"])
+}
+
+func TestBuildExportersNoAdditionalHTTPHeaders(t *testing.T) {
+	agent := configManager{
+		endpoints: []endpoint{{
+			site:    "datadoghq.com",
+			apiKeys: []string{"test_key"},
+		}},
+		endpointsTotalLength: 1,
+	}
+	conf := make(confMap)
+	buildExporters(conf, agent)
+
+	exporters, ok := conf["exporters"].(confMap)
+	require.True(t, ok)
+	exporter, ok := exporters["otlphttp/datadoghq.com_0"].(confMap)
+	require.True(t, ok)
+	headers, ok := exporter["headers"].(confMap)
+	require.True(t, ok)
+
+	assert.Equal(t, "test_key", headers["dd-api-key"])
+	assert.Len(t, headers, 3) // dd-api-key, dd-evp-origin, dd-evp-origin-version
+}
+
+func TestBuildExportersAdditionalHTTPHeadersDoNotOverrideRequired(t *testing.T) {
+	agent := configManager{
+		endpoints: []endpoint{{
+			site:    "datadoghq.com",
+			apiKeys: []string{"test_key"},
+		}},
+		endpointsTotalLength: 1,
+		hostProfilerConfig: hostProfilerConfig{
+			AdditionalHTTPHeaders: map[string]string{
+				"dd-api-key": "should-not-override",
+			},
+		},
+	}
+	conf := make(confMap)
+	buildExporters(conf, agent)
+
+	exporters, ok := conf["exporters"].(confMap)
+	require.True(t, ok)
+	exporter, ok := exporters["otlphttp/datadoghq.com_0"].(confMap)
+	require.True(t, ok)
+	headers, ok := exporter["headers"].(confMap)
+	require.True(t, ok)
+
+	assert.Equal(t, "test_key", headers["dd-api-key"], "required headers must not be overridden")
+}

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager.go
@@ -11,12 +11,11 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/go-viper/mapstructure/v2"
 )
 
 // hostProfilerConfig holds host-profiler settings extracted from the Agent config.
 type hostProfilerConfig struct {
-	Debug confMap `mapstructure:"debug"`
+	Debug confMap
 }
 
 type endpoint struct {
@@ -84,11 +83,11 @@ func newConfigManager(config config.Component) configManager {
 		log.Warnf("No API key registered for main site %s", usedSite)
 	}
 
-	var hostProfilerConfig hostProfilerConfig
-	if raw := config.GetStringMap("hostprofiler"); len(raw) > 0 {
-		if err := mapstructure.Decode(raw, &hostProfilerConfig); err != nil {
-			log.Warnf("Failed to decode host_profiler config: %v", err)
-		}
+	// Read hostprofiler fields from leaf keys directly. GetStringMap on the parent
+	// key ("hostprofiler") returns defaults instead of env var overrides, so
+	// mapstructure.Decode on the parent map silently drops env-var-set values.
+	hostProfilerConfig := hostProfilerConfig{
+		Debug: config.GetStringMap("hostprofiler.debug"),
 	}
 
 	return configManager{

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager.go
@@ -15,7 +15,8 @@ import (
 
 // hostProfilerConfig holds host-profiler settings extracted from the Agent config.
 type hostProfilerConfig struct {
-	Debug confMap
+	Debug                 confMap
+	AdditionalHTTPHeaders map[string]string
 }
 
 type endpoint struct {
@@ -87,7 +88,8 @@ func newConfigManager(config config.Component) configManager {
 	// key ("hostprofiler") returns defaults instead of env var overrides, so
 	// mapstructure.Decode on the parent map silently drops env-var-set values.
 	hostProfilerConfig := hostProfilerConfig{
-		Debug: config.GetStringMap("hostprofiler.debug"),
+		Debug:                 config.GetStringMap("hostprofiler.debug"),
+		AdditionalHTTPHeaders: config.GetStringMapString("hostprofiler.additional_http_headers"),
 	}
 
 	return configManager{

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager_test.go
@@ -38,3 +38,44 @@ site: datadoghq.com
 
 	assert.Equal(t, "detailed", mgr.hostProfilerConfig.Debug["verbosity"])
 }
+
+func TestNewConfigManagerAdditionalHTTPHeadersFromYAML(t *testing.T) {
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+hostprofiler:
+  additional_http_headers:
+    x-custom-header: custom-value
+    x-another: another-value
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.Equal(t, map[string]string{
+		"x-custom-header": "custom-value",
+		"x-another":       "another-value",
+	}, mgr.hostProfilerConfig.AdditionalHTTPHeaders)
+}
+
+func TestNewConfigManagerAdditionalHTTPHeadersFromEnvVar(t *testing.T) {
+	t.Setenv("DD_HOSTPROFILER_ADDITIONAL_HTTP_HEADERS", `{"x-custom-header":"custom-value"}`)
+
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.Equal(t, map[string]string{
+		"x-custom-header": "custom-value",
+	}, mgr.hostProfilerConfig.AdditionalHTTPHeaders)
+}
+
+func TestNewConfigManagerAdditionalHTTPHeadersEmpty(t *testing.T) {
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.Empty(t, mgr.hostProfilerConfig.AdditionalHTTPHeaders)
+}

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager_test.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && test
+
+package agentprovider
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewConfigManagerDebugFromYAML(t *testing.T) {
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+hostprofiler:
+  debug:
+    verbosity: detailed
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.Equal(t, "detailed", mgr.hostProfilerConfig.Debug["verbosity"])
+}
+
+func TestNewConfigManagerDebugFromEnvVar(t *testing.T) {
+	t.Setenv("DD_HOSTPROFILER_DEBUG", `{"verbosity":"detailed"}`)
+
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.Equal(t, "detailed", mgr.hostProfilerConfig.Debug["verbosity"])
+}

--- a/comp/host-profiler/collector/impl/agentprovider/provider_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/provider_test.go
@@ -225,6 +225,16 @@ func TestProvider(t *testing.T) {
 			agentConfig:  "provider/debug-multi-field/agent.yaml",
 			expectedOTel: "provider/debug-multi-field/otel.yaml",
 		},
+		{
+			name:         "additional-http-headers",
+			agentConfig:  "provider/add-headers/agent.yaml",
+			expectedOTel: "provider/add-headers/otel.yaml",
+		},
+		{
+			name:         "additional-http-headers-with-debug",
+			agentConfig:  "provider/add-headers-debug/agent.yaml",
+			expectedOTel: "provider/add-headers-debug/otel.yaml",
+		},
 	}
 
 	for _, tt := range tests {

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/agent.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/agent.yaml
@@ -1,0 +1,7 @@
+site: datadoghq.com
+api_key: test_api_key_123
+hostprofiler:
+    debug:
+        verbosity: detailed
+    additional_http_headers:
+        x-datadog-profiling-metadata: "workspace:peterg17"

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
@@ -1,0 +1,77 @@
+exporters:
+    debug:
+        verbosity: detailed
+    otlphttp/datadoghq.com_0:
+        headers:
+            dd-api-key: test_api_key_123
+            dd-evp-origin: host-profiler
+            dd-evp-origin-version: 7.0.0-test
+            x-datadog-profiling-metadata: workspace:peterg17
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+extensions:
+    ddprofiling/default: {}
+    hpflare/default: {}
+processors:
+    cumulativetodelta: {}
+    filter:
+        metrics:
+            exclude:
+                match_type: regexp
+                metric_names:
+                    - ^scrape_.*$
+                    - ^up$
+                    - ^promhttp_metric_handler_errors_total$
+    infraattributes/default:
+        allow_hostname_override: true
+        cardinality: 2
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
+receivers:
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: test_api_key_123
+                  site: datadoghq.com
+    prometheus:
+        config:
+            scrape_configs:
+                - fallback_scrape_protocol: PrometheusText0.0.4
+                  job_name: host-profiler-internal
+                  metric_name_escaping_scheme: underscores
+                  metric_name_validation_scheme: legacy
+                  scrape_interval: 60s
+                  scrape_protocols:
+                    - PrometheusText0.0.4
+                  static_configs:
+                    - targets:
+                        - 127.0.0.1:8888
+service:
+    pipelines:
+        metrics:
+            exporters:
+                - otlphttp/datadoghq.com_0
+                - debug
+            processors:
+                - filter
+                - cumulativetodelta
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - prometheus
+        profiles:
+            exporters:
+                - otlphttp/datadoghq.com_0
+                - debug
+            processors:
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/agent.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/agent.yaml
@@ -1,0 +1,6 @@
+site: datadoghq.com
+api_key: test_api_key_123
+hostprofiler:
+    additional_http_headers:
+        x-datadog-profiling-metadata: "workspace:peterg17,env:staging"
+        x-custom-routing: "some-value"

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
@@ -1,0 +1,74 @@
+exporters:
+    otlphttp/datadoghq.com_0:
+        headers:
+            dd-api-key: test_api_key_123
+            dd-evp-origin: host-profiler
+            dd-evp-origin-version: 7.0.0-test
+            x-custom-routing: some-value
+            x-datadog-profiling-metadata: workspace:peterg17,env:staging
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+extensions:
+    ddprofiling/default: {}
+    hpflare/default: {}
+processors:
+    cumulativetodelta: {}
+    filter:
+        metrics:
+            exclude:
+                match_type: regexp
+                metric_names:
+                    - ^scrape_.*$
+                    - ^up$
+                    - ^promhttp_metric_handler_errors_total$
+    infraattributes/default:
+        allow_hostname_override: true
+        cardinality: 2
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
+receivers:
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: test_api_key_123
+                  site: datadoghq.com
+    prometheus:
+        config:
+            scrape_configs:
+                - fallback_scrape_protocol: PrometheusText0.0.4
+                  job_name: host-profiler-internal
+                  metric_name_escaping_scheme: underscores
+                  metric_name_validation_scheme: legacy
+                  scrape_interval: 60s
+                  scrape_protocols:
+                    - PrometheusText0.0.4
+                  static_configs:
+                    - targets:
+                        - 127.0.0.1:8888
+service:
+    pipelines:
+        metrics:
+            exporters:
+                - otlphttp/datadoghq.com_0
+            processors:
+                - filter
+                - cumulativetodelta
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - prometheus
+        profiles:
+            exporters:
+                - otlphttp/datadoghq.com_0
+            processors:
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - hostprofiler

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1057,6 +1057,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	// Individual debug options don't need to be registered here - the section is
 	// passed as-is to the OTel debug exporter which handles its own validation.
 	config.BindEnvAndSetDefault("hostprofiler.debug", map[string]any{})
+	config.BindEnvAndSetDefault("hostprofiler.additional_http_headers", map[string]string{})
 }
 
 func agent(config pkgconfigmodel.Setup) {


### PR DESCRIPTION
### What does this PR do?

**Bug fix**: `hostprofiler.debug` set via `DD_HOSTPROFILER_DEBUG` env var was silently dropped. `GetStringMap` on the parent key (`hostprofiler`) returns defaults instead of env var overrides, so `mapstructure.Decode` never saw the actual values. Replaced mapstructure with direct leaf key reads via `GetStringMap`/`GetStringMapString`.

**Feature**: Adds support for configuring arbitrary HTTP headers on OTLP exporter requests in bundled mode via `hostprofiler.additional_http_headers`:

```yaml
hostprofiler:
  additional_http_headers:
    x-datadog-profiling-metadata: "workspace:peterg17,env:staging"
    x-custom-routing: "some-value"
```

Or via env var: `DD_HOSTPROFILER_ADDITIONAL_HTTP_HEADERS='{"x-custom-header":"value"}'`

Required headers (`dd-api-key`, `dd-evp-origin`, `dd-evp-origin-version`) are set after additional headers to prevent accidental overrides.

Standalone mode already supports custom headers directly in the OTEL collector yaml config.

### Motivation

The host-profiler needs a way to attach arbitrary HTTP headers for routing and filtering purposes. Rather than introducing a special-purpose header, this provides a generic mechanism.

Builds on top of #48364 which added the `hostprofiler` config section.

### Describe how you validated your changes

- Tests for `Debug` config reading from both YAML and env var (demonstrates the bug fix)
- Tests for `AdditionalHTTPHeaders` from YAML, env var, and empty
- Tests for `buildExporters`: headers present, absent, and required headers not overridable
- All tests verified on Linux workspace

### Additional Notes

Docker-compose dev environment defaults to `{"x-datadog-profiling-metadata":"workspace:<name>"}` when `WORKSPACE_NAME` is set.