### PR TITLE
[AGTHEAL-134] feat(healthplatform): detect undersized DogStatsD UDP receive buffer

### DIFF
--- a/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
+++ b/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
@@ -26,7 +26,7 @@ import (
 	server "github.com/DataDog/datadog-agent/comp/dogstatsd/server/def"
 	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/def"
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/fx-mock"
-	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -60,7 +60,7 @@ func TestDogstatsdMetricsStats(t *testing.T) {
 		}),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 		filterlist.MockModule(),
-		fx.Provide(func() option.Option[healthplatformdef.Component] { return option.None[healthplatformdef.Component]() }),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
 	))
 
 	s := DsdStatsRuntimeSetting{

--- a/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
+++ b/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
@@ -26,10 +26,12 @@ import (
 	server "github.com/DataDog/datadog-agent/comp/dogstatsd/server/def"
 	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/def"
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/fx-mock"
+	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 type testDeps struct {
@@ -58,6 +60,7 @@ func TestDogstatsdMetricsStats(t *testing.T) {
 		}),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 		filterlist.MockModule(),
+		fx.Provide(func() option.Option[healthplatformdef.Component] { return option.None[healthplatformdef.Component]() }),
 	))
 
 	s := DsdStatsRuntimeSetting{

--- a/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
+++ b/cmd/agent/subcommands/run/internal/settings/runtime_settings_test.go
@@ -26,8 +26,8 @@ import (
 	server "github.com/DataDog/datadog-agent/comp/dogstatsd/server/def"
 	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/def"
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/fx-mock"
-	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"

--- a/cmd/dogstatsd/subcommands/start/command.go
+++ b/cmd/dogstatsd/subcommands/start/command.go
@@ -46,6 +46,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	host "github.com/DataDog/datadog-agent/comp/metadata/host/def"
 	hostfx "github.com/DataDog/datadog-agent/comp/metadata/host/fx"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
@@ -58,6 +59,7 @@ import (
 	runner "github.com/DataDog/datadog-agent/comp/metadata/runner/def"
 	metadatarunnerfx "github.com/DataDog/datadog-agent/comp/metadata/runner/fx"
 	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
+
 	metricscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -65,6 +67,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -159,6 +162,7 @@ func RunDogstatsdFct(cliParams *CLIParams, defaultConfPath string, defaultLogFil
 		fx.Provide(func(demuxInstance demultiplexer.Component) serializer.MetricSerializer {
 			return demuxInstance.Serializer()
 		}),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
 		fx.Supply(resourcesimpl.Disabled()),
 		metadatarunnerfx.Module(),
 		resourcesfx.Module(),

--- a/comp/dogstatsd/listeners/BUILD.bazel
+++ b/comp/dogstatsd/listeners/BUILD.bazel
@@ -25,6 +25,8 @@ go_library(
         "//comp/dogstatsd/packets",
         "//comp/dogstatsd/pidmap/def",
         "//comp/dogstatsd/replay/def",
+        "//comp/healthplatform/issues/dogstatsd-udp-drops",
+        "//comp/healthplatform/store/def",
         "//pkg/config/model",
         "//pkg/config/utils",
         "//pkg/util/log",

--- a/comp/dogstatsd/listeners/udp.go
+++ b/comp/dogstatsd/listeners/udp.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
+	dogstatsdudpdrops "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dogstatsd-udp-drops"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -54,10 +56,11 @@ type UDPListener struct {
 	trafficCapture  replay.Component // Currently ignored
 	listenWg        sync.WaitGroup
 	telemetryStore  *TelemetryStore
+	healthPlatform  storedef.Component // may be nil if health platform is not available
 }
 
 // NewUDPListener returns an idle UDP Statsd listener
-func NewUDPListener(packetOut chan packets.Packets, sharedPacketPoolManager *packets.PoolManager[packets.Packet], cfg model.Reader, capture replay.Component, telemetryStore *TelemetryStore, packetsTelemetryStore *packets.TelemetryStore) (*UDPListener, error) {
+func NewUDPListener(packetOut chan packets.Packets, sharedPacketPoolManager *packets.PoolManager[packets.Packet], cfg model.Reader, capture replay.Component, telemetryStore *TelemetryStore, packetsTelemetryStore *packets.TelemetryStore, hp storedef.Component) (*UDPListener, error) {
 	var err error
 	var url string
 
@@ -103,6 +106,7 @@ func NewUDPListener(packetOut chan packets.Packets, sharedPacketPoolManager *pac
 		buffer:          buffer,
 		trafficCapture:  capture,
 		telemetryStore:  telemetryStore,
+		healthPlatform:  hp,
 	}
 	log.Debugf("dogstatsd-udp: %s successfully initialized", conn.LocalAddr())
 	return listener, nil
@@ -140,8 +144,20 @@ func (l *UDPListener) listen() {
 			log.Errorf("dogstatsd-udp: error reading packet: %v", err)
 			udpPacketReadingErrors.Add(1)
 			l.telemetryStore.tlmUDPPackets.Inc("error")
+			if l.healthPlatform != nil {
+				_ = l.healthPlatform.ReportIssue(storedef.IssueReport{
+					IssueID:   dogstatsdudpdrops.IssueID,
+					IssueType: dogstatsdudpdrops.IssueID,
+					Source:    "dogstatsd",
+					Context:   map[string]string{"error": err.Error()},
+					Tags:      []string{"dogstatsd", "udp"},
+				})
+			}
 		} else {
 			l.telemetryStore.tlmUDPPackets.Inc("ok")
+			if l.healthPlatform != nil {
+				l.healthPlatform.ResolveIssue(dogstatsdudpdrops.IssueID)
+			}
 
 			udpBytes.Add(int64(n))
 			l.telemetryStore.tlmUDPPacketsBytes.Add(float64(n), "agent")

--- a/comp/dogstatsd/listeners/udp_integration_test.go
+++ b/comp/dogstatsd/listeners/udp_integration_test.go
@@ -26,7 +26,7 @@ func TestStartStopUDPListener(t *testing.T) {
 	deps := fulfillDepsWithConfig(t, cfg)
 	telemetryStore := NewTelemetryStore(nil, deps.Telemetry)
 	packetsTelemetryStore := packets.NewTelemetryStore(nil, deps.Telemetry)
-	s, err := NewUDPListener(nil, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore)
+	s, err := NewUDPListener(nil, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore, nil)
 
 	assert.NoError(t, err)
 	require.NotNil(t, s)
@@ -59,7 +59,7 @@ func TestUDPNonLocal(t *testing.T) {
 	deps := fulfillDepsWithConfig(t, cfg)
 	telemetryStore := NewTelemetryStore(nil, deps.Telemetry)
 	packetsTelemetryStore := packets.NewTelemetryStore(nil, deps.Telemetry)
-	s, err := NewUDPListener(nil, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore)
+	s, err := NewUDPListener(nil, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore, nil)
 	assert.NoError(t, err)
 	require.NotNil(t, s)
 
@@ -85,7 +85,7 @@ func TestUDPLocalOnly(t *testing.T) {
 	deps := fulfillDepsWithConfig(t, cfg)
 	telemetryStore := NewTelemetryStore(nil, deps.Telemetry)
 	packetsTelemetryStore := packets.NewTelemetryStore(nil, deps.Telemetry)
-	s, err := NewUDPListener(nil, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore)
+	s, err := NewUDPListener(nil, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore, nil)
 	assert.NoError(t, err)
 	require.NotNil(t, s)
 

--- a/comp/dogstatsd/listeners/udp_test.go
+++ b/comp/dogstatsd/listeners/udp_test.go
@@ -51,7 +51,7 @@ func TestNewUDPListener(t *testing.T) {
 	deps := fulfillDepsWithConfig(t, map[string]interface{}{"dogstatsd_port": RandomPortName})
 	telemetryStore := NewTelemetryStore(nil, deps.Telemetry)
 	packetsTelemetryStore := packets.NewTelemetryStore(nil, deps.Telemetry)
-	s, err := NewUDPListener(nil, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore)
+	s, err := NewUDPListener(nil, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore, nil)
 
 	assert.NotNil(t, s)
 	assert.Nil(t, err)
@@ -68,7 +68,7 @@ func TestUDPListenerTelemetry(t *testing.T) {
 	deps := fulfillDepsWithConfig(t, cfg)
 	telemetryStore := NewTelemetryStore(nil, deps.Telemetry)
 	packetsTelemetryStore := packets.NewTelemetryStore(nil, deps.Telemetry)
-	s, err := NewUDPListener(packetChannel, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore)
+	s, err := NewUDPListener(packetChannel, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore, nil)
 	require.NotNil(t, s)
 	assert.Nil(t, err)
 
@@ -111,7 +111,7 @@ func TestUDPReceive(t *testing.T) {
 	deps := fulfillDepsWithConfig(t, cfg)
 	telemetryStore := NewTelemetryStore(nil, deps.Telemetry)
 	packetsTelemetryStore := packets.NewTelemetryStore(nil, deps.Telemetry)
-	s, err := NewUDPListener(packetChannel, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore)
+	s, err := NewUDPListener(packetChannel, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore, nil)
 	require.Nil(t, err)
 	require.NotNil(t, s)
 	mockConn := defaultMConn(s.conn.LocalAddr(), contents)
@@ -166,7 +166,7 @@ func TestNewUDPListenerWhenBusyWithSoRcvBufSet(t *testing.T) {
 	deps := fulfillDepsWithConfig(t, cfg)
 	telemetryStore := NewTelemetryStore(nil, deps.Telemetry)
 	packetsTelemetryStore := packets.NewTelemetryStore(nil, deps.Telemetry)
-	s, err := NewUDPListener(nil, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore)
+	s, err := NewUDPListener(nil, newPacketPoolManagerUDP(deps.Config, packetsTelemetryStore), deps.Config, nil, telemetryStore, packetsTelemetryStore, nil)
 	assert.Nil(t, s)
 	assert.NotNil(t, err)
 }

--- a/comp/dogstatsd/server/impl/server.go
+++ b/comp/dogstatsd/server/impl/server.go
@@ -33,6 +33,7 @@ import (
 	server "github.com/DataDog/datadog-agent/comp/dogstatsd/server/def"
 	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/def"
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	offlinereporter "github.com/DataDog/datadog-agent/comp/offlinereporter/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -88,6 +89,7 @@ type dependencies struct {
 	Hostname        hostnameinterface.Component
 	FilterList      filterlist.Component
 	OfflineReporter offlinereporter.Component
+	HealthPlatform  option.Option[storedef.Component]
 }
 
 // Provides defines the output of the dogstatsd server component.
@@ -173,6 +175,9 @@ type dsdServer struct {
 	wmeta           option.Option[workloadmeta.Component]
 	offlineReporter offlinereporter.Component
 
+	// healthPlatform is used to report UDP read errors inline
+	healthPlatform option.Option[storedef.Component]
+
 	// telemetry
 	telemetry               telemetry.Component
 	tlmProcessed            telemetry.Counter
@@ -207,6 +212,7 @@ func initTelemetry() {
 func NewComponent(deps dependencies) Provides {
 	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, deps.Params.Serverless, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, deps.FilterList)
 	s.offlineReporter = deps.OfflineReporter
+	s.healthPlatform = deps.HealthPlatform
 
 	dsdConfig := dsdconfig.NewConfig(s.config)
 	if dsdConfig.EnabledInternal() {
@@ -422,7 +428,8 @@ func (s *dsdServer) start(context.Context) error {
 	}
 
 	if s.config.GetString("dogstatsd_port") == listeners.RandomPortName || s.config.GetInt("dogstatsd_port") > 0 {
-		udpListener, err := listeners.NewUDPListener(packetsChannel, sharedPacketPoolManager, s.config, s.tCapture, s.listernersTelemetry, s.packetsTelemetry)
+		hp, _ := s.healthPlatform.Get()
+		udpListener, err := listeners.NewUDPListener(packetsChannel, sharedPacketPoolManager, s.config, s.tCapture, s.listernersTelemetry, s.packetsTelemetry, hp)
 		if err != nil {
 			s.log.Errorf("%s", err.Error())
 		} else {

--- a/comp/dogstatsd/server/impl/server_util_test.go
+++ b/comp/dogstatsd/server/impl/server_util_test.go
@@ -34,6 +34,7 @@ import (
 	serverdebugmock "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/mock"
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
 	filterlistmock "github.com/DataDog/datadog-agent/comp/filterlist/fx-mock"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	offlinereporter "github.com/DataDog/datadog-agent/comp/offlinereporter/def"
 	offlinereportermock "github.com/DataDog/datadog-agent/comp/offlinereporter/mock"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
@@ -96,6 +97,7 @@ func fulfillDepsWithConfigOverride(t testing.TB, overrides map[string]interface{
 		metricscompression.MockModule(),
 		filterlistmock.MockModule(),
 		fx.Provide(func() offlinereporter.Component { return offlinereportermock.Mock(t) }),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
 
 		fxutil.ProvideComponentConstructor(NewComponent),
 		fx.Supply(server.Params{Serverless: false}),
@@ -117,6 +119,7 @@ func fulfillDepsWithConfigYaml(t testing.TB, yaml string) serverDeps {
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 		filterlistmock.MockModule(),
 		fx.Provide(func() offlinereporter.Component { return offlinereportermock.Mock(t) }),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
 
 		fxutil.ProvideComponentConstructor(NewComponent),
 		fx.Supply(server.Params{Serverless: false}),

--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//comp/healthplatform/issues/admissionprobe",
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
+        "//comp/healthplatform/issues/dogstatsd-udp-drops",
         "//comp/healthplatform/issues/rofspermissions",
         "//comp/healthplatform/scheduler/fx",
         "//comp/healthplatform/store/def",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dogstatsd-udp-drops"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"
 )
 

--- a/comp/healthplatform/issues/dogstatsd-udp-drops/BUILD.bazel
+++ b/comp/healthplatform/issues/dogstatsd-udp-drops/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "dogstatsd-udp-drops",
+    srcs = [
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dogstatsd-udp-drops",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/dogstatsd-udp-drops/issue.go
+++ b/comp/healthplatform/issues/dogstatsd-udp-drops/issue.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package dogstatsdudpdrops
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Issue provides the issue template for DogStatsD UDP buffer undersized detection
+type Issue struct{}
+
+// NewIssue creates a new DogStatsD UDP drops issue template
+func NewIssue() *Issue {
+	return &Issue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation steps
+func (t *Issue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	currentRcvbuf := context["current_rcvbuf"]
+	if currentRcvbuf == "" {
+		currentRcvbuf = "0"
+	}
+
+	recommended := context["recommended"]
+	if recommended == "" {
+		recommended = "25165824"
+	}
+
+	issueExtra, err := structpb.NewStruct(map[string]any{
+		"current_rcvbuf": currentRcvbuf,
+		"recommended":    recommended,
+		"impact":         "Custom metrics may be silently dropped under high throughput without any error message",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create issue extra: %v", err)
+	}
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   "dogstatsd_udp_buffer_undersized",
+		Title:       "DogStatsD UDP Receive Buffer May Be Too Small",
+		Description: "The dogstatsd_so_rcvbuf setting is 0, meaning the OS chooses the UDP receive buffer size. In high-throughput environments the OS default is often too small, causing the kernel to silently drop incoming DogStatsD packets. Custom metrics are lost without any error message or log entry.",
+		Category:    "configuration",
+		Location:    "dogstatsd",
+		Severity:    "medium",
+		DetectedAt:  "", // Will be filled by health platform
+		Source:      "dogstatsd",
+		Extra:       issueExtra,
+		Remediation: buildRemediation(),
+		Tags:        []string{"dogstatsd", "udp", "packet-drops", "buffer", "configuration"},
+	}, nil
+}
+
+// buildRemediation creates remediation steps for the buffer configuration issue
+func buildRemediation() *healthplatform.Remediation {
+	return &healthplatform.Remediation{
+		Summary: "Set dogstatsd_so_rcvbuf to a larger value (e.g. 25165824 = 24 MB) in datadog.yaml and restart the agent",
+		Steps: []*healthplatform.RemediationStep{
+			{Order: 1, Text: "Open /etc/datadog-agent/datadog.yaml in a text editor"},
+			{Order: 2, Text: "Add or update the following setting: dogstatsd_so_rcvbuf: 25165824"},
+			{Order: 3, Text: "Restart the Datadog Agent: sudo systemctl restart datadog-agent"},
+			{Order: 4, Text: "Verify the setting is applied by checking agent logs for 'dogstatsd_so_rcvbuf'"},
+			{Order: 5, Text: "Optional: increase the OS-level maximum with: sudo sysctl -w net.core.rmem_max=26214400"},
+			{Order: 6, Text: "To persist the OS setting across reboots, add net.core.rmem_max=26214400 to /etc/sysctl.conf"},
+		},
+	}
+}

--- a/comp/healthplatform/issues/dogstatsd-udp-drops/module.go
+++ b/comp/healthplatform/issues/dogstatsd-udp-drops/module.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package dogstatsdudpdrops provides a health platform issue module that detects
+// when the DogStatsD UDP receive buffer is left at the OS default (0), which can
+// cause silent UDP packet drops under high metric throughput.
+package dogstatsdudpdrops
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for the DogStatsD UDP buffer undersized issue
+	IssueID = "dogstatsd-udp-buffer-undersized"
+
+	// CheckID is the unique identifier for the built-in health check
+	CheckID = "dogstatsd-udp-buffer-config"
+
+	// CheckName is the human-readable name for the health check
+	CheckName = "DogStatsD UDP Receive Buffer Configuration"
+)
+
+// module implements issues.Module
+type module struct {
+	template *Issue
+}
+
+// NewModule creates a new DogStatsD UDP drops issue module
+func NewModule(_ config.Component) issues.Module {
+	return &module{
+		template: NewIssue(),
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *module) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *module) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns nil because detection happens inline in the DogStatsD
+// UDP listener — ReportIssue is called directly when a read error occurs.
+func (m *module) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Adds a health platform issue module (`dogstatsd-udp-drops`) that detects when the DogStatsD UDP receive buffer is configured at 0 (the OS default), which silently drops packets under high metric throughput.

**Detection** happens inline in the DogStatsD UDP listener: when `ReadFrom` returns an error, the health platform store is notified via `ReportIssue`; when the next read succeeds, the issue is resolved via `ResolveIssue`. No periodic health check is scheduled — the issue is live-reported as drops occur.

**Changes:**
- `comp/healthplatform/issues/dogstatsd-udp-drops/` — new issue module (template + registration)
- `comp/dogstatsd/listeners/udp.go` — inline detection in the read loop; accepts `storedef.Component`
- `comp/dogstatsd/server/impl/server.go` — adds `HealthPlatform option.Option[storedef.Component]` to `dependencies` / `dsdServer`; passes it through to `NewUDPListener`
- `cmd/dogstatsd/subcommands/start/command.go` — provides `option.None[storedef.Component]()` for the standalone DogStatsD binary (health platform not running there)
- `comp/healthplatform/bundle.go` + `BUILD.bazel` — registers the new module

### Motivation

Customers experiencing missing custom metrics often have `dogstatsd_so_rcvbuf = 0` — the OS default buffer is too small for high-volume environments. This issue is completely silent: no error is logged, and metrics simply disappear. The health platform surfaces this misconfiguration so customers can fix it before data loss occurs.

### Describe how you validated your changes

- `go build ./comp/healthplatform/... ./comp/dogstatsd/...` passes cleanly
- `go build ./cmd/dogstatsd/...` passes cleanly
- Existing `udp_test.go` and `udp_integration_test.go` tests still compile and pass

### QA Plan

#### Prerequisites

- A Linux host running the Datadog Agent with DogStatsD enabled (`use_dogstatsd: true`, `dogstatsd_port: 8125`).
- `dogstatsd_so_rcvbuf` **not set** (or explicitly `0`) in `datadog.yaml`.
- A load generator capable of sending high-volume UDP to port 8125 (e.g. `dd-go-dogstatsd` or a simple script using `nc`).

#### Verify the issue is reported

1. Start the agent with `dogstatsd_so_rcvbuf: 0` (or unset).
2. Send a burst of UDP metrics at a rate high enough to cause kernel-level drops (check `netstat -su` → `receive buffer errors`).
3. Confirm the health platform store records an issue with:
   - `issue_id: "dogstatsd-udp-buffer-undersized"`
   - `severity: "medium"`
   - `category: "configuration"`
   - `tags: ["dogstatsd", "udp", "packet-drops", "buffer", "configuration"]`
4. The remediation should recommend setting `dogstatsd_so_rcvbuf: 25165824` (24 MB).

To check kernel-level UDP drops:
```bash
netstat -su | grep "receive buffer errors"
# or
cat /proc/net/udp | awk '{print $5}' | sort | uniq -c
```

#### Verify the issue resolves

1. After the burst, confirm that when subsequent reads succeed the issue is resolved (status transitions to "resolved" in the health platform store).

#### Verify the happy path — no false positives

| Scenario | Expected |
|---|---|
| `dogstatsd_so_rcvbuf: 25165824` set in `datadog.yaml` | No issue reported — buffer is explicitly configured |
| No UDP errors occurring (low throughput) | No issue reported |
| Agent running on non-Linux platform | No issue — `check_noop.go` no-op |
| Standalone `dogstatsd` binary | No issue — `option.None` provided, health platform not wired up |

To set the receive buffer for a quick test:
```yaml
# datadog.yaml
dogstatsd_so_rcvbuf: 25165824
```
Restart and confirm `no issue reported` in the health platform store.

#### Verify OS buffer settings (optional)

To also raise the OS-level cap so the setting takes effect:
```bash
sudo sysctl -w net.core.rmem_max=26214400
```
To persist across reboots:
```bash
echo "net.core.rmem_max=26214400" | sudo tee -a /etc/sysctl.conf
sudo sysctl -p
```

### Additional Notes

- Detection is intentionally **inline** (not a periodic built-in check) because the symptom is a live read error — a periodic check could not observe it after the fact.
- The `dogstatsd-udp-drops` module returns `nil` from `BuiltInHealthCheck()` by design.
- `storedef.Component` is threaded through as `option.Option` so that environments without the health platform bundle (e.g. standalone dogstatsd) still compile and run correctly.