### PR TITLE
[AGTHEAL-133] feat(healthplatform): detect DogStatsD metrics dropped due to tag count limit

### DIFF
--- a/comp/dogstatsd/server/impl/server.go
+++ b/comp/dogstatsd/server/impl/server.go
@@ -33,6 +33,8 @@ import (
 	server "github.com/DataDog/datadog-agent/comp/dogstatsd/server/def"
 	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/def"
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
+	dogstatsdtaglimit "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dogstatsd-tag-limit"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	offlinereporter "github.com/DataDog/datadog-agent/comp/offlinereporter/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -88,6 +90,7 @@ type dependencies struct {
 	Hostname        hostnameinterface.Component
 	FilterList      filterlist.Component
 	OfflineReporter offlinereporter.Component
+	HealthPlatform  option.Option[storedef.Component]
 }
 
 // Provides defines the output of the dogstatsd server component.
@@ -172,6 +175,8 @@ type dsdServer struct {
 
 	wmeta           option.Option[workloadmeta.Component]
 	offlineReporter offlinereporter.Component
+	healthPlatform  option.Option[storedef.Component]
+	maxTagsCount    int
 
 	// telemetry
 	telemetry               telemetry.Component
@@ -207,6 +212,7 @@ func initTelemetry() {
 func NewComponent(deps dependencies) Provides {
 	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, deps.Params.Serverless, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, deps.FilterList)
 	s.offlineReporter = deps.OfflineReporter
+	s.healthPlatform = deps.HealthPlatform
 
 	dsdConfig := dsdconfig.NewConfig(s.config)
 	if dsdConfig.EnabledInternal() {
@@ -320,6 +326,7 @@ func newServerCompat(cfg model.ReaderWriter, log log.Component, hostname hostnam
 			serverlessMode:            serverless,
 		},
 		wmeta:                   wmeta,
+		maxTagsCount:            cfg.GetInt("dogstatsd_max_tags_count"),
 		telemetry:               telemetrycomp,
 		filterList:              filterList,
 		tlmProcessed:            dogstatsdTelemetryCount,
@@ -851,6 +858,12 @@ func (s *dsdServer) parseMetricMessage(metricSamples []metrics.MetricSample, par
 			metricSamples[idx].Tags = metricSamples[0].Tags
 		}
 
+		// Enforce tag count limit if configured
+		if s.maxTagsCount > 0 && len(metricSamples[idx].Tags) > s.maxTagsCount {
+			s.reportTagLimitExceeded(metricSamples[idx].Name, len(metricSamples[idx].Tags))
+			metricSamples[idx].Tags = metricSamples[idx].Tags[:s.maxTagsCount]
+		}
+
 		// If we're receiving runtime metrics, we need to convert the default source to the runtime source
 		if s.enrichConfig.serverlessMode && strings.HasPrefix(metricSamples[idx].Name, "runtime.") {
 			metricSamples[idx].Source = serverlessSourceCustomToRuntime(metricSamples[idx].Source)
@@ -860,6 +873,25 @@ func (s *dsdServer) parseMetricMessage(metricSamples []metrics.MetricSample, par
 		okCnt.Inc()
 	}
 	return metricSamples, nil
+}
+
+// reportTagLimitExceeded reports a tag-limit issue to the health platform if configured.
+func (s *dsdServer) reportTagLimitExceeded(metricName string, tagCount int) {
+	hp, ok := s.healthPlatform.Get()
+	if !ok {
+		return
+	}
+	_ = hp.ReportIssue(storedef.IssueReport{
+		IssueID:   dogstatsdtaglimit.IssueID,
+		IssueType: dogstatsdtaglimit.IssueID,
+		Source:    "dogstatsd",
+		Context: map[string]string{
+			"metricName":   metricName,
+			"tagCount":     strconv.Itoa(tagCount),
+			"maxTagsCount": strconv.Itoa(s.maxTagsCount),
+		},
+		Tags: []string{"dogstatsd", "tag-limit"},
+	})
 }
 
 func (s *dsdServer) parseEventMessage(parser *parser, message []byte, origin string, processID uint32) (*event.Event, error) {

--- a/comp/dogstatsd/server/impl/server_util_test.go
+++ b/comp/dogstatsd/server/impl/server_util_test.go
@@ -34,6 +34,7 @@ import (
 	serverdebugmock "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/mock"
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
 	filterlistmock "github.com/DataDog/datadog-agent/comp/filterlist/fx-mock"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	offlinereporter "github.com/DataDog/datadog-agent/comp/offlinereporter/def"
 	offlinereportermock "github.com/DataDog/datadog-agent/comp/offlinereporter/mock"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
@@ -96,6 +97,7 @@ func fulfillDepsWithConfigOverride(t testing.TB, overrides map[string]interface{
 		metricscompression.MockModule(),
 		filterlistmock.MockModule(),
 		fx.Provide(func() offlinereporter.Component { return offlinereportermock.Mock(t) }),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
 
 		fxutil.ProvideComponentConstructor(NewComponent),
 		fx.Supply(server.Params{Serverless: false}),
@@ -117,6 +119,7 @@ func fulfillDepsWithConfigYaml(t testing.TB, yaml string) serverDeps {
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 		filterlistmock.MockModule(),
 		fx.Provide(func() offlinereporter.Component { return offlinereportermock.Mock(t) }),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
 
 		fxutil.ProvideComponentConstructor(NewComponent),
 		fx.Supply(server.Params{Serverless: false}),
@@ -141,6 +144,7 @@ func fulfillDepsWithInactiveServer(t *testing.T, cfg map[string]interface{}) (de
 		logscompression.MockModule(),
 		filterlistmock.MockModule(),
 		fx.Provide(func() offlinereporter.Component { return offlinereportermock.Mock(t) }),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
 	))
 
 	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, false, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, deps.FilterList)

--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//comp/healthplatform/issues/admissionprobe",
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
+        "//comp/healthplatform/issues/dogstatsd-tag-limit",
         "//comp/healthplatform/issues/rofspermissions",
         "//comp/healthplatform/scheduler/fx",
         "//comp/healthplatform/store/def",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dogstatsd-tag-limit"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"
 )
 

--- a/comp/healthplatform/issues/dogstatsd-tag-limit/BUILD.bazel
+++ b/comp/healthplatform/issues/dogstatsd-tag-limit/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "dogstatsd-tag-limit",
+    srcs = [
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dogstatsd-tag-limit",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/dogstatsd-tag-limit/issue.go
+++ b/comp/healthplatform/issues/dogstatsd-tag-limit/issue.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package dogstatsdtaglimit
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Issue provides the complete issue template for the DogStatsD tag count limit drop issue
+type Issue struct{}
+
+// NewIssue creates a new DogStatsD tag count limit issue template
+func NewIssue() *Issue {
+	return &Issue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation steps
+func (t *Issue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	maxTagsCount := context["maxTagsCount"]
+	if maxTagsCount == "" {
+		maxTagsCount = strconv.Itoa(defaultMaxTagsCount)
+	}
+
+	extra, err := structpb.NewStruct(map[string]any{
+		"max_tags_count": maxTagsCount,
+		"config_key":     "dogstatsd_max_tags_count",
+		"impact":         "Metrics with more than the maximum number of tags are silently discarded, causing gaps in custom metrics dashboards",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create issue extra: %v", err)
+	}
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   "dogstatsd_tag_limit_drop",
+		Title:       "DogStatsD Metrics Dropped Due to Tag Count Limit",
+		Description: "DogStatsD silently drops metrics that exceed the maximum tag count limit (default: 100 tags). Metrics with more tags are silently discarded with no error message, causing invisible gaps in custom metrics.",
+		Category:    "configuration",
+		Location:    "dogstatsd",
+		Severity:    "high",
+		DetectedAt:  "", // Will be filled by health platform
+		Source:      "dogstatsd",
+		Extra:       extra,
+		Remediation: &healthplatform.Remediation{
+			Summary: "Either reduce the number of tags per metric or increase dogstatsd_max_tags_count in datadog.yaml",
+			Steps: []*healthplatform.RemediationStep{
+				{Order: 1, Text: "Check DogStatsD stats to identify metrics with many tags: datadog-agent dogstatsd-stats"},
+				{Order: 2, Text: "Review how many tags are being sent per metric in your application code"},
+				{Order: 3, Text: "Option A: Reduce tags per metric to stay under the limit (preferred for performance)"},
+				{Order: 4, Text: "Option B: Increase the limit in datadog.yaml: dogstatsd_max_tags_count: 200"},
+				{Order: 5, Text: "Restart the agent after making config changes: systemctl restart datadog-agent"},
+			},
+		},
+		Tags: []string{"dogstatsd", "tags", "metrics-dropped", "configuration"},
+	}, nil
+}

--- a/comp/healthplatform/issues/dogstatsd-tag-limit/module.go
+++ b/comp/healthplatform/issues/dogstatsd-tag-limit/module.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package dogstatsdtaglimit provides a health platform issue module that detects
+// when DogStatsD metrics may be silently dropped due to the tag count limit.
+package dogstatsdtaglimit
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for the DogStatsD tag count limit drop issue
+	IssueID = "dogstatsd-tag-limit-drop"
+
+	// CheckID is the unique identifier for the built-in health check
+	CheckID = "dogstatsd-tag-limit-config"
+
+	// CheckName is the human-readable name for the health check
+	CheckName = "DogStatsD Tag Count Limit"
+
+	// defaultMaxTagsCount is the fallback value used in issue templates when
+	// the actual limit is not provided in the context.
+	defaultMaxTagsCount = 100
+)
+
+// module implements issues.Module
+type module struct {
+	template *Issue
+}
+
+// NewModule creates a new DogStatsD tag count limit issue module
+func NewModule(_ config.Component) issues.Module {
+	return &module{
+		template: NewIssue(),
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *module) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *module) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns nil — tag limit drops are detected inline by the
+// DogStatsD server via ReportIssue when metrics are actually truncated.
+func (m *module) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return nil
+}

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1710,6 +1710,10 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)
 	config.BindEnvAndSetDefault("dogstatsd_tags", []string{})
+	// dogstatsd_max_tags_count limits the number of tags per metric. Metrics with more tags
+	// will have their tags truncated to the first dogstatsd_max_tags_count tags.
+	// Default is 0 (no limit). Set to a positive value to enforce a limit.
+	config.BindEnvAndSetDefault("dogstatsd_max_tags_count", 0)
 	config.BindEnvAndSetDefault("dogstatsd_mapper_cache_size", 1000)
 	config.BindEnvAndSetDefault("dogstatsd_string_interner_size", 4096)
 	// Enable check for Entity-ID presence when enriching Dogstatsd metrics with tags


### PR DESCRIPTION
### What does this PR do?

Adds a health platform issue module (`dogstatsd-tag-limit`) that detects when DogStatsD metrics are silently dropped because they exceed the maximum tag count limit (`dogstatsd_max_tags_count`, default: 0 = no limit).

**Detection** happens inline in the DogStatsD server's metric parse loop: when a metric's tag count exceeds `dogstatsd_max_tags_count`, the tags are truncated and `ReportIssue` is called on the health platform store. No periodic check is scheduled — the issue is live-reported the moment truncation occurs.

**Changes:**
- `comp/healthplatform/issues/dogstatsd-tag-limit/` — new issue module (template + registration)
- `comp/dogstatsd/server/impl/server.go` — inline detection in `parseMetricMessage`; reads `dogstatsd_max_tags_count`, truncates tags, calls `reportTagLimitExceeded`
- `pkg/config/setup/common_settings.go` — registers `dogstatsd_max_tags_count` config key (default `0` = no limit)
- `comp/healthplatform/bundle.go` + `BUILD.bazel` — registers the new module

### Motivation

When customers send DogStatsD metrics with more than `dogstatsd_max_tags_count` tags, those metrics are silently truncated — no error is logged, and the extra tags simply disappear. This is a common cause of unexplained gaps in custom metrics dashboards. The health platform surfaces this issue proactively so customers can fix it before data loss occurs.

### Describe how you validated your changes

- `go build ./comp/healthplatform/... ./comp/dogstatsd/server/...` passes cleanly
- Existing dogstatsd server tests compile and pass

### QA Plan

#### Prerequisites

- A Linux host running the Datadog Agent with DogStatsD enabled.
- `dogstatsd_max_tags_count` set to a small positive value in `datadog.yaml` (e.g. `5` for easy testing):

  ```yaml
  # datadog.yaml
  use_dogstatsd: true
  dogstatsd_port: 8125
  dogstatsd_max_tags_count: 5
  ```

  Restart the agent after changing config.

#### Verify the issue is reported

1. Send a DogStatsD metric with more tags than the configured limit:

   ```bash
   echo "custom.metric:1|c|#tag1:v1,tag2:v2,tag3:v3,tag4:v4,tag5:v5,tag6:v6" | nc -u -w1 127.0.0.1 8125
   ```

2. Confirm the health platform store records an issue with:
   - `issue_id: "dogstatsd-tag-limit-drop"`
   - `severity: "high"`
   - `category: "configuration"`
   - `tags: ["dogstatsd", "tags", "metrics-dropped", "configuration"]`

3. The issue context should include `maxTagsCount`, `metricName`, and `tagCount`.

4. The remediation steps should offer two options:
   - Reduce tags per metric
   - Increase `dogstatsd_max_tags_count` (e.g. `dogstatsd_max_tags_count: 200`)

#### Verify the happy path — no false positives

| Scenario | Expected |
|---|---|
| `dogstatsd_max_tags_count: 0` (default) | No issue — tag limit disabled |
| Metric has fewer tags than the limit | No issue |
| DogStatsD disabled (`use_dogstatsd: false`) | No issue |

#### Verify tag truncation behaviour

With `dogstatsd_max_tags_count: 5` and a metric sent with 6 tags:
- The metric **is** forwarded to Datadog, but with only the first 5 tags.
- The 6th tag is silently dropped and the issue is reported.
- Verify in Datadog UI that the metric appears with only 5 tags.

#### Config key reference

| Key | Default | Description |
|---|---|---|
| `dogstatsd_max_tags_count` | `0` (no limit) | Maximum number of tags per DogStatsD metric. Excess tags are truncated. |

To set during testing:
```yaml
dogstatsd_max_tags_count: 100
```

Or via environment variable:
```bash
DD_DOGSTATSD_MAX_TAGS_COUNT=100
```

### Additional Notes

- Detection is intentionally **inline** (not a periodic built-in check) because the symptom is a live truncation event — a periodic check could not detect it retroactively.
- The `dogstatsd-tag-limit` module returns `nil` from `BuiltInHealthCheck()` by design.
- `storedef.Component` is threaded through as `option.Option` so environments without the health platform bundle still compile and run correctly.