### PR TITLE
[AGTHEAL-132] feat(healthplatform): detect APM container tag enrichment failure on Kubernetes with cgroup v2

### DIFF
--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//comp/healthplatform/forwarder/fx",
         "//comp/healthplatform/issues/admisconfig",
         "//comp/healthplatform/issues/admissionprobe",
+        "//comp/healthplatform/issues/apm-cgroup-v2-container-tags",
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
         "//comp/healthplatform/issues/rofspermissions",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -23,6 +23,7 @@ import (
 	// must not import other impl packages.
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admisconfig"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/apm-cgroup-v2-container-tags"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"

--- a/comp/healthplatform/issues/apm-cgroup-v2-container-tags/BUILD.bazel
+++ b/comp/healthplatform/issues/apm-cgroup-v2-container-tags/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "apm-cgroup-v2-container-tags",
+    srcs = [
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/apm-cgroup-v2-container-tags",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+    ],
+)

--- a/comp/healthplatform/issues/apm-cgroup-v2-container-tags/issue.go
+++ b/comp/healthplatform/issues/apm-cgroup-v2-container-tags/issue.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package apmcgroupv2
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+)
+
+// Issue provides the issue template for APM cgroup v2 container tag enrichment failures
+type Issue struct{}
+
+// NewIssue creates a new APM cgroup v2 issue template
+func NewIssue() *Issue {
+	return &Issue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation steps
+func (t *Issue) BuildIssue(_ map[string]string) (*healthplatform.Issue, error) {
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   "apm_cgroup_v2_container_tags_missing",
+		Title:       "APM Traces Missing Container Tags on Kubernetes with cgroup v2",
+		Description: "The agent is running in a Kubernetes environment with cgroup v2, and the APM container ID resolver cannot read container IDs from the cgroup filesystem. This prevents container-level tags (container_id, kube_container_name, kube_namespace, etc.) from being added to traces.",
+		Category:    "runtime",
+		Location:    "apm",
+		Severity:    "medium",
+		DetectedAt:  "", // Will be filled by health platform
+		Source:      "apm",
+		Remediation: buildRemediation(),
+		Tags:        []string{"apm", "cgroup", "kubernetes", "container-tags", "traces", "linux"},
+	}, nil
+}
+
+// buildRemediation creates the remediation steps for the APM cgroup v2 issue
+func buildRemediation() *healthplatform.Remediation {
+	return &healthplatform.Remediation{
+		Summary: "Ensure the APM container ID resolver can read cgroup v2 information and that the Agent version supports cgroup v2",
+		Steps: []*healthplatform.RemediationStep{
+			{Order: 1, Text: fmt.Sprintf("Check agent log for: %q", "Failed to identify cgroups version")},
+			{Order: 2, Text: "Verify cgroup version: stat /sys/fs/cgroup/cgroup.controllers (file exists = cgroup v2 is active)"},
+			{Order: 3, Text: "Ensure Agent version >= 7.35.0 which has proper cgroup v2 support"},
+			{Order: 4, Text: "If using Docker Desktop or kind, verify the kubelet uses cgroup v2 driver (--cgroup-driver=systemd)"},
+			{Order: 5, Text: "Check that DD_KUBELET_TLS_VERIFY is not causing kubelet auth failures that prevent container metadata resolution"},
+		},
+	}
+}

--- a/comp/healthplatform/issues/apm-cgroup-v2-container-tags/module.go
+++ b/comp/healthplatform/issues/apm-cgroup-v2-container-tags/module.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package apmcgroupv2 detects when APM trace container ID resolution may fail due to cgroup v2.
+package apmcgroupv2
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() { issues.RegisterModuleFactory(NewModule) }
+
+const (
+	// IssueID is the unique identifier for APM cgroup v2 container tag issues
+	IssueID = "apm-cgroup-v2-container-tags-missing"
+
+	// CheckID is the unique identifier for the built-in health check
+	CheckID = "apm-cgroup-v2-container-id"
+
+	// CheckName is the human-readable name for the health check
+	CheckName = "APM Container ID Resolution on cgroup v2"
+)
+
+// apmCgroupV2Module implements issues.Module
+type apmCgroupV2Module struct {
+	template *Issue
+}
+
+// NewModule creates a new APM cgroup v2 container tags issue module
+func NewModule(_ config.Component) issues.Module {
+	return &apmCgroupV2Module{
+		template: NewIssue(),
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *apmCgroupV2Module) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *apmCgroupV2Module) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns nil: the cgroup v2 issue is detected inline by the trace
+// agent on startup via ReportIssue(), not by a background poll.
+func (m *apmCgroupV2Module) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return nil
+}

--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -28,6 +28,7 @@ import (
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	statsd "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	traceagent "github.com/DataDog/datadog-agent/comp/trace/agent/def"
 	compression "github.com/DataDog/datadog-agent/comp/trace/compression/def"
 	traceconfigdef "github.com/DataDog/datadog-agent/comp/trace/config/def"
@@ -42,6 +43,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
@@ -70,6 +72,7 @@ type dependencies struct {
 	Compressor            compression.Component
 	IPC                   ipc.Component
 	TracerPayloadModifier pkgagent.TracerPayloadModifier
+	HealthPlatform        option.Option[storedef.Component]
 }
 
 var _ traceagent.Component = (*component)(nil)
@@ -155,6 +158,8 @@ func NewAgent(deps dependencies) (traceagent.Component, error) {
 		deps.Compressor,
 	)
 	c.Agent.TracerPayloadModifier = deps.TracerPayloadModifier
+
+	checkCgroupV2Health(tracecfg, deps.HealthPlatform)
 
 	c.config.OnUpdateAPIKey(c.UpdateAPIKey)
 

--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -72,7 +72,7 @@ type dependencies struct {
 	Compressor            compression.Component
 	IPC                   ipc.Component
 	TracerPayloadModifier pkgagent.TracerPayloadModifier
-	HealthPlatform        option.Option[storedef.Component]
+	HealthPlatform        option.Option[storedef.Component] `optional:"true"`
 }
 
 var _ traceagent.Component = (*component)(nil)

--- a/comp/trace/agent/impl/cgroupcheck_linux.go
+++ b/comp/trace/agent/impl/cgroupcheck_linux.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package agentimpl
+
+import (
+	"strings"
+
+	apmcgroupv2 "github.com/DataDog/datadog-agent/comp/healthplatform/issues/apm-cgroup-v2-container-tags"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	tracecfg "github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+// checkCgroupV2Health reports a health platform issue if the cgroup reader fails to
+// initialize, which prevents APM from resolving container IDs on cgroup v2 + Kubernetes.
+func checkCgroupV2Health(conf *tracecfg.AgentConfig, hp option.Option[storedef.Component]) {
+	store, ok := hp.Get()
+	if !ok {
+		return
+	}
+
+	var hostPrefix string
+	if strings.HasPrefix(conf.ContainerProcRoot, "/host") {
+		hostPrefix = "/host"
+	}
+
+	_, err := cgroups.NewReader(
+		cgroups.WithCgroupV1BaseController("memory"),
+		cgroups.WithProcPath(conf.ContainerProcRoot),
+		cgroups.WithHostPrefix(hostPrefix),
+		cgroups.WithReaderFilter(cgroups.ContainerFilter),
+	)
+	if err != nil {
+		_ = store.ReportIssue(storedef.IssueReport{
+			IssueID:   apmcgroupv2.IssueID,
+			IssueType: apmcgroupv2.IssueID,
+			Source:    "apm",
+			Context:   map[string]string{"error": err.Error()},
+			Tags:      []string{"apm", "cgroup", "kubernetes"},
+		})
+		return
+	}
+
+	// Clear any previously reported issue on successful initialization.
+	store.ResolveIssue(apmcgroupv2.IssueID)
+}

--- a/comp/trace/agent/impl/cgroupcheck_noop.go
+++ b/comp/trace/agent/impl/cgroupcheck_noop.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+package agentimpl
+
+import (
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	tracecfg "github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+func checkCgroupV2Health(_ *tracecfg.AgentConfig, _ option.Option[storedef.Component]) {}


### PR DESCRIPTION
### What does this PR do?

Adds a health platform issue module (`apm-cgroup-v2-container-tags`) that detects when APM traces may be missing container tags because the cgroup v2 container ID resolver cannot initialize properly on Kubernetes.

**Detection** happens once at trace-agent startup: `checkCgroupV2Health` calls `cgroups.NewReader` with the agent's configured `ContainerProcRoot`. If initialization fails, the issue is reported to the health platform store. If it succeeds, any previously reported issue is resolved.

**Changes:**
- `comp/healthplatform/issues/apm-cgroup-v2-container-tags/` — new issue module (template + registration)
- `comp/trace/agent/impl/cgroupcheck_linux.go` — startup detection using `cgroups.NewReader`
- `comp/trace/agent/impl/cgroupcheck_noop.go` — no-op stub for non-Linux platforms
- `comp/trace/agent/impl/agent.go` — wires `option.Option[storedef.Component]` into `dependencies`, calls `checkCgroupV2Health` after agent init
- `comp/healthplatform/bundle.go` + `BUILD.bazel` — registers the new module

### Motivation

On modern Kubernetes clusters using cgroup v2 (default in kernel ≥ 4.5), the APM container ID resolver may fail to read container IDs from the cgroup filesystem. This silently prevents container-level tags (`container_id`, `kube_container_name`, `kube_namespace`, etc.) from being added to APM traces. The agent logs a warning but customers often miss it. This health check surfaces the issue proactively.

The check fires when `cgroups.NewReader` returns an error — the same condition under which `pkg/trace/api.NewIDProvider` falls back to a noop provider.

### Describe how you validated your changes

- `go build ./comp/healthplatform/... ./comp/trace/agent/...` passes cleanly
- Existing trace agent tests compile and pass

### QA Plan

#### Prerequisites

- A Kubernetes node using **cgroup v2** (kernel ≥ 4.5; most clusters since 2022):
  ```bash
  # Confirm cgroup v2 is active on the node
  stat /sys/fs/cgroup/cgroup.controllers   # exists → cgroup v2
  stat /sys/fs/cgroup/memory               # absent → pure cgroup v2 (no cgroup v1 fallback)
  ```
- The Datadog Agent deployed as a DaemonSet in the cluster with APM enabled (`DD_APM_ENABLED=true`).

#### Verify the issue is detected (error path)

1. Run the agent pod on a cgroup v2 node where the cgroup reader initialization fails.  
   To simulate: temporarily make the cgroup filesystem unreadable or point `apm_config.container_proc_root` to a non-existent path:

   ```yaml
   # datadog.yaml
   apm_config:
     container_proc_root: /nonexistent/proc
   ```

2. At startup, `checkCgroupV2Health` fires. Confirm the health platform store records an issue with:
   - `issue_id: "apm-cgroup-v2-container-tags-missing"`
   - `severity: "medium"`
   - `category: "runtime"`
   - `location: "apm"`
   - `tags: ["apm", "cgroup", "kubernetes", "container-tags", "traces", "linux"]`

3. The remediation steps should guide the user to:
   - Check agent logs for `"Failed to identify cgroups version"`
   - Verify cgroup v2 is active (`stat /sys/fs/cgroup/cgroup.controllers`)
   - Ensure Agent ≥ 7.35.0
   - Check kubelet `--cgroup-driver=systemd`

#### Verify the issue is not reported (happy path)

| Scenario | Expected |
|---|---|
| Agent on cgroup v1 node (no `cgroup.controllers` file) | No issue — `cgroups.NewReader` succeeds |
| Agent with correct `container_proc_root` on cgroup v2 | No issue — reader initializes successfully |
| Agent running on non-Linux platform (macOS, Windows) | No issue — `cgroupcheck_noop.go` no-op |
| Health platform store not wired up | No issue — `option.None` short-circuits |

#### Verify resolution

1. After fixing the cgroup config (set `container_proc_root` back to the real path), restart the agent.
2. On the next startup, `checkCgroupV2Health` succeeds and calls `ResolveIssue`.
3. Confirm the issue transitions to `"resolved"` in the health platform store.

#### Check the agent log

To correlate with the existing warning:
```bash
kubectl logs -l app=datadog -c agent | grep -i "cgroup"
# Look for: "Failed to identify cgroups version" or similar
```

### Additional Notes

- Detection is intentionally **startup-only** (not periodic) — the cgroup filesystem layout is stable for the lifetime of a node.
- `storedef.Component` is threaded through as `option.Option` so environments without the health platform bundle (e.g. standalone trace agent) still compile and run correctly.
- The `apm-cgroup-v2-container-tags` module returns `nil` from `BuiltInHealthCheck()` by design.