### PR TITLE
[AGTHEAL-130] feat(healthplatform): detect multi_line rules silently ignored on journald/JSON log sources

### DIFF
--- a/comp/anomalydetection/logssource/impl/logssource.go
+++ b/comp/anomalydetection/logssource/impl/logssource.go
@@ -20,6 +20,7 @@ import (
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/flare"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
@@ -138,7 +139,7 @@ func NewComponent(deps Requires) (Provides, error) {
 	launchersMgr := launchers.NewLaunchers(logSources, pipeline, deps.Auditor, tracker)
 	launchersMgr.AddLauncher(fileLauncher)
 	launchersMgr.AddLauncher(launcher)
-	launchersMgr.AddLauncher(journaldlauncher.NewLauncher(flare.NewFlareController(), deps.Tagger))
+	launchersMgr.AddLauncher(journaldlauncher.NewLauncher(flare.NewFlareController(), deps.Tagger, option.None[storedef.Component]()))
 
 	registerKubeletJournaldSource(logSources, deps.Log)
 

--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//comp/healthplatform/issues/admissionprobe",
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
+        "//comp/healthplatform/issues/logs-multiline-journald",
         "//comp/healthplatform/issues/rofspermissions",
         "//comp/healthplatform/scheduler/fx",
         "//comp/healthplatform/store/def",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/logs-multiline-journald"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"
 )
 

--- a/comp/healthplatform/issues/logs-multiline-journald/BUILD.bazel
+++ b/comp/healthplatform/issues/logs-multiline-journald/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "logs-multiline-journald",
+    srcs = [
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/logs-multiline-journald",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/logs-multiline-journald/issue.go
+++ b/comp/healthplatform/issues/logs-multiline-journald/issue.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package logsmultilinejournal
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Issue provides the issue template for multi_line-on-journald misconfiguration
+type Issue struct{}
+
+// NewIssue creates a new Issue template
+func NewIssue() *Issue {
+	return &Issue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation steps.
+// Expected context keys:
+//   - "affectedSources": comma-separated list of affected source names
+//   - "sourceType":      "journald"
+func (t *Issue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	affectedSources := context["affectedSources"]
+	if affectedSources == "" {
+		affectedSources = "unknown"
+	}
+
+	sourceType := context["sourceType"]
+	if sourceType == "" {
+		sourceType = "journald"
+	}
+
+	extra, err := structpb.NewStruct(map[string]any{
+		"affected_sources": affectedSources,
+		"source_type":      sourceType,
+		"impact":           "Logs are collected as individual entries without the expected multi-line aggregation.",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create issue extra: %v", err)
+	}
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   "logs_multiline_journald_unsupported",
+		Title:       "multi_line Aggregation Has No Effect on journald Log Sources",
+		Description: "One or more log sources are configured with `multi_line` processing rules but use journald sources, where multi_line aggregation is not supported. Each journald entry is already a complete pre-framed event, so the rules are silently ignored — logs are collected as individual entries without the expected aggregation.",
+		Category:    "configuration",
+		Location:    "logs-agent",
+		Severity:    "medium",
+		Source:      "logs",
+		Extra:       extra,
+		Remediation: buildRemediation(affectedSources),
+		Tags:        []string{"logs", "multiline", "journald", "configuration", "aggregation"},
+	}, nil
+}
+
+func buildRemediation(affectedSources string) *healthplatform.Remediation {
+	return &healthplatform.Remediation{
+		Summary: fmt.Sprintf("Remove multi_line processing rules from journald log sources (%s) or switch to a supported aggregation approach.", affectedSources),
+		Steps: []*healthplatform.RemediationStep{
+			{Order: 1, Text: "Identify the affected log source configuration files (usually under /etc/datadog-agent/conf.d/)."},
+			{Order: 2, Text: "Open the relevant conf.yaml and locate the `log_processing_rules` block for the journald source."},
+			{Order: 3, Text: "Remove or comment out any rule with `type: multi_line` from the affected journald log source."},
+			{Order: 4, Text: "If multi-line aggregation is still required, consider forwarding journal entries to a file tailer that supports multi_line, or restructure the application to emit single-line JSON events."},
+			{Order: 5, Text: "Restart the Datadog Agent: systemctl restart datadog-agent"},
+			{Order: 6, Text: "Verify with `datadog-agent status` that no warnings are shown for the log source."},
+		},
+	}
+}

--- a/comp/healthplatform/issues/logs-multiline-journald/module.go
+++ b/comp/healthplatform/issues/logs-multiline-journald/module.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package logsmultilinejournal provides a health check for misconfigured
+// multi_line rules on journald log sources, where multi_line aggregation has no effect.
+package logsmultilinejournal
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for multi_line-on-journald issues
+	IssueID = "logs-multiline-journald-unsupported"
+)
+
+// module implements issues.Module
+type module struct {
+	template *Issue
+}
+
+// NewModule creates a new multi_line-on-journald issue module
+func NewModule(_ config.Component) issues.Module {
+	return &module{template: NewIssue()}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *module) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *module) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns nil because detection is done inline by the journald
+// launcher when it processes a source with multi_line rules, via ReportIssue().
+func (m *module) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return nil
+}

--- a/comp/logs/agent/agentimpl/agent.go
+++ b/comp/logs/agent/agentimpl/agent.go
@@ -36,6 +36,7 @@ import (
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	integrationsimpl "github.com/DataDog/datadog-agent/comp/logs/integrations/impl"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -87,6 +88,7 @@ type dependencies struct {
 	Tagger             tagger.Component
 	Compression        logscompression.Component
 	Secrets            secrets.Component
+	HealthPlatform     option.Option[storedef.Component]
 }
 
 type provides struct {
@@ -125,6 +127,7 @@ type logAgent struct {
 	schedulerProviders        []schedulers.Scheduler
 	integrationsLogs          integrations.Component
 	compression               logscompression.Component
+	healthPlatform            option.Option[storedef.Component]
 
 	// make sure this is done only once, when we're ready
 	prepareSchedulers sync.Once
@@ -166,6 +169,7 @@ func newLogsAgent(deps dependencies) provides {
 			tagger:             deps.Tagger,
 			compression:        deps.Compression,
 			secrets:            deps.Secrets,
+			healthPlatform:     deps.HealthPlatform,
 		}
 		deps.Lc.Append(fx.Hook{
 			OnStart: logsAgent.start,

--- a/comp/logs/agent/agentimpl/agent.go
+++ b/comp/logs/agent/agentimpl/agent.go
@@ -27,6 +27,7 @@ import (
 	statusComponent "github.com/DataDog/datadog-agent/comp/core/status"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
@@ -36,7 +37,6 @@ import (
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	integrationsimpl "github.com/DataDog/datadog-agent/comp/logs/integrations/impl"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
-	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -88,7 +88,7 @@ type dependencies struct {
 	Tagger             tagger.Component
 	Compression        logscompression.Component
 	Secrets            secrets.Component
-	HealthPlatform     option.Option[storedef.Component]
+	HealthPlatform     option.Option[storedef.Component] `optional:"true"`
 }
 
 type provides struct {

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -161,7 +161,7 @@ func (a *logAgent) addLauncherInstances(lnchrs *launchers.Launchers, wmeta optio
 		fingerprinter,
 	))
 	lnchrs.AddLauncher(listener.NewLauncher(a.config.GetInt("logs_config.frame_size")))
-	lnchrs.AddLauncher(journald.NewLauncher(a.flarecontroller, a.tagger))
+	lnchrs.AddLauncher(journald.NewLauncher(a.flarecontroller, a.tagger, a.healthPlatform))
 	lnchrs.AddLauncher(windowsevent.NewLauncher())
 	lnchrs.AddLauncher(container.NewLauncher(a.sources, wmeta, a.tagger))
 	lnchrs.AddLauncher(integrationLauncher.NewLauncher(

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -38,6 +38,7 @@ import (
 	integrationsimpl "github.com/DataDog/datadog-agent/comp/logs/integrations/impl"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
 
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	kubehealthdef "github.com/DataDog/datadog-agent/comp/logs-library/kubehealth/def"
 	kubehealthmock "github.com/DataDog/datadog-agent/comp/logs-library/kubehealth/mock"
 	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
@@ -54,7 +55,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	logsStatus "github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
-	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -54,7 +54,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	logsStatus "github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
@@ -514,6 +516,7 @@ func (suite *AgentTestSuite) createDeps() dependencies {
 		}),
 		auditorfx.Module(),
 		fx.Provide(kubehealthmock.NewProvides),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
 	))
 }
 

--- a/comp/logs/agent/agentimpl/mock.go
+++ b/comp/logs/agent/agentimpl/mock.go
@@ -13,6 +13,7 @@ import (
 
 	"go.uber.org/fx"
 
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
@@ -26,7 +27,9 @@ import (
 func MockModule() fxutil.Module {
 	return fxutil.Component(
 		fx.Provide(newMock),
-		fx.Provide(func(m agent.Mock) agent.Component { return m }))
+		fx.Provide(func(m agent.Mock) agent.Component { return m }),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
+	)
 }
 
 type mockLogsAgent struct {

--- a/pkg/logs/launchers/journald/launcher.go
+++ b/pkg/logs/launchers/journald/launcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coreos/go-systemd/v22/sdjournal"
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
@@ -23,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/journald"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
@@ -49,21 +51,23 @@ type Launcher struct {
 	journalFactory   tailer.JournalFactory
 	fc               *flareController.FlareController
 	tagger           tagger.Component
+	healthPlatform   option.Option[storedef.Component]
 }
 
 // NewLauncher returns a new Launcher.
-func NewLauncher(fc *flareController.FlareController, tagger tagger.Component) *Launcher {
-	return NewLauncherWithFactory(&SDJournalFactory{}, fc, tagger)
+func NewLauncher(fc *flareController.FlareController, tagger tagger.Component, hp option.Option[storedef.Component]) *Launcher {
+	return NewLauncherWithFactory(&SDJournalFactory{}, fc, tagger, hp)
 }
 
 // NewLauncherWithFactory returns a new Launcher.
-func NewLauncherWithFactory(journalFactory tailer.JournalFactory, fc *flareController.FlareController, tagger tagger.Component) *Launcher {
+func NewLauncherWithFactory(journalFactory tailer.JournalFactory, fc *flareController.FlareController, tagger tagger.Component, hp option.Option[storedef.Component]) *Launcher {
 	return &Launcher{
 		tailers:        make(map[string]*tailer.Tailer),
 		stop:           make(chan struct{}),
 		journalFactory: journalFactory,
 		fc:             fc,
 		tagger:         tagger,
+		healthPlatform: hp,
 	}
 }
 
@@ -97,6 +101,16 @@ func (l *Launcher) run() {
 					allJournalSources = append(allJournalSources, "/var/log/journal")
 				} else if _, err := os.Stat("/run/log/journal"); err == nil {
 					allJournalSources = append(allJournalSources, "/run/log/journal")
+				}
+			}
+
+			// Detect multi_line rules on journald sources — silently ignored since
+			// journald entries are pre-framed; report to health platform if configured.
+			for _, rule := range source.Config.ProcessingRules {
+				if rule.Type == config.MultiLine {
+					log.Warnf("multi_line aggregation is not supported for journald log sources (source: %s) — rules will be ignored", identifier)
+					l.reportMultiLineIssue(identifier)
+					break
 				}
 			}
 
@@ -150,3 +164,24 @@ func (l *Launcher) setupTailer(source *sources.LogSource) (*tailer.Tailer, error
 	}
 	return tailer, nil
 }
+
+// reportMultiLineIssue reports a multi_line-on-journald misconfiguration to the health platform.
+func (l *Launcher) reportMultiLineIssue(sourceName string) {
+	store, ok := l.healthPlatform.Get()
+	if !ok {
+		return
+	}
+	if err := store.ReportIssue(storedef.IssueReport{
+		IssueID:   multiLineJournaldIssueID,
+		IssueType: multiLineJournaldIssueID,
+		Source:    "logs",
+		Context:   map[string]string{"source": sourceName, "sourceType": "journald"},
+		Tags:      []string{"logs", "journald", "multiline"},
+	}); err != nil {
+		log.Warnf("Failed to report multiline-journald issue to health platform: %v", err)
+	}
+}
+
+// multiLineJournaldIssueID mirrors the constant from the logs-multiline-journald
+// issue package, inlined here to avoid an import cycle.
+const multiLineJournaldIssueID = "logs-multiline-journald-unsupported"

--- a/pkg/logs/launchers/journald/launcher_nosystemd.go
+++ b/pkg/logs/launchers/journald/launcher_nosystemd.go
@@ -10,18 +10,20 @@ package journald
 
 import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 // Launcher is not supported on no systemd environment.
 type Launcher struct{}
 
 // NewLauncher returns a new Launcher
-func NewLauncher(*flareController.FlareController, tagger.Component) *Launcher {
+func NewLauncher(_ *flareController.FlareController, _ tagger.Component, _ option.Option[storedef.Component]) *Launcher {
 	return &Launcher{}
 }
 

--- a/pkg/logs/launchers/journald/launcher_test.go
+++ b/pkg/logs/launchers/journald/launcher_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/flare"
@@ -24,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/journald"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 type MockJournal struct{}
@@ -57,7 +59,7 @@ func newTestLauncher(t *testing.T) *Launcher {
 
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 
-	launcher := NewLauncherWithFactory(&MockJournalFactory{}, flare.NewFlareController(), fakeTagger)
+	launcher := NewLauncherWithFactory(&MockJournalFactory{}, flare.NewFlareController(), fakeTagger, option.None[storedef.Component]())
 	launcher.Start(launchers.NewMockSourceProvider(), pipeline.NewMockProvider(), auditorMock.NewMockRegistry(), tailers.NewTailerTracker())
 	return launcher
 }


### PR DESCRIPTION
### What does this PR do?

Adds a health platform issue module (`logs-multiline-journald`) that detects when `multi_line` log processing rules are configured on journald log sources, where they have no effect. Detection runs inline in the journald launcher when a new source with `multi_line` rules is processed.

**Why multi_line doesn't work on journald:** Each journald entry is already a complete pre-framed event (binary framing). The multi_line aggregation layer runs on the raw byte stream and never observes multi-line boundaries. Rules are silently ignored — there is no error in the logs today.

**Changes:**
- `comp/healthplatform/issues/logs-multiline-journald/` — new issue module (template + registration)
- `pkg/logs/launchers/journald/launcher.go` — detects multi_line rules when processing each source, logs a warning, calls `reportMultiLineIssue` via `storedef.IssueReport`
- `pkg/logs/launchers/journald/launcher_nosystemd.go` — updated noop signature to match
- `pkg/logs/launchers/journald/launcher_test.go` — passes `option.None` to `NewLauncherWithFactory`
- `comp/logs/agent/agentimpl/agent.go` — adds `HealthPlatform option.Option[storedef.Component]` to `dependencies` and `logAgent`, propagates to `agent_core_init.go`
- `comp/logs/agent/agentimpl/mock.go` + `agent_test.go` — provides `option.None[storedef.Component]()`
- `comp/healthplatform/bundle.go` + `BUILD.bazel` — registers the new module

### Motivation

Customers who configure `multi_line` on journald sources see their rules silently ignored, leading to unexpected single-line log entries in Datadog. There is no warning or error in the agent logs today. This health check surfaces the misconfiguration proactively.

### Describe how you validated your changes

- `go build ./comp/healthplatform/... ./comp/logs/agent/... ./pkg/logs/launchers/journald/...` passes cleanly
- Existing journald launcher tests compile with the new `option.None` parameter

### QA Plan

#### Prerequisites

- A Linux host with **systemd** and journald enabled (the check only fires on `//go:build systemd` builds).
- The Datadog Agent installed with log collection enabled (`logs_enabled: true`).
- A journald log source configured with a `multi_line` processing rule. Example integration config:

  ```yaml
  # /etc/datadog-agent/conf.d/my-service.d/conf.yaml
  logs:
    - type: journald
      source: my-service
      service: my-service
      log_processing_rules:
        - type: multi_line
          name: new_log_start_with_date
          pattern: \d{4}-\d{2}-\d{2}
  ```

#### Verify the issue is detected

1. Start the agent with the above configuration.
2. When the journald launcher processes the `my-service` source, it detects the `multi_line` rule.
3. The agent logs a warning: `multi_line aggregation is not supported for journald log sources (source: my-service) — rules will be ignored`
4. Confirm the health platform store records an issue with:
   - `issue_id: "logs-multiline-journald-unsupported"`
   - `severity: "medium"`
   - `category: "configuration"`
   - `location: "logs-agent"`
   - `tags: ["logs", "multiline", "journald", "configuration", "aggregation"]`
5. The issue context should include:
   - `source: "my-service"` (or the journal path)
   - `sourceType: "journald"`

#### Verify the issue is not reported (happy path)

| Scenario | Expected |
|---|---|
| No `log_processing_rules` on the journald source | No issue |
| `log_processing_rules` with `type: exclude_at_match` (not multi_line) | No issue |
| Source type is `file` (not journald), has `multi_line` | No issue — only journald sources are checked |
| Non-systemd build (macOS, Windows, no-systemd Linux) | No issue — noop launcher |
| Health platform store not wired up | No issue — `option.None` short-circuits |

#### Verify the remediation steps

The issue remediation should recommend:
1. Locate the config file under `/etc/datadog-agent/conf.d/`
2. Remove or comment out the `type: multi_line` rule from the journald source
3. Optionally: forward journal entries to a file tailer that supports `multi_line`
4. Restart the agent: `systemctl restart datadog-agent`

#### Example fix

Remove the `multi_line` rule from the journald source config:

```yaml
# /etc/datadog-agent/conf.d/my-service.d/conf.yaml
logs:
  - type: journald
    source: my-service
    service: my-service
    # log_processing_rules removed — multi_line not supported on journald
```

Restart and confirm the issue is no longer reported.

### Additional Notes

- Detection is **inline** (not periodic) — it fires when each source is added to the launcher via the source channel. No startup scan needed.
- The issue ID constant is inlined in `launcher.go` to avoid an import cycle.
- `storedef.Component` is threaded through as `option.Option` so environments without the health platform bundle still compile and run correctly.