### PR TITLE
[AGTHEAL-129] feat(healthplatform): detect Docker log rotation risk when using socket-based tailing

### DIFF
--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//comp/healthplatform/issues/admisconfig",
         "//comp/healthplatform/issues/admissionprobe",
         "//comp/healthplatform/issues/checkfailure",
+        "//comp/healthplatform/issues/docker-logs-rotation",
         "//comp/healthplatform/issues/dockerpermissions",
         "//comp/healthplatform/issues/rofspermissions",
         "//comp/healthplatform/scheduler/fx",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admisconfig"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/docker-logs-rotation"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"
 )

--- a/comp/healthplatform/issues/docker-logs-rotation/BUILD.bazel
+++ b/comp/healthplatform/issues/docker-logs-rotation/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "docker-logs-rotation",
+    srcs = [
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/docker-logs-rotation",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/docker-logs-rotation/issue.go
+++ b/comp/healthplatform/issues/docker-logs-rotation/issue.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package dockerlogsrotation
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Issue provides the issue template for Docker log rotation risk
+type Issue struct{}
+
+// NewIssue creates a new Docker logs rotation issue template
+func NewIssue() *Issue {
+	return &Issue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation steps
+func (t *Issue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	dockerLogDir := context["dockerLogDir"]
+	if dockerLogDir == "" {
+		dockerLogDir = "/var/lib/docker/containers"
+	}
+
+	reason := context["reason"]
+
+	issueExtra, err := structpb.NewStruct(map[string]any{
+		"integration": "docker",
+		"docker_dir":  dockerLogDir,
+		"reason":      reason,
+		"impact":      "Docker log rotation can cause the agent to lose its position in the log stream, resulting in log gaps or complete collection failure until the agent is restarted",
+		"fix":         "Enable file-based Docker log tailing with logs_config.docker_container_use_file: true",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create issue extra: %v", err)
+	}
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   "docker_logs_rotation_risk",
+		Title:       "Docker Container Logs May Stop After Log Rotation",
+		Description: "The agent is collecting Docker container logs via socket-based tailing (docker_container_use_file: false). Socket-based tailing does not handle Docker log rotation gracefully — when Docker rotates log files, the agent may lose the file position and stop receiving new logs until the agent is restarted.",
+		Category:    "configuration",
+		Location:    "logs-agent",
+		Severity:    "medium",
+		DetectedAt:  "", // Will be filled by health platform
+		Source:      "logs",
+		Extra:       issueExtra,
+		Remediation: buildRemediation(),
+		Tags:        []string{"docker", "logs", "rotation", "file-tailing", "socket-tailing"},
+	}, nil
+}
+
+func buildRemediation() *healthplatform.Remediation {
+	return &healthplatform.Remediation{
+		Summary: "Switch to file-based Docker log tailing to handle log rotation correctly",
+		Steps: []*healthplatform.RemediationStep{
+			{Order: 1, Text: "Enable file-based Docker log tailing: add `logs_config.docker_container_use_file: true` to datadog.yaml"},
+			{Order: 2, Text: "Restart the agent: systemctl restart datadog-agent"},
+			{Order: 3, Text: "Alternatively, configure Docker to disable log rotation: set \"log-opts\": {\"max-size\": \"0\"} in /etc/docker/daemon.json (requires Docker daemon restart)"},
+			{Order: 4, Text: "Verify: datadog-agent status | grep -A 10 \"Log Agent\""},
+		},
+	}
+}

--- a/comp/healthplatform/issues/docker-logs-rotation/module.go
+++ b/comp/healthplatform/issues/docker-logs-rotation/module.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package dockerlogsrotation provides the issue module for Docker container log rotation risk.
+package dockerlogsrotation
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for Docker log rotation risk issues
+	IssueID = "docker-logs-rotation-risk"
+)
+
+// module implements issues.Module
+type module struct {
+	template *Issue
+}
+
+// NewModule creates a new Docker logs rotation issue module
+func NewModule(_ config.Component) issues.Module {
+	return &module{template: NewIssue()}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *module) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *module) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns nil because detection happens in-workflow when the
+// Docker socket tailer is initialized in socket-based mode.
+func (m *module) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return nil
+}

--- a/comp/logs/agent/agentimpl/agent.go
+++ b/comp/logs/agent/agentimpl/agent.go
@@ -36,6 +36,7 @@ import (
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	integrationsimpl "github.com/DataDog/datadog-agent/comp/logs/integrations/impl"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -87,6 +88,7 @@ type dependencies struct {
 	Tagger             tagger.Component
 	Compression        logscompression.Component
 	Secrets            secrets.Component
+	HealthPlatform     option.Option[storedef.Component]
 }
 
 type provides struct {
@@ -125,6 +127,7 @@ type logAgent struct {
 	schedulerProviders        []schedulers.Scheduler
 	integrationsLogs          integrations.Component
 	compression               logscompression.Component
+	healthPlatform            option.Option[storedef.Component]
 
 	// make sure this is done only once, when we're ready
 	prepareSchedulers sync.Once
@@ -166,6 +169,7 @@ func newLogsAgent(deps dependencies) provides {
 			tagger:             deps.Tagger,
 			compression:        deps.Compression,
 			secrets:            deps.Secrets,
+			healthPlatform:     deps.HealthPlatform,
 		}
 		deps.Lc.Append(fx.Hook{
 			OnStart: logsAgent.start,

--- a/comp/logs/agent/agentimpl/agent.go
+++ b/comp/logs/agent/agentimpl/agent.go
@@ -27,6 +27,7 @@ import (
 	statusComponent "github.com/DataDog/datadog-agent/comp/core/status"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
@@ -36,7 +37,6 @@ import (
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	integrationsimpl "github.com/DataDog/datadog-agent/comp/logs/integrations/impl"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
-	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
@@ -88,7 +88,7 @@ type dependencies struct {
 	Tagger             tagger.Component
 	Compression        logscompression.Component
 	Secrets            secrets.Component
-	HealthPlatform     option.Option[storedef.Component]
+	HealthPlatform     option.Option[storedef.Component] `optional:"true"`
 }
 
 type provides struct {

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -163,7 +163,7 @@ func (a *logAgent) addLauncherInstances(lnchrs *launchers.Launchers, wmeta optio
 	lnchrs.AddLauncher(listener.NewLauncher(a.config.GetInt("logs_config.frame_size")))
 	lnchrs.AddLauncher(journald.NewLauncher(a.flarecontroller, a.tagger))
 	lnchrs.AddLauncher(windowsevent.NewLauncher())
-	lnchrs.AddLauncher(container.NewLauncher(a.sources, wmeta, a.tagger))
+	lnchrs.AddLauncher(container.NewLauncher(a.sources, wmeta, a.tagger, a.healthPlatform))
 	lnchrs.AddLauncher(integrationLauncher.NewLauncher(
 		afero.NewOsFs(),
 		a.sources, integrationsLogs))

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -54,7 +54,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	logsStatus "github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
@@ -141,6 +143,7 @@ func createAgent(suite *AgentTestSuite, endpoints *config.Endpoints) (*logAgent,
 		inventoryagentmock.MockModule(),
 		auditorfx.Module(),
 		fx.Provide(kubehealthmock.NewProvides),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
 	))
 
 	fakeTagger := taggerfxmock.SetupFakeTagger(suite.T())
@@ -514,6 +517,7 @@ func (suite *AgentTestSuite) createDeps() dependencies {
 		}),
 		auditorfx.Module(),
 		fx.Provide(kubehealthmock.NewProvides),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
 	))
 }
 

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -38,6 +38,7 @@ import (
 	integrationsimpl "github.com/DataDog/datadog-agent/comp/logs/integrations/impl"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
 
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	kubehealthdef "github.com/DataDog/datadog-agent/comp/logs-library/kubehealth/def"
 	kubehealthmock "github.com/DataDog/datadog-agent/comp/logs-library/kubehealth/mock"
 	"github.com/DataDog/datadog-agent/comp/logs-library/metrics"
@@ -54,7 +55,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	logsStatus "github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
-	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"

--- a/comp/logs/agent/agentimpl/mock.go
+++ b/comp/logs/agent/agentimpl/mock.go
@@ -13,6 +13,7 @@ import (
 
 	"go.uber.org/fx"
 
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
@@ -26,7 +27,9 @@ import (
 func MockModule() fxutil.Module {
 	return fxutil.Component(
 		fx.Provide(newMock),
-		fx.Provide(func(m agent.Mock) agent.Component { return m }))
+		fx.Provide(func(m agent.Mock) agent.Component { return m }),
+		fx.Provide(func() option.Option[storedef.Component] { return option.None[storedef.Component]() }),
+	)
 }
 
 type mockLogsAgent struct {

--- a/pkg/logs/launchers/container/launcher.go
+++ b/pkg/logs/launchers/container/launcher.go
@@ -13,6 +13,7 @@ import (
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
@@ -59,16 +60,18 @@ type Launcher struct {
 
 	wmeta option.Option[workloadmeta.Component]
 
-	tagger tagger.Component
+	tagger         tagger.Component
+	healthPlatform option.Option[storedef.Component]
 }
 
 // NewLauncher returns a new launcher
-func NewLauncher(sources *sourcesPkg.LogSources, wmeta option.Option[workloadmeta.Component], tagger tagger.Component) *Launcher {
+func NewLauncher(sources *sourcesPkg.LogSources, wmeta option.Option[workloadmeta.Component], tagger tagger.Component, hp option.Option[storedef.Component]) *Launcher {
 	launcher := &Launcher{
-		sources: sources,
-		tailers: make(map[*sourcesPkg.LogSource]tailerfactory.Tailer),
-		wmeta:   wmeta,
-		tagger:  tagger,
+		sources:        sources,
+		tailers:        make(map[*sourcesPkg.LogSource]tailerfactory.Tailer),
+		wmeta:          wmeta,
+		tagger:         tagger,
+		healthPlatform: hp,
 	}
 	return launcher
 }
@@ -80,7 +83,7 @@ func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvid
 	l.cancel = cancel
 	l.stopped = make(chan struct{})
 
-	l.tailerFactory = tailerfactory.New(l.sources, pipelineProvider, registry, l.wmeta, l.tagger)
+	l.tailerFactory = tailerfactory.New(l.sources, pipelineProvider, registry, l.wmeta, l.tagger, l.healthPlatform)
 	go l.run(ctx, sourceProvider)
 }
 

--- a/pkg/logs/launchers/container/launcher_no_kubelet_and_docker.go
+++ b/pkg/logs/launchers/container/launcher_no_kubelet_and_docker.go
@@ -11,6 +11,7 @@ package container
 import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
@@ -25,7 +26,7 @@ import (
 type Launcher struct{}
 
 // NewLauncher returns a new launcher
-func NewLauncher(_ *sourcesPkg.LogSources, _ option.Option[workloadmeta.Component], _ tagger.Component) *Launcher {
+func NewLauncher(_ *sourcesPkg.LogSources, _ option.Option[workloadmeta.Component], _ tagger.Component, _ option.Option[storedef.Component]) *Launcher {
 	return &Launcher{}
 }
 

--- a/pkg/logs/launchers/container/launcher_test.go
+++ b/pkg/logs/launchers/container/launcher_test.go
@@ -17,6 +17,7 @@ import (
 
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	auditorMock "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
@@ -40,7 +41,7 @@ func (tf *testFactory) MakeTailer(source *sources.LogSource) (tailerfactory.Tail
 func TestStartStop(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 
-	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger)
+	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger, option.None[storedef.Component]())
 
 	sp := launchers.NewMockSourceProvider()
 	pl := pipeline.NewMockProvider()
@@ -60,7 +61,7 @@ func TestStartStop(t *testing.T) {
 func TestAddsRemovesSource(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 
-	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger)
+	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger, option.None[storedef.Component]())
 	l.tailerFactory = &testFactory{
 		makeTailer: func(source *sources.LogSource) (tailerfactory.Tailer, error) {
 			return &tailerfactory.TestTailer{Name: source.Name}, nil
@@ -91,7 +92,7 @@ func TestAddsRemovesSource(t *testing.T) {
 func TestCannotMakeTailer(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 
-	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger)
+	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger, option.None[storedef.Component]())
 	l.tailerFactory = &testFactory{
 		makeTailer: func(_ *sources.LogSource) (tailerfactory.Tailer, error) {
 			return nil, errors.New("uhoh")
@@ -114,7 +115,7 @@ func TestCannotMakeTailer(t *testing.T) {
 func TestCannotStartTailer(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 
-	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger)
+	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger, option.None[storedef.Component]())
 	l.tailerFactory = &testFactory{
 		makeTailer: func(source *sources.LogSource) (tailerfactory.Tailer, error) {
 			return &tailerfactory.TestTailer{Name: source.Name, StartError: true}, nil

--- a/pkg/logs/launchers/container/tailerfactory/factory.go
+++ b/pkg/logs/launchers/container/tailerfactory/factory.go
@@ -12,6 +12,7 @@ package tailerfactory
 import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/containersorpods"
@@ -61,13 +62,14 @@ type factory struct {
 	// dockerUtilGetter memoizes a DockerUtil instance; fetch this with dockerUtilGetter.get()
 	dockerUtilGetter dockerUtilGetter
 
-	tagger tagger.Component
+	tagger         tagger.Component
+	healthPlatform option.Option[storedef.Component]
 }
 
 var _ Factory = (*factory)(nil)
 
 // New creates a new Factory.
-func New(sources *sources.LogSources, pipelineProvider pipeline.Provider, registry auditor.Registry, workloadmetaStore option.Option[workloadmeta.Component], tagger tagger.Component) Factory {
+func New(sources *sources.LogSources, pipelineProvider pipeline.Provider, registry auditor.Registry, workloadmetaStore option.Option[workloadmeta.Component], tagger tagger.Component, hp option.Option[storedef.Component]) Factory {
 	return &factory{
 		sources:           sources,
 		pipelineProvider:  pipelineProvider,
@@ -76,6 +78,7 @@ func New(sources *sources.LogSources, pipelineProvider pipeline.Provider, regist
 		cop:               containersorpods.NewChooser(),
 		dockerUtilGetter:  &dockerUtilGetterImpl{},
 		tagger:            tagger,
+		healthPlatform:    hp,
 	}
 }
 

--- a/pkg/logs/launchers/container/tailerfactory/socket.go
+++ b/pkg/logs/launchers/container/tailerfactory/socket.go
@@ -21,8 +21,10 @@ import (
 	dockerutilPkg "github.com/DataDog/datadog-agent/pkg/util/docker"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers/container/tailerfactory/tailers"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // get gets a DockerUtil instance, either returning a memoized value
@@ -66,7 +68,7 @@ func (tf *factory) makeSocketTailer(source *sources.LogSource) (Tailer, error) {
 	// apply defaults for source and service directly to the LogSource struct (!!)
 	source.Config.Source, source.Config.Service = tf.defaultSourceAndService(source, tf.cop.Get())
 
-	return tailers.NewDockerSocketTailer(
+	t := tailers.NewDockerSocketTailer(
 		du,
 		containerID,
 		source,
@@ -74,5 +76,25 @@ func (tf *factory) makeSocketTailer(source *sources.LogSource) (Tailer, error) {
 		readTimeout,
 		tf.registry,
 		tf.tagger,
-	), nil
+	)
+
+	// Report Docker log rotation risk: socket-based tailing does not handle
+	// Docker log rotation gracefully — the agent may lose its position after rotation.
+	if store, ok := tf.healthPlatform.Get(); ok {
+		if err := store.ReportIssue(storedef.IssueReport{
+			IssueID:   dockerLogsRotationIssueID,
+			IssueType: dockerLogsRotationIssueID,
+			Source:    "logs",
+			Context:   map[string]string{"mode": "socket"},
+			Tags:      []string{"logs", "docker", "rotation"},
+		}); err != nil {
+			log.Debugf("healthplatform: failed to report docker-logs-rotation-risk: %v", err)
+		}
+	}
+
+	return t, nil
 }
+
+// dockerLogsRotationIssueID mirrors the constant from the docker-logs-rotation
+// issue package, inlined here to avoid an import cycle.
+const dockerLogsRotationIssueID = "docker-logs-rotation-risk"


### PR DESCRIPTION
### What does this PR do?

Adds a health platform issue module (`docker-logs-rotation`) that detects when Docker container logs are collected via socket-based tailing, which does not handle Docker log rotation gracefully.

**Detection** happens inline in `makeSocketTailer` (the tailer factory) each time a Docker socket tailer is created: the issue is reported to the health platform store via `storedef.IssueReport`.

**Why socket-based tailing is risky:** When Docker rotates log files (its default behavior), the agent may continue reading from a stale file descriptor or fail to follow the new file, resulting in log gaps or complete collection failure until restart. File-based tailing (`docker_container_use_file: true`) follows inode changes and handles rotation correctly.

**Changes:**
- `comp/healthplatform/issues/docker-logs-rotation/` — new issue module (template + registration)
- `pkg/logs/launchers/container/tailerfactory/socket.go` — reports the issue via `storedef.IssueReport` when `makeSocketTailer` creates a Docker socket tailer
- `pkg/logs/launchers/container/tailerfactory/factory.go` — adds `healthPlatform option.Option[storedef.Component]` field, updated `New()` signature
- `pkg/logs/launchers/container/launcher.go` — adds `healthPlatform` field, updated `NewLauncher()` signature, passes it to `tailerfactory.New()`
- `pkg/logs/launchers/container/launcher_no_kubelet_and_docker.go` — updated noop signature
- `pkg/logs/launchers/container/launcher_test.go` — passes `option.None` to `NewLauncher`
- `comp/logs/agent/agentimpl/agent.go` — adds `HealthPlatform option.Option[storedef.Component]` to deps/struct
- `comp/logs/agent/agentimpl/agent_core_init.go` — passes `healthPlatform` to `container.NewLauncher`
- `comp/logs/agent/agentimpl/mock.go` + `agent_test.go` — provides `option.None[storedef.Component]()`
- `comp/healthplatform/bundle.go` + `BUILD.bazel` — registers the new module

### Motivation

Docker log rotation can silently break log collection when socket-based tailing is used. There is no error in the agent logs or status today — collection simply stops. This health check surfaces the configuration risk proactively.

### Describe how you validated your changes

- `go build ./comp/healthplatform/... ./comp/logs/agent/... ./pkg/logs/launchers/container/...` passes cleanly
- Existing container launcher tests compile with the updated `NewLauncher` signature

### QA Plan

#### Prerequisites

- A Linux host running the Datadog Agent with Docker log collection enabled:

  ```yaml
  # datadog.yaml
  logs_enabled: true
  container_collect_all: true
  # docker_container_use_file: false  ← default, or explicitly set to false
  ```

- At least one Docker container running and producing logs.
- Docker configured with log rotation (the default):

  ```json
  // /etc/docker/daemon.json (default Docker behavior)
  {
    "log-driver": "json-file",
    "log-opts": {
      "max-size": "100m",
      "max-file": "3"
    }
  }
  ```

#### Verify the issue is detected

1. Start the agent with `docker_container_use_file: false` (or unset) and `container_collect_all: true`.
2. When the agent creates a Docker socket tailer for a container, `makeSocketTailer` fires.
3. Confirm the health platform store records an issue with:
   - `issue_id: "docker-logs-rotation-risk"`
   - `severity: "medium"`
   - `category: "configuration"`
   - `location: "logs-agent"`
   - `tags: ["docker", "logs", "rotation", "file-tailing", "socket-tailing"]`
4. The issue context should include `mode: "socket"`.
5. The remediation should recommend:
   - Set `logs_config.docker_container_use_file: true` in `datadog.yaml`
   - Or disable Docker log rotation with `"max-size": "0"` in `/etc/docker/daemon.json`

#### Verify the issue is not reported (happy path)

| Scenario | Expected |
|---|---|
| `docker_container_use_file: true` | No issue — file-based tailing handles rotation correctly |
| No Docker containers running | No issue — `makeSocketTailer` never called |
| No Docker socket available | No issue — tailer factory falls back to file tailing |
| Non-Docker container (Kubernetes pod) | No issue — `makeSocketTailer` only fires for `type: docker` |
| Health platform store not wired up | No issue — `option.None` short-circuits |

#### Fix and verify resolution

Set file-based tailing in `datadog.yaml`:

```yaml
logs_config:
  docker_container_use_file: true
```

Restart the agent:

```bash
systemctl restart datadog-agent
```

After restart, `makeSocketTailer` is no longer called for Docker containers (file-based tailing is used instead), so the issue is not reported again.

#### Simulate log rotation (advanced)

To verify the symptom that motivates this issue:

```bash
# Trigger Docker log rotation
docker kill --signal=USR1 $(docker ps -q --filter name=mycontainer)
# or rotate by filling max-size
docker run --log-opt max-size=1m --log-opt max-file=1 ...
```

With `docker_container_use_file: false`: log collection may stop after rotation.
With `docker_container_use_file: true`: log collection continues seamlessly.

### Additional Notes

- Detection is **per-container** (fires each time a socket tailer is created).
- The issue ID constant is inlined in `socket.go` to avoid an import cycle.
- `storedef.Component` is threaded through as `option.Option` so environments without the health platform bundle still compile and run correctly.