### PR TITLE
fix: CLC metadata panic

### DIFF
--- a/comp/metadata/clusterchecks/impl/clusterchecks.go
+++ b/comp/metadata/clusterchecks/impl/clusterchecks.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	clusterchecksmetadata "github.com/DataDog/datadog-agent/comp/metadata/clusterchecks/def"
 	"github.com/DataDog/datadog-agent/comp/metadata/internal/util"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
@@ -268,8 +269,13 @@ func (cc *clusterChecksImpl) collectClusterCheckMetadata(payload *Payload) {
 				initConfig = string(config.InitConfig)
 			}
 
+			var firstInstance integration.Data
+			if len(config.Instances) > 0 {
+				firstInstance = config.Instances[0]
+			}
+
 			checkMetadata := metadata{
-				"config.hash":     checkid.BuildID(checkName, config.IntDigest(), config.Instances[0], config.InitConfig),
+				"config.hash":     checkid.BuildID(checkName, config.IntDigest(), firstInstance, config.InitConfig),
 				"config.provider": config.Provider,
 				"config.source":   config.Source,
 				"init_config":     initConfig,
@@ -304,8 +310,13 @@ func (cc *clusterChecksImpl) collectClusterCheckMetadata(payload *Payload) {
 			initConfig = string(config.InitConfig)
 		}
 
+		var firstInstance integration.Data
+		if len(config.Instances) > 0 {
+			firstInstance = config.Instances[0]
+		}
+
 		checkMetadata := metadata{
-			"config.hash":     checkid.BuildID(checkName, config.IntDigest(), config.Instances[0], config.InitConfig),
+			"config.hash":     checkid.BuildID(checkName, config.IntDigest(), firstInstance, config.InitConfig),
 			"config.provider": config.Provider,
 			"config.source":   config.Source,
 			"init_config":     initConfig,


### PR DESCRIPTION
### What does this PR do?

Check `config.Instances` to avoid `panic: runtime error: index out of range [0] with length 0`.

### Motivation

Fixes https://github.com/DataDog/helm-charts/issues/2349

### Describe how you validated your changes
CI and E2E tests.

### Additional Notes
