### PR TITLE
fix(rust): Let omnibus strip debug symbols instead of build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,4 +63,3 @@ tempfile = "3.0"
 [profile.release]
 lto = "fat"
 opt-level = "z"
-strip = "symbols"

--- a/bazel/configs/rust.bazelrc
+++ b/bazel/configs/rust.bazelrc
@@ -1,6 +1,5 @@
 build:rust-release --@rules_rust//rust/settings:lto=fat # Enable fat LTO
 build:rust-release --@rules_rust//rust/settings:extra_rustc_flag=-Copt-level=z # Optimize for size
 build:rust-release --@rules_rust//rust/settings:extra_rustc_flag=-Ccodegen-units=1 # Single codegen unit for maximum optimization
-build:rust-release --@rules_rust//rust/settings:extra_rustc_flag=-Cstrip=symbols # Strip debug symbols
 # It was discussed in the Bazel/Rust round if we should drop this flag. Therefore, commenting it out for now.
 # build:rust-release --@rules_rust//rust/settings:extra_rustc_flag=-Cpanic=abort # Remove stack unwinding


### PR DESCRIPTION
### What does this PR do?

Removes the `strip = "symbols"` setting from the Rust release profile in `Cargo.toml` and the corresponding `-Cstrip=symbols` rustc flag from the Bazel rust release config. Debug symbols are no longer stripped during the Rust build step.

### Motivation

Stripping symbols at build time prevents debugging and profiling of the resulting binaries. By deferring symbol stripping to omnibus (which strips all ELFs during packaging), we:

- Match the behavior of C/Go binaries
- Enable debugging and profiling of pre-packaging binaries
- Ship Rust binary debug symbols in the separate debug packages

### Describe how you validated your changes

CI, static package sizes unchanged.

Also extracted the debug deb and checked that `system-probe-lite.dbg` had symbols (earlier it was present but had no symbols).

```
$ dpkg-deb -x datadog-agent-dbg_7.79.0~devel.git.301.321f91f.pipeline.105218664-1_amd64.deb foo
$ nm -C foo/opt/datadog-agent/.debug/opt/datadog-agent/embedded/bin/system-probe-lite.dbg
```