### PR TITLE
refactor(host-profiler): drop linux build tag from platform-independent packages

### DIFF
--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux
-
 // Package agentprovider generates OpenTelemetry Collector configuration from Datadog Agent configuration.
 package agentprovider
 

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux && test
+//go:build test
 
 package agentprovider
 

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux
-
 package agentprovider
 
 import (

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux && test
+//go:build test
 
 package agentprovider
 

--- a/comp/host-profiler/collector/impl/agentprovider/provider.go
+++ b/comp/host-profiler/collector/impl/agentprovider/provider.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux
-
 package agentprovider
 
 import (

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux && test
+//go:build test
 
 package converters
 

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux
-
 // Package converters implements the converters for the host profiler collector.
 package converters
 

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux
-
 // Package converters implements OTEL collector configuration converters for the host profiler.
 //
 // Converters normalize user-provided OTEL collector configs by adding required Datadog-specific

--- a/comp/host-profiler/collector/impl/converters/converters_test.go
+++ b/comp/host-profiler/collector/impl/converters/converters_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux && test
+//go:build test
 
 package converters
 

--- a/comp/host-profiler/collector/impl/params/params.go
+++ b/comp/host-profiler/collector/impl/params/params.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux
-
 // Package params defines the interface for collector configuration parameters.
 package params
 

--- a/comp/host-profiler/symboluploader/pipeline/pipeline.go
+++ b/comp/host-profiler/symboluploader/pipeline/pipeline.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-//go:build linux
-
 // Package pipeline provides a concurrent processing pipeline for symbol upload operations.
 package pipeline
 

--- a/comp/host-profiler/symboluploader/pipeline/pipeline_test.go
+++ b/comp/host-profiler/symboluploader/pipeline/pipeline_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-//go:build linux
-
 package pipeline
 
 import (

--- a/comp/host-profiler/symboluploader/testdata/helloworld.go
+++ b/comp/host-profiler/symboluploader/testdata/helloworld.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-//go:build linux
-
 package main
 
 import (

--- a/comp/host-profiler/version/version.go
+++ b/comp/host-profiler/version/version.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux
-
 // Package version provides version information for the host profiler.
 package version
 


### PR DESCRIPTION
### What does this PR do?

Removes `//go:build linux` from host-profiler packages that have no Linux-specific dependencies (no eBPF, syscall, or `/proc` access):

- `comp/host-profiler/collector/impl/agentprovider/`
- `comp/host-profiler/collector/impl/converters/`
- `comp/host-profiler/collector/impl/params/`
- `comp/host-profiler/version/`

Test build tags updated from `linux && test` to `test` where possible. `provider_test.go` retains `linux && test` because it imports the `receiver` package which depends on the eBPF profiler.

### Motivation

These packages are pure config manipulation, no eBPF, no syscalls, no `/proc`. The `linux` tag was applied as a blanket constraint rather than a technical one, preventing local test execution on macOS.

### Describe how you validated your changes

- All agentprovider and converters tests pass locally on macOS with `go test -tags test`
- Verified that `provider_test.go` correctly retains `linux && test` (it imports the linux-only receiver package)

### Additional Notes

Stacked on #48651.