### PR TITLE
Move `bazelisk` check from build time to module extension

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -339,4 +339,4 @@ include("//deps:go.MODULE.bazel")
 # to the build command to enable it.
 bazel_dep(name = "apple_support", version = "2.3.0")
 
-use_repo_rule("//bazel/tools:bazelisk_check.bzl", "bazelisk_check")(name = "bazelisk_check")
+use_extension("//bazel/tools:bazelisk_check.bzl", "bazelisk_check")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -386,6 +386,19 @@
         }
       }
     },
+    "//bazel/tools:bazelisk_check.bzl%bazelisk_check": {
+      "general": {
+        "bzlTransitiveDigest": "vIQYQXzy/Q+owB/yz0XcUOwOyn9G0aQIpTxYlBfiCcQ=",
+        "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
+        "recordedInputs": [
+          "FILE:@@//.bazelversion 59b003a1f3465ae6084432329f8265e860cbaac0bd4a92a4f3ea6b979a6eed66",
+          "FILE:@@//tools/bazel 6804bf06e2253629bf30d0a777fc8baf943b50529d230a059f1dc46296dbf4d6",
+          "FILE:@@//tools/bazel.bat c2f0c08f179108517d08b1e34d19b3aabd80458d9e2575f9de08e640ba9b4ac3",
+          "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
+        ],
+        "generatedRepoSpecs": {}
+      }
+    },
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "dnnhvKMf9MIXMulhbhHBblZdDAfAkiSVjApIXpUz9Y8=",

--- a/bazel/tools/BUILD.bazel
+++ b/bazel/tools/BUILD.bazel
@@ -1,8 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazelisk_check//:defs.bzl", "check_bazel_version")
 load("@rules_python//python:py_binary.bzl", "py_binary")
-
-check_bazel_version()
 
 py_binary(
     name = "go_mod_tidy_all",

--- a/bazel/tools/bazelisk_check.bzl
+++ b/bazel/tools/bazelisk_check.bzl
@@ -6,35 +6,24 @@ a Bazel binary in their PATH:
 - https://gerrit.googlesource.com/prolog-cafe/+/master/tools/bzl/bazelisk_version.bzl
 """
 
-_template = """
-load("@bazel_skylib//lib:versions.bzl", "versions")
-
-def check_bazel_version():
-    versions.check(
-        bazel_version = "{current_version}",
-        maximum_bazel_version = "{required_version}",
-        minimum_bazel_version = "{required_version}",
-    )
-""".strip()
-
-def _impl(repository_ctx):
+def _impl(mctx):
     file_to_path = {
-        f: repository_ctx.path(Label("//:" + f))
-        for f in (".bazelversion", "tools/bazel", "tools/bazel.bat")
+        f: mctx.path(Label("//:" + f))
+        for f in (".bazelversion", "tools/bazel", "tools/bazel.bat", "tools/bazelisk.md")
     }
 
     for required_file, path in file_to_path.items():
         if not path.exists or path.is_dir:
             fail("Required file not found: `{}` - did you (re)move it?".format(required_file))
-        repository_ctx.watch(path)
+        mctx.watch(path)
 
-    repository_ctx.file("BUILD.bazel")
-    repository_ctx.file(
-        "defs.bzl",
-        content = _template.format(
-            current_version = native.bazel_version,
-            required_version = repository_ctx.read(file_to_path[".bazelversion"]).strip(),
-        ),
-    )
+    required_version = mctx.read(file_to_path[".bazelversion"]).strip()
+    if native.bazel_version != required_version:
+        fail("""Bazel version mismatch: expected {}, actual {}.
+{}""".format(
+            required_version,
+            native.bazel_version,
+            mctx.read(file_to_path["tools/bazelisk.md"]),
+        ))
 
-bazelisk_check = repository_rule(configure = True, implementation = _impl, local = True)
+bazelisk_check = module_extension(implementation = _impl)

--- a/tools/bazelisk.md
+++ b/tools/bazelisk.md
@@ -1,24 +1,13 @@
 ❌ ERROR: `bazelisk` is required to build this project.
 
-To maximize reproducibility, `bazelisk` is the only supported entry point to bootstrap `bazel` and build the agent.
+A system-wide `bazel` binary is likely taking precedence over `bazelisk` and its `bazel` symlink.
 
-Actions:
+`bazelisk` is the only supported entry point: it reads `.bazelversion` and bootstraps the required version of `bazel`,
+whereas any other version is at best speculatively compatible.
 
-1. [mandatory] ensure `bazelisk` is installed (see options below),
-2. [recommended] create a symlink in your PATH named `bazel` pointing to `bazelisk`
-   (so you can simply run `bazel` everywhere),
-3. [recommended] uninstall any previously installed `bazel` binaries.
+To fix this, uninstall any system-wide Bazel for your platform:
+- Ubuntu Linux: sudo apt purge bazel
+- Windows: choco uninstall bazel / scoop uninstall bazel / winget uninstall bazel
+- macOS: brew uninstall bazel
 
-Quick install options (any reasonably recent version works):
-
-- brew install bazelisk
-- go install github.com/bazelbuild/bazelisk@latest
-- npm install -g @bazel/bazelisk
-
-For more install options, including native binaries:
-
-- https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#installation
-- https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#requirements
-- https://github.com/bazelbuild/bazelisk/releases
-
-💡 `bazelisk` is intended to become the only local/host dependency needed to build the agent.
+💡 Please run `inv install-tools`, which installs `bazelisk` and its `bazel` symlink alongside other Go binaries.


### PR DESCRIPTION
### What does this PR do?
Convert `bazelisk_check` from a `repository_rule` _potentially_ triggered at build time to a `module_extension` that _systematically_ verifies the Bazel version against `.bazelversion` at module loading time.

Update `tools/bazelisk.md` with refreshed platform-specific remediation steps, embedded verbatim in the error message.

### Motivation
Several contributors were silently affected by system-wide `bazel` binaries (from `apt` on Ubuntu or `brew` on macOS) taking precedence over `bazelisk`-managed `bazel` symlinks, causing the wrong Bazel version to be used without an obvious error, for instance on:
- [March 3, 2026](https://dd.slack.com/archives/C06PBHLD4DQ/p1772543631418939),
- [March 10, 2026](https://dd.slack.com/archives/C08SK4B0FK8/p1773133388295009).

The build-time `check_bazel_version()` call in `bazel/tools/BUILD.bazel` was only reached when targeted either explicitly or through `//...`, so the misconfiguration went undetected until much later, if at all.

Module extensions fire at loading time, giving the earliest possible detection regardless of the target being built.

### Describe how you validated your changes
Using an apt-installed `bazel` pinned to an earlier version, `bazel cmd` (cmd: any command but `info`) now fails immediately with a version mismatch error and more actionable instructions:
```sh
/usr/bin/bazel-8.6.0 mod tidy; echo $?
WARNING: Option 'remote_local_fallback_strategy' is deprecated
ERROR: /path/to/datadog-agent/bazel/tools/bazelisk_check.bzl:22:13: Traceback (most recent call last):
	File "/path/to/datadog-agent/bazel/tools/bazelisk_check.bzl", line 22, column 13, in _impl
		fail("""Bazel version mismatch: expected {}, actual {}.
Error in fail: Bazel version mismatch: expected 9.0.1, actual 8.6.0.
...
2
```