### PR TITLE
[observer] Filter out log anomalies

### DIFF
--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -631,6 +631,13 @@ type StorageReader interface {
 	// Uses binary search for efficiency. Returns 0 if the series is not found.
 	PointCountUpTo(handle SeriesRef, endTime int64) int
 
+	// SumRange returns the sum of the specified aggregate over all points with
+	// timestamp in (start, end] without allocating any intermediate slices.
+	// Returns 0 if the series is not found or the range is empty.
+	// This is more efficient than ForEachPoint when only the aggregate total
+	// is needed (e.g. computing an average rate over a window).
+	SumRange(handle SeriesRef, start, end int64, agg Aggregate) float64
+
 	// WriteGeneration returns a per-series counter that increments on every
 	// write to that series, including same-bucket merges. Use this to detect
 	// updates to an existing series even when its point count does not change.
@@ -658,13 +665,15 @@ type Detector interface {
 // reaches correlators and reporters. Filters are evaluated in order; the first
 // filter that returns true discards the anomaly.
 //
-// Implementations should be stateless and fast — they run synchronously inside
-// the detection loop on every anomaly produced by every detector.
-// Filtering criteria are based on the anomaly's source namespace, metric name,
-// and its current value (e.g. rate) as reported by DebugInfo.CurrentValue.
+// Implementations should be fast — they run synchronously inside the detection
+// loop on every anomaly produced by every detector. Storage is provided so
+// filters can query historical data (e.g. compute a windowed average rate)
+// rather than relying solely on the single-point value in DebugInfo.
 type DetectorFilter interface {
 	// Name returns the filter name for debugging and logging.
 	Name() string
 	// ShouldFilterOut returns true when the anomaly should be discarded.
-	ShouldFilterOut(a Anomaly) bool
+	// storage and dataTime are provided so filters can query the series
+	// history up to the current advance timestamp.
+	ShouldFilterOut(a Anomaly, storage StorageReader, dataTime int64) bool
 }

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -270,7 +270,6 @@ type LogMetricsExtractorOutput struct {
 	Telemetry []ObserverTelemetry
 }
 
-
 // SeriesDescriptor is the fully resolved identity of a time series.
 // It carries namespace, metric name, tags, and aggregation — everything
 // needed to display, key, and compare series across correlators and API.
@@ -653,4 +652,19 @@ type Detector interface {
 	// The detector queries storage for whatever data it needs.
 	// dataTime is the current data timestamp (for determinism - only read data <= dataTime).
 	Detect(storage StorageReader, dataTime int64) DetectionResult
+}
+
+// DetectorFilter decides whether an anomaly should be suppressed before it
+// reaches correlators and reporters. Filters are evaluated in order; the first
+// filter that returns true discards the anomaly.
+//
+// Implementations should be stateless and fast — they run synchronously inside
+// the detection loop on every anomaly produced by every detector.
+// Filtering criteria are based on the anomaly's source namespace, metric name,
+// and its current value (e.g. rate) as reported by DebugInfo.CurrentValue.
+type DetectorFilter interface {
+	// Name returns the filter name for debugging and logging.
+	Name() string
+	// ShouldFilterOut returns true when the anomaly should be discarded.
+	ShouldFilterOut(a Anomaly) bool
 }

--- a/comp/observer/impl/bench_detection_test.go
+++ b/comp/observer/impl/bench_detection_test.go
@@ -27,7 +27,7 @@ func BenchmarkDetection_SeriesCount(b *testing.B) {
 		numSeries := numSeries
 		b.Run(fmt.Sprintf("series=%d", numSeries), func(b *testing.B) {
 			storage := buildSyntheticStorage(numSeries, 600)
-			detectors, correlators, _, _ := defaultCatalog().Instantiate(benchmarkSettings)
+			detectors, correlators, _, _, _ := defaultCatalog().Instantiate(benchmarkSettings)
 			e := newEngine(engineConfig{
 				storage:     storage,
 				detectors:   detectors,
@@ -68,7 +68,7 @@ func BenchmarkDetection_AdvanceFrequency(b *testing.B) {
 		newSecs := newSecs
 		b.Run(fmt.Sprintf("newSecs=%d", newSecs), func(b *testing.B) {
 			storage := buildSyntheticStorage(numSeries, 600)
-			detectors, correlators, _, _ := defaultCatalog().Instantiate(benchmarkSettings)
+			detectors, correlators, _, _, _ := defaultCatalog().Instantiate(benchmarkSettings)
 			e := newEngine(engineConfig{
 				storage:     storage,
 				detectors:   detectors,

--- a/comp/observer/impl/bench_log_ingestion_test.go
+++ b/comp/observer/impl/bench_log_ingestion_test.go
@@ -77,7 +77,7 @@ func BenchmarkLogExtraction_SeriesCount(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				_, _, extractors, _ := defaultCatalog().Instantiate(benchmarkSettings)
+				_, _, extractors, _, _ := defaultCatalog().Instantiate(benchmarkSettings)
 				storage := newTimeSeriesStorage()
 				e := newEngine(engineConfig{
 					storage:    storage,
@@ -114,7 +114,7 @@ func BenchmarkLogExtraction_DiversePatterns(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				_, _, extractors, _ := defaultCatalog().Instantiate(benchmarkSettings)
+				_, _, extractors, _, _ := defaultCatalog().Instantiate(benchmarkSettings)
 				storage := newTimeSeriesStorage()
 				e := newEngine(engineConfig{
 					storage:    storage,

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -14,6 +14,7 @@ const (
 	componentDetector componentKind = iota
 	componentCorrelator
 	componentExtractor
+	componentFilter
 )
 
 // componentEntry describes a registered pipeline component.
@@ -80,7 +81,7 @@ type ComponentSettings struct {
 //
 //	catalog := defaultCatalog()
 //	settings := ComponentSettings{ ... } // from agent config, testbench UI, etc.
-//	detectors, correlators, extractors, components := catalog.Instantiate(settings)
+//	detectors, correlators, extractors, filters, components := catalog.Instantiate(settings)
 type componentCatalog struct {
 	entries []componentEntry
 }
@@ -156,6 +157,14 @@ func defaultCatalog() *componentCatalog {
 				factory:        func(any) any { return NewScanWelchDetector() },
 				defaultEnabled: false,
 			},
+			// ---- Filters ----
+			{
+				name:           "log_pattern_rate_filter",
+				displayName:    "Log Pattern Rate Filter",
+				kind:           componentFilter,
+				factory:        func(any) any { return NewLogPatternRateFilter() },
+				defaultEnabled: true,
+			},
 			// ---- Correlators ----
 			{
 				name:           "cross_signal",
@@ -192,6 +201,7 @@ func (c *componentCatalog) Instantiate(settings ComponentSettings) (
 	detectors []observerdef.Detector,
 	correlators []observerdef.Correlator,
 	extractors []observerdef.LogMetricsExtractor,
+	filters []observerdef.DetectorFilter,
 	components map[string]*componentInstance,
 ) {
 	components = make(map[string]*componentInstance, len(c.entries))
@@ -234,9 +244,13 @@ func (c *componentCatalog) Instantiate(settings ComponentSettings) (
 			if ext, ok := instance.(observerdef.LogMetricsExtractor); ok {
 				extractors = append(extractors, ext)
 			}
+		case componentFilter:
+			if f, ok := instance.(observerdef.DetectorFilter); ok {
+				filters = append(filters, f)
+			}
 		}
 	}
-	return detectors, correlators, extractors, components
+	return detectors, correlators, extractors, filters, components
 }
 
 // CatalogEntry is a public view of a catalog component for CLI use.
@@ -259,8 +273,25 @@ func TestbenchCatalogEntries() []CatalogEntry {
 			kind = "correlator"
 		case componentExtractor:
 			kind = "extractor"
+		case componentFilter:
+			kind = "filter"
 		}
 		result[i] = CatalogEntry{Name: e.name, Kind: kind}
+	}
+	return result
+}
+
+// catalogEnabledFilters returns the enabled DetectorFilter instances from a components map.
+func catalogEnabledFilters(components map[string]*componentInstance, catalog *componentCatalog) []observerdef.DetectorFilter {
+	var result []observerdef.DetectorFilter
+	for _, entry := range catalog.entries {
+		ci, ok := components[entry.name]
+		if !ok || !ci.enabled || ci.entry.kind != componentFilter {
+			continue
+		}
+		if f, ok := ci.instance.(observerdef.DetectorFilter); ok {
+			result = append(result, f)
+		}
 	}
 	return result
 }

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -110,7 +110,7 @@ func defaultCatalog() *componentCatalog {
 				defaultEnabled: true,
 			},
 			{
-				name:           "log_pattern_extractor",
+				name:           LogPatternExtractorName,
 				displayName:    "Log Pattern Extractor",
 				kind:           componentExtractor,
 				defaultConfig:  DefaultLogPatternExtractorConfig(),

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -321,7 +321,7 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 		for _, anomaly := range result.Anomalies {
 			// First filter out anomaly if needed
 			for _, filter := range e.detectorFilters {
-				if filter.ShouldFilterOut(anomaly) {
+				if filter.ShouldFilterOut(anomaly, e.storage, upTo) {
 					continue anomalyLoop
 				}
 			}

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -579,6 +579,14 @@ func (e *engine) SetDetectors(detectors []observerdef.Detector) {
 	}
 }
 
+// SetDetectorFilters replaces the engine's detector filters.
+func (e *engine) SetDetectorFilters(filters []observerdef.DetectorFilter) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.detectorFilters = filters
+}
+
 // SetCorrelators replaces the engine's correlators.
 func (e *engine) SetCorrelators(correlators []observerdef.Correlator) {
 	e.mu.Lock()

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -46,6 +46,7 @@ type engine struct {
 	storage          *timeSeriesStorage
 	extractors       []observerdef.LogMetricsExtractor
 	detectors        []observerdef.Detector
+	detectorFilters  []observerdef.DetectorFilter
 	correlators      []observerdef.Correlator
 	contextProviders map[string]observerdef.ContextProvider // namespace → provider
 	contextRefs      map[string]seriesContextRef
@@ -102,6 +103,7 @@ type engineConfig struct {
 	storage          *timeSeriesStorage
 	extractors       []observerdef.LogMetricsExtractor
 	detectors        []observerdef.Detector
+	detectorFilters  []observerdef.DetectorFilter
 	correlators      []observerdef.Correlator
 	contextProviders map[string]observerdef.ContextProvider // namespace → provider
 
@@ -124,6 +126,7 @@ func newEngine(cfg engineConfig) *engine {
 		storage:          cfg.storage,
 		extractors:       cfg.extractors,
 		detectors:        cfg.detectors,
+		detectorFilters:  cfg.detectorFilters,
 		correlators:      cfg.correlators,
 		contextProviders: cfg.contextProviders,
 		contextRefs:      make(map[string]seriesContextRef),
@@ -314,7 +317,16 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 		processingTime := time.Since(processingStartTime)
 		allTelemetry = append(allTelemetry, newTelemetryGauge([]string{"detector:" + detector.Name()}, telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), upTo))
 
+	anomalyLoop:
 		for _, anomaly := range result.Anomalies {
+			// First filter out anomaly if needed
+			for _, filter := range e.detectorFilters {
+				if filter.ShouldFilterOut(anomaly) {
+					continue anomalyLoop
+				}
+			}
+
+			// Enrich and process anomalies with correlators
 			e.enrichAnomaly(&anomaly)
 			if !e.captureRawAnomaly(anomaly) {
 				continue // duplicate — skip correlators, events, and reporters

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -354,7 +354,7 @@ func TestEnrichAnomalyWithRealLogPatternExtractorUsesStoredSeriesTags(t *testing
 
 	e.enrichAnomaly(&anomaly)
 	require.NotNil(t, anomaly.Context)
-	assert.Equal(t, "log_pattern_extractor", anomaly.Context.Source)
+	assert.Equal(t, LogPatternExtractorName, anomaly.Context.Source)
 	assert.Equal(t, "GET /users/123 returned 500", anomaly.Context.Example)
 	assert.Contains(t, anomaly.Context.Pattern, "*")
 	assert.NotContains(t, anomaly.Context.Example, "456")

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -13,6 +13,11 @@ import (
 	"github.com/DataDog/datadog-agent/comp/observer/impl/patterns"
 )
 
+// LogPatternExtractorName is the canonical name for the log pattern extractor.
+// It is used as the storage namespace for emitted metrics, as the component
+// name in the catalog, and as a lookup key in notify and filter logic.
+const LogPatternExtractorName = "log_pattern_extractor"
+
 // defaultMinClusterSizeBeforeEmitMetrics is the minimum number of logs
 // inside a cluster (pattern) before we emit a metric.
 const defaultMinClusterSizeBeforeEmitMetrics = 5
@@ -67,7 +72,7 @@ func NewLogPatternExtractor() *LogPatternExtractor {
 
 // Name returns the extractor name.
 func (e *LogPatternExtractor) Name() string {
-	return "log_pattern_extractor"
+	return LogPatternExtractorName
 }
 
 // Reset clears clustering and cached per-series context so reanalysis starts

--- a/comp/observer/impl/log_pattern_extractor_test.go
+++ b/comp/observer/impl/log_pattern_extractor_test.go
@@ -29,7 +29,7 @@ func TestLogPatternExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
 
 	ctx, ok := e.GetContextByKey(res.Metrics[0].ContextKey)
 	require.True(t, ok)
-	assert.Equal(t, "log_pattern_extractor", ctx.Source)
+	assert.Equal(t, LogPatternExtractorName, ctx.Source)
 	assert.Equal(t, "GET /users/123 returned 500", ctx.Example)
 	assert.NotEmpty(t, ctx.Pattern)
 }

--- a/comp/observer/impl/log_pattern_filter.go
+++ b/comp/observer/impl/log_pattern_filter.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+
+// minLogPatternRateLogsPerSec is the minimum log rate (logs/s) for a
+// log_pattern_extractor anomaly to be forwarded to correlators and reporters.
+// Anomalies on patterns that arrive slower than this threshold are suppressed
+// because they are unlikely to represent a meaningful workload change.
+const minLogPatternRateLogsPerSec = 1.0
+
+// logPatternRateFilter suppresses anomalies produced by the log_pattern_extractor
+// when the current metric rate (DebugInfo.CurrentValue, in logs/s) is below
+// minLogPatternRateLogsPerSec.
+//
+// Rationale: patterns that fire less than once per second are too sparse to
+// generate reliable anomaly signals — baseline estimation is noisy and false
+// positives are common. The threshold can be adjusted via the constant above.
+type logPatternRateFilter struct{}
+
+var _ observerdef.DetectorFilter = (*logPatternRateFilter)(nil)
+
+// NewLogPatternRateFilter returns a DetectorFilter that discards low-rate
+// log_pattern_extractor anomalies (< 1 log/s at detection time).
+func NewLogPatternRateFilter() observerdef.DetectorFilter {
+	return &logPatternRateFilter{}
+}
+
+// defaultDetectorFilters returns the set of DetectorFilters applied in every
+// engine instance (live observer and testbench replay).
+func defaultDetectorFilters() []observerdef.DetectorFilter {
+	return []observerdef.DetectorFilter{
+		NewLogPatternRateFilter(),
+	}
+}
+
+// Name returns the filter name.
+func (f *logPatternRateFilter) Name() string {
+	return "log_pattern_rate_filter"
+}
+
+// ShouldFilterOut returns true when the anomaly originates from the
+// log_pattern_extractor namespace and its current rate is below 1 log/s.
+// Anomalies that lack DebugInfo (no rate information) are passed through
+// to avoid silently dropping detections from detectors that do not populate it.
+func (f *logPatternRateFilter) ShouldFilterOut(a observerdef.Anomaly) bool {
+	if a.Source.Namespace != "log_pattern_extractor" {
+		return false
+	}
+	if a.DebugInfo == nil {
+		return false
+	}
+	return a.DebugInfo.CurrentValue < minLogPatternRateLogsPerSec
+}

--- a/comp/observer/impl/log_pattern_filter.go
+++ b/comp/observer/impl/log_pattern_filter.go
@@ -30,14 +30,6 @@ func NewLogPatternRateFilter() observerdef.DetectorFilter {
 	return &logPatternRateFilter{}
 }
 
-// defaultDetectorFilters returns the set of DetectorFilters applied in every
-// engine instance (live observer and testbench replay).
-func defaultDetectorFilters() []observerdef.DetectorFilter {
-	return []observerdef.DetectorFilter{
-		NewLogPatternRateFilter(),
-	}
-}
-
 // Name returns the filter name.
 func (f *logPatternRateFilter) Name() string {
 	return "log_pattern_rate_filter"

--- a/comp/observer/impl/log_pattern_filter.go
+++ b/comp/observer/impl/log_pattern_filter.go
@@ -48,7 +48,7 @@ func (f *logPatternRateFilter) Name() string {
 // Anomalies that lack DebugInfo (no rate information) are passed through
 // to avoid silently dropping detections from detectors that do not populate it.
 func (f *logPatternRateFilter) ShouldFilterOut(a observerdef.Anomaly) bool {
-	if a.Source.Namespace != "log_pattern_extractor" {
+	if a.Source.Namespace != LogPatternExtractorName {
 		return false
 	}
 	if a.DebugInfo == nil {

--- a/comp/observer/impl/log_pattern_filter.go
+++ b/comp/observer/impl/log_pattern_filter.go
@@ -7,28 +7,57 @@ package observerimpl
 
 import observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 
-// Suppress log_pattern_extractor anomalies below this log rate (logs/s)
+// logPatternRateWindowSec is the window over which log rate is averaged.
+const logPatternRateWindowSec = 60
+
+// minLogPatternRateLogsPerSec is the minimum average log rate (logs/s) over the
+// last logPatternRateWindowSec for a log_pattern_extractor anomaly to be
+// forwarded. Anomalies on patterns averaging below this rate are suppressed
+// because they are too sparse to produce actionable signals.
+//
+// Implementation note: log_pattern_extractor emits Value=1 per log, so
+// AggregateAverage is always 1.0 (constant series — BOCPD never fires on it).
+// Anomalies only fire on the AggregateCount series where each point equals the
+// number of logs in that 1-second bucket. Summing the last 60 points and
+// dividing by the window gives the average log rate in logs/s.
 const minLogPatternRateLogsPerSec = 1.0
 
-// logPatternRateFilter filters out low-rate log_pattern_extractor anomalies
+// logPatternRateFilter suppresses anomalies produced by the log_pattern_extractor
+// when the average log rate over the last logPatternRateWindowSec is below
+// minLogPatternRateLogsPerSec.
 type logPatternRateFilter struct{}
 
 var _ observerdef.DetectorFilter = (*logPatternRateFilter)(nil)
 
-// NewLogPatternRateFilter creates a log_pattern rate-based filter
+// NewLogPatternRateFilter returns a DetectorFilter that discards low-rate
+// log_pattern_extractor anomalies (average < 1 log/s over the last 60 s).
 func NewLogPatternRateFilter() observerdef.DetectorFilter {
 	return &logPatternRateFilter{}
 }
 
+// Name returns the filter name.
 func (f *logPatternRateFilter) Name() string {
 	return "log_pattern_rate_filter"
 }
 
-// Filter out log_pattern_extractor anomalies with rate < 1 log/s. Pass through if no DebugInfo.
-func (f *logPatternRateFilter) ShouldFilterOut(a observerdef.Anomaly) bool {
+// ShouldFilterOut returns true when the anomaly originates from the
+// log_pattern_extractor namespace and the average AggregateCount rate over the
+// last logPatternRateWindowSec is below minLogPatternRateLogsPerSec.
+//
+// When SourceRef is nil (no storage-backed series) the filter falls back to
+// DebugInfo.CurrentValue so anomalies from detectors that do not populate
+// SourceRef are never silently dropped.
+func (f *logPatternRateFilter) ShouldFilterOut(a observerdef.Anomaly, storage observerdef.StorageReader, dataTime int64) bool {
 	if a.Source.Namespace != LogPatternExtractorName {
 		return false
 	}
+
+	if a.SourceRef != nil {
+		totalLogs := storage.SumRange(a.SourceRef.Ref, dataTime-logPatternRateWindowSec, dataTime, observerdef.AggregateCount)
+		return totalLogs/logPatternRateWindowSec < minLogPatternRateLogsPerSec
+	}
+
+	// Fallback: no storage ref available.
 	if a.DebugInfo == nil {
 		return false
 	}

--- a/comp/observer/impl/log_pattern_filter.go
+++ b/comp/observer/impl/log_pattern_filter.go
@@ -7,38 +7,24 @@ package observerimpl
 
 import observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 
-// minLogPatternRateLogsPerSec is the minimum log rate (logs/s) for a
-// log_pattern_extractor anomaly to be forwarded to correlators and reporters.
-// Anomalies on patterns that arrive slower than this threshold are suppressed
-// because they are unlikely to represent a meaningful workload change.
+// Suppress log_pattern_extractor anomalies below this log rate (logs/s)
 const minLogPatternRateLogsPerSec = 1.0
 
-// logPatternRateFilter suppresses anomalies produced by the log_pattern_extractor
-// when the current metric rate (DebugInfo.CurrentValue, in logs/s) is below
-// minLogPatternRateLogsPerSec.
-//
-// Rationale: patterns that fire less than once per second are too sparse to
-// generate reliable anomaly signals — baseline estimation is noisy and false
-// positives are common. The threshold can be adjusted via the constant above.
+// logPatternRateFilter filters out low-rate log_pattern_extractor anomalies
 type logPatternRateFilter struct{}
 
 var _ observerdef.DetectorFilter = (*logPatternRateFilter)(nil)
 
-// NewLogPatternRateFilter returns a DetectorFilter that discards low-rate
-// log_pattern_extractor anomalies (< 1 log/s at detection time).
+// NewLogPatternRateFilter creates a log_pattern rate-based filter
 func NewLogPatternRateFilter() observerdef.DetectorFilter {
 	return &logPatternRateFilter{}
 }
 
-// Name returns the filter name.
 func (f *logPatternRateFilter) Name() string {
 	return "log_pattern_rate_filter"
 }
 
-// ShouldFilterOut returns true when the anomaly originates from the
-// log_pattern_extractor namespace and its current rate is below 1 log/s.
-// Anomalies that lack DebugInfo (no rate information) are passed through
-// to avoid silently dropping detections from detectors that do not populate it.
+// Filter out log_pattern_extractor anomalies with rate < 1 log/s. Pass through if no DebugInfo.
 func (f *logPatternRateFilter) ShouldFilterOut(a observerdef.Anomaly) bool {
 	if a.Source.Namespace != LogPatternExtractorName {
 		return false

--- a/comp/observer/impl/log_pattern_filter_test.go
+++ b/comp/observer/impl/log_pattern_filter_test.go
@@ -1,0 +1,184 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// ---------------------------------------------------------------------------
+// logPatternRateFilter unit tests
+// ---------------------------------------------------------------------------
+
+func TestLogPatternRateFilter_Name(t *testing.T) {
+	f := NewLogPatternRateFilter()
+	assert.Equal(t, "log_pattern_rate_filter", f.Name())
+}
+
+func TestLogPatternRateFilter_PassesNonLogPatternNamespace(t *testing.T) {
+	f := NewLogPatternRateFilter()
+
+	// Anomalies from any other namespace must never be filtered out,
+	// regardless of CurrentValue.
+	for _, ns := range []string{"dogstatsd", "cpu_detector", "", "log_pattern_extractor_v2"} {
+		a := observerdef.Anomaly{
+			Source:    observerdef.SeriesDescriptor{Namespace: ns},
+			DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: 0.0},
+		}
+		assert.False(t, f.ShouldFilterOut(a), "unexpected filter for namespace %q", ns)
+	}
+}
+
+func TestLogPatternRateFilter_PassesAboveThreshold(t *testing.T) {
+	f := NewLogPatternRateFilter()
+
+	for _, rate := range []float64{1.0, 1.01, 5.0, 100.0} {
+		a := observerdef.Anomaly{
+			Source:    observerdef.SeriesDescriptor{Namespace: LogPatternExtractorName},
+			DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: rate},
+		}
+		assert.False(t, f.ShouldFilterOut(a), "should not filter rate=%.2f (>= 1 log/s)", rate)
+	}
+}
+
+func TestLogPatternRateFilter_FiltersBelowThreshold(t *testing.T) {
+	f := NewLogPatternRateFilter()
+
+	for _, rate := range []float64{0.0, 0.1, 0.5, 0.99} {
+		a := observerdef.Anomaly{
+			Source:    observerdef.SeriesDescriptor{Namespace: LogPatternExtractorName},
+			DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: rate},
+		}
+		assert.True(t, f.ShouldFilterOut(a), "should filter rate=%.2f (< 1 log/s)", rate)
+	}
+}
+
+func TestLogPatternRateFilter_PassesNilDebugInfo(t *testing.T) {
+	f := NewLogPatternRateFilter()
+
+	// When DebugInfo is absent we cannot evaluate the rate, so the anomaly
+	// must pass through to avoid silently dropping unrecognised detectors.
+	a := observerdef.Anomaly{
+		Source:    observerdef.SeriesDescriptor{Namespace: LogPatternExtractorName},
+		DebugInfo: nil,
+	}
+	assert.False(t, f.ShouldFilterOut(a))
+}
+
+// ---------------------------------------------------------------------------
+// Engine integration: detectorFilters wire-up
+// ---------------------------------------------------------------------------
+
+// alwaysFilterDetectorFilter is a filter that always discards every anomaly.
+type alwaysFilterDetectorFilter struct{}
+
+func (f *alwaysFilterDetectorFilter) Name() string                               { return "always_filter" }
+func (f *alwaysFilterDetectorFilter) ShouldFilterOut(_ observerdef.Anomaly) bool { return true }
+
+// neverFilterDetectorFilter is a filter that never discards any anomaly.
+type neverFilterDetectorFilter struct{}
+
+func (f *neverFilterDetectorFilter) Name() string                               { return "never_filter" }
+func (f *neverFilterDetectorFilter) ShouldFilterOut(_ observerdef.Anomaly) bool { return false }
+
+func TestEngine_DetectorFilterSuppressesAnomalies(t *testing.T) {
+	anomalies := []observerdef.Anomaly{
+		{Source: observerdef.SeriesDescriptor{Name: "cpu", Aggregate: observerdef.AggregateAverage}, DetectorName: "test", Timestamp: 99},
+	}
+
+	e := newEngine(engineConfig{
+		storage: newTimeSeriesStorage(),
+		detectors: []observerdef.Detector{
+			&anomalyDetector{name: "test", anomalies: anomalies},
+		},
+		detectorFilters: []observerdef.DetectorFilter{&alwaysFilterDetectorFilter{}},
+	})
+
+	result := e.Advance(100)
+
+	assert.Empty(t, result.anomalies, "all anomalies should have been filtered out")
+	assert.Equal(t, 0, e.TotalAnomalyCount(), "filtered anomalies should not increment total count")
+}
+
+func TestEngine_DetectorFilterNeverFilterPassesAnomalies(t *testing.T) {
+	anomalies := []observerdef.Anomaly{
+		{Source: observerdef.SeriesDescriptor{Name: "cpu", Aggregate: observerdef.AggregateAverage}, DetectorName: "test", Timestamp: 99},
+		{Source: observerdef.SeriesDescriptor{Name: "mem", Aggregate: observerdef.AggregateAverage}, DetectorName: "test", Timestamp: 99},
+	}
+
+	e := newEngine(engineConfig{
+		storage: newTimeSeriesStorage(),
+		detectors: []observerdef.Detector{
+			&anomalyDetector{name: "test", anomalies: anomalies},
+		},
+		detectorFilters: []observerdef.DetectorFilter{&neverFilterDetectorFilter{}},
+	})
+
+	result := e.Advance(100)
+
+	assert.Len(t, result.anomalies, 2, "no anomalies should have been filtered out")
+}
+
+func TestEngine_NoFiltersPassesAllAnomalies(t *testing.T) {
+	anomalies := []observerdef.Anomaly{
+		{Source: observerdef.SeriesDescriptor{Name: "cpu", Aggregate: observerdef.AggregateAverage}, DetectorName: "test", Timestamp: 99},
+	}
+
+	e := newEngine(engineConfig{
+		storage: newTimeSeriesStorage(),
+		detectors: []observerdef.Detector{
+			&anomalyDetector{name: "test", anomalies: anomalies},
+		},
+		// detectorFilters intentionally left nil
+	})
+
+	result := e.Advance(100)
+
+	assert.Len(t, result.anomalies, 1)
+}
+
+func TestEngine_FilteredAnomalyDoesNotEmitEvent(t *testing.T) {
+	anomalies := []observerdef.Anomaly{
+		{Source: observerdef.SeriesDescriptor{Name: "cpu", Aggregate: observerdef.AggregateAverage}, DetectorName: "test", Timestamp: 99},
+	}
+
+	e := newEngine(engineConfig{
+		storage: newTimeSeriesStorage(),
+		detectors: []observerdef.Detector{
+			&anomalyDetector{name: "test", anomalies: anomalies},
+		},
+		detectorFilters: []observerdef.DetectorFilter{&alwaysFilterDetectorFilter{}},
+	})
+
+	sink := &collectingSink{}
+	e.Subscribe(sink)
+	e.Advance(100)
+
+	assert.Empty(t, sink.eventsOfKind(eventAnomalyCreated), "filtered anomaly should not emit an event")
+}
+
+// ---------------------------------------------------------------------------
+// defaultDetectorFilters
+// ---------------------------------------------------------------------------
+
+func TestDefaultDetectorFilters_ContainsLogPatternRateFilter(t *testing.T) {
+	filters := defaultDetectorFilters()
+	require.NotEmpty(t, filters)
+
+	var found bool
+	for _, f := range filters {
+		if f.Name() == "log_pattern_rate_filter" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "defaultDetectorFilters should contain log_pattern_rate_filter")
+}

--- a/comp/observer/impl/log_pattern_filter_test.go
+++ b/comp/observer/impl/log_pattern_filter_test.go
@@ -15,7 +15,36 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// logPatternRateFilter unit tests
+// Helpers
+// ---------------------------------------------------------------------------
+
+// logPatternAnomalyWithRef builds a minimal log_pattern_extractor anomaly with a
+// storage-backed SourceRef for the given series ref and aggregation.
+func logPatternAnomalyWithRef(ref observerdef.SeriesRef, agg observerdef.Aggregate) observerdef.Anomaly {
+	return observerdef.Anomaly{
+		Source: observerdef.SeriesDescriptor{
+			Namespace: LogPatternExtractorName,
+			Aggregate: agg,
+		},
+		SourceRef: &observerdef.QueryHandle{Ref: ref, Aggregate: agg},
+	}
+}
+
+// populateLogPatternStorage adds `logsPerSec` count-1 writes per second for
+// [startSec, endSec) into the storage under the log_pattern_extractor namespace.
+// Returns the SeriesRef for the written series.
+func populateLogPatternStorage(s *timeSeriesStorage, metricName string, startSec, endSec, logsPerSec int64) observerdef.SeriesRef {
+	for sec := startSec; sec < endSec; sec++ {
+		for i := int64(0); i < logsPerSec; i++ {
+			s.Add(LogPatternExtractorName, metricName, 1.0, sec, nil)
+		}
+	}
+	metas := s.ListSeries(observerdef.SeriesFilter{Namespace: LogPatternExtractorName})
+	return metas[0].Ref
+}
+
+// ---------------------------------------------------------------------------
+// logPatternRateFilter unit tests — fallback path (no SourceRef)
 // ---------------------------------------------------------------------------
 
 func TestLogPatternRateFilter_Name(t *testing.T) {
@@ -25,52 +54,111 @@ func TestLogPatternRateFilter_Name(t *testing.T) {
 
 func TestLogPatternRateFilter_PassesNonLogPatternNamespace(t *testing.T) {
 	f := NewLogPatternRateFilter()
+	storage := newTimeSeriesStorage()
 
-	// Anomalies from any other namespace must never be filtered out,
-	// regardless of CurrentValue.
 	for _, ns := range []string{"dogstatsd", "cpu_detector", "", "log_pattern_extractor_v2"} {
 		a := observerdef.Anomaly{
 			Source:    observerdef.SeriesDescriptor{Namespace: ns},
 			DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: 0.0},
 		}
-		assert.False(t, f.ShouldFilterOut(a), "unexpected filter for namespace %q", ns)
+		assert.False(t, f.ShouldFilterOut(a, storage, 100), "unexpected filter for namespace %q", ns)
 	}
 }
 
-func TestLogPatternRateFilter_PassesAboveThreshold(t *testing.T) {
+// Fallback: no SourceRef, use CurrentValue.
+func TestLogPatternRateFilter_FallbackPassesAboveThreshold(t *testing.T) {
 	f := NewLogPatternRateFilter()
+	storage := newTimeSeriesStorage()
 
 	for _, rate := range []float64{1.0, 1.01, 5.0, 100.0} {
 		a := observerdef.Anomaly{
 			Source:    observerdef.SeriesDescriptor{Namespace: LogPatternExtractorName},
 			DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: rate},
 		}
-		assert.False(t, f.ShouldFilterOut(a), "should not filter rate=%.2f (>= 1 log/s)", rate)
+		assert.False(t, f.ShouldFilterOut(a, storage, 100), "should not filter CurrentValue=%.2f (>= 1 log/s)", rate)
 	}
 }
 
-func TestLogPatternRateFilter_FiltersBelowThreshold(t *testing.T) {
+func TestLogPatternRateFilter_FallbackFiltersBelowThreshold(t *testing.T) {
 	f := NewLogPatternRateFilter()
+	storage := newTimeSeriesStorage()
 
 	for _, rate := range []float64{0.0, 0.1, 0.5, 0.99} {
 		a := observerdef.Anomaly{
 			Source:    observerdef.SeriesDescriptor{Namespace: LogPatternExtractorName},
 			DebugInfo: &observerdef.AnomalyDebugInfo{CurrentValue: rate},
 		}
-		assert.True(t, f.ShouldFilterOut(a), "should filter rate=%.2f (< 1 log/s)", rate)
+		assert.True(t, f.ShouldFilterOut(a, storage, 100), "should filter CurrentValue=%.2f (< 1 log/s)", rate)
 	}
 }
 
-func TestLogPatternRateFilter_PassesNilDebugInfo(t *testing.T) {
+func TestLogPatternRateFilter_FallbackPassesNilDebugInfo(t *testing.T) {
 	f := NewLogPatternRateFilter()
+	storage := newTimeSeriesStorage()
 
-	// When DebugInfo is absent we cannot evaluate the rate, so the anomaly
-	// must pass through to avoid silently dropping unrecognised detectors.
 	a := observerdef.Anomaly{
 		Source:    observerdef.SeriesDescriptor{Namespace: LogPatternExtractorName},
 		DebugInfo: nil,
 	}
-	assert.False(t, f.ShouldFilterOut(a))
+	assert.False(t, f.ShouldFilterOut(a, storage, 100))
+}
+
+// ---------------------------------------------------------------------------
+// logPatternRateFilter unit tests — windowed average path (with SourceRef)
+// ---------------------------------------------------------------------------
+
+func TestLogPatternRateFilter_WindowedAverageFiltersLowRate(t *testing.T) {
+	// 30 logs over 60 seconds = 0.5 log/s average → should be filtered.
+	s := newTimeSeriesStorage()
+	ref := populateLogPatternStorage(s, "log.pattern.count", 1, 61, 1) // 1 log/s × 60s = 60 logs... but
+	// Override: spread only 30 logs over 60s by writing 1 log every other second.
+	s2 := newTimeSeriesStorage()
+	for sec := int64(1); sec <= 60; sec += 2 {
+		s2.Add(LogPatternExtractorName, "log.pattern.count", 1.0, sec, nil)
+	}
+	metas := s2.ListSeries(observerdef.SeriesFilter{Namespace: LogPatternExtractorName})
+	ref = metas[0].Ref
+
+	a := logPatternAnomalyWithRef(ref, observerdef.AggregateCount)
+	f := NewLogPatternRateFilter()
+
+	assert.True(t, f.ShouldFilterOut(a, s2, 60), "0.5 log/s average should be filtered")
+}
+
+func TestLogPatternRateFilter_WindowedAveragePassesHighRate(t *testing.T) {
+	// 5 logs/s × 60 seconds = 300 total → average 5 log/s → should pass.
+	s := newTimeSeriesStorage()
+	ref := populateLogPatternStorage(s, "log.pattern.count", 1, 61, 5)
+
+	a := logPatternAnomalyWithRef(ref, observerdef.AggregateCount)
+	f := NewLogPatternRateFilter()
+
+	assert.False(t, f.ShouldFilterOut(a, s, 60), "5 log/s average should not be filtered")
+}
+
+func TestLogPatternRateFilter_WindowedAverageExactlyAtThreshold(t *testing.T) {
+	// Exactly 1 log/s (60 logs over 60s) → average == 1.0 → not < 1.0, should pass.
+	s := newTimeSeriesStorage()
+	ref := populateLogPatternStorage(s, "log.pattern.count", 1, 61, 1)
+
+	a := logPatternAnomalyWithRef(ref, observerdef.AggregateCount)
+	f := NewLogPatternRateFilter()
+
+	assert.False(t, f.ShouldFilterOut(a, s, 60), "exactly 1 log/s should not be filtered")
+}
+
+func TestLogPatternRateFilter_WindowedAverageOnlyLooksAtLastMinute(t *testing.T) {
+	// Seconds 1-60: 5 logs/s (busy). Seconds 61-120: 0 logs/s (silent).
+	// At dataTime=120, the 60s window covers [61,120] where rate=0 → filtered.
+	// At dataTime=60,  the 60s window covers [1,60]  where rate=5 → passes.
+	s := newTimeSeriesStorage()
+	ref := populateLogPatternStorage(s, "log.pattern.count", 1, 61, 5)
+
+	a := logPatternAnomalyWithRef(ref, observerdef.AggregateCount)
+	f := NewLogPatternRateFilter()
+
+	assert.False(t, f.ShouldFilterOut(a, s, 60), "window [1,60] at 5 log/s should not be filtered")
+	assert.True(t, f.ShouldFilterOut(a, s, 120), "window [61,120] with no data should be filtered")
 }
 
 // ---------------------------------------------------------------------------
@@ -80,14 +168,18 @@ func TestLogPatternRateFilter_PassesNilDebugInfo(t *testing.T) {
 // alwaysFilterDetectorFilter is a filter that always discards every anomaly.
 type alwaysFilterDetectorFilter struct{}
 
-func (f *alwaysFilterDetectorFilter) Name() string                               { return "always_filter" }
-func (f *alwaysFilterDetectorFilter) ShouldFilterOut(_ observerdef.Anomaly) bool { return true }
+func (f *alwaysFilterDetectorFilter) Name() string { return "always_filter" }
+func (f *alwaysFilterDetectorFilter) ShouldFilterOut(_ observerdef.Anomaly, _ observerdef.StorageReader, _ int64) bool {
+	return true
+}
 
 // neverFilterDetectorFilter is a filter that never discards any anomaly.
 type neverFilterDetectorFilter struct{}
 
-func (f *neverFilterDetectorFilter) Name() string                               { return "never_filter" }
-func (f *neverFilterDetectorFilter) ShouldFilterOut(_ observerdef.Anomaly) bool { return false }
+func (f *neverFilterDetectorFilter) Name() string { return "never_filter" }
+func (f *neverFilterDetectorFilter) ShouldFilterOut(_ observerdef.Anomaly, _ observerdef.StorageReader, _ int64) bool {
+	return false
+}
 
 func TestEngine_DetectorFilterSuppressesAnomalies(t *testing.T) {
 	anomalies := []observerdef.Anomaly{

--- a/comp/observer/impl/log_pattern_filter_test.go
+++ b/comp/observer/impl/log_pattern_filter_test.go
@@ -166,11 +166,12 @@ func TestEngine_FilteredAnomalyDoesNotEmitEvent(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// defaultDetectorFilters
+// Catalog integration: filters are wired through defaultCatalog
 // ---------------------------------------------------------------------------
 
-func TestDefaultDetectorFilters_ContainsLogPatternRateFilter(t *testing.T) {
-	filters := defaultDetectorFilters()
+func TestCatalog_DefaultFiltersContainLogPatternRateFilter(t *testing.T) {
+	catalog := defaultCatalog()
+	_, _, _, filters, _ := catalog.Instantiate(ComponentSettings{})
 	require.NotEmpty(t, filters)
 
 	var found bool
@@ -180,5 +181,5 @@ func TestDefaultDetectorFilters_ContainsLogPatternRateFilter(t *testing.T) {
 			break
 		}
 	}
-	assert.True(t, found, "defaultDetectorFilters should contain log_pattern_rate_filter")
+	assert.True(t, found, "default catalog should produce a log_pattern_rate_filter")
 }

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -24,16 +24,18 @@ import (
 // eventSender formats and dispatches one Datadog event per correlation.
 // When api is nil, send prints to stdout (dry-run mode) instead of calling the API.
 type eventSender struct {
-	api    *datadogV2.EventsApi
-	ctx    context.Context
-	logger log.Component
+	api     *datadogV2.EventsApi
+	ctx     context.Context
+	logger  log.Component
+	storage observerdef.StorageReader
 }
 
 // newEventSender creates an eventSender. It reads observer.event_reporter.sending_enabled
 // from cfg; when false, api is left nil and events are only logged (dry-run mode).
-func newEventSender(cfg config.Component, logger log.Component) (*eventSender, error) {
+// storage is used to compute windowed log rates for display in event messages.
+func newEventSender(cfg config.Component, logger log.Component, storage observerdef.StorageReader) (*eventSender, error) {
 	if !cfg.GetBool("observer.event_reporter.sending_enabled") {
-		return &eventSender{logger: logger}, nil
+		return &eventSender{logger: logger, storage: storage}, nil
 	}
 	apiKey := cfg.GetString("api_key")
 	if apiKey == "" {
@@ -45,14 +47,29 @@ func newEventSender(cfg config.Component, logger log.Component) (*eventSender, e
 		map[string]datadog.APIKey{"apiKeyAuth": {Key: apiKey}},
 	)
 	return &eventSender{
-		api:    datadogV2.NewEventsApi(datadog.NewAPIClient(datadog.NewConfiguration())),
-		ctx:    ctx,
-		logger: logger,
+		api:     datadogV2.NewEventsApi(datadog.NewAPIClient(datadog.NewConfiguration())),
+		ctx:     ctx,
+		logger:  logger,
+		storage: storage,
 	}, nil
 }
 
+// logPatternRate returns the average log/s over the last logPatternRateWindowSec seconds
+// for the given anomaly. It uses SumRange on storage when a series ref is available,
+// otherwise falls back to DebugInfo.CurrentValue.
+func logPatternRate(a observerdef.Anomaly, storage observerdef.StorageReader) (rate float64, ok bool) {
+	if a.SourceRef != nil && storage != nil {
+		total := storage.SumRange(a.SourceRef.Ref, a.Timestamp-logPatternRateWindowSec, a.Timestamp, observerdef.AggregateCount)
+		return total / logPatternRateWindowSec, true
+	}
+	if a.DebugInfo != nil {
+		return a.DebugInfo.CurrentValue, true
+	}
+	return 0, false
+}
+
 // correlationMessage builds the event message body for a correlation.
-func correlationMessage(c observerdef.ActiveCorrelation) string {
+func correlationMessage(c observerdef.ActiveCorrelation, storage observerdef.StorageReader) string {
 	var metricLines, logLines []string
 	for _, a := range c.Anomalies {
 		if a.Description == "" {
@@ -73,10 +90,10 @@ func correlationMessage(c observerdef.ActiveCorrelation) string {
 					example = "\tlog example: " + strings.TrimSpace(a.Context.Example)
 				}
 				var ratePart string
-				if a.DebugInfo != nil {
-					ratePart = fmt.Sprintf("\tcurrent rate: %.1flog/s", a.DebugInfo.CurrentValue)
+				if rate, ok := logPatternRate(a, storage); ok {
+					ratePart = fmt.Sprintf("\tavg rate (60s): %.1flog/s", rate)
 				} else {
-					ratePart = "\tcurrent rate: unknown"
+					ratePart = "\tavg rate (60s): unknown"
 				}
 				logDescription := fmt.Sprintf("Log pattern change rate detected: %s%s%s", pattern, example, ratePart)
 				logLines = append(logLines, "- "+logDescription)
@@ -102,7 +119,7 @@ func correlationMessage(c observerdef.ActiveCorrelation) string {
 
 // send formats a correlation into an event and either prints or posts it.
 func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
-	text := correlationMessage(c)
+	text := correlationMessage(c, s.storage)
 	ts := time.Unix(c.FirstSeen, 0).UTC().Format(time.RFC3339)
 
 	s.logger.Infof("[observer] sending event: pattern=%s title=%q timestamp=%s\n%s\n", c.Pattern, c.Title, ts, text)

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -67,7 +67,7 @@ func correlationMessage(c observerdef.ActiveCorrelation) string {
 			}
 			// If this metric is a log related one, find its pattern and create a custom message
 			// TODO(celian): When this will be split by tags, add tags to the description. Then be sure that we don't have twice (pattern, tags) tuples
-			if a.Source.Namespace == "log_pattern_extractor" && pattern != "" {
+			if a.Source.Namespace == LogPatternExtractorName && pattern != "" {
 				var example string
 				if a.Context.Example != "" {
 					example = "\tlog example: " + strings.TrimSpace(a.Context.Example)

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -220,6 +220,7 @@ func NewComponent(deps Requires) Provides {
 		storage:          newTimeSeriesStorage(),
 		extractors:       extractors,
 		detectors:        detectors,
+		detectorFilters:  defaultDetectorFilters(),
 		correlators:      correlators,
 		contextProviders: collectContextProviders(extractors),
 		scheduler:        &currentBehaviorPolicy{},

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -214,13 +214,13 @@ func NewComponent(deps Requires) Provides {
 	cfg := deps.Config
 	catalog := defaultCatalog()
 	settings := settingsFromAgentConfig(catalog, cfg)
-	detectors, correlators, extractors, _ := catalog.Instantiate(settings)
+	detectors, correlators, extractors, filters, _ := catalog.Instantiate(settings)
 
 	eng := newEngine(engineConfig{
 		storage:          newTimeSeriesStorage(),
 		extractors:       extractors,
 		detectors:        detectors,
-		detectorFilters:  defaultDetectorFilters(),
+		detectorFilters:  filters,
 		correlators:      correlators,
 		contextProviders: collectContextProviders(extractors),
 		scheduler:        &currentBehaviorPolicy{},

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -262,7 +262,7 @@ func NewComponent(deps Requires) Provides {
 
 	// Optionally add the event reporter when sending is enabled via config.
 	if cfg.GetBool("observer.event_reporter.sending_enabled") {
-		if sender, err := newEventSender(deps.Config, deps.Log); err != nil {
+		if sender, err := newEventSender(deps.Config, deps.Log, eng.Storage()); err != nil {
 			deps.Log.Warnf("[observer] event_reporter disabled: %v", err)
 		} else {
 			eventReporter := &EventReporter{sender: sender, logger: deps.Log}

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -101,7 +101,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 
 		if verbose {
 			oc.Title = corr.Title
-			oc.Message = correlationMessage(corr)
+			oc.Message = correlationMessage(corr, tb.engine.Storage())
 			oc.Tags = []string{"source:agent-q-branch-observer", "pattern:" + corr.Pattern}
 			oc.MemberSeries = make([]string, len(corr.Members))
 			for j, m := range corr.Members {

--- a/comp/observer/impl/profile_test.go
+++ b/comp/observer/impl/profile_test.go
@@ -36,7 +36,7 @@ func buildRealisticEngine(numMetrics, numSeconds int, windowSec int64) *engine {
 	storage := buildRealisticStorage(numMetrics, numSeconds)
 
 	catalog := defaultCatalog()
-	detectors, correlators, _, _ := catalog.Instantiate(ComponentSettings{})
+	detectors, correlators, _, _, _ := catalog.Instantiate(ComponentSettings{})
 
 	// Apply window to all seriesDetectorAdapters.
 	if windowSec > 0 {

--- a/comp/observer/impl/reporter_testbench.go
+++ b/comp/observer/impl/reporter_testbench.go
@@ -33,6 +33,7 @@ type ReportedEvent struct {
 type replayReporter struct {
 	seenPatterns map[string]bool
 	events       []ReportedEvent
+	storage      observerdef.StorageReader
 }
 
 // Name satisfies observerdef.Reporter.
@@ -52,7 +53,7 @@ func (r *replayReporter) Report(output observerdef.ReportOutput) {
 
 	for _, ac := range output.ActiveCorrelations {
 		if !r.seenPatterns[ac.Pattern] {
-			msg := correlationMessage(ac)
+			msg := correlationMessage(ac, r.storage)
 			tags := []string{"source:agent-q-branch-observer", "pattern:" + ac.Pattern}
 			r.events = append(r.events, ReportedEvent{
 				Pattern:       ac.Pattern,

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -946,6 +946,51 @@ func (s *timeSeriesStorage) GetSeriesRange(ref observer.SeriesRef, start, end in
 	}
 }
 
+// SumRange returns the aggregate total over the time range (start, end] without
+// allocating any intermediate slices. It operates directly on the columnar
+// data arrays, using binary search to locate the range boundaries.
+// Returns 0 if the series is not found or the range is empty.
+func (s *timeSeriesStorage) SumRange(ref observer.SeriesRef, start, end int64, agg Aggregate) float64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	stats := s.resolveByID(ref)
+	if stats == nil {
+		return 0
+	}
+
+	lo := searchAfter(stats.timestamps, start)
+	hi := searchAfter(stats.timestamps, end)
+	if lo >= hi {
+		return 0
+	}
+
+	var total float64
+	switch agg {
+	case AggregateSum:
+		for _, v := range stats.sums[lo:hi] {
+			total += v
+		}
+	case AggregateCount:
+		for _, c := range stats.counts[lo:hi] {
+			total += float64(c)
+		}
+	case AggregateMin:
+		for _, v := range stats.mins[lo:hi] {
+			total += v
+		}
+	case AggregateMax:
+		for _, v := range stats.maxes[lo:hi] {
+			total += v
+		}
+	default: // AggregateAverage
+		for i := lo; i < hi; i++ {
+			total += stats.aggregateAt(i, agg)
+		}
+	}
+	return total
+}
+
 // pointBufPool reuses point buffers across ForEachPoint calls to avoid
 // per-call allocation. Each buffer grows to its high-water mark and stays.
 var pointBufPool = sync.Pool{

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -24,7 +24,7 @@ const (
 	telemetryRRCFThreshold = "observer.rrcf.threshold"
 
 	// Log pattern extractor — counter: delta (new clusters) per processed log
-	telemetryLogPatternExtractorPatternCount = "observer.log_pattern_extractor.pattern_count"
+	telemetryLogPatternExtractorPatternCount = "observer." + LogPatternExtractorName + ".pattern_count"
 )
 
 // This is used to:

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -191,6 +191,7 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 		storage:          newTimeSeriesStorage(),
 		extractors:       extractors,
 		detectors:        detectors,
+		detectorFilters:  defaultDetectorFilters(),
 		correlators:      correlators,
 		contextProviders: collectContextProviders(extractors),
 		scheduler:        &currentBehaviorPolicy{},

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -677,7 +677,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	// Register a replay reporter before the run so it captures events exactly as
 	// EventReporter would in live mode: one event per pattern appearance, with
 	// patterns eligible to re-fire after going inactive.
-	replay := &replayReporter{}
+	replay := &replayReporter{storage: tb.engine.Storage()}
 	unsub := tb.engine.Subscribe(&reporterEventSink{
 		reporters: []observerdef.Reporter{replay},
 		state:     tb.engine.StateView(),
@@ -1331,7 +1331,7 @@ func (tb *TestBench) RunSendAnomalyEvents(scenario string) error {
 
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
-	sender, err := newEventSender(tb.config.Cfg, tb.config.Logger)
+	sender, err := newEventSender(tb.config.Cfg, tb.config.Logger, tb.engine.Storage())
 	if err != nil {
 		return err
 	}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -185,13 +185,13 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 	}
 
 	catalog := defaultCatalog()
-	detectors, correlators, extractors, components := catalog.Instantiate(config.ComponentSettings)
+	detectors, correlators, extractors, filters, components := catalog.Instantiate(config.ComponentSettings)
 
 	eng := newEngine(engineConfig{
 		storage:          newTimeSeriesStorage(),
 		extractors:       extractors,
 		detectors:        detectors,
-		detectorFilters:  defaultDetectorFilters(),
+		detectorFilters:  filters,
 		correlators:      correlators,
 		contextProviders: collectContextProviders(extractors),
 		scheduler:        &currentBehaviorPolicy{},
@@ -668,6 +668,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	tb.engine.SetDetectors(catalogEnabledDetectors(tb.components, tb.catalog))
 	tb.engine.SetCorrelators(catalogEnabledCorrelators(tb.components, tb.catalog))
 	tb.engine.SetExtractors(catalogEnabledExtractors(tb.components, tb.catalog))
+	tb.engine.SetDetectorFilters(catalogEnabledFilters(tb.components, tb.catalog))
 	tb.engine.resetFull()
 
 	// Reset ALL components (not just enabled) so disabled ones clear stale state

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -1540,7 +1540,7 @@ func (tb *TestBench) GetLogPatterns() []LogPatternInfo {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	ci, ok := tb.components["log_pattern_extractor"]
+	ci, ok := tb.components[LogPatternExtractorName]
 	if !ok {
 		return []LogPatternInfo{}
 	}
@@ -1595,7 +1595,7 @@ func (tb *TestBench) GetLogPatterns() []LogPatternInfo {
 func (tb *TestBench) getLogPatternExtractor() *LogPatternExtractor {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
-	ci, ok := tb.components["log_pattern_extractor"]
+	ci, ok := tb.components[LogPatternExtractorName]
 	if !ok {
 		return nil
 	}

--- a/comp/observer/impl/testbench_api_test.go
+++ b/comp/observer/impl/testbench_api_test.go
@@ -126,14 +126,14 @@ func TestHandleSeriesListMarksLogPatternExtractorSeriesAsVirtual(t *testing.T) {
 	var logPatternSeen bool
 	for _, s := range body {
 		switch s.Namespace {
-		case "log_pattern_extractor":
+		case LogPatternExtractorName:
 			logPatternSeen = true
-			assert.True(t, s.Virtual, "log_pattern_extractor series should be virtual")
+			assert.True(t, s.Virtual, LogPatternExtractorName+" series should be virtual")
 		case "full":
 			assert.False(t, s.Virtual, "non-extractor namespace should not be virtual")
 		}
 	}
-	require.True(t, logPatternSeen, "expected at least one log_pattern_extractor series in /api/series")
+	require.True(t, logPatternSeen, "expected at least one "+LogPatternExtractorName+" series in /api/series")
 }
 
 // Telemetry counters used to be listed as avg+count+sum with identical tags, which produced three


### PR DESCRIPTION
### What does this PR do?

We want to filter out some anomalies (e.g. log rate < 1 log/s), added a component to do so + computed log rate over the last minute (instead of last second which isn't accurate).
This way if we have a small spike of logs, it is ignored.

Introduce a DetectorFilter pipeline stage that suppresses anomalies before
they reach correlators, with a concrete filter for low-volume log patterns.

Adds:
- DetectorFilter interface with StorageReader access for history-based filtering
- StorageReader.SumRange for zero-allocation range aggregation
- logPatternRateFilter: drops log pattern anomalies below 1 log/s (60s avg)
- Component catalog integration, enabled by default

### Motivation

### Describe how you validated your changes

### Additional Notes
