### PR TITLE
chore(pre-commit): Pin hooks to SHA with frozen comment for Renovate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,23 +8,23 @@ default_stages:
 
 repos:
 - repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 7cc5848088fd8412905ab79feea6c8edc3ac76c6 # 2.1.5
+  rev: 7cc5848088fd8412905ab79feea6c8edc3ac76c6 # frozen: 2.1.5
   hooks:
     - id: shellcheck
       args: ["--severity=info", "-e", "SC2059", "-e", "SC2028"]
 - repo: https://github.com/tekwizely/pre-commit-golang
-  rev: bd69b816c43306f28bad4d7b303d981b0ecd2fd5 # v1.0.0-beta.5
+  rev: bd69b816c43306f28bad4d7b303d981b0ecd2fd5 # frozen: v1.0.0-beta.5
   hooks:
     - id: go-fmt
       args: [ "-w", "-s" ]
       exclude: ^.*.(pb.go|_gen.go)$
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: end-of-file-fixer
         files: release.json
 - repo: https://github.com/rhysd/actionlint
-  rev: v1.7.11
+  rev: 393031adb9afb225ee52ae2ccd7a5af5525e03e8 # frozen: v1.7.11
   hooks:
     - id: actionlint
       args: [ "-ignore", "shellcheck" ]


### PR DESCRIPTION
### What does this PR do?

Pins all external pre-commit hook `rev` values to commit SHAs with the `# frozen: <version>` comment format, enabling Renovate to automatically manage version updates for pre-commit hooks.

Changes:
- `jumanjihouse/pre-commit-hooks`: `# 2.1.5` → `# frozen: 2.1.5`
- `tekwizely/pre-commit-golang`: `# v1.0.0-beta.5` → `# frozen: v1.0.0-beta.5`
- `pre-commit/pre-commit-hooks`: `v6.0.0` (tag) → `3e8a870...` `# frozen: v6.0.0` (SHA)
- `rhysd/actionlint`: `v1.7.11` (tag) → `393031a...` `# frozen: v1.7.11` (SHA)

### Motivation

Renovate now supports updating pre-commit hooks pinned to commit SHAs when using the `# frozen: <version>` comment format ([renovatebot/renovate#22567](https://github.com/renovatebot/renovate/issues/22567), implemented in [renovatebot/renovate#36693](https://github.com/renovatebot/renovate/pull/36693)).

This is part of the ongoing Dependabot → Renovate migration and enables Renovate to manage pre-commit hook updates automatically.

### Describe how you validated your changes

Verified that the commit SHAs match the expected tags via `git ls-remote`. Pre-commit hooks pass on commit.

### Additional Notes

No functional change — hooks resolve to the same code. Only the `rev` format changes.