### PR TITLE
fix(oracle): fix Data Guard interval precision overflow (ORA-01873)

### DIFF
--- a/pkg/collector/corechecks/oracle/data_guard.go
+++ b/pkg/collector/corechecks/oracle/data_guard.go
@@ -47,7 +47,11 @@ func (c *Check) dataGuard() error {
 		return fmt.Errorf("failed to initialize sender: %w", err)
 	}
 	var stats []dataguardStats
-	err = selectWrapper(c, &stats, `SELECT name, EXTRACT(DAY from TO_DSINTERVAL(value)*86400) value
+	err = selectWrapper(c, &stats, `SELECT name,
+	EXTRACT(DAY FROM TO_DSINTERVAL(value)) * 86400 +
+	EXTRACT(HOUR FROM TO_DSINTERVAL(value)) * 3600 +
+	EXTRACT(MINUTE FROM TO_DSINTERVAL(value)) * 60 +
+	EXTRACT(SECOND FROM TO_DSINTERVAL(value)) AS value
 	FROM v$dataguard_stats WHERE name IN ('apply lag','transport lag')`)
 	if err != nil {
 		return fmt.Errorf("failed to query data guard statistics %w", err)

--- a/releasenotes/notes/fix-oracle-dataguard-interval-overflow-7452b1c41ec51fe9.yaml
+++ b/releasenotes/notes/fix-oracle-dataguard-interval-overflow-7452b1c41ec51fe9.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed Oracle Data Guard metrics query that caused ORA-01873 (interval precision overflow)
+    when the replication lag exceeded ~100 seconds. The query now extracts each interval
+    component (day, hour, minute, second) individually instead of multiplying the entire
+    interval by 86400.


### PR DESCRIPTION
## What does this PR do?

Fixes the Oracle Data Guard metrics query that causes `ORA-01873: the leading precision of the interval is too small` when DataGuard replication lag exceeds ~100 seconds.

## Motivation

The existing query in `data_guard.go` multiplies the entire `TO_DSINTERVAL(value)` interval by 86400:

```sql
SELECT name, EXTRACT(DAY from TO_DSINTERVAL(value)*86400) value
FROM v$dataguard_stats WHERE name IN ('apply lag','transport lag')
```

Oracle's default `INTERVAL DAY TO SECOND` has a DAY precision of 2 digits (max 99 days). Multiplying any interval by 86400 easily overflows — e.g. a 2-minute lag × 86400 = 120 days, exceeding the 99-day limit.

This bug has been present since the original Data Guard implementation (commit 9778ab3a029, Nov 2023) and exists on all branches.

## The Fix

Extract each interval component individually, then compute total seconds:

```sql
SELECT name,
  EXTRACT(DAY FROM TO_DSINTERVAL(value)) * 86400 +
  EXTRACT(HOUR FROM TO_DSINTERVAL(value)) * 3600 +
  EXTRACT(MINUTE FROM TO_DSINTERVAL(value)) * 60 +
  EXTRACT(SECOND FROM TO_DSINTERVAL(value)) AS value
FROM v$dataguard_stats WHERE name IN ('apply lag','transport lag')
```

This avoids interval multiplication entirely — each `EXTRACT` returns a plain number, and the arithmetic stays in the numeric domain.

## Impact

When this bug fires, it:
- Prevents DataGuard lag metrics (`oracle.data_guard.apply_lag`, `oracle.data_guard.transport_lag`) from being collected
- Causes the Oracle check's service check to report `CRITICAL` on every run (even though all other metrics are collected fine)
- Generates continuous ERROR log entries

## Describe how you validated your changes

- Identified via customer escalation (SDBM-2505) with Agent 7.71.0
- Confirmed the error fires deterministically in agent logs (~every minute)
- Verified other Oracle metrics (DBM sessions, statements, sysmetrics) continue collecting despite the error
- The fix uses standard Oracle SQL — same approach used in Oracle documentation and the customer's own working custom queries

## Additional Notes

- Discovered via support escalation: the customer had 8 Oracle instances with DataGuard, all hitting this error
- The customer had independently written working custom queries using `REGEXP_SUBSTR` to parse the lag value — confirming the data is available and the issue is purely in our SQL

/team:database-monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)