### PR TITLE
fix(oracle): fix Data Guard interval precision overflow (ORA-01873)

### DIFF
--- a/pkg/collector/corechecks/oracle/data_guard.go
+++ b/pkg/collector/corechecks/oracle/data_guard.go
@@ -47,7 +47,11 @@ func (c *Check) dataGuard() error {
 		return fmt.Errorf("failed to initialize sender: %w", err)
 	}
 	var stats []dataguardStats
-	err = selectWrapper(c, &stats, `SELECT name, EXTRACT(DAY from TO_DSINTERVAL(value)*86400) value
+	err = selectWrapper(c, &stats, `SELECT name,
+	EXTRACT(DAY FROM TO_DSINTERVAL(value)) * 86400 +
+	EXTRACT(HOUR FROM TO_DSINTERVAL(value)) * 3600 +
+	EXTRACT(MINUTE FROM TO_DSINTERVAL(value)) * 60 +
+	EXTRACT(SECOND FROM TO_DSINTERVAL(value)) AS value
 	FROM v$dataguard_stats WHERE name IN ('apply lag','transport lag')`)
 	if err != nil {
 		return fmt.Errorf("failed to query data guard statistics %w", err)

--- a/pkg/collector/corechecks/oracle/data_guard.go
+++ b/pkg/collector/corechecks/oracle/data_guard.go
@@ -48,11 +48,14 @@ func (c *Check) dataGuard() error {
 	}
 	var stats []dataguardStats
 	err = selectWrapper(c, &stats, `SELECT name,
-	EXTRACT(DAY FROM TO_DSINTERVAL(value)) * 86400 +
-	EXTRACT(HOUR FROM TO_DSINTERVAL(value)) * 3600 +
-	EXTRACT(MINUTE FROM TO_DSINTERVAL(value)) * 60 +
-	EXTRACT(SECOND FROM TO_DSINTERVAL(value)) AS value
-	FROM v$dataguard_stats WHERE name IN ('apply lag','transport lag')`)
+	EXTRACT(DAY FROM ival) * 86400 +
+	EXTRACT(HOUR FROM ival) * 3600 +
+	EXTRACT(MINUTE FROM ival) * 60 +
+	EXTRACT(SECOND FROM ival) AS value
+	FROM (
+		SELECT name, TO_DSINTERVAL(value) AS ival
+		FROM v$dataguard_stats WHERE name IN ('apply lag','transport lag')
+	)`)
 	if err != nil {
 		return fmt.Errorf("failed to query data guard statistics %w", err)
 	}

--- a/releasenotes/notes/fix-oracle-dataguard-interval-overflow-7452b1c41ec51fe9.yaml
+++ b/releasenotes/notes/fix-oracle-dataguard-interval-overflow-7452b1c41ec51fe9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed Oracle Data Guard metrics query that caused ORA-01873 (interval precision overflow).


### PR DESCRIPTION
## What does this PR do?

Fixes the Oracle Data Guard metrics query that causes `ORA-01873: the leading precision of the interval is too small`.

## Motivation

Customer-reported issue (SDBM-2505). The existing query in `data_guard.go` multiplies the entire `TO_DSINTERVAL(value)` interval by 86400, which overflows Oracle's default 2-digit DAY precision when the lag value is read from a VARCHAR2 column at runtime.

## The Fix

Extract each interval component individually, then compute total seconds:

```sql
SELECT name,
  EXTRACT(DAY FROM TO_DSINTERVAL(value)) * 86400 +
  EXTRACT(HOUR FROM TO_DSINTERVAL(value)) * 3600 +
  EXTRACT(MINUTE FROM TO_DSINTERVAL(value)) * 60 +
  EXTRACT(SECOND FROM TO_DSINTERVAL(value)) AS value
FROM v$dataguard_stats WHERE name IN ('apply lag','transport lag')
```

## Impact

Continuous ERROR log entries: `failed to query data guard statistics ORA-01873: the leading precision of the interval is too small`.

## Describe how you validated your changes

Reproduced against Oracle 21c XE (`gvenzl/oracle-xe:21-slim`) in Docker. Created a table mimicking `v$dataguard_stats` (VARCHAR2 `value` column) with various lag values (5s, 2m30s, 1h30m45s, 3d12h5m10s):

- **Old query** → `ORA-01873: the leading precision of the interval is too small` (no rows returned)
- **New query** → Correct values: 5, 150, 5445, 302710

Note: the error only triggers when `TO_DSINTERVAL` reads from a VARCHAR2 column at runtime (default `DAY(2)` precision). Literal expressions are optimized at parse time with full precision, which is why the overflow doesn't occur with hardcoded values.

/team:database-monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)