### PR TITLE
fix(installer): Restore LSA password and SCM credentials on uninstall rollback

### DIFF
--- a/releasenotes/notes/msi-uninstall-rollback-service-account-c0884ed50c262237.yaml
+++ b/releasenotes/notes/msi-uninstall-rollback-service-account-c0884ed50c262237.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    On Windows, if the MSI uninstallation fails and triggers a rollback, the service account password is now correctly restored. This ensures that the Agent services can start successfully after the rollback completes.

--- a/test/new-e2e/tests/windows/install-test/uninstall_rollback_test.go
+++ b/test/new-e2e/tests/windows/install-test/uninstall_rollback_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package installtest
+
+import (
+	"path/filepath"
+	"testing"
+
+	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
+)
+
+type testUninstallRollbackSuite struct {
+	baseAgentMSISuite
+}
+
+func TestUninstallRollback(t *testing.T) {
+	s := &testUninstallRollbackSuite{}
+	Run(t, s)
+}
+
+// TestUninstallRollback verifies that when an uninstall fails and rolls back,
+// the agent service can still start. This tests that the LSA password and SCM
+// service credentials are properly restored during rollback.
+func (s *testUninstallRollbackSuite) TestUninstallRollback() {
+	vm := s.Env().RemoteHost
+
+	// Install the agent normally
+	s.installAgentPackage(vm, s.AgentPackage)
+
+	// Trigger an uninstall that will fail during the deferred phase and roll back
+	s.Run("uninstall rollback", func() {
+		product, err := windowsAgent.GetDatadogAgentProductCode(vm)
+		s.Require().NoError(err, "should get product code")
+
+		err = windowsCommon.UninstallMSI(vm, product,
+			"WIXFAILWHENDEFERRED=1",
+			filepath.Join(s.SessionOutputDir(), "uninstall-rollback.log"))
+		s.Require().Error(err, "uninstall should fail and roll back")
+	})
+
+	// Start the agent service — MSI rollback does not restart services that
+	// were stopped during uninstall. This is the key assertion: if the password
+	// was not restored, the service will fail to start because it runs as
+	// ddagentuser and needs the password to log on.
+	s.Run("agent service starts after rollback", func() {
+		err := windowsCommon.StartService(vm, "datadogagent")
+		s.Require().NoError(err, "should be able to start agent service after uninstall rollback")
+		err = s.waitForServiceRunning(vm, "datadogagent", 300)
+		s.Require().NoError(err, "agent service should be running after uninstall rollback")
+	})
+
+	// TODO(WINA-2538): Enable TestInstallExpectations once CleanupFiles no longer
+	// deletes embedded3 before RemoveFiles, which prevents rollback restoration of
+	// the Python distribution.
+	// s.Run("agent is still installed", func() {
+	// 	t := s.newTester(vm)
+	// 	t.TestInstallExpectations(s.T())
+	// })
+}

--- a/test/new-e2e/tests/windows/install-test/uninstall_rollback_test.go
+++ b/test/new-e2e/tests/windows/install-test/uninstall_rollback_test.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
+	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 )
 
 type testUninstallRollbackSuite struct {

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/InstallStateCustomActions.cs
@@ -45,6 +45,7 @@ namespace Datadog.AgentCustomActions
                     RegistryValueProperty(_session, "APPLICATIONDATADIRECTORY", subkey, "ConfigRoot");
                 }
 
+                LoadAgentPasswordProperty();
                 GetWindowsBuildVersion();
                 SetDDDriverRollback();
                 SetRemoveFolderExProperties();
@@ -56,6 +57,36 @@ namespace Datadog.AgentCustomActions
             }
 
             return ActionResult.Success;
+        }
+
+        /// <summary>
+        /// Reads the agent password from the LSA secret store and stores it in the
+        /// DDAGENTUSER_LSA_PASSWORD_BACKUP MSI property for use during uninstall rollback.
+        /// </summary>
+        /// <remarks>
+        /// The password must be available as an MSI property during the immediate phase so that
+        /// it can be passed to the UninstallUserRollback deferred action via CustomActionData.
+        /// We intentionally do not log the password value.
+        /// </remarks>
+        private void LoadAgentPasswordProperty()
+        {
+            try
+            {
+                var keyName = ConfigureUserCustomActions.AgentPasswordPrivateDataKey();
+                var password = _nativeMethods.FetchSecret(keyName);
+                if (!string.IsNullOrEmpty(password))
+                {
+                    // Use lowercase property name so MSI treats it as a private property.
+                    // Do not log the password value.
+                    _session["DDAGENTUSER_LSA_PASSWORD_BACKUP"] = password;
+                    _session.Log("Read agent password from LSA for rollback");
+                }
+            }
+            catch (Exception e)
+            {
+                // Not an error - the password may not exist (e.g., fresh install or service account)
+                _session.Log($"Could not read agent password from LSA for rollback: {e}");
+            }
         }
 
         // <summary>

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -764,7 +764,8 @@ namespace Datadog.CustomActions
                     // because the new version of the Agent will need it. Technically it should already have it
                     // because it's fetched in ProcessDDAgentUserCredentials, which runs before the existing
                     // products are removed, but we don't want to lose it on rollback.
-                    // TODO(WINA-1357): rollback the password if the upgrade fails
+                    // TODO(WINA-1357): rollback the password if the upgrade fails.
+                    //   Note: the uninstall rollback case is handled by UninstallUserRollback/RestoreAgentCredentials.
                     // If this is a Fleet Automation upgrade (uninstall->install workflow), we don't want to remove
                     // the password from the LSA secret store because the new version of the Agent will need it.
                     _session.Log($"Upgrade detected, not removing password from LSA secret store");
@@ -811,8 +812,69 @@ namespace Datadog.CustomActions
 
         public ActionResult UninstallUserRollback()
         {
+            RestoreAgentCredentials();
             RunRollbackDataRestore();
             return ActionResult.Success;
+        }
+
+        /// <summary>
+        /// Restores the agent password to the LSA secret store and resets the SCM service
+        /// logon credentials on all ddagentuser services.
+        /// </summary>
+        /// <remarks>
+        /// The password was saved in CustomActionData by ReadInstallState during the immediate
+        /// phase. We restore both the LSA secret (for future upgrades/Fleet Automation) and the
+        /// SCM service credentials (since MSI's DeleteServices rollback does not restore
+        /// passwords — QueryServiceConfig does not return them).
+        /// </remarks>
+        private void RestoreAgentCredentials()
+        {
+            var password = _session.Property("DDAGENTUSER_LSA_PASSWORD_BACKUP");
+            if (string.IsNullOrEmpty(password))
+            {
+                _session.Log("No agent password in rollback data, skipping credential restore");
+                return;
+            }
+
+            // Restore the LSA secret
+            try
+            {
+                var keyName = AgentPasswordPrivateDataKey();
+                _nativeMethods.StoreSecret(keyName, password);
+                _session.Log("Restored agent password to LSA secret store");
+            }
+            catch (Exception e)
+            {
+                _session.Log($"Failed to restore agent password to LSA: {e}");
+            }
+
+            // Restore the SCM service logon credentials
+            var ddAgentUserName = _session.Property("DDAGENTUSER_NAME");
+            if (string.IsNullOrEmpty(ddAgentUserName))
+            {
+                _session.Log("No agent user name in rollback data, skipping SCM credential restore");
+                return;
+            }
+
+            try
+            {
+                var userFound = _nativeMethods.LookupAccountName(ddAgentUserName,
+                    out _, out _, out var ddAgentUserSID, out _);
+                if (!userFound || ddAgentUserSID == null)
+                {
+                    _session.Log($"Could not find user {ddAgentUserName}, skipping SCM credential restore");
+                    return;
+                }
+
+                ServiceCustomAction.SetDdAgentUserServiceCredentials(
+                    _serviceController, _nativeMethods, _session,
+                    ddAgentUserName, password, ddAgentUserSID);
+                _session.Log("Restored SCM service logon credentials");
+            }
+            catch (Exception e)
+            {
+                _session.Log($"Failed to restore SCM service credentials: {e}");
+            }
         }
 
         public static ActionResult UninstallUserRollback(Session session)

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
@@ -167,17 +167,48 @@ namespace Datadog.CustomActions
         private void ConfigureServiceUsers(string ddAgentUserName, SecurityIdentifier ddAgentUserSID)
         {
             var ddAgentUserPassword = _session.Property("DDAGENTUSER_PROCESSED_PASSWORD");
-            var isServiceAccount = _nativeMethods.IsServiceAccount(ddAgentUserSID);
+
+            SetDdAgentUserServiceCredentials(
+                _serviceController, _nativeMethods, _session,
+                ddAgentUserName, ddAgentUserPassword, ddAgentUserSID);
+
+            // SYSTEM
+            // LocalSystem is a SCM specific shorthand that doesn't need to be localized
+            _serviceController.SetCredentials(Constants.SystemProbeServiceName, "LocalSystem", "");
+            _serviceController.SetCredentials(Constants.ProcessAgentServiceName, "LocalSystem", "");
+            _serviceController.SetCredentials(Constants.InstallerServiceName, "LocalSystem", "");
+        }
+
+        /// <summary>
+        /// Sets the logon credentials on all services that run as ddagentuser.
+        /// Handles SCM name normalization for well-known SIDs and password rules
+        /// per the ChangeServiceConfig API.
+        /// </summary>
+        /// <remarks>
+        /// This is a shared helper used by both ConfigureServiceUsers (install/upgrade)
+        /// and UninstallUserRollback (uninstall rollback) to avoid duplicating the service
+        /// list and credential logic.
+        /// </remarks>
+        public static void SetDdAgentUserServiceCredentials(
+            IServiceController serviceController,
+            INativeMethods nativeMethods,
+            ISession session,
+            string ddAgentUserName,
+            string ddAgentUserPassword,
+            SecurityIdentifier ddAgentUserSID)
+        {
+            var isServiceAccount = nativeMethods.IsServiceAccount(ddAgentUserSID);
             if (!isServiceAccount && string.IsNullOrEmpty(ddAgentUserPassword))
             {
-                _session.Log("Password not provided, will not change service user password");
+                session.Log("Password not provided, will not change service user password");
                 // set to null so we don't modify the service config
                 ddAgentUserPassword = null;
             }
             else if (isServiceAccount)
             {
-                _session.Log("Ignoring provided password because account is a service account");
+                session.Log("Ignoring provided password because account is a service account");
                 // Follow rules for ChangeServiceConfig
+                // https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-changeserviceconfigw
                 if (ddAgentUserSID.IsWellKnown(WellKnownSidType.LocalSystemSid) ||
                     ddAgentUserSID.IsWellKnown(WellKnownSidType.LocalServiceSid) ||
                     ddAgentUserSID.IsWellKnown(WellKnownSidType.NetworkServiceSid))
@@ -192,9 +223,9 @@ namespace Datadog.CustomActions
                 }
             }
 
-            _session.Log($"Configuring services with account {ddAgentUserName}");
+            session.Log($"Configuring ddagentuser services with account {ddAgentUserName}");
 
-            // ddagentuser
+            // Normalize well-known SID names for SCM
             if (ddAgentUserSID.IsWellKnown(WellKnownSidType.LocalSystemSid))
             {
                 ddAgentUserName = "LocalSystem";
@@ -207,20 +238,14 @@ namespace Datadog.CustomActions
             {
                 ddAgentUserName = "NetworkService";
             }
-            _serviceController.SetCredentials(Constants.AgentServiceName, ddAgentUserName, ddAgentUserPassword);
-            _serviceController.SetCredentials(Constants.TraceAgentServiceName, ddAgentUserName, ddAgentUserPassword);
-            if (_serviceController.ServiceExists(Constants.PrivateActionRunnerServiceName))
+
+            serviceController.SetCredentials(Constants.AgentServiceName, ddAgentUserName, ddAgentUserPassword);
+            serviceController.SetCredentials(Constants.TraceAgentServiceName, ddAgentUserName, ddAgentUserPassword);
+            serviceController.SetCredentials(Constants.SecurityAgentServiceName, ddAgentUserName, ddAgentUserPassword);
+            if (serviceController.ServiceExists(Constants.PrivateActionRunnerServiceName))
             {
-                _serviceController.SetCredentials(Constants.PrivateActionRunnerServiceName, ddAgentUserName, ddAgentUserPassword);
+                serviceController.SetCredentials(Constants.PrivateActionRunnerServiceName, ddAgentUserName, ddAgentUserPassword);
             }
-
-            // SYSTEM
-            // LocalSystem is a SCM specific shorthand that doesn't need to be localized
-            _serviceController.SetCredentials(Constants.SystemProbeServiceName, "LocalSystem", "");
-            _serviceController.SetCredentials(Constants.ProcessAgentServiceName, "LocalSystem", "");
-            _serviceController.SetCredentials(Constants.InstallerServiceName, "LocalSystem", "");
-
-            _serviceController.SetCredentials(Constants.SecurityAgentServiceName, ddAgentUserName, ddAgentUserPassword);
         }
 
         private void UpdateAndLogAccessControl(string serviceName, CommonSecurityDescriptor securityDescriptor)

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -442,7 +442,10 @@ namespace WixSetup.Datadog_Agent
             {
                 Execute = Execute.rollback,
                 Impersonate = false,
-            };
+            }
+                .SetProperties("DDAGENTUSER_LSA_PASSWORD_BACKUP=[DDAGENTUSER_LSA_PASSWORD_BACKUP], " +
+                               "DDAGENTUSER_NAME=[DDAGENTUSER_NAME]")
+                .HideTarget(true);
 
             ProcessDdAgentUserCredentials = new CustomAction<CustomActions>(
                     new Id(nameof(ProcessDdAgentUserCredentials)),


### PR DESCRIPTION
### What does this PR do?

Restores the agent password (LSA secret and SCM service logon credentials) when an MSI uninstall rolls back.

During a rollback of a full uninstall, two things independently fail:

1. **SCM service credentials** — MSI's built-in `DeleteServices` rollback does not restore service logon passwords (`QueryServiceConfig` does not return them). Without the password, the agent service cannot start because it runs as `ddagentuser` and needs the password to log on.
2. **LSA secret** — Used by Fleet Automation for remote upgrades. Without it, future remote upgrades would fail to authenticate as `ddagentuser`.

**Changes:**
- `ReadInstallState` now reads the LSA password during the immediate phase into `DDAGENTUSER_LSA_PASSWORD_BACKUP`, passed to `UninstallUserRollback` via `CustomActionData` (in-memory only, never written to disk)
- `UninstallUserRollback` restores both the LSA secret and SCM service credentials
- Extracts `SetDdAgentUserServiceCredentials` from `ServiceCustomAction` as a shared helper to avoid duplicating the service list and credential logic
- Adds E2E test `TestUninstallRollback`

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2540 
A failed uninstall that rolls back would leave the agent service unable to start (lost SCM credentials) and break future Fleet Automation remote upgrades (lost LSA secret).

### Describe how you validated your changes

- MSI unit tests pass (100 + 4)
- E2E test `TestUninstallRollback` passes: installs agent, triggers uninstall rollback with `WIXFAILWHENDEFERRED=1`, verifies agent service starts successfully after rollback
- MSI log confirms `LoadAgentPasswordProperty` reads the password and `UninstallUserRollback` restores it

### Additional Notes

- The password is passed via MSI `CustomActionData` (in-memory) and `.HideTarget(true)` prevents it from appearing in MSI logs
- Discovered a separate bug (WINA-2538) where `CleanupFiles` deletes `embedded3` before `RemoveFiles`, preventing Python distribution restoration on rollback. `TestInstallExpectations` is skipped pending that fix.
- The upgrade rollback case (WINA-1357) remains a separate issue