### PR TITLE
fix(ksm): cancel existing ksm store reflector when rebuilding

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -431,6 +431,10 @@ func (k *KSMCheck) buildStores() error {
 	builder.WithFamilyGeneratorFilter(allowDenyList)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel existing store to avoid memory leaks.
+	if k.cancel != nil {
+		k.cancel()
+	}
 	k.cancel = cancel
 	builder.WithContext(ctx)
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -431,11 +431,6 @@ func (k *KSMCheck) buildStores() error {
 	builder.WithFamilyGeneratorFilter(allowDenyList)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	// Cancel existing store to avoid memory leaks.
-	if k.cancel != nil {
-		k.cancel()
-	}
-	k.cancel = cancel
 	builder.WithContext(ctx)
 
 	resyncPeriod := k.instance.ResyncPeriod
@@ -473,10 +468,12 @@ func (k *KSMCheck) buildStores() error {
 	}
 
 	if err = builder.WithAllowLabels(allowedLabels); err != nil {
+		cancel()
 		return err
 	}
 
 	if err := builder.WithEnabledResources(cr.collectors); err != nil {
+		cancel()
 		return err
 	}
 
@@ -494,6 +491,13 @@ func (k *KSMCheck) buildStores() error {
 
 	// Start the collection process
 	k.allStores = builder.BuildStores()
+
+	// Cancel the old reflectors after the new store is created. Cancelling the
+	// old context ensures previous reflectors release their resources.
+	if k.cancel != nil {
+		k.cancel()
+	}
+	k.cancel = cancel
 
 	return nil
 }

--- a/pkg/kubestatemetrics/builder/builder.go
+++ b/pkg/kubestatemetrics/builder/builder.go
@@ -336,7 +336,7 @@ func (b *Builder) startReflector(
 	if useAPIServerCache {
 		listWatcher = newCacheEnabledListerWatcher(listWatcher)
 	}
-	reflector := cache.NewReflector(listWatcher, expectedType, store, b.resync*time.Second)
+	reflector := cache.NewReflector(listWatcher, expectedType, store, b.resync)
 	go reflector.Run(b.ctx.Done())
 }
 

--- a/pkg/kubestatemetrics/builder/builder.go
+++ b/pkg/kubestatemetrics/builder/builder.go
@@ -334,21 +334,23 @@ func (b *Builder) startReflector(
 	useAPIServerCache bool,
 ) {
 	if useAPIServerCache {
-		listWatcher = newCacheEnabledListerWatcher(listWatcher)
+		listWatcher = newCacheEnabledListerWatcher(b.ctx, listWatcher)
 	}
 	reflector := cache.NewReflector(listWatcher, expectedType, store, b.resync)
 	go reflector.Run(b.ctx.Done())
 }
 
 type cacheEnabledListerWatcher struct {
-	lw cache.ListerWatcherWithContext
-	rv string
+	lw  cache.ListerWatcherWithContext
+	rv  string
+	ctx context.Context
 }
 
-func newCacheEnabledListerWatcher(lw cache.ListerWatcher) cache.ListerWatcher {
+func newCacheEnabledListerWatcher(ctx context.Context, lw cache.ListerWatcher) cache.ListerWatcher {
 	return &cacheEnabledListerWatcher{
-		lw: cache.ToListerWatcherWithContext(lw),
-		rv: "0",
+		ctx: ctx,
+		lw:  cache.ToListerWatcherWithContext(lw),
+		rv:  "0",
 	}
 }
 
@@ -361,7 +363,7 @@ func newCacheEnabledListerWatcher(lw cache.ListerWatcher) cache.ListerWatcher {
 func (c *cacheEnabledListerWatcher) List(options v1.ListOptions) (runtime.Object, error) {
 	options.ResourceVersion = c.rv
 	options.ResourceVersionMatch = v1.ResourceVersionMatchNotOlderThan
-	res, err := c.lw.ListWithContext(context.TODO(), options)
+	res, err := c.lw.ListWithContext(c.ctx, options)
 	if err == nil {
 		metadataAccessor, err := meta.ListAccessor(res)
 		if err != nil {
@@ -375,7 +377,7 @@ func (c *cacheEnabledListerWatcher) List(options v1.ListOptions) (runtime.Object
 
 // Watch simply delegates to the wrapped ListerWatcherWithContext
 func (c *cacheEnabledListerWatcher) Watch(options v1.ListOptions) (apiwatch.Interface, error) {
-	return c.lw.WatchWithContext(context.TODO(), options)
+	return c.lw.WatchWithContext(c.ctx, options)
 }
 
 func handlePodCollection[T any](b *Builder, store cache.Store, client T, listWatchFunc func(kubeClient T, ns string, fieldSelector string) cache.ListerWatcher, namespace string, useAPIServerCache bool) {

--- a/releasenotes/notes/fix-memory-leak-in-ksm-check-370b4ecf54dc0e08.yaml
+++ b/releasenotes/notes/fix-memory-leak-in-ksm-check-370b4ecf54dc0e08.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a memory leak in the ``kubernetes_state_core`` check caused by
+    orphaned reflector goroutines in the KSM store during rebuilds. This led
+    to unbounded memory growth and potential OOM kills.


### PR DESCRIPTION
### What does this PR do?

Fixes a memory leak in the KSM (`kubernetes_state_core`) check where calling `buildStores()` on a CRD discoverer update created new `cache.Reflector` goroutines without cancelling the previous context first. The old cancel function was silently overwritten at `k.cancel = cancel`, orphaning all prior reflectors and their `watch.StreamWatcher` connections to the API server.

**Growing goroutine count of stream watchers:**
<img width="1684" height="702" alt="image" src="https://github.com/user-attachments/assets/29b5d5d7-38c5-4963-ad79-e8d792e2c150" />

The fix calls `k.cancel()` before overwriting, ensuring old reflectors are stopped before new ones start.

### Motivation

CLC runners in large clusters have been OOMing with memory profiles dominated by `k8s.io/apimachinery/pkg/watch` and `k8s.io/client-go/rest/watch` — indicating accumulating watch streams.

The leak was introduced in [#43315](https://github.com/DataDog/datadog-agent/pull/43315) which refactored `buildStores()` into a reusable method and added a rebuild path in `Run()` triggered by CRD changes. Previously, the context/cancel pattern was safe because it only ran once during `Configure()`. After the refactor, each CRD event leaks an entire set of reflectors. 

In large clusters with frequent CRD churn, the leak scales as `(CRD events) × (resource types) × (namespaces)`.

### Describe how you validated your changes

- Deployed custom image on internal `gizmo` cluster and saw reduction in OOM'ing events and stabilized memory usage.
   * https://github.com/DataDog/k8s-datadog-agent-ops/pull/7891
   * https://github.com/DataDog/k8s-datadog-agent-ops/pull/7888

### Additional Notes

- Reflectors in `pkg/kubestatemetrics/builder/builder.go:340` are fire-and-forget goroutines (`go reflector.Run(b.ctx.Done())`) — context cancellation is the only mechanism to stop them.
- Only affects agents running the KSM check with the CRD discoverer active (not in `node_kubelet` mode). CLC runners are the primary deployment pattern affected.