### PR TITLE
Fix workloadmeta ResourceExhausted client/server gRPC message size mismatch

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/generic.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/generic.go
@@ -116,6 +116,13 @@ func (c *GenericCollector) Start(ctx context.Context, store workloadmeta.Compone
 
 	opts = append(opts, grpc.WithTransportCredentials(c.StreamHandler.Credentials()))
 
+	// Same max message size as core agent AgentSecure gRPC (impl-agent.BuildServer).
+	maxMsgSize := pkgconfigsetup.Datadog().GetInt("cluster_agent.cluster_tagger.grpc_max_message_size")
+	opts = append(opts, grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(maxMsgSize),
+		grpc.MaxCallSendMsgSize(maxMsgSize),
+	))
+
 	log.Infof("initializing remote collector with address: %s", address)
 
 	conn, err := grpc.DialContext( //nolint:staticcheck // TODO (ASC) fix grpc.DialContext is deprecated


### PR DESCRIPTION
### What does this PR do?
Sets `grpc.WithDefaultCallOptions(MaxCallRecvMsgSize, MaxCallSendMsgSize)` on the remote workloadmeta client dial path (`GenericCollector.Start`) using the same config as the core agent’s AgentSecure gRPC server: `cluster_agent.cluster_tagger.grpc_max_message_size`. That keeps process agent and system-probe consistent with the core agent’s `MaxRecvMsgSize` / `MaxSendMsgSize` in `comp/api/grpcserver/impl-agent/grpc.go`, instead of relying on the gRPC client defaults alone.

### Motivation
Customers can see `ResourceExhausted: trying to send message larger than max (... vs. 4194304)` on process/system-probe when workloadmeta snapshots exceed 4 MiB. The core server already honors the configurable max; sub-agents did not mirror that on the client connection, so limits could disagree and streams could fail/reconnect in a loop, spaming logs (see [AGENT-15889](https://datadoghq.atlassian.net/browse/AGENT-15889)). This change makes client limits track the same knob as the server so raising (or defaulting) the cap applies end-to-end.

### Describe how you validated your changes
`go build ./comp/core/workloadmeta/collectors/internal/remote/` (package compiles with the new dial options).
Ran `go test ./comp/core/workloadmeta/collectors/internal/remote/... -count=1`
Ran `dda inv test --targets=./comp/core/workloadmeta/collectors/internal/remote/...`

### Additional Notes
- Config name is historical: `cluster_agent.cluster_tagger.grpc_max_message_size` is also used on the node AgentSecure server, not only when a Cluster Agent is deployed; ECS / non-Kubernetes installs still use it for this path.
- Unrelated setting: `serializer_max_uncompressed_payload_size` is for intake serialization, not this internal gRPC channel.
- Customers who already bumped the YAML/env limit on the core agent get a matching client without needing a separate workaround once this ships.

[AGENT-15889]: https://datadoghq.atlassian.net/browse/AGENT-15889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ