### PR TITLE
Disable auto test retry

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -58,6 +58,7 @@
     - export DD_ENV=nativetest # TODO: Remove after testing native instrumentation
     - export DD_CIVISIBILITY_ENABLED=true
     - export DD_CIVISIBILITY_AGENTLESS_ENABLED=true
+    - export DD_CIVISIBILITY_FLAKY_RETRY_ENABLED=false
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
     # set the environment variables for the windows test signing
     - export WINDOWS_DDNPM_DRIVER=${WINDOWS_DDNPM_DRIVER:-$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDNPM_DRIVER" --no-worktree)}


### PR DESCRIPTION
### What does this PR do?

Automatic test retries does not work well with some of our e2e tests. Let's disable globally to avoid having it enabled by mistake on the UI

### Motivation

### Describe how you validated your changes

### Additional Notes
