### PR TITLE
feat(renovate): Prevent updates on git_override and deactivate pyenv

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,6 +65,10 @@
         "enabled": false
       },
       {
+        "matchManagers": ["pyenv"],
+        "enabled": false
+      },
+      {
         "matchManagers": ["maven"],
         "matchUpdateTypes": ["major", "minor"],
         "enabled": false
@@ -75,8 +79,18 @@
         "enabled": false
       },
       {
-        "matchManagers": ["gomod", "dockerfile", "docker-compose"],
+        "matchManagers": ["gomod"],
+        "matchDepNames": ["go"],
+        "enabled": false
+      },
+      {
+        "matchManagers": ["dockerfile", "docker-compose"],
         "matchDepNames": ["golang"],
+        "enabled": false
+      },
+      {
+        "matchManagers": ["bazel-module"],
+        "matchDepTypes": ["git_override"],
         "enabled": false
       }
     ],


### PR DESCRIPTION
### What does this PR do?
- Prevent updates on `git_override` statement on `bazel-module` configuration. It's done to pin a on specific non-yet released version, so we should not update to the latest commit of a branch
- Deactivate the `pyenv` manager. It touches to the python version we use in the repo but this is not updated when a version is produced, rather when we need it specifically. It has its own schedule so we don't need auto-update here

### Motivation
Dependency management

### Describe how you validated your changes
Configuration changes only

### Additional Notes
