### PR TITLE
NDMC-284: Add integration tests for snmp device discovery

### DIFF
--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -55,12 +55,13 @@ const (
 // SNMPListener implements SNMP discovery
 type SNMPListener struct {
 	sync.RWMutex
-	newService    chan<- Service
-	delService    chan<- Service
-	stop          chan bool
-	config        snmp.ListenerConfig
-	services      map[string]*SNMPService
-	deviceDeduper devicededuper.DeviceDeduper
+	newService     chan<- Service
+	delService     chan<- Service
+	stop           chan bool
+	config         snmp.ListenerConfig
+	services       map[string]*SNMPService
+	deviceDeduper  devicededuper.DeviceDeduper
+	sessionFactory snmpSessionFactory
 }
 
 // SNMPService implements and store results from the Service interface for the SNMP listener
@@ -105,10 +106,11 @@ func NewSNMPListener(ServiceListernerDeps) (ServiceListener, error) {
 		return nil, err
 	}
 	return &SNMPListener{
-		services:      map[string]*SNMPService{},
-		stop:          make(chan bool),
-		config:        snmpConfig,
-		deviceDeduper: devicededuper.NewDeviceDeduper(snmpConfig),
+		services:       map[string]*SNMPService{},
+		stop:           make(chan bool),
+		config:         snmpConfig,
+		deviceDeduper:  devicededuper.NewDeviceDeduper(snmpConfig),
+		sessionFactory: newGosnmpSession,
 	}, nil
 }
 
@@ -230,22 +232,22 @@ func (l *SNMPListener) checkDevice(job snmpJob) {
 }
 
 func (l *SNMPListener) checkDeviceReachable(authentication snmp.Authentication, port uint16, deviceIP string) bool {
-	params, err := authentication.BuildSNMPParams(deviceIP, port)
+	sess, err := l.sessionFactory(authentication, deviceIP, port)
 	if err != nil {
 		log.Errorf("Error building params for device %s: %v", deviceIP, err)
 		return false
 	}
 
-	if err := params.Connect(); err != nil {
+	if err := sess.Connect(); err != nil {
 		log.Debugf("SNMP connect to %s error: %v", deviceIP, err)
 		return false
 	}
 
-	defer params.Conn.Close()
+	defer sess.Close()
 
 	// Since `params<GoSNMP>.ContextEngineID` is empty
 	// `params.GetNext` might lead to multiple SNMP GET calls when using SNMP v3
-	value, err := params.GetNext([]string{snmp.DeviceReachableGetNextOid})
+	value, err := sess.GetNext([]string{snmp.DeviceReachableGetNextOid})
 	if err != nil {
 		log.Debugf("SNMP get to %s error: %v", deviceIP, err)
 		return false
@@ -265,19 +267,19 @@ func (l *SNMPListener) checkDeviceInfo(authentication snmp.Authentication, port 
 		return devicededuper.DeviceInfo{}
 	}
 
-	params, err := authentication.BuildSNMPParams(deviceIP, port)
+	sess, err := l.sessionFactory(authentication, deviceIP, port)
 	if err != nil {
 		log.Errorf("Error building params for device %s: %v", deviceIP, err)
 		return devicededuper.DeviceInfo{}
 	}
 
-	if err := params.Connect(); err != nil {
+	if err := sess.Connect(); err != nil {
 		log.Debugf("SNMP connect to %s error: %v", deviceIP, err)
 		return devicededuper.DeviceInfo{}
 	}
 
-	defer params.Conn.Close()
-	value, err := params.Get([]string{snmp.DeviceSysNameOid, snmp.DeviceSysDescrOid, snmp.DeviceSysUptimeOid, snmp.DeviceSysObjectIDOid})
+	defer sess.Close()
+	value, err := sess.Get([]string{snmp.DeviceSysNameOid, snmp.DeviceSysDescrOid, snmp.DeviceSysUptimeOid, snmp.DeviceSysObjectIDOid})
 	if err != nil {
 		return devicededuper.DeviceInfo{}
 	}

--- a/comp/core/autodiscovery/listeners/snmp_fake_session.go
+++ b/comp/core/autodiscovery/listeners/snmp_fake_session.go
@@ -1,0 +1,189 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2020-present Datadog, Inc.
+
+//go:build test
+
+package listeners
+
+import (
+	"errors"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp"
+	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
+)
+
+// numbersToOID converts a list of numbers back to a dotted OID string.
+func numbersToOID(nums []int) string {
+	parts := make([]string, len(nums))
+	for i, n := range nums {
+		parts[i] = strconv.Itoa(n)
+	}
+	return strings.Join(parts, ".")
+}
+
+// fakeSession implements snmpSession with in-memory PDU data.
+// Missing OIDs return NoSuchObject; GetNext returns EndOfMibView past the end.
+type fakeSession struct {
+	connectErr error
+	data       map[string]gosnmp.SnmpPDU
+}
+
+// createFakeSession creates a new fakeSession with an empty set of data.
+func createFakeSession() *fakeSession {
+	return &fakeSession{data: make(map[string]gosnmp.SnmpPDU)}
+}
+
+// Set adds a PDU with the given attributes, replacing any with the same OID.
+func (fs *fakeSession) Set(oid string, typ gosnmp.Asn1BER, val any) *fakeSession {
+	fs.data[oid] = gosnmp.SnmpPDU{Name: oid, Type: typ, Value: val}
+	return fs
+}
+
+// SetStr adds an OctetString PDU with the given OID and value.
+func (fs *fakeSession) SetStr(oid string, value string) *fakeSession {
+	return fs.Set(oid, gosnmp.OctetString, []byte(value))
+}
+
+// SetObj adds an ObjectIdentifier PDU with the given OID and value.
+func (fs *fakeSession) SetObj(oid string, value string) *fakeSession {
+	return fs.Set(oid, gosnmp.ObjectIdentifier, value)
+}
+
+// SetTime adds a TimeTicks PDU with the given OID and value.
+func (fs *fakeSession) SetTime(oid string, ticks uint32) *fakeSession {
+	return fs.Set(oid, gosnmp.TimeTicks, ticks)
+}
+
+// sortedOIDs returns all OIDs in data sorted lexicographically.
+func (fs *fakeSession) sortedOIDs() [][]int {
+	oids := make([][]int, 0, len(fs.data))
+	for oid := range fs.data {
+		nums, err := gosnmplib.OIDToInts(oid)
+		if err != nil {
+			continue
+		}
+		oids = append(oids, nums)
+	}
+	sort.Slice(oids, func(i, j int) bool {
+		return gosnmplib.CmpOIDs(oids[i], oids[j]).IsBefore()
+	})
+	return oids
+}
+
+// Connect returns connectErr if set, nil otherwise.
+func (fs *fakeSession) Connect() error { return fs.connectErr }
+
+// Close is a no-op.
+func (fs *fakeSession) Close() error { return nil }
+
+// Get returns the PDUs for the requested OIDs, or NoSuchObject for missing ones.
+func (fs *fakeSession) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+	vars := make([]gosnmp.SnmpPDU, len(oids))
+	for i, oid := range oids {
+		v, ok := fs.data[oid]
+		if !ok {
+			v = gosnmp.SnmpPDU{Name: oid, Type: gosnmp.NoSuchObject, Value: nil}
+		}
+		vars[i] = v
+	}
+	return &gosnmp.SnmpPacket{Variables: vars}, nil
+}
+
+// GetNext returns the first PDU after each requested OID, or EndOfMibView past the end.
+func (fs *fakeSession) GetNext(oids []string) (*gosnmp.SnmpPacket, error) {
+	knownOIDs := fs.sortedOIDs()
+	vars := make([]gosnmp.SnmpPDU, len(oids))
+	for i, oid := range oids {
+		nums, err := gosnmplib.OIDToInts(oid)
+		if err != nil {
+			vars[i] = gosnmp.SnmpPDU{Name: oid, Type: gosnmp.EndOfMibView, Value: nil}
+			continue
+		}
+		idx := sort.Search(len(knownOIDs), func(j int) bool {
+			return gosnmplib.CmpOIDs(nums, knownOIDs[j]).IsBefore()
+		})
+		if idx >= len(knownOIDs) {
+			vars[i] = gosnmp.SnmpPDU{Name: oid, Type: gosnmp.EndOfMibView, Value: nil}
+		} else {
+			vars[i] = fs.data[numbersToOID(knownOIDs[idx])]
+		}
+	}
+	return &gosnmp.SnmpPacket{Variables: vars}, nil
+}
+
+// errorSession implements snmpSession returning configurable errors for each operation.
+type errorSession struct {
+	connectErr error
+	getNextErr error
+	getErr     error
+	getNextPkt *gosnmp.SnmpPacket
+	getPkt     *gosnmp.SnmpPacket
+}
+
+func (es *errorSession) Connect() error                           { return es.connectErr }
+func (es *errorSession) Close() error                             { return nil }
+func (es *errorSession) Get([]string) (*gosnmp.SnmpPacket, error) { return es.getPkt, es.getErr }
+func (es *errorSession) GetNext([]string) (*gosnmp.SnmpPacket, error) {
+	return es.getNextPkt, es.getNextErr
+}
+
+// testFactoryCall records a single invocation of the test session factory.
+type testFactoryCall struct {
+	Auth     snmp.Authentication
+	DeviceIP string
+	Port     uint16
+}
+
+// testSessionFactory maps device IPs (with optional auth) to fake sessions.
+// Unregistered devices default to returning a connection error.
+type testSessionFactory struct {
+	mu       sync.Mutex
+	sessions map[string]snmpSession
+	calls    []testFactoryCall
+}
+
+// newTestSessionFactory creates a factory with no registered sessions.
+func newTestSessionFactory() *testSessionFactory {
+	return &testSessionFactory{sessions: make(map[string]snmpSession)}
+}
+
+// build looks up a session by "IP:community", "IP:user", or "IP" in that order.
+func (f *testSessionFactory) build(auth snmp.Authentication, deviceIP string, port uint16) (snmpSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, testFactoryCall{Auth: auth, DeviceIP: deviceIP, Port: port})
+
+	for _, key := range []string{
+		deviceIP + ":" + auth.Community,
+		deviceIP + ":" + auth.User,
+		deviceIP,
+	} {
+		if sess, ok := f.sessions[key]; ok {
+			return sess, nil
+		}
+	}
+	return &errorSession{connectErr: errors.New("connection refused")}, nil
+}
+
+// makeReachableSession creates a fakeSession that passes the reachability check.
+func makeReachableSession() *fakeSession {
+	return createFakeSession().SetStr("1.0.0.1", "reachable")
+}
+
+// makeReachableSessionWithDeviceInfo creates a fakeSession that passes reachability
+// and returns device info for deduplication.
+func makeReachableSessionWithDeviceInfo(sysName, sysDescr, sysObjectID string, sysUptime uint32) *fakeSession {
+	return makeReachableSession().
+		SetStr(snmp.DeviceSysNameOid, sysName).
+		SetStr(snmp.DeviceSysDescrOid, sysDescr).
+		SetTime(snmp.DeviceSysUptimeOid, sysUptime).
+		SetObj(snmp.DeviceSysObjectIDOid, sysObjectID)
+}

--- a/comp/core/autodiscovery/listeners/snmp_session.go
+++ b/comp/core/autodiscovery/listeners/snmp_session.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2020-present Datadog, Inc.
+
+package listeners
+
+import (
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp"
+)
+
+// snmpSessionFactory creates SNMP sessions from authentication params.
+type snmpSessionFactory func(auth snmp.Authentication, deviceIP string, port uint16) (snmpSession, error)
+
+// snmpSession abstracts SNMP operations needed by the listener for device discovery.
+// Note: A similar, more complete interface exists at pkg/collector/corechecks/snmp/internal/session.Session
+type snmpSession interface {
+	Connect() error
+	Close() error
+	Get(oids []string) (result *gosnmp.SnmpPacket, err error)
+	GetNext(oids []string) (result *gosnmp.SnmpPacket, err error)
+}
+
+// gosnmpSession wraps *gosnmp.GoSNMP to implement snmpSession.
+type gosnmpSession struct {
+	gosnmpInst *gosnmp.GoSNMP
+}
+
+func (s *gosnmpSession) Connect() error {
+	return s.gosnmpInst.Connect()
+}
+
+func (s *gosnmpSession) Close() error {
+	if s.gosnmpInst.Conn == nil {
+		return nil
+	}
+	return s.gosnmpInst.Conn.Close()
+}
+
+func (s *gosnmpSession) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+	return s.gosnmpInst.Get(oids)
+}
+
+func (s *gosnmpSession) GetNext(oids []string) (*gosnmp.SnmpPacket, error) {
+	return s.gosnmpInst.GetNext(oids)
+}
+
+// newGosnmpSession is the production session factory.
+func newGosnmpSession(auth snmp.Authentication, deviceIP string, port uint16) (snmpSession, error) {
+	params, err := auth.BuildSNMPParams(deviceIP, port)
+	if err != nil {
+		return nil, err
+	}
+	return &gosnmpSession{gosnmpInst: params}, nil
+}

--- a/comp/core/autodiscovery/listeners/snmp_test.go
+++ b/comp/core/autodiscovery/listeners/snmp_test.go
@@ -8,12 +8,17 @@ package listeners
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"testing"
+	"time"
 
+	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/persistentcache"
@@ -21,6 +26,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/snmp/devicededuper"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 )
+
+// ===========================================================================
+// Unit tests: config parsing, job dispatch, cache, and service extra config
+// ===========================================================================
 
 func TestSNMPListener(t *testing.T) {
 	newSvc := make(chan Service, 10)
@@ -101,9 +110,10 @@ func TestSNMPListenerSubnets(t *testing.T) {
 
 	services := map[string]*SNMPService{}
 	l := &SNMPListener{
-		services: services,
-		stop:     make(chan bool),
-		config:   snmpListenerConfig,
+		services:       services,
+		stop:           make(chan bool),
+		config:         snmpListenerConfig,
+		sessionFactory: newGosnmpSession,
 	}
 
 	l.Listen(newSvc, delSvc)
@@ -732,4 +742,443 @@ func TestMigrateCache(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ===========================================================================
+// Integration tests: device discovery flow with fake SNMP sessions
+// ===========================================================================
+
+var defaultWorkerFunc = worker
+
+func setupTestListener(t *testing.T, configs []interface{}, extraOpts map[string]interface{}) (*SNMPListener, *testSessionFactory) {
+	t.Helper()
+
+	// Restore worker to the default in case a previous test overrode it
+	worker = defaultWorkerFunc
+
+	testDir := t.TempDir()
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("run_path", testDir)
+	mockConfig.SetWithoutSource("network_devices.autodiscovery.configs", configs)
+	mockConfig.SetWithoutSource("network_devices.autodiscovery.workers", 1)
+	for k, v := range extraOpts {
+		mockConfig.SetWithoutSource(k, v)
+	}
+
+	factory := newTestSessionFactory()
+
+	listenerConfig, err := snmp.NewListenerConfig()
+	require.NoError(t, err)
+
+	l := &SNMPListener{
+		services:       map[string]*SNMPService{},
+		stop:           make(chan bool),
+		config:         listenerConfig,
+		deviceDeduper:  devicededuper.NewDeviceDeduper(listenerConfig),
+		sessionFactory: factory.build,
+	}
+	return l, factory
+}
+
+func collectServices(t *testing.T, ch <-chan Service, expected int, timeout time.Duration) []*SNMPService {
+	t.Helper()
+	var services []*SNMPService
+	for i := 0; i < expected; i++ {
+		select {
+		case svc := <-ch:
+			services = append(services, svc.(*SNMPService))
+		case <-time.After(timeout):
+			t.Fatalf("timed out waiting for service %d/%d", i+1, expected)
+		}
+	}
+	return services
+}
+
+func noMoreServices(t *testing.T, ch <-chan Service, wait time.Duration) {
+	t.Helper()
+	select {
+	case svc := <-ch:
+		t.Fatalf("unexpected service: %v", svc.(*SNMPService).deviceIP)
+	case <-time.After(wait):
+		// OK
+	}
+}
+
+func TestCheckDeviceReachableSuccess(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
+
+	factory.sessions["192.168.0.1"] = makeReachableSession()
+
+	auth := snmp.Authentication{Community: "public"}
+	assert.True(t, l.checkDeviceReachable(auth, 161, "192.168.0.1"))
+}
+
+func TestCheckDeviceReachableConnectError(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
+
+	factory.sessions["192.168.0.1"] = &errorSession{connectErr: errors.New("timeout")}
+
+	auth := snmp.Authentication{Community: "public"}
+	assert.False(t, l.checkDeviceReachable(auth, 161, "192.168.0.1"))
+}
+
+func TestCheckDeviceReachableGetNextError(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
+
+	factory.sessions["192.168.0.1"] = &errorSession{getNextErr: errors.New("request timeout")}
+
+	auth := snmp.Authentication{Community: "public"}
+	assert.False(t, l.checkDeviceReachable(auth, 161, "192.168.0.1"))
+}
+
+func TestCheckDeviceReachableEmptyVars(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
+
+	factory.sessions["192.168.0.1"] = &errorSession{
+		getNextPkt: &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{}},
+	}
+
+	auth := snmp.Authentication{Community: "public"}
+	assert.False(t, l.checkDeviceReachable(auth, 161, "192.168.0.1"))
+}
+
+func TestCheckDeviceReachableNilValue(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
+
+	factory.sessions["192.168.0.1"] = &errorSession{
+		getNextPkt: &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{
+			{Name: "1.0.0.1", Type: gosnmp.NoSuchObject, Value: nil},
+		}},
+	}
+
+	auth := snmp.Authentication{Community: "public"}
+	assert.False(t, l.checkDeviceReachable(auth, 161, "192.168.0.1"))
+}
+
+func TestCheckDeviceInfoParsing(t *testing.T) {
+	l, _ := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, map[string]interface{}{
+		"network_devices.autodiscovery.use_deduplication": true,
+	})
+
+	sess := makeReachableSessionWithDeviceInfo("router-1", "Cisco IOS", "1.3.6.1.4.1.9.1.1", 100000)
+	l.sessionFactory = func(_ snmp.Authentication, _ string, _ uint16) (snmpSession, error) {
+		return sess, nil
+	}
+
+	auth := snmp.Authentication{Community: "public"}
+	info := l.checkDeviceInfo(auth, 161, "192.168.0.1")
+
+	assert.Equal(t, "router-1", info.Name)
+	assert.Equal(t, "Cisco IOS", info.Description)
+	assert.Equal(t, "1.3.6.1.4.1.9.1.1", info.SysObjectID)
+	// sysUptime = 100000 hundredths of a second = 1000 seconds
+	// BootTimeMs should be approximately now - 1000s
+	assert.InDelta(t, time.Now().Add(-1000*time.Second).UnixMilli(), info.BootTimeMs, 5000)
+}
+
+func TestCheckDeviceInfoNoDedup(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
+	// Deduplicate defaults to false
+
+	// Should not make any SNMP calls
+	auth := snmp.Authentication{Community: "public"}
+	info := l.checkDeviceInfo(auth, 161, "192.168.0.1")
+
+	assert.Equal(t, devicededuper.DeviceInfo{}, info)
+	assert.Empty(t, factory.calls, "no SNMP calls should be made when dedup is disabled")
+}
+
+func TestListenCreatesService(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
+	t.Cleanup(func() { l.Stop() })
+
+	factory.sessions["192.168.0.1"] = makeReachableSession()
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.Listen(newSvc, delSvc)
+
+	services := collectServices(t, newSvc, 1, 5*time.Second)
+	svc := services[0]
+
+	assert.Equal(t, "192.168.0.1", svc.deviceIP)
+	assert.Equal(t, "snmp", svc.adIdentifier)
+
+	// Verify Service interface methods
+	hosts, err := svc.GetHosts()
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.0.1", hosts[""])
+
+	ports, err := svc.GetPorts()
+	require.NoError(t, err)
+	assert.Equal(t, 161, ports[0].Port)
+
+	adIDs := svc.GetADIdentifiers()
+	assert.Equal(t, []string{"snmp"}, adIDs)
+
+	community, err := svc.GetExtraConfig("community")
+	require.NoError(t, err)
+	assert.Equal(t, "public", community)
+}
+
+func TestListenMultipleSubnets(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+		map[string]interface{}{"network": "10.0.0.0/30", "community": "private"},
+	}, nil)
+	t.Cleanup(func() { l.Stop() })
+
+	factory.sessions["192.168.0.1"] = makeReachableSession()
+	factory.sessions["10.0.0.1"] = makeReachableSession()
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.Listen(newSvc, delSvc)
+
+	services := collectServices(t, newSvc, 2, 5*time.Second)
+
+	ips := map[string]string{}
+	for _, svc := range services {
+		community, _ := svc.GetExtraConfig("community")
+		ips[svc.deviceIP] = community
+	}
+
+	assert.Equal(t, "public", ips["192.168.0.1"])
+	assert.Equal(t, "private", ips["10.0.0.1"])
+}
+
+func TestListenMultipleAuthFirstMatch(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{
+			"network": "192.168.0.0/30",
+			"authentications": []interface{}{
+				map[string]interface{}{"community_string": "first"},
+				map[string]interface{}{"community_string": "second"},
+			},
+		},
+	}, nil)
+	t.Cleanup(func() { l.Stop() })
+
+	// Device responds to first auth
+	factory.sessions["192.168.0.1:first"] = makeReachableSession()
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.Listen(newSvc, delSvc)
+
+	services := collectServices(t, newSvc, 1, 5*time.Second)
+	community, _ := services[0].GetExtraConfig("community")
+	assert.Equal(t, "first", community)
+}
+
+func TestListenMultipleAuthFirstMatchWithDeduplication(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{
+			"network": "192.168.0.0/30",
+			"authentications": []interface{}{
+				map[string]interface{}{"community_string": "first"},
+				map[string]interface{}{"community_string": "second"},
+			},
+		},
+	}, map[string]interface{}{
+		"network_devices.autodiscovery.use_deduplication": true,
+	})
+	t.Cleanup(func() { l.Stop() })
+
+	// Device responds to first auth with full device info so dedup path is exercised
+	factory.sessions["192.168.0.1:first"] = makeReachableSessionWithDeviceInfo(
+		"router-1", "Cisco IOS", "1.3.6.1.4.1.9.1.1", 100000,
+	)
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.Listen(newSvc, delSvc)
+
+	services := collectServices(t, newSvc, 1, 5*time.Second)
+	community, _ := services[0].GetExtraConfig("community")
+	assert.Equal(t, "first", community)
+}
+
+func TestListenMultipleAuthSecondMatch(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{
+			"network": "192.168.0.0/30",
+			"authentications": []interface{}{
+				map[string]interface{}{"community_string": "wrong"},
+				map[string]interface{}{"community_string": "correct"},
+			},
+		},
+	}, nil)
+	t.Cleanup(func() { l.Stop() })
+
+	// Device responds only to second auth
+	factory.sessions["192.168.0.1:correct"] = makeReachableSession()
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.Listen(newSvc, delSvc)
+
+	services := collectServices(t, newSvc, 1, 5*time.Second)
+	community, _ := services[0].GetExtraConfig("community")
+	assert.Equal(t, "correct", community)
+}
+
+func TestListenUnreachable(t *testing.T) {
+	l, _ := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
+	t.Cleanup(func() { l.Stop() })
+
+	// No sessions configured — all devices unreachable
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.Listen(newSvc, delSvc)
+
+	// /30 has 4 IPs; with 1 worker processing sequentially, allow time for all
+	noMoreServices(t, newSvc, 3*time.Second)
+}
+
+func TestListenDeduplication(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, map[string]interface{}{
+		"network_devices.autodiscovery.use_deduplication": true,
+	})
+	t.Cleanup(func() { l.Stop() })
+
+	// Both IPs respond with identical device info → only lowest IP should be registered
+	factory.sessions["192.168.0.0"] = makeReachableSessionWithDeviceInfo("router-1", "Cisco IOS", "1.3.6.1.4.1.9.1.1", 100000)
+	factory.sessions["192.168.0.1"] = makeReachableSessionWithDeviceInfo("router-1", "Cisco IOS", "1.3.6.1.4.1.9.1.1", 100000)
+	factory.sessions["192.168.0.2"] = makeReachableSessionWithDeviceInfo("router-1", "Cisco IOS", "1.3.6.1.4.1.9.1.1", 100000)
+	factory.sessions["192.168.0.3"] = makeReachableSessionWithDeviceInfo("router-1", "Cisco IOS", "1.3.6.1.4.1.9.1.1", 100000)
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.Listen(newSvc, delSvc)
+
+	services := collectServices(t, newSvc, 1, 5*time.Second)
+	assert.Equal(t, "192.168.0.0", services[0].deviceIP)
+
+	noMoreServices(t, newSvc, 2*time.Second)
+}
+
+func TestListenDeduplicationDifferentDevices(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, map[string]interface{}{
+		"network_devices.autodiscovery.use_deduplication": true,
+	})
+	t.Cleanup(func() { l.Stop() })
+
+	// Two IPs respond with different sysName → both should be registered
+	factory.sessions["192.168.0.0"] = makeReachableSessionWithDeviceInfo("router-1", "Cisco IOS", "1.3.6.1.4.1.9.1.1", 100000)
+	factory.sessions["192.168.0.1"] = makeReachableSessionWithDeviceInfo("switch-1", "Cisco NX-OS", "1.3.6.1.4.1.9.1.2", 200000)
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.Listen(newSvc, delSvc)
+
+	services := collectServices(t, newSvc, 2, 5*time.Second)
+	ips := []string{services[0].deviceIP, services[1].deviceIP}
+	sort.Strings(ips)
+	assert.Equal(t, []string{"192.168.0.0", "192.168.0.1"}, ips)
+}
+
+func TestCheckDeviceDeleteAfterAllowedFailures(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.newService = newSvc
+	l.delService = delSvc
+	l.config.AllowedFailures = 3
+
+	subnets := l.initializeSubnets()
+	subnet := &subnets[0]
+
+	// First scan: device is reachable
+	factory.sessions["192.168.0.1"] = makeReachableSession()
+	job := snmpJob{subnet: subnet, currentIP: net.ParseIP("192.168.0.1")}
+	l.checkDevice(job)
+
+	services := collectServices(t, newSvc, 1, 2*time.Second)
+	assert.Equal(t, "192.168.0.1", services[0].deviceIP)
+
+	// Remove the reachable session so device becomes unreachable
+	factory.mu.Lock()
+	delete(factory.sessions, "192.168.0.1")
+	factory.mu.Unlock()
+
+	// Scan 3 more times (failures 1, 2, 3)
+	for i := 0; i < 3; i++ {
+		l.checkDevice(job)
+	}
+
+	// After 3 failures, device should be deleted
+	deleted := collectServices(t, delSvc, 1, 2*time.Second)
+	assert.Equal(t, "192.168.0.1", deleted[0].deviceIP)
+}
+
+func TestCheckDeviceFailureResetOnSuccess(t *testing.T) {
+	l, factory := setupTestListener(t, []interface{}{
+		map[string]interface{}{"network": "192.168.0.0/30", "community": "public"},
+	}, nil)
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.newService = newSvc
+	l.delService = delSvc
+	l.config.AllowedFailures = 3
+
+	subnets := l.initializeSubnets()
+	subnet := &subnets[0]
+
+	// First scan: device is reachable
+	factory.sessions["192.168.0.1"] = makeReachableSession()
+	job := snmpJob{subnet: subnet, currentIP: net.ParseIP("192.168.0.1")}
+	l.checkDevice(job)
+	collectServices(t, newSvc, 1, 2*time.Second)
+
+	// Make device unreachable for 2 scans (below threshold of 3)
+	factory.mu.Lock()
+	delete(factory.sessions, "192.168.0.1")
+	factory.mu.Unlock()
+
+	l.checkDevice(job)
+	l.checkDevice(job)
+
+	// Make device reachable again
+	factory.mu.Lock()
+	factory.sessions["192.168.0.1"] = makeReachableSession()
+	factory.mu.Unlock()
+
+	l.checkDevice(job)
+
+	// Should not have been deleted
+	noMoreServices(t, delSvc, 500*time.Millisecond)
+
+	// Verify failures were reset
+	entityID := subnet.config.Digest("192.168.0.1")
+	device, exists := subnet.devices[entityID]
+	assert.True(t, exists)
+	assert.Equal(t, 0, device.Failures)
 }


### PR DESCRIPTION
### What does this PR do?

Adds integration tests for the SNMP listener's device discovery flow. To make the listener testable without real SNMP devices, this introduces a `snmpSession` interface and session factory that the listener uses instead of calling `gosnmp` directly. Tests use fake sessions to test out different autodiscovery scenarios.

### Motivation

The SNMP listener had no tests covering the end-to-end discovery flow. Existing tests only covered config parsing, subnet iteration, and caching. The tight coupling to `gosnmp` made it impossible to test discovery logic without a real SNMP device on the network.

### Describe how you validated your changes

- Tests pass as expected
- Running locally and on staging works as usual

### Additional Notes

- No changelog was added since no behavioral changes are expected for this PR.
