### PR TITLE
_nix.go vs gazelle

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -473,7 +473,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/util/tmplvar
 # gazelle:exclude pkg/util/trie
 # gazelle:exclude pkg/util/trivy
-# gazelle:exclude pkg/util/uuid
 # gazelle:exclude pkg/util/winutil
 # gazelle:exclude pkg/util/workqueue
 # gazelle:exclude pkg/util/xc

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -1,1 +1,46 @@
-# gazelle:ignore
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "log",
+    srcs = [
+        "klog_redirect.go",
+        "levels.go",
+        "log.go",
+        "log_limit.go",
+        "log_podman_util.go",
+        "log_test_init.go",
+        "logger.go",
+        "logger_test_utils.go",
+        "wrapper.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/util/log",
+    tags = ["test"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/log/slog",
+        "//pkg/util/log/types",
+        "//pkg/util/scrubber",
+        "@org_golang_x_time//rate",
+        "@org_uber_go_atomic//:atomic",
+    ],
+)
+
+go_test(
+    name = "log_test",
+    srcs = [
+        "klog_redirect_test.go",
+        "log_bench_test.go",
+        "log_limit_test.go",
+        "log_podman_util_test.go",
+        "log_test.go",
+        "wrapper_test.go",
+    ],
+    embed = [":log"],
+    gotags = ["test"],
+    deps = [
+        "//pkg/util/scrubber",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_uber_go_atomic//:atomic",
+    ],
+)

--- a/pkg/util/uuid/BUILD.bazel
+++ b/pkg/util/uuid/BUILD.bazel
@@ -1,0 +1,81 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "uuid",
+    srcs = [
+        "uuid.go",
+        "uuid_nix.go",
+        "uuid_windows.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/util/uuid",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/cache",
+    ] + select({
+        "@rules_go//go/platform:aix": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:android": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:js": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:osx": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:plan9": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:qnx": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:windows": [
+            "//pkg/util/log",
+            "@org_golang_x_sys//windows",
+        ],
+        "//conditions:default": [],
+    }),
+)


### PR DESCRIPTION
### What does this PR do?

Tries to migrate pkg/util/uuid.  The code uses  x_nix.go, x_windows.go.  gazelle does something dumb with _nix, expanding to everything. How do we make that look nice, where "nice" is something like
```
select({
    windows: ...
    condidtions/default: ...
})
```
or 
```
select({
    macos: ...
    windows: ...
    condidtions/default: ...
})
```
IFF there is also x_macos.go.