### PR TITLE
pkg/trace: move trace-agent to container tags with completeness

### DIFF
--- a/comp/trace/config/impl/setup.go
+++ b/comp/trace/config/impl/setup.go
@@ -126,6 +126,9 @@ func prepareConfig(c corecompcfg.Component, tagger tagger.Component, ipc ipc.Com
 	cfg.ContainerTags = func(cid string) ([]string, error) {
 		return tagger.Tag(types.NewEntityID(types.ContainerID, cid), types.HighCardinality)
 	}
+	cfg.ContainerTagsWithCompleteness = func(cid string) ([]string, bool, error) {
+		return tagger.TagWithCompleteness(types.NewEntityID(types.ContainerID, cid), types.HighCardinality)
+	}
 	cfg.ContainerIDFromOriginInfo = func(originInfo origindetection.OriginInfo) (string, error) {
 		return tagger.GenerateContainerIDFromOriginInfo(originInfo)
 	}

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -1279,7 +1279,7 @@ func getContainerTagsList(fn func(string) ([]string, error), containerID string)
 	return list
 }
 
-// getContainerTag returns container and orchestrator tags belonging to containerID. If containerID
+// getContainerTags returns container and orchestrator tags belonging to containerID. If containerID
 // is empty or no tags are found, an empty string is returned.
 func getContainerTags(fn func(string) ([]string, error), containerID string) string {
 	ctags := getContainerTagsList(fn, containerID)

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -520,6 +520,10 @@ type AgentConfig struct {
 
 	// ContainerTags ...
 	ContainerTags func(cid string) ([]string, error) `json:"-"`
+	// ContainerTagsWithCompleteness returns the tags for a given container ID
+	// along with a completeness flag indicating whether all expected tag
+	// sources have reported data for this container.
+	ContainerTagsWithCompleteness func(cid string) ([]string, bool, error) `json:"-"`
 	// ContainerTagsBuffer enables buffering of payloads until full container tags extraction
 	ContainerTagsBuffer bool
 
@@ -647,11 +651,12 @@ func New() *AgentConfig {
 
 		GlobalTags: computeGlobalTags(),
 
-		Proxy:                     http.ProxyFromEnvironment,
-		OTLPReceiver:              &OTLP{},
-		ContainerTags:             noopContainerTagsFunc,
-		ContainerTagsBuffer:       false, // disabled here for otlp collector exporter, enabled in comp/trace-agent
-		ContainerIDFromOriginInfo: NoopContainerIDFromOriginInfoFunc,
+		Proxy:                         http.ProxyFromEnvironment,
+		OTLPReceiver:                  &OTLP{},
+		ContainerTags:                 noopContainerTagsFunc,
+		ContainerTagsWithCompleteness: noopContainerTagsWithCompletenessFunc,
+		ContainerTagsBuffer:           false, // disabled here for otlp collector exporter, enabled in comp/trace-agent
+		ContainerIDFromOriginInfo:     NoopContainerIDFromOriginInfoFunc,
 		TelemetryConfig: &TelemetryConfig{
 			Endpoints: []*Endpoint{{Host: TelemetryEndpointPrefix + "datadoghq.com"}},
 		},
@@ -687,6 +692,10 @@ var ErrContainerTagsFuncNotDefined = errors.New("containerTags function not defi
 
 func noopContainerTagsFunc(_ string) ([]string, error) {
 	return nil, ErrContainerTagsFuncNotDefined
+}
+
+func noopContainerTagsWithCompletenessFunc(_ string) ([]string, bool, error) {
+	return nil, false, ErrContainerTagsFuncNotDefined
 }
 
 // ErrContainerIDFromOriginInfoFuncNotDefined is returned when the ContainerIDFromOriginInfo function is not defined.

--- a/pkg/trace/containertags/buffer.go
+++ b/pkg/trace/containertags/buffer.go
@@ -50,7 +50,7 @@ type ContainerTagsBuffer interface {
 
 type containerTagsBuffer struct {
 	conf        *config.AgentConfig
-	resolveFunc func(string) ([]string, error)
+	resolveFunc func(string) ([]string, bool, error)
 	statsd      statsd.ClientInterface
 
 	in        chan bufferInput
@@ -105,7 +105,7 @@ func newContainerTagsBuffer(conf *config.AgentConfig, statsd statsd.ClientInterf
 	if ctb.maxSize == 0 {
 		ctb.maxSize = maxSizeForNoLimit
 	}
-	ctb.resolveFunc = conf.ContainerTags
+	ctb.resolveFunc = conf.ContainerTagsWithCompleteness
 	return ctb
 }
 
@@ -209,7 +209,7 @@ func (p *containerTagsBuffer) IsEnabled() bool {
 }
 
 func (p *containerTagsBuffer) resolveContainerTagsWithSource(containerID string) ([]string, bool, error) {
-	ctags, err := p.resolveFunc(containerID)
+	ctags, _, err := p.resolveFunc(containerID)
 	// cheat - testing kube tag presence, waiting for tagger to expose source
 	var okSource bool
 	for _, tag := range ctags {

--- a/pkg/trace/containertags/buffer_test.go
+++ b/pkg/trace/containertags/buffer_test.go
@@ -35,10 +35,10 @@ func (m *mockResolver) setTags(t []string) {
 	m.tags = t
 }
 
-func (m *mockResolver) Resolve(string) ([]string, error) {
+func (m *mockResolver) Resolve(string) ([]string, bool, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.tags, m.err
+	return m.tags, true, m.err
 }
 
 func TestBuffer_DelayedSuccess(t *testing.T) {
@@ -116,8 +116,8 @@ func TestAsyncEnrichment_DeniedContainer(t *testing.T) {
 	conf := &config.AgentConfig{
 		MaxMemory:           1000,
 		ContainerTagsBuffer: true,
-		ContainerTags: func(string) ([]string, error) {
-			return []string{"image:only"}, nil
+		ContainerTagsWithCompleteness: func(string) ([]string, bool, error) {
+			return []string{"image:only"}, true, nil
 		},
 	}
 
@@ -143,9 +143,9 @@ func TestAsyncEnrichment_DeniedContainer(t *testing.T) {
 func TestAsyncEnrichment_MemoryLimit(t *testing.T) {
 	mock := &mockResolver{tags: []string{"short_image:java"}}
 	conf := &config.AgentConfig{
-		MaxMemory:           100, // Max size will be 10 (10%)
-		ContainerTagsBuffer: true,
-		ContainerTags:       mock.Resolve,
+		MaxMemory:                     100, // Max size will be 10 (10%)
+		ContainerTagsBuffer:           true,
+		ContainerTagsWithCompleteness: mock.Resolve,
 	}
 
 	ctb := newContainerTagsBuffer(conf, &statsd.NoOpClient{})
@@ -181,8 +181,8 @@ func TestAsyncEnrichment_ImmediateResolution(t *testing.T) {
 	conf := &config.AgentConfig{
 		MaxMemory:           10000,
 		ContainerTagsBuffer: true,
-		ContainerTags: func(string) ([]string, error) {
-			return []string{"kube_pod_name:abc", "image:123"}, nil
+		ContainerTagsWithCompleteness: func(string) ([]string, bool, error) {
+			return []string{"kube_pod_name:abc", "image:123"}, true, nil
 		},
 	}
 	ctb := newContainerTagsBuffer(conf, &statsd.NoOpClient{})
@@ -207,8 +207,8 @@ func TestAsyncEnrichment_Buffered_Expiration(t *testing.T) {
 	conf := &config.AgentConfig{
 		MaxMemory:           10000,
 		ContainerTagsBuffer: true,
-		ContainerTags: func(string) ([]string, error) {
-			return []string{"image:only"}, nil
+		ContainerTagsWithCompleteness: func(string) ([]string, bool, error) {
+			return []string{"image:only"}, true, nil
 		},
 	}
 
@@ -245,8 +245,8 @@ func TestAsyncEnrichment_Buffered_HardLimit(t *testing.T) {
 	conf := &config.AgentConfig{
 		MaxMemory:           10000,
 		ContainerTagsBuffer: true,
-		ContainerTags: func(string) ([]string, error) {
-			return []string{"image:only"}, nil
+		ContainerTagsWithCompleteness: func(string) ([]string, bool, error) {
+			return []string{"image:only"}, true, nil
 		},
 	}
 
@@ -291,15 +291,15 @@ func syncTestAsyncEnrichmentConcurrentMixedScenarios(t *testing.T) {
 	conf := &config.AgentConfig{
 		MaxMemory:           10 * 1024 * 1024,
 		ContainerTagsBuffer: true,
-		ContainerTags: func(cid string) ([]string, error) {
+		ContainerTagsWithCompleteness: func(cid string) ([]string, bool, error) {
 			if strings.Contains(cid, "c-error") {
-				return nil, errors.New("container not found")
+				return nil, false, errors.New("container not found")
 			}
 
 			if shouldResolveContainers.Load() {
-				return []string{"kube_image:" + cid}, nil
+				return []string{"kube_image:" + cid}, true, nil
 			}
-			return []string{"tag:incomplete_tags"}, nil
+			return []string{"tag:incomplete_tags"}, true, nil
 		},
 	}
 

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -495,6 +495,7 @@ func TestInfoConfig(t *testing.T) {
 	conf.ProfilingProxy.AdditionalEndpoints = scrubbedAddEp
 
 	conf.ContainerTags = nil
+	conf.ContainerTagsWithCompleteness = nil
 	conf.ContainerIDFromOriginInfo = nil
 
 	assert.Equal(*conf, confCopy) // ensure all fields have been exported then parsed correctly


### PR DESCRIPTION
Adding the new api that fetches container tags with completeness on the container tags buffer and trace-agent config.
Skipping supporting it for profiling/dsm/DI/otlp exporter etc to experiment first properly on spans / apm stats

Behind the scenes, this calls the same underlying Tagger code but with the bool of wether the tagset is deemed complete (missing a reporting integration)

While the APIs are different they all fall in under the same code



[Tag](https://github.com/DataDog/datadog-agent/blob/082be224ae/comp/core/tagger/impl/tagger.go#L244-L251) ──────────────────► [getTags](https://github.com/DataDog/datadog-agent/blob/082be224ae/comp/core/tagger/impl/tagger.go#L200-L215) ──────────────────► [LookupHashed](https://github.com/DataDog/datadog-agent/blob/082be224ae/comp/core/tagger/tagstore/tagstore.go#L264-L27)
                                                          │
                                                          ▼
                                                     getHashedTags ──► tags
                                                          ▲
                                                          │
  [TagWithCompleteness](https://github.com/DataDog/datadog-agent/blob/082be224ae/comp/core/tagger/impl/tagger.go#L255-L262) ──► [getTagsWithCompleteness](https://github.com/DataDog/datadog-agent/blob/082be224ae/comp/core/tagger/impl/tagger.go#L217-L234) ──► [LookupHashedWithCompleteness](https://github.com/DataDog/datadog-agent/blob/082be224ae/comp/core/tagger/tagstore/tagstore.go#L278-L288)