### PR TITLE
[ABLD-8] Add //:release config setting

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -71,8 +71,13 @@ common:ci --noexperimental_convenience_symlinks # not CI-suitable: "These symlin
 import %workspace%/bazel/configs/rust.bazelrc
 
 # Global release config ------------------------------------------------------------------------------------------------
-# This should aggregate all the release configs for all the languages with enabled optimizations, stripping, etc.
+# This should aggregate all the release configs for all the languages with enabled optimizations,
+# stripping, etc.  It does not strictly mean that this build is the one to be released as a product.
+# It just selects all the flags we should use on product builds.  For example, we need to build with
+# optimization and compress packages in CI so that we can run performance and size gates, even
+# though we will never release that instance of the package to customers.
 common:release --config=rust-release
+common:release --//:release
 
 # Local development options --------------------------------------------------------------------------------------------
 try-import %workspace%/user.bazelrc

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 # Global build settings
 
 load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 
@@ -632,4 +632,20 @@ string_flag(
     name = "output_config_dir",
     build_setting_default = "/tmp",
     make_variable = "OUTPUT_CONFIG_DIR",
+)
+
+# Use this configuration setting to select options that should be applied for
+# to a non-developer version of the product. It does not mean this is a delivery
+# pipeline. This is set for most CI runs, so that size and performance tests
+# are accurate.
+bool_flag(
+    name = "release",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "is_release",
+    flag_values = {
+        "//:release": "True",
+    },
 )


### PR DESCRIPTION
### What does this PR do?

Creates a bazel flag to indicate we should do all the optimizations that we would for a release build.

### Motivation

As we build start doing the packaging rules for deb/rpm files with Bazel, we will need simple ways to trigger the things that are specific to release builds as opposed to developer builds.  Other PRs in fight can use this to select expensive tasks such as signing binaries or compressing tarballs in packages

Also: [ABLD-399]