### PR TITLE
Prevent infinite loop in removeSorted on murmur3 hash collision

### DIFF
--- a/pkg/tagset/hashing_tags_accumulator.go
+++ b/pkg/tagset/hashing_tags_accumulator.go
@@ -158,7 +158,7 @@ func (h *HashingTagsAccumulator) removeSorted(o *HashingTagsAccumulator) {
 			h.data[i] = holeData
 			h.hash[i] = holeHash
 			i++
-		case h.hash[i] < o.hash[j]:
+		case h.hash[i] <= o.hash[j]:
 			i++
 		case h.hash[i] > o.hash[j]:
 			j++

--- a/pkg/tagset/hashing_tags_accumulator.go
+++ b/pkg/tagset/hashing_tags_accumulator.go
@@ -158,9 +158,9 @@ func (h *HashingTagsAccumulator) removeSorted(o *HashingTagsAccumulator) {
 			h.data[i] = holeData
 			h.hash[i] = holeHash
 			i++
-		case h.hash[i] <= o.hash[j]:
+		case h.hash[i] < o.hash[j] || (h.hash[i] == o.hash[j] && h.data[i] < o.data[j]):
 			i++
-		case h.hash[i] > o.hash[j]:
+		default:
 			j++
 		}
 	}

--- a/pkg/tagset/hashing_tags_accumulator_test.go
+++ b/pkg/tagset/hashing_tags_accumulator_test.go
@@ -111,12 +111,13 @@ func TestRemoveSorted(t *testing.T) {
 func TestRemoveSortedHashCollision(t *testing.T) {
 	const collisionHash = uint64(0xdeadbeef)
 
+	// h's tag is alphabetically before the colliding tag in o — no match, tag must be kept.
 	h := NewHashingTagsAccumulator()
 	h.data = []string{"tag:keep"}
 	h.hash = []uint64{collisionHash}
 
 	o := NewHashingTagsAccumulator()
-	o.data = []string{"tag:other"} // same hash, different string
+	o.data = []string{"tag:other"} // same hash, different string; "tag:other" > "tag:keep"
 	o.hash = []uint64{collisionHash}
 
 	done := make(chan struct{})
@@ -131,6 +132,23 @@ func TestRemoveSortedHashCollision(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("removeSorted hung: infinite loop on hash collision")
 	}
+}
+
+func TestRemoveSortedHashCollisionWithMatch(t *testing.T) {
+	const collisionHash = uint64(0xdeadbeef)
+
+	// h's tag is alphabetically AFTER the colliding tag in o, but o also contains h's tag — it must be removed.
+	// o sorted by (hash, string): ["tag:aaa"@collisionHash, "tag:zoo"@collisionHash]
+	h := NewHashingTagsAccumulator()
+	h.data = []string{"tag:zoo"}
+	h.hash = []uint64{collisionHash}
+
+	o := NewHashingTagsAccumulator()
+	o.data = []string{"tag:aaa", "tag:zoo"} // "tag:aaa" collides with same hash, comes before "tag:zoo"
+	o.hash = []uint64{collisionHash, collisionHash}
+
+	h.removeSorted(o)
+	assert.Empty(t, h.Get(), "tag:zoo must be removed since o contains it, despite hash collision with tag:aaa")
 }
 
 func testTagsMatchHash(t *testing.T, acc *HashingTagsAccumulator) {

--- a/pkg/tagset/hashing_tags_accumulator_test.go
+++ b/pkg/tagset/hashing_tags_accumulator_test.go
@@ -7,6 +7,7 @@ package tagset
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/twmb/murmur3"
@@ -105,6 +106,31 @@ func TestRemoveSorted(t *testing.T) {
 	r.SortUniq()
 	r.removeSorted(l)
 	assert.ElementsMatch(t, []string{"A", "e"}, r.Get())
+}
+
+func TestRemoveSortedHashCollision(t *testing.T) {
+	const collisionHash = uint64(0xdeadbeef)
+
+	h := NewHashingTagsAccumulator()
+	h.data = []string{"tag:keep"}
+	h.hash = []uint64{collisionHash}
+
+	o := NewHashingTagsAccumulator()
+	o.data = []string{"tag:other"} // same hash, different string
+	o.hash = []uint64{collisionHash}
+
+	done := make(chan struct{})
+	go func() {
+		h.removeSorted(o)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		assert.ElementsMatch(t, []string{"tag:keep"}, h.Get())
+	case <-time.After(3 * time.Second):
+		t.Fatal("removeSorted hung: infinite loop on hash collision")
+	}
 }
 
 func testTagsMatchHash(t *testing.T, acc *HashingTagsAccumulator) {


### PR DESCRIPTION
### What does this PR do?

Fixes a theoretically-possible infinite loop on murmur3 hash collisions. Unlikely because the code path is only used for non-deduped tag sets with more than 512 tags (and the infinite loop can only happen with a murmur3 hash collision)

#### Details

When two distinct tags share the same 64-bit murmur3 hash, the switch in `removeSorted()` had no matching case (`h.hash[i] == o.hash[j]` but `h.data[i] != o.data[j]`), causing `i` and `j` to never advance and the loop to spin forever.

Fix by changing `h.hash[i] < o.hash[j]` to `h.hash[i] <= o.hash[j]`, so a collision with a non-matching string advances i (the tag in h is not in o and should be kept).


### Motivation

### Describe how you validated your changes

Add TestRemoveSortedHashCollision to catch regressions: it injects an artificial collision via direct field assignment and asserts the call completes within 3 seconds.

### Additional Notes
