### PR TITLE
[ABLD-364] Change tar compression in .deb packaging depending on type of build.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,9 @@ env_vars(
     # Each variable needs a justification. Every time you use one, the
     # target using it is potentially uncachable.
     variables = [
+        # This gets set by omnibus builds in many cases. It's used in the script
+        # to set things like compression, so we'll mimic that for now.
+        "DEPLOY_AGENT",
         # For some tests we want to run with higher compression, but
         # not break caching and rebuild the binaries.
         "FORCED_PACKAGE_COMPRESSION_LEVEL",

--- a/bazel/rules/compression.bzl
+++ b/bazel/rules/compression.bzl
@@ -36,8 +36,8 @@ def get_compression_level():
     """
     if env_vars.FORCED_PACKAGE_COMPRESSION_LEVEL:
         compression_level = int(env_vars.FORCED_PACKAGE_COMPRESSION_LEVEL)
-        if compression_level > 0:
-            return compression_level
+        if compression_level >= 0:
+            return compression_level if compression_level > 0 else COMPRESSION_OFF
 
     if env_vars.DEPLOY_AGENT:
         if env_vars.DEPLOY_AGENT == "true":

--- a/bazel/rules/compression.bzl
+++ b/bazel/rules/compression.bzl
@@ -1,0 +1,46 @@
+"""Determine compression level for tar files.
+
+This is an abstraction to hide the logic of how we choose the compression level.
+What exists now is a mix of choices, depending on if you are doing a a developer
+build vs. a CI run, vs. a deployment.
+"""
+
+load("@agent_volatile//:env_vars.bzl", "env_vars")
+
+COMPRESSION_HIGH = 9
+COMPRESSION_MEDIUM = 5
+
+# Due to a bug in pkg_tar, setting compression to 0 results in using
+# the default, which is 6.
+# https://github.com/bazelbuild/rules_pkg/issues/1048
+COMPRESSION_OFF = 1
+
+def get_compression_level():
+    """Returns the compression level we should use for archives.
+
+    The logic essentially mimics what we are currently doing in omnibus builds.
+
+      if ENV['FORCED_PACKAGE_COMPRESSION_LEVEL']
+        # This is only used for armhf (32 bit) builds right now.
+        COMPRESSION_LEVEL = int(ENV['FORCED_PACKAGE_COMPRESSION_LEVEL'])
+      elif ENV["DEPLOY_AGENT"] == "true"
+        COMPRESSION_LEVEL = 9
+      else
+        COMPRESSION_LEVEL = 5
+
+    TODO: improve this so developer (desktop) builds skip compression entirely and non-release
+    CI builds make a choice that balances compress time vs. artifact upload speed.
+
+    Returns:
+        int
+    """
+    if env_vars.FORCED_PACKAGE_COMPRESSION_LEVEL:
+        compression_level = int(env_vars.FORCED_PACKAGE_COMPRESSION_LEVEL)
+        if compression_level > 0:
+            return compression_level
+
+    if env_vars.DEPLOY_AGENT:
+        if env_vars.DEPLOY_AGENT == "true":
+            return COMPRESSION_HIGH
+
+    return COMPRESSION_MEDIUM

--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -10,6 +10,7 @@ load(
 )
 load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//bazel/rules:compression.bzl", "get_compression_level")
 load("//bazel/rules:dd_agent_pkg_mklink.bzl", "dd_agent_pkg_mklink")
 load("//compliance:package_licenses.bzl", "package_licenses")
 load("//packages/rules:package_naming.bzl", "package_name_variables")
@@ -97,11 +98,10 @@ pkg_filegroup(
 pkg_tar(
     name = "whole_distro_tar",
     srcs = [":whole_distro"],
-    extension = "tar.xz",
     # TODO: account for pipeline injected compression level.
     # https://datadoghq.atlassian.net/browse/ABLD-364
-    # compression_threads COMPRESSION_THREADS
-    # compression_level COMPRESSION_LEVEL
+    compression_level = get_compression_level(),
+    extension = "tar.xz",
     owner = "0.0",
 )
 

--- a/packages/ddot/BUILD.bazel
+++ b/packages/ddot/BUILD.bazel
@@ -7,6 +7,7 @@ load(
 )
 load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//bazel/rules:compression.bzl", "get_compression_level")
 load("//compliance:package_licenses.bzl", "package_licenses")
 load("//packages/rules:package_naming.bzl", "package_name_variables")
 
@@ -62,6 +63,7 @@ pkg_filegroup(
 pkg_tar(
     name = "whole_distro_tar",
     srcs = [":whole_distro"],
+    compression_level = get_compression_level(),
     extension = "tar.xz",
     owner = "0.0",
 )

--- a/packages/dogstatsd/BUILD.bazel
+++ b/packages/dogstatsd/BUILD.bazel
@@ -7,6 +7,7 @@ load(
 )
 load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//bazel/rules:compression.bzl", "get_compression_level")
 load("//compliance:package_licenses.bzl", "package_licenses")
 load("//packages/rules:package_naming.bzl", "package_name_variables")
 
@@ -54,6 +55,7 @@ pkg_filegroup(
 pkg_tar(
     name = "whole_distro_tar",
     srcs = [":whole_distro"],
+    compression_level = get_compression_level(),
     extension = "tar.xz",
     owner = "0.0",
 )

--- a/packages/iot/BUILD.bazel
+++ b/packages/iot/BUILD.bazel
@@ -7,6 +7,7 @@ load(
 )
 load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//bazel/rules:compression.bzl", "get_compression_level")
 load("//compliance:package_licenses.bzl", "package_licenses")
 load("//packages/rules:package_naming.bzl", "package_name_variables")
 
@@ -54,6 +55,7 @@ pkg_filegroup(
 pkg_tar(
     name = "whole_distro_tar",
     srcs = [":whole_distro"],
+    compression_level = get_compression_level(),
     extension = "tar.xz",
     owner = "0.0",
 )


### PR DESCRIPTION
- Create a function to return the "right" compression.
  - function mimics what we do in omnibus builds today
  - that will work during migration, but I think we should rethink defaults later.
- Apply to the existing pkg_tar rules.

## Futures:
Change the overall logic across omnibus, bazel, and tasks to be:
- builds with no flags have no compression (the default developer build case)
- builds with `--config=release` get high compression
- iot armhf uses no compression in spite of any release flag


## Verification
Note the compression level changing across invocations.

```
$ bazel cquery --output=build //packages/agent/linux:whole_distro_tar
# /root/repos/datadog-agent/packages/agent/linux/BUILD.bazel:98:8
pkg_tar_impl(
  name = "whole_distro_tar",
  generator_name = "whole_distro_tar",
  generator_function = "pkg_tar",
  generator_location = "packages/agent/linux/BUILD.bazel:98:8",
  srcs = ["//packages/agent/linux:whole_distro"],
  owner = "0.0",
  extension = "tar.xz",
  compression_level = 5,
  out = "//packages/agent/linux:whole_distro_tar.tar.xz",
  private_stamp_detect = False,
)

$ DEPLOY_AGENT=true bazel cquery --output=build //packages/agent/linux:whole_distro_tar
# /root/repos/datadog-agent/packages/agent/linux/BUILD.bazel:98:8
pkg_tar_impl(
  name = "whole_distro_tar",
  generator_name = "whole_distro_tar",
  generator_function = "pkg_tar",
  generator_location = "packages/agent/linux/BUILD.bazel:98:8",
  srcs = ["//packages/agent/linux:whole_distro"],
  owner = "0.0",
  extension = "tar.xz",
  compression_level = 9,
  out = "//packages/agent/linux:whole_distro_tar.tar.xz",
  private_stamp_detect = False,
)

$ FORCED_PACKAGE_COMPRESSION_LEVEL=1 bazel cquery --output=build //packages/agent/linux:whole_distro_tar
# /root/repos/datadog-agent/packages/agent/linux/BUILD.bazel:98:8
pkg_tar_impl(
  name = "whole_distro_tar",
  generator_name = "whole_distro_tar",
  generator_function = "pkg_tar",
  generator_location = "packages/agent/linux/BUILD.bazel:98:8",
  srcs = ["//packages/agent/linux:whole_distro"],
  owner = "0.0",
  extension = "tar.xz",
  compression_level = 1,
  out = "//packages/agent/linux:whole_distro_tar.tar.xz",
  private_stamp_detect = False,
)
```
