### PR TITLE
[observer] Add detection parity instrumentation for live vs replay debugging

### DIFF
--- a/comp/observer/impl/advance_log.go
+++ b/comp/observer/impl/advance_log.go
@@ -6,7 +6,6 @@
 package observerimpl
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -88,18 +87,15 @@ func newAdvanceLogComparator(path string) (*advanceLogComparator, error) {
 
 	advances := make(map[int64]advanceEntry)
 	var totalLate, totalDropped int64
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
+	dec := json.NewDecoder(f)
+	for dec.More() {
 		var e advanceEntry
-		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
-			return nil, fmt.Errorf("parse advance log line: %w", err)
+		if err := dec.Decode(&e); err != nil {
+			return nil, fmt.Errorf("parse advance log entry: %w", err)
 		}
 		advances[e.DataTime] = e
 		totalLate += e.LatePoints
 		totalDropped += e.DroppedObs
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read advance log: %w", err)
 	}
 
 	return &advanceLogComparator{

--- a/comp/observer/impl/advance_log.go
+++ b/comp/observer/impl/advance_log.go
@@ -1,0 +1,176 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+)
+
+const advanceLogFileName = "advances.jsonl"
+
+// advanceEntry records a single advance call, including data ingestion counters
+// accumulated since the previous advance.
+type advanceEntry struct {
+	DataTime   int64  `json:"data_time"`
+	Reason     string `json:"reason"`
+	LatePoints int64  `json:"late_points,omitempty"` // points ingested after their timestamp was analyzed
+	DroppedObs int64  `json:"dropped_obs,omitempty"` // observations dropped due to full channel
+}
+
+func advanceReasonString(r advanceReason) string {
+	switch r {
+	case advanceReasonInputDriven:
+		return "input"
+	case advanceReasonPeriodicFlush:
+		return "periodic"
+	case advanceReasonReplayEnd:
+		return "replay_end"
+	case advanceReasonManual:
+		return "manual"
+	default:
+		return "unknown"
+	}
+}
+
+// advanceLogRecorder writes advance entries to a JSONL file.
+type advanceLogRecorder struct {
+	mu  sync.Mutex
+	f   *os.File
+	enc *json.Encoder
+}
+
+func newAdvanceLogRecorder(path string) (*advanceLogRecorder, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("create advance log %s: %w", path, err)
+	}
+	return &advanceLogRecorder{f: f, enc: json.NewEncoder(f)}, nil
+}
+
+func (r *advanceLogRecorder) record(e advanceEntry) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.enc.Encode(e); err != nil {
+		log.Printf("[observer] advance log record error: %v", err)
+	}
+}
+
+func (r *advanceLogRecorder) close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.f.Close()
+}
+
+// advanceLogComparator compares advance sequences between live and replay.
+type advanceLogComparator struct {
+	liveAdvances    map[int64]advanceEntry // dataTime → full entry
+	replayOnly      []advanceEntry
+	liveOnly        []advanceEntry
+	matched         int
+	totalLatePoints int64
+	totalDroppedObs int64
+}
+
+func newAdvanceLogComparator(path string) (*advanceLogComparator, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open advance log %s: %w", path, err)
+	}
+	defer f.Close()
+
+	advances := make(map[int64]advanceEntry)
+	var totalLate, totalDropped int64
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var e advanceEntry
+		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
+			return nil, fmt.Errorf("parse advance log line: %w", err)
+		}
+		advances[e.DataTime] = e
+		totalLate += e.LatePoints
+		totalDropped += e.DroppedObs
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read advance log: %w", err)
+	}
+
+	return &advanceLogComparator{
+		liveAdvances:    advances,
+		totalLatePoints: totalLate,
+		totalDroppedObs: totalDropped,
+	}, nil
+}
+
+// compare is called for each replay advance.
+func (c *advanceLogComparator) compare(e advanceEntry) {
+	if _, ok := c.liveAdvances[e.DataTime]; ok {
+		c.matched++
+		delete(c.liveAdvances, e.DataTime) // mark as seen
+	} else {
+		c.replayOnly = append(c.replayOnly, e)
+	}
+}
+
+// finalize collects live-only advances (those not matched by replay).
+func (c *advanceLogComparator) finalize() {
+	for _, entry := range c.liveAdvances {
+		c.liveOnly = append(c.liveOnly, entry)
+	}
+}
+
+func (c *advanceLogComparator) printSummary() {
+	c.finalize()
+	total := c.matched + len(c.liveOnly)
+
+	// Always report ingestion anomalies from the live run — these are the
+	// most likely explanation for detection divergences.
+	if c.totalLatePoints > 0 || c.totalDroppedObs > 0 {
+		fmt.Printf("[testbench] Live ingestion anomalies: %d late points, %d dropped observations\n",
+			c.totalLatePoints, c.totalDroppedObs)
+	}
+
+	if len(c.replayOnly) == 0 && len(c.liveOnly) == 0 {
+		fmt.Printf("[testbench] Advance log: %d/%d advances matched\n", c.matched, total)
+		return
+	}
+
+	fmt.Println()
+	fmt.Println("=== ADVANCE SEQUENCE DIVERGENCES ===")
+	if len(c.liveOnly) > 0 {
+		fmt.Printf("  %d advances in live but NOT in replay:\n", len(c.liveOnly))
+		limit := len(c.liveOnly)
+		if limit > 10 {
+			limit = 10
+		}
+		for _, e := range c.liveOnly[:limit] {
+			fmt.Printf("    dataTime=%d reason=%s\n", e.DataTime, e.Reason)
+		}
+		if len(c.liveOnly) > 10 {
+			fmt.Printf("    ... and %d more\n", len(c.liveOnly)-10)
+		}
+	}
+	if len(c.replayOnly) > 0 {
+		fmt.Printf("  %d advances in replay but NOT in live:\n", len(c.replayOnly))
+		limit := len(c.replayOnly)
+		if limit > 10 {
+			limit = 10
+		}
+		for _, e := range c.replayOnly[:limit] {
+			fmt.Printf("    dataTime=%d reason=%s\n", e.DataTime, e.Reason)
+		}
+		if len(c.replayOnly) > 10 {
+			fmt.Printf("    ... and %d more\n", len(c.replayOnly)-10)
+		}
+	}
+	fmt.Printf("\nSummary: %d matched, %d live-only, %d replay-only\n",
+		c.matched, len(c.liveOnly), len(c.replayOnly))
+	fmt.Println("====================================")
+}

--- a/comp/observer/impl/detect_digest.go
+++ b/comp/observer/impl/detect_digest.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+const detectDigestFileName = "detect_digests.jsonl"
+
+// detectDigest captures the output and input summary of a single Detect() call.
+// Primary comparison is on anomaly output; input hash is secondary.
+type detectDigest struct {
+	DetectorName        string   `json:"detector"`
+	DataTime            int64    `json:"data_time"`
+	AnomalyCount        int      `json:"anomaly_count"`
+	AnomalyFingerprints []string `json:"anomaly_fingerprints,omitempty"`
+	InputHash           uint64   `json:"input_hash"`
+	ReadCount           int      `json:"read_count"`
+	PointCount          int      `json:"point_count"`
+}
+
+// anomalyFingerprint produces a stable string identifying an anomaly's key fields.
+// Uses the same fields as anomalyDedupKey minus DetectorName (already on the digest).
+func anomalyFingerprint(a observerdef.Anomaly) string {
+	return fmt.Sprintf("%s|%d|%s", a.Source.Key(), a.Timestamp, a.Title)
+}
+
+// detectDigestKey builds a map key for matching digests across live and replay.
+func detectDigestKey(detectorName string, dataTime int64) string {
+	return fmt.Sprintf("%s|%d", detectorName, dataTime)
+}

--- a/comp/observer/impl/detect_digest_log.go
+++ b/comp/observer/impl/detect_digest_log.go
@@ -1,0 +1,266 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+)
+
+// detectDigestRecorder writes detect digests to a JSONL file.
+type detectDigestRecorder struct {
+	mu  sync.Mutex
+	f   *os.File
+	enc *json.Encoder
+}
+
+func newDetectDigestRecorder(path string) (*detectDigestRecorder, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("create detect digest log %s: %w", path, err)
+	}
+	return &detectDigestRecorder{
+		f:   f,
+		enc: json.NewEncoder(f),
+	}, nil
+}
+
+func (r *detectDigestRecorder) record(d detectDigest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.enc.Encode(d); err != nil {
+		log.Printf("[observer] detect digest record error: %v", err)
+	}
+}
+
+func (r *detectDigestRecorder) close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.f.Close()
+}
+
+// enableDetectDigestRecordingToFile creates a recorder and wires it to the engine.
+// Returns a cleanup function that disables recording and closes the file.
+func enableDetectDigestRecordingToFile(e *engine, path string) (func(), error) {
+	rec, err := newDetectDigestRecorder(path)
+	if err != nil {
+		return nil, err
+	}
+	e.enableDetectDigestRecording(rec.record)
+	log.Printf("[observer] detect digest recording enabled: %s", path)
+	return func() {
+		e.enableDetectDigestRecording(nil)
+		rec.close()
+	}, nil
+}
+
+// DetectDivergence describes a mismatch between live and replay detection results.
+type DetectDivergence struct {
+	DetectorName       string
+	DataTime           int64
+	LiveAnomalyCount   int
+	ReplayAnomalyCount int
+	LiveFingerprints   []string
+	ReplayFingerprints []string
+	InputHashMatch     bool
+	LiveInputHash      uint64
+	ReplayInputHash    uint64
+}
+
+func (d DetectDivergence) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "  %s @ dataTime=%d: live=%d anomalies, replay=%d anomalies\n",
+		d.DetectorName, d.DataTime, d.LiveAnomalyCount, d.ReplayAnomalyCount)
+
+	// Show fingerprints only present on one side.
+	liveSet := make(map[string]bool, len(d.LiveFingerprints))
+	for _, fp := range d.LiveFingerprints {
+		liveSet[fp] = true
+	}
+	replaySet := make(map[string]bool, len(d.ReplayFingerprints))
+	for _, fp := range d.ReplayFingerprints {
+		replaySet[fp] = true
+	}
+	var liveOnly, replayOnly []string
+	for _, fp := range d.LiveFingerprints {
+		if !replaySet[fp] {
+			liveOnly = append(liveOnly, fp)
+		}
+	}
+	for _, fp := range d.ReplayFingerprints {
+		if !liveSet[fp] {
+			replayOnly = append(replayOnly, fp)
+		}
+	}
+	if len(liveOnly) > 0 {
+		fmt.Fprintf(&b, "    live-only:   %v\n", liveOnly)
+	}
+	if len(replayOnly) > 0 {
+		fmt.Fprintf(&b, "    replay-only: %v\n", replayOnly)
+	}
+
+	if d.InputHashMatch {
+		fmt.Fprintf(&b, "    (input hash matches — same data, different result)\n")
+	} else {
+		fmt.Fprintf(&b, "    (input hash differs: live=%016x replay=%016x)\n",
+			d.LiveInputHash, d.ReplayInputHash)
+	}
+	return b.String()
+}
+
+// detectDigestComparator compares replay digests against a live recording.
+type detectDigestComparator struct {
+	mu              sync.Mutex
+	expected        map[string]detectDigest // keyed by "detector|dataTime"
+	visited         map[string]bool         // keys seen during replay
+	divergences     []DetectDivergence
+	inputOnlyDiffs  int
+	matched         int
+	replayOnly      int
+}
+
+func newDetectDigestComparator(path string) (*detectDigestComparator, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open detect digest log %s: %w", path, err)
+	}
+	defer f.Close()
+
+	expected := make(map[string]detectDigest)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var d detectDigest
+		if err := json.Unmarshal(scanner.Bytes(), &d); err != nil {
+			return nil, fmt.Errorf("parse detect digest line: %w", err)
+		}
+		expected[detectDigestKey(d.DetectorName, d.DataTime)] = d
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read detect digest log: %w", err)
+	}
+
+	return &detectDigestComparator{
+		expected: expected,
+		visited:  make(map[string]bool, len(expected)),
+	}, nil
+}
+
+// compare is called for each replay Detect() result.
+func (c *detectDigestComparator) compare(actual detectDigest) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := detectDigestKey(actual.DetectorName, actual.DataTime)
+	live, ok := c.expected[key]
+	if !ok {
+		c.replayOnly++
+		return
+	}
+	c.visited[key] = true
+
+	// Check result divergence (anomaly count or fingerprints differ).
+	resultMatch := live.AnomalyCount == actual.AnomalyCount &&
+		fingerprintsEqual(live.AnomalyFingerprints, actual.AnomalyFingerprints)
+	inputMatch := live.InputHash == actual.InputHash
+
+	if resultMatch && inputMatch {
+		c.matched++
+		return
+	}
+
+	if resultMatch && !inputMatch {
+		// Input differs but results are the same — benign.
+		c.matched++
+		c.inputOnlyDiffs++
+		return
+	}
+
+	// Result divergence.
+	c.divergences = append(c.divergences, DetectDivergence{
+		DetectorName:       actual.DetectorName,
+		DataTime:           actual.DataTime,
+		LiveAnomalyCount:   live.AnomalyCount,
+		ReplayAnomalyCount: actual.AnomalyCount,
+		LiveFingerprints:   live.AnomalyFingerprints,
+		ReplayFingerprints: actual.AnomalyFingerprints,
+		InputHashMatch:     inputMatch,
+		LiveInputHash:      live.InputHash,
+		ReplayInputHash:    actual.InputHash,
+	})
+}
+
+func (c *detectDigestComparator) printSummary() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	total := len(c.expected)
+	liveOnly := total - len(c.visited)
+
+	if len(c.divergences) == 0 && liveOnly == 0 {
+		fmt.Printf("[testbench] Detection digest: %d/%d matched", c.matched, total)
+		if c.inputOnlyDiffs > 0 {
+			fmt.Printf(", %d input-only diffs (benign)", c.inputOnlyDiffs)
+		}
+		if c.replayOnly > 0 {
+			fmt.Printf(", %d replay-only steps", c.replayOnly)
+		}
+		fmt.Println()
+		return
+	}
+
+	fmt.Println()
+	fmt.Println("=== DETECTION RESULT DIVERGENCES ===")
+	for _, d := range c.divergences {
+		fmt.Print(d.String())
+	}
+	if liveOnly > 0 {
+		fmt.Printf("\n  %d live-only digest entries (replay never advanced to these):\n", liveOnly)
+		printed := 0
+		for key, d := range c.expected {
+			if c.visited[key] {
+				continue
+			}
+			if printed < 10 {
+				fmt.Printf("    %s @ dataTime=%d: %d anomalies\n", d.DetectorName, d.DataTime, d.AnomalyCount)
+			}
+			printed++
+		}
+		if printed > 10 {
+			fmt.Printf("    ... and %d more\n", printed-10)
+		}
+	}
+	fmt.Printf("\nSummary: %d/%d matched, %d result divergences",
+		c.matched, total, len(c.divergences))
+	if c.inputOnlyDiffs > 0 {
+		fmt.Printf(", %d input-only diffs (benign)", c.inputOnlyDiffs)
+	}
+	if liveOnly > 0 {
+		fmt.Printf(", %d live-only", liveOnly)
+	}
+	if c.replayOnly > 0 {
+		fmt.Printf(", %d replay-only", c.replayOnly)
+	}
+	fmt.Println()
+	fmt.Println("====================================")
+}
+
+// fingerprintsEqual compares two sorted fingerprint slices.
+func fingerprintsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/comp/observer/impl/detect_digest_log.go
+++ b/comp/observer/impl/detect_digest_log.go
@@ -6,7 +6,6 @@
 package observerimpl
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -135,16 +134,13 @@ func newDetectDigestComparator(path string) (*detectDigestComparator, error) {
 	defer f.Close()
 
 	expected := make(map[string]detectDigest)
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
+	dec := json.NewDecoder(f)
+	for dec.More() {
 		var d detectDigest
-		if err := json.Unmarshal(scanner.Bytes(), &d); err != nil {
-			return nil, fmt.Errorf("parse detect digest line: %w", err)
+		if err := dec.Decode(&d); err != nil {
+			return nil, fmt.Errorf("parse detect digest entry: %w", err)
 		}
 		expected[detectDigestKey(d.DetectorName, d.DataTime)] = d
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read detect digest log: %w", err)
 	}
 
 	return &detectDigestComparator{

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -7,6 +7,7 @@ package observerimpl
 
 import (
 	"math"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -95,6 +96,15 @@ type engine struct {
 	replayAdvances        atomic.Int64
 	replayAnomalies       atomic.Int64
 	replayPhase           atomic.Value // string: "", "loading", "detecting", "done"
+
+	// Optional instrumentation for live/replay parity debugging.
+	onDetectDigest func(detectDigest)
+	instrStorage   *instrumentedStorage
+	onAdvance      func(advanceEntry) // scheduler trace
+
+	// Counters for data ingestion anomalies, reset after each advance.
+	latePoints  atomic.Int64 // points ingested after their timestamp was already analyzed
+	droppedObs  atomic.Int64 // observations dropped due to full channel
 }
 
 // engineConfig holds the parameters for constructing an engine.
@@ -143,6 +153,17 @@ func newEngine(cfg engineConfig) *engine {
 	return e
 }
 
+// enableDetectDigestRecording sets a callback invoked after each Detect() call
+// with a digest of the detection output and input hash. Pass nil to disable.
+func (e *engine) enableDetectDigestRecording(fn func(detectDigest)) {
+	e.onDetectDigest = fn
+	if fn != nil {
+		e.instrStorage = newInstrumentedStorage(e.storage)
+	} else {
+		e.instrStorage = nil
+	}
+}
+
 // Subscribe registers an event sink to receive engine events.
 // Returns an unsubscribe function that removes the sink.
 func (e *engine) Subscribe(sink eventSink) func() {
@@ -181,6 +202,11 @@ func (e *engine) emit(evt engineEvent) {
 // that the caller should execute via Advance.
 func (e *engine) IngestMetric(source string, m *metricObs) []advanceRequest {
 	e.storage.Add(source, m.name, m.value, m.timestamp, m.tags)
+	// Track points that arrive after their timestamp was already analyzed.
+	// These points are in storage but were invisible to detectors at analysis time.
+	if m.timestamp <= e.lastAnalyzedDataTime {
+		e.latePoints.Add(1)
+	}
 	e.trackLatestDataTime(m.timestamp)
 	return e.scheduler.onObservation(m.timestamp, e.schedulerState())
 }
@@ -285,6 +311,15 @@ func (e *engine) advanceWithReason(upToSec int64, reason advanceReason) advanceR
 	e.lastAnalyzedDataTime = upToSec
 	e.mu.Unlock()
 
+	if e.onAdvance != nil {
+		e.onAdvance(advanceEntry{
+			DataTime:   upToSec,
+			Reason:     advanceReasonString(reason),
+			LatePoints: e.latePoints.Swap(0),
+			DroppedObs: e.droppedObs.Swap(0),
+		})
+	}
+
 	result := e.runDetectorsAndCorrelatorsSnapshot(upToSec, detectors, correlators)
 
 	e.emit(engineEvent{
@@ -309,10 +344,40 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 	var allTelemetry []observerdef.ObserverTelemetry
 
 	for _, detector := range detectors {
+		// Use instrumented storage when digest recording is active.
+		storageForDetect := observerdef.StorageReader(e.storage)
+		if e.instrStorage != nil {
+			e.instrStorage.inner = e.storage // rebind in case storage was swapped
+			e.instrStorage.reset()
+			storageForDetect = e.instrStorage
+		}
+
 		processingStartTime := time.Now()
-		result := detector.Detect(e.storage, upTo)
+		result := detector.Detect(storageForDetect, upTo)
 		processingTime := time.Since(processingStartTime)
 		allTelemetry = append(allTelemetry, newTelemetryGauge([]string{"detector:" + detector.Name()}, telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), upTo))
+
+		// Emit detect digest (captures raw result BEFORE dedup).
+		if e.onDetectDigest != nil {
+			fps := make([]string, len(result.Anomalies))
+			for i, a := range result.Anomalies {
+				fps[i] = anomalyFingerprint(a)
+			}
+			sort.Strings(fps)
+			dd := detectDigest{
+				DetectorName:        detector.Name(),
+				DataTime:            upTo,
+				AnomalyCount:        len(result.Anomalies),
+				AnomalyFingerprints: fps,
+			}
+			if e.instrStorage != nil {
+				rd := e.instrStorage.digest(detector.Name(), upTo)
+				dd.InputHash = rd.Hash
+				dd.ReadCount = rd.ReadCount
+				dd.PointCount = rd.PointCount
+			}
+			e.onDetectDigest(dd)
+		}
 
 		for _, anomaly := range result.Anomalies {
 			e.enrichAnomaly(&anomaly)

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -257,6 +258,30 @@ func NewComponent(deps Requires) Provides {
 
 	if recorder, ok := deps.Recorder.Get(); ok {
 		obs.handleFunc = recorder.GetHandle(obs.handleFunc)
+
+		// Record detect digests and advance log alongside parquet for parity debugging.
+		parquetDir := cfg.GetString("observer.recording.parquet_output_dir")
+		if parquetDir != "" {
+			digestPath := filepath.Join(parquetDir, detectDigestFileName)
+			cleanup, err := enableDetectDigestRecordingToFile(eng, digestPath)
+			if err != nil {
+				deps.Log.Warnf("[observer] detect digest recording disabled: %v", err)
+			} else {
+				obs.digestCleanup = cleanup
+			}
+
+			advPath := filepath.Join(parquetDir, advanceLogFileName)
+			advRec, err := newAdvanceLogRecorder(advPath)
+			if err != nil {
+				deps.Log.Warnf("[observer] advance log recording disabled: %v", err)
+			} else {
+				eng.onAdvance = advRec.record
+				obs.advanceLogCleanup = func() {
+					eng.onAdvance = nil
+					advRec.close()
+				}
+			}
+		}
 	}
 
 	// Optionally add the event reporter when sending is enabled via config.
@@ -404,7 +429,9 @@ type observerImpl struct {
 	// fetcher pulls traces/profiles from remote trace-agents
 	fetcher *observerFetcher
 
-	telemetryHandler *telemetryHandler
+	telemetryHandler    *telemetryHandler
+	digestCleanup      func() // flushes detect digest recording file
+	advanceLogCleanup  func() // flushes advance log recording file
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -583,7 +610,7 @@ func (o *observerImpl) GetHandle(name string) observerdef.Handle {
 
 // innerHandle creates the base handle without any middleware wrapping.
 func (o *observerImpl) innerHandle(name string) observerdef.Handle {
-	return &handle{ch: o.obsCh, source: name}
+	return &handle{ch: o.obsCh, source: name, dropCount: &o.engine.droppedObs}
 }
 
 // noopHandle returns a handle that discards all observations.
@@ -611,8 +638,9 @@ func (o *observerImpl) DumpMetrics(path string) error {
 // handle is the lightweight observation interface passed to other components.
 // It only holds a channel and source name - all processing happens in the observer.
 type handle struct {
-	ch     chan<- observation
-	source string
+	ch         chan<- observation
+	source     string
+	dropCount  *atomic.Int64 // shared counter for channel-full drops (nil = don't track)
 }
 
 // ObserveMetric observes a DogStatsD metric sample.
@@ -640,11 +668,12 @@ func (h *handle) ObserveMetric(sample observerdef.MetricView) {
 	}
 
 	// Non-blocking send - drop if channel is full.
-	// In production, this prevents slow consumers from blocking data ingestion.
-	// For demo comparison, this means faster correlators see more data.
 	select {
 	case h.ch <- obs:
 	default:
+		if h.dropCount != nil {
+			h.dropCount.Add(1)
+		}
 	}
 }
 
@@ -668,6 +697,9 @@ func (h *handle) ObserveLog(msg observerdef.LogView) {
 	select {
 	case h.ch <- obs:
 	default:
+		if h.dropCount != nil {
+			h.dropCount.Add(1)
+		}
 	}
 }
 
@@ -718,6 +750,9 @@ func (h *handle) ObserveTrace(trace observerdef.TraceView) {
 	select {
 	case h.ch <- obs:
 	default:
+		if h.dropCount != nil {
+			h.dropCount.Add(1)
+		}
 	}
 }
 
@@ -754,6 +789,9 @@ func (h *handle) ObserveProfile(profile observerdef.ProfileView) {
 	select {
 	case h.ch <- obs:
 	default:
+		if h.dropCount != nil {
+			h.dropCount.Add(1)
+		}
 	}
 }
 

--- a/comp/observer/impl/storage_instrumented.go
+++ b/comp/observer/impl/storage_instrumented.go
@@ -118,12 +118,22 @@ func (s *instrumentedStorage) ListSeries(filter observerdef.SeriesFilter) []obse
 	s.readCount++
 	result := s.inner.ListSeries(filter)
 
+	// Hash each series identity independently, then sort and combine.
+	// ListSeries iterates a Go map internally, so slice order is non-deterministic.
+	perSeries := make([]uint64, len(result))
+	for i, m := range result {
+		ih := newCallHasher()
+		ih.mixSeriesIdentity(m.Namespace, m.Name, m.Tags)
+		perSeries[i] = ih.sum()
+	}
+	sort.Slice(perSeries, func(i, j int) bool { return perSeries[i] < perSeries[j] })
+
 	ch := newCallHasher()
 	ch.mixString("ListSeries")
 	ch.mixString(filter.Namespace)
 	ch.mixInt64(int64(len(result)))
-	for _, m := range result {
-		ch.mixSeriesIdentity(m.Namespace, m.Name, m.Tags)
+	for _, h := range perSeries {
+		ch.mixUint64(h)
 	}
 	s.callHashes = append(s.callHashes, ch.sum())
 	return result

--- a/comp/observer/impl/storage_instrumented.go
+++ b/comp/observer/impl/storage_instrumented.go
@@ -1,0 +1,223 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"encoding/binary"
+	"hash"
+	"hash/fnv"
+	"math"
+	"sort"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// readDigest captures the cumulative hash of all storage reads during a single
+// Detect() call, along with metadata for matching across live/replay runs.
+type readDigest struct {
+	DetectorName string `json:"detector"`
+	DataTime     int64  `json:"data_time"`
+	Hash         uint64 `json:"hash"`
+	ReadCount    int    `json:"read_count"`
+	PointCount   int    `json:"point_count"`
+}
+
+// instrumentedStorage wraps a StorageReader and hashes every read to produce
+// a deterministic digest of what a detector actually saw.
+//
+// Each storage call produces an independent hash. At digest time, these
+// per-call hashes are sorted and combined so the final hash is independent
+// of the order detectors call storage methods. This is critical because
+// ListSeries may return series in different order between live and replay.
+type instrumentedStorage struct {
+	inner observerdef.StorageReader
+
+	callHashes []uint64 // one hash per storage call
+	readCount  int
+	pointCount int
+}
+
+func newInstrumentedStorage(inner observerdef.StorageReader) *instrumentedStorage {
+	return &instrumentedStorage{inner: inner}
+}
+
+func (s *instrumentedStorage) reset() {
+	s.callHashes = s.callHashes[:0]
+	s.readCount = 0
+	s.pointCount = 0
+}
+
+func (s *instrumentedStorage) digest(detectorName string, dataTime int64) readDigest {
+	// Combine per-call hashes in sorted order for order-independence.
+	sorted := make([]uint64, len(s.callHashes))
+	copy(sorted, s.callHashes)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	h := fnv.New64a()
+	var buf [8]byte
+	for _, ch := range sorted {
+		binary.LittleEndian.PutUint64(buf[:], ch)
+		h.Write(buf[:])
+	}
+
+	return readDigest{
+		DetectorName: detectorName,
+		DataTime:     dataTime,
+		Hash:         h.Sum64(),
+		ReadCount:    s.readCount,
+		PointCount:   s.pointCount,
+	}
+}
+
+// callHasher builds a hash for a single storage call.
+type callHasher struct {
+	h hash.Hash64
+}
+
+func newCallHasher() *callHasher {
+	return &callHasher{h: fnv.New64a()}
+}
+
+func (c *callHasher) mixBytes(data []byte)  { c.h.Write(data) }
+func (c *callHasher) mixString(v string)    { c.h.Write([]byte(v)) }
+func (c *callHasher) mixUint64(v uint64)    { var b [8]byte; binary.LittleEndian.PutUint64(b[:], v); c.h.Write(b[:]) }
+func (c *callHasher) mixInt64(v int64)      { c.mixUint64(uint64(v)) }
+func (c *callHasher) mixFloat64(v float64)  { c.mixUint64(math.Float64bits(v)) }
+func (c *callHasher) sum() uint64           { return c.h.Sum64() }
+
+func (c *callHasher) mixSeriesIdentity(namespace, name string, tags []string) {
+	c.mixString(namespace)
+	c.mixString(name)
+	c.mixInt64(int64(len(tags)))
+	for _, tag := range tags {
+		c.mixString(tag)
+	}
+}
+
+func (c *callHasher) mixSeries(series *observerdef.Series) int {
+	if series == nil {
+		c.mixUint64(0)
+		return 0
+	}
+	c.mixUint64(1)
+	c.mixSeriesIdentity(series.Namespace, series.Name, series.Tags)
+	c.mixInt64(int64(len(series.Points)))
+	for _, p := range series.Points {
+		c.mixInt64(p.Timestamp)
+		c.mixFloat64(p.Value)
+	}
+	return len(series.Points)
+}
+
+// --- StorageReader interface ---
+
+func (s *instrumentedStorage) ListSeries(filter observerdef.SeriesFilter) []observerdef.SeriesMeta {
+	s.readCount++
+	result := s.inner.ListSeries(filter)
+
+	ch := newCallHasher()
+	ch.mixString("ListSeries")
+	ch.mixString(filter.Namespace)
+	ch.mixInt64(int64(len(result)))
+	for _, m := range result {
+		ch.mixSeriesIdentity(m.Namespace, m.Name, m.Tags)
+	}
+	s.callHashes = append(s.callHashes, ch.sum())
+	return result
+}
+
+func (s *instrumentedStorage) GetSeriesRange(ref observerdef.SeriesRef, start, end int64, agg observerdef.Aggregate) *observerdef.Series {
+	s.readCount++
+	result := s.inner.GetSeriesRange(ref, start, end, agg)
+
+	ch := newCallHasher()
+	ch.mixString("GetSeriesRange")
+	ch.mixInt64(start)
+	ch.mixInt64(end)
+	ch.mixInt64(int64(agg))
+	pts := ch.mixSeries(result)
+	s.pointCount += pts
+	s.callHashes = append(s.callHashes, ch.sum())
+	return result
+}
+
+func (s *instrumentedStorage) ForEachPoint(ref observerdef.SeriesRef, start, end int64, agg observerdef.Aggregate, fn func(*observerdef.Series, observerdef.Point)) bool {
+	s.readCount++
+
+	ch := newCallHasher()
+	ch.mixString("ForEachPoint")
+	ch.mixInt64(start)
+	ch.mixInt64(end)
+	ch.mixInt64(int64(agg))
+
+	var callPointCount int
+	var identityHashed bool
+	found := s.inner.ForEachPoint(ref, start, end, agg, func(series *observerdef.Series, p observerdef.Point) {
+		if !identityHashed {
+			ch.mixSeriesIdentity(series.Namespace, series.Name, series.Tags)
+			identityHashed = true
+		}
+		ch.mixInt64(p.Timestamp)
+		ch.mixFloat64(p.Value)
+		callPointCount++
+		s.pointCount++
+		fn(series, p)
+	})
+
+	ch.mixInt64(int64(callPointCount))
+	if found {
+		ch.mixUint64(1)
+	} else {
+		ch.mixUint64(0)
+	}
+	s.callHashes = append(s.callHashes, ch.sum())
+	return found
+}
+
+func (s *instrumentedStorage) PointCount(ref observerdef.SeriesRef) int {
+	s.readCount++
+	result := s.inner.PointCount(ref)
+
+	ch := newCallHasher()
+	ch.mixString("PointCount")
+	ch.mixInt64(int64(result))
+	s.callHashes = append(s.callHashes, ch.sum())
+	return result
+}
+
+func (s *instrumentedStorage) PointCountUpTo(ref observerdef.SeriesRef, endTime int64) int {
+	s.readCount++
+	result := s.inner.PointCountUpTo(ref, endTime)
+
+	ch := newCallHasher()
+	ch.mixString("PointCountUpTo")
+	ch.mixInt64(endTime)
+	ch.mixInt64(int64(result))
+	s.callHashes = append(s.callHashes, ch.sum())
+	return result
+}
+
+func (s *instrumentedStorage) WriteGeneration(ref observerdef.SeriesRef) int64 {
+	s.readCount++
+	result := s.inner.WriteGeneration(ref)
+
+	ch := newCallHasher()
+	ch.mixString("WriteGeneration")
+	ch.mixInt64(result)
+	s.callHashes = append(s.callHashes, ch.sum())
+	return result
+}
+
+func (s *instrumentedStorage) SeriesGeneration() uint64 {
+	s.readCount++
+	result := s.inner.SeriesGeneration()
+
+	ch := newCallHasher()
+	ch.mixString("SeriesGeneration")
+	ch.mixUint64(result)
+	s.callHashes = append(s.callHashes, ch.sum())
+	return result
+}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -395,10 +395,56 @@ func (tb *TestBench) LoadScenario(name string) error {
 	}
 	fmt.Printf("  Parquet loading took %s\n", time.Since(parquetStart))
 
+	// Check for parity debugging files from a live recording.
+	var digestComp *detectDigestComparator
+	var advComp *advanceLogComparator
+
+	// Detection digest comparison.
+	digestPath := filepath.Join(scenarioPath, detectDigestFileName)
+	if _, err := os.Stat(digestPath); os.IsNotExist(err) {
+		digestPath = filepath.Join(scenarioPath, "parquet", detectDigestFileName)
+	}
+	if _, statErr := os.Stat(digestPath); statErr == nil {
+		comp, loadErr := newDetectDigestComparator(digestPath)
+		if loadErr != nil {
+			fmt.Printf("[testbench] WARNING: failed to load detection digest: %v\n", loadErr)
+		} else {
+			digestComp = comp
+			tb.engine.enableDetectDigestRecording(comp.compare)
+			fmt.Printf("[testbench] Detection digest comparison enabled (%d live digests loaded)\n", len(comp.expected))
+		}
+	}
+
+	// Advance log comparison.
+	advPath := filepath.Join(scenarioPath, advanceLogFileName)
+	if _, err := os.Stat(advPath); os.IsNotExist(err) {
+		advPath = filepath.Join(scenarioPath, "parquet", advanceLogFileName)
+	}
+	if _, statErr := os.Stat(advPath); statErr == nil {
+		comp, loadErr := newAdvanceLogComparator(advPath)
+		if loadErr != nil {
+			fmt.Printf("[testbench] WARNING: failed to load advance log: %v\n", loadErr)
+		} else {
+			advComp = comp
+			tb.engine.onAdvance = advComp.compare
+			fmt.Printf("[testbench] Advance log comparison enabled (%d live advances loaded)\n", len(comp.liveAdvances))
+		}
+	}
+
 	// Run analyses on all loaded data (detectors sync, correlators async)
 	analysisStart := time.Now()
 	tb.rerunDetectorsLocked()
 	fmt.Printf("  Detector phase took %s\n", time.Since(analysisStart))
+
+	// Print parity debugging summaries.
+	if advComp != nil {
+		advComp.printSummary()
+		tb.engine.onAdvance = nil
+	}
+	if digestComp != nil {
+		digestComp.printSummary()
+		tb.engine.enableDetectDigestRecording(nil)
+	}
 	fmt.Printf("  Total scenario load took %s\n", time.Since(scenarioStart))
 	rs := tb.replayStats
 	fmt.Printf("Scenario loaded: %d metric samples (%d unique series), %d metric anomalies, %d log entries, %d log anomalies\n",
@@ -435,19 +481,11 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 
 	// Batch add all metrics to storage
 	for _, m := range metrics {
-		// Strip aggregation suffix from metric name (e.g., ":avg", ":count")
 		metricName := m.Name
 
 		// filter internal Datadog Agent telemetry
 		if strings.HasPrefix(metricName, "datadog.") {
 			continue
-		}
-
-		if idx := strings.LastIndex(metricName, ":"); idx != -1 {
-			suffix := metricName[idx+1:]
-			if suffix == "avg" || suffix == "count" || suffix == "sum" || suffix == "min" || suffix == "max" {
-				metricName = metricName[:idx]
-			}
 		}
 
 		byTimestampCounter[m.Timestamp]++

--- a/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
@@ -216,7 +216,7 @@ for EP_SPEC in "${EP_LIST[@]}"; do
       #   tmp/gensim-archive/results/<scenario>.json  (produced by play-episode.sh)
       mkdir -p /workspace/zip-staging/tmp/gensim-archive/parquet
       mkdir -p /workspace/zip-staging/tmp/gensim-archive/results
-      cp /workspace/results/parquet/*.parquet /workspace/zip-staging/tmp/gensim-archive/parquet/ 2>/dev/null || true
+      cp /workspace/results/parquet/* /workspace/zip-staging/tmp/gensim-archive/parquet/ 2>/dev/null || true
       # play-episode.sh writes results to /workspace/results/<scenario>-<cycle>.json
       cp /workspace/results/*.json /workspace/zip-staging/tmp/gensim-archive/results/ 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

- Add instrumentation to systematically narrow down why the testbench finds anomalies during replay that the live observer doesn't detect
- Record diagnostic data during live runs, auto-compare during testbench replay
- Remove dead suffix-stripping code from testbench, fix gensim ZIP to include all files

## Problem

The testbench finds anomalies when replaying recorded data that the live observer does not detect during the original recording. Both paths use the same engine, detectors, and scheduler policy, so the divergence is subtle.

## Hypothesis tree

There are three mutually exclusive explanations:

| Hypothesis | Description | Implication |
|---|---|---|
| **H1** | Detectors are called at different times | Scheduling bug or timing policy difference |
| **H2** | Same times, different data | Data ingestion divergence (drops, late arrival) |
| **H3** | Same times, same data, different results | Non-deterministic detector |

## What this PR adds

Three data streams written to `parquet_output_dir` alongside parquet recordings:

**`advances.jsonl`** — Every advance records `{dataTime, reason, latePoints, droppedObs}`. Late points = metrics ingested after their timestamp was already analyzed (invisible to live detectors, visible in replay). Dropped obs = metrics dropped from full channel but still recorded to parquet (never in live storage, present in replay). Discriminates **H1** and provides evidence for **H2**.

**`detect_digests.jsonl`** — Every `Detect()` call records `{detector, dataTime, anomalyCount, anomalyFingerprints, inputHash}`. Input hash uses an order-independent scheme (per-call hashes sorted before combining) with series identity instead of `SeriesRef` for stability across live/replay. Discriminates **H2 vs H3**.

**Instrumented storage wrapper** — Transparently wraps `StorageReader` during `Detect()` calls to hash all data actually read by detectors.

**Testbench auto-comparison** — When loading a scenario containing these files, prints:
- Advance sequence divergences (matched, live-only, replay-only)
- Live ingestion anomalies (total late points and dropped observations)
- Detection result divergences (detector, time, anomaly diff, input hash match/differ)

## How to interpret results

Run with `--mode=live-and-record`, download, load in testbench:

| Output | Conclusion |
|--------|------------|
| Advance sequences differ | **H1** — scheduling divergence |
| Result divergence + input hash differs + late points > 0 | **H2 via late data** — points arrived after analysis |
| Result divergence + input hash differs + dropped obs > 0 | **H2 via drops** — observations dropped from full channel but recorded to parquet |
| Result divergence + input hash matches | **H3** — non-deterministic detector |
| No result divergences | Divergence is downstream of detection |

## Other changes

- Removed dead suffix-stripping code from testbench `loadParquetDir` (`:avg`/`:count` suffixes only exist transiently inside `seriesDetectorAdapter`, never in parquet data)
- Changed gensim orchestrator ZIP to include all files in parquet dir (not just `*.parquet`) so JSONL diagnostic files are captured

## Test plan

- [x] `go build ./comp/observer/impl/` compiles
- [x] `go test ./comp/observer/impl/` passes
- [x] `go build ./cmd/observer-testbench/` compiles
- [ ] Run gensim scenario with `--mode=live-and-record`, download, load in testbench, verify comparison output