### PR TITLE
Migrate BindEnv to BindEnvAndSetDefault and IsSet to IsConfigured

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -356,10 +356,10 @@ func (c *TracerConfig) AsEnvVar() corev1.EnvVar {
 
 type initResourceRequirementConfiguration map[corev1.ResourceName]resource.Quantity
 
-// getOptionalBoolValue returns a pointer to a bool corresponding to the config value if the key is set in the config
+// getOptionalBoolValue returns a pointer to a bool corresponding to the config value if the key is configured
 func getOptionalBoolValue(datadogConfig config.Component, key string) *bool {
 	var value *bool
-	if datadogConfig.IsSet(key) {
+	if datadogConfig.IsConfigured(key) {
 		tmp := datadogConfig.GetBool(key)
 		value = &tmp
 	}
@@ -367,10 +367,10 @@ func getOptionalBoolValue(datadogConfig config.Component, key string) *bool {
 	return value
 }
 
-// getOptionalBoolValue returns a pointer to a bool corresponding to the config value if the key is set in the config
+// getOptionalStringValue returns a pointer to a string corresponding to the config value if the key is configured
 func getOptionalStringValue(datadogConfig config.Component, key string) *string {
 	var value *string
-	if datadogConfig.IsSet(key) {
+	if datadogConfig.IsConfigured(key) {
 		tmp := datadogConfig.GetString(key)
 		value = &tmp
 	}
@@ -417,32 +417,28 @@ func getPinnedLibraries(libVersions map[string]string, registry string, checkDef
 func initDefaultResources(datadogConfig config.Component) (initResourceRequirementConfiguration, error) {
 	conf := initResourceRequirementConfiguration{}
 
-	if datadogConfig.IsSet("admission_controller.auto_instrumentation.init_resources.cpu") {
+	if datadogConfig.IsConfigured("admission_controller.auto_instrumentation.init_resources.cpu") {
 		quantity, err := resource.ParseQuantity(datadogConfig.GetString("admission_controller.auto_instrumentation.init_resources.cpu"))
 		if err != nil {
 			return conf, err
 		}
 		conf[corev1.ResourceCPU] = quantity
-	} /* else {
-		conf[corev1.ResourceCPU] = *resource.NewMilliQuantity(minimumCPULimit, resource.DecimalSI)
-	}*/
+	}
 
-	if datadogConfig.IsSet("admission_controller.auto_instrumentation.init_resources.memory") {
+	if datadogConfig.IsConfigured("admission_controller.auto_instrumentation.init_resources.memory") {
 		quantity, err := resource.ParseQuantity(datadogConfig.GetString("admission_controller.auto_instrumentation.init_resources.memory"))
 		if err != nil {
 			return conf, err
 		}
 		conf[corev1.ResourceMemory] = quantity
-	} /*else {
-		conf[corev1.ResourceCPU] = *resource.NewMilliQuantity(minimumMemoryLimit, resource.DecimalSI)
-	}*/
+	}
 
 	return conf, nil
 }
 
 func parseInitSecurityContext(datadogConfig config.Component) (*corev1.SecurityContext, error) {
 	confKey := "admission_controller.auto_instrumentation.init_security_context"
-	if datadogConfig.IsSet(confKey) {
+	if datadogConfig.IsConfigured(confKey) {
 		confValue := datadogConfig.GetString(confKey)
 		var securityContext corev1.SecurityContext
 		err := json.Unmarshal([]byte(confValue), &securityContext)

--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -199,7 +199,7 @@ func containsVolumeMount(volumeMounts []corev1.VolumeMount, element corev1.Volum
 // config option, and falls back to the default container registry if no
 // webhook-specific container registry is set.
 func ContainerRegistry(datadogConfig config.Component, specificConfigOpt string) string {
-	if datadogConfig.IsSet(specificConfigOpt) {
+	if datadogConfig.IsConfigured(specificConfigOpt) {
 		return datadogConfig.GetString(specificConfigOpt)
 	}
 

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/mutator.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/mutator.go
@@ -120,7 +120,7 @@ func injectTagsFromLabels(labels map[string]string, pod *corev1.Pod) (bool, bool
 }
 
 func ownerCacheTTL(datadogConfig config.Component) time.Duration {
-	if datadogConfig.IsSet("admission_controller.pod_owners_cache_validity") { // old option. Kept for backwards compatibility
+	if datadogConfig.IsConfigured("admission_controller.pod_owners_cache_validity") { // old option. Kept for backwards compatibility
 		return datadogConfig.GetDuration("admission_controller.pod_owners_cache_validity") * time.Minute
 	}
 

--- a/pkg/collector/corechecks/system/cpu/cpu/context_switches_linux.go
+++ b/pkg/collector/corechecks/system/cpu/cpu/context_switches_linux.go
@@ -24,8 +24,8 @@ import (
 func GetContextSwitches() (ctxSwitches int64, err error) {
 	log.Debug("collecting ctx switches")
 	procfsPath := "/proc"
-	if pkgconfigsetup.Datadog().IsSet("procfs_path") {
-		procfsPath = pkgconfigsetup.Datadog().GetString("procfs_path")
+	if v := pkgconfigsetup.Datadog().GetString("procfs_path"); v != "" {
+		procfsPath = v
 	}
 	filePath := procfsPath + "/stat"
 	file, err := os.Open(filePath)

--- a/pkg/collector/corechecks/system/memory/memory_nix.go
+++ b/pkg/collector/corechecks/system/memory/memory_nix.go
@@ -147,8 +147,8 @@ func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, rawInsta
 
 func (c *Check) collectVMStatPressureMetrics(sender sender.Sender) {
 	procfsPath := "/proc"
-	if pkgconfigsetup.Datadog().IsSet("procfs_path") {
-		procfsPath = pkgconfigsetup.Datadog().GetString("procfs_path")
+	if v := pkgconfigsetup.Datadog().GetString("procfs_path"); v != "" {
+		procfsPath = v
 	}
 
 	filePath := procfsPath + "/vmstat"

--- a/pkg/collector/python/embed_python.go
+++ b/pkg/collector/python/embed_python.go
@@ -37,8 +37,7 @@ func pySetup(paths ...string) (pythonVersion, pythonHome, pythonPath string) {
 }
 
 func pyPrepareEnv() error {
-	if pkgconfigsetup.Datadog().IsSet("procfs_path") {
-		procfsPath := pkgconfigsetup.Datadog().GetString("procfs_path")
+	if procfsPath := pkgconfigsetup.Datadog().GetString("procfs_path"); procfsPath != "" {
 		return SetPythonPsutilProcPath(procfsPath)
 	}
 	return nil

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -173,7 +173,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 
 	config.BindEnvAndSetDefault("prometheus_scrape.enabled", false)           // Enables the prometheus config provider
 	config.BindEnvAndSetDefault("prometheus_scrape.service_endpoints", false) // Enables Service Endpoints checks in the prometheus config provider
-	config.BindEnv("prometheus_scrape.checks")                                //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv' // Defines any extra prometheus/openmetrics check configurations to be handled by the prometheus config provider
+	config.BindEnvAndSetDefault("prometheus_scrape.checks", "")               // Defines any extra prometheus/openmetrics check configurations to be handled by the prometheus config provider
 	config.BindEnvAndSetDefault("prometheus_scrape.version", 1)               // Version of the openmetrics check to be scheduled by the Prometheus auto-discovery
 
 	// Network Devices Monitoring
@@ -643,7 +643,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.pod_owners_cache_validity", 10) // in minutes
-	config.BindEnv("admission_controller.pod_owners_cache_validity")                              //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv' // Alias for admission_controller.inject_tags.pod_owners_cache_validity. Was added without the "inject_tags" prefix by mistake but needs to be kept for backwards compatibility
+	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10)             // deprecated alias for `admission_controller.inject_tags.pod_owners_cache_validity`
 	config.BindEnvAndSetDefault("admission_controller.namespace_selector_fallback", false)
 	config.BindEnvAndSetDefault("admission_controller.failure_policy", "Ignore")
 	config.BindEnvAndSetDefault("admission_controller.reinvocation_policy", "IfNeeded")
@@ -653,7 +653,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.probe.grace_period", 60) // in seconds
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.endpoint", "/injectlib")
-	config.BindEnv("admission_controller.auto_instrumentation.container_registry") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.container_registry", "")
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.default_dd_registries", []string{
 		"gcr.io/datadoghq",
 		"docker.io/datadog",
@@ -665,24 +665,24 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider", false)                                // to be enabled only in e2e tests
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json") // to be used only in e2e tests
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_auto_detected_libraries", true)                                    // allows injecting libraries for languages detected by automatic language detection feature
-	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu")                                                                   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")                                                                //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("admission_controller.auto_instrumentation.init_security_context")                                                                //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("admission_controller.auto_instrumentation.asm.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED")           //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv' // config for ASM which is implemented in the client libraries
-	config.BindEnv("admission_controller.auto_instrumentation.iast.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_IAST_ENABLED")            //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv' // config for IAST which is implemented in the client libraries
-	config.BindEnv("admission_controller.auto_instrumentation.asm_sca.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_SCA_ENABLED")   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv' // config for SCA
-	config.BindEnv("admission_controller.auto_instrumentation.profiling.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PROFILING_ENABLED")  //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv' // config for profiling
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.init_resources.cpu", "")
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.init_resources.memory", "")
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.init_security_context", "")
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.asm.enabled", false, "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED")         // config for ASM which is implemented in the client libraries
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.iast.enabled", false, "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_IAST_ENABLED")          // config for IAST which is implemented in the client libraries
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.asm_sca.enabled", false, "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_SCA_ENABLED") // config for SCA
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.profiling.enabled", "", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PROFILING_ENABLED")   // config for profiling
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.pod_endpoint", "/inject-pod-cws")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.command_endpoint", "/inject-command-cws")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.include", []string{})
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.exclude", []string{})
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.mutate_unlabelled", false)
-	config.BindEnv("admission_controller.cws_instrumentation.container_registry") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.container_registry", "")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.image_name", "cws-instrumentation")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.image_tag", "latest")
-	config.BindEnv("admission_controller.cws_instrumentation.init_resources.cpu")    //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("admission_controller.cws_instrumentation.init_resources.memory") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.init_resources.cpu", "")
+	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.init_resources.memory", "")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.mode", "remote_copy")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.remote_copy.mount_volume", false)
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.remote_copy.directory", "/tmp")
@@ -694,7 +694,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.selectors", "[]")
 	// Should be able to parse it to a list of env vars and resource limits
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.profiles", "[]")
-	config.BindEnv("admission_controller.agent_sidecar.container_registry") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.container_registry", "")
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.image_name", "agent")
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.image_tag", "latest")
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.cluster_agent.enabled", "true")
@@ -1343,6 +1343,13 @@ func autoconfig(config pkgconfigmodel.Setup) {
 }
 
 func containerSyspath(config pkgconfigmodel.Setup) {
+	// Bind env vars with empty defaults; conditional SetDefault calls below
+	// set the real values based on the runtime environment.
+	config.BindEnvAndSetDefault("procfs_path", "")
+	config.BindEnvAndSetDefault("container_proc_root", "")
+	config.BindEnvAndSetDefault("container_cgroup_root", "")
+	config.BindEnvAndSetDefault("container_pid_mapper", "")
+
 	if pkgconfigenv.IsContainerized() {
 		// In serverless-containerized environments (e.g Fargate)
 		// it's impossible to mount host volumes.
@@ -1376,10 +1383,6 @@ func containerSyspath(config pkgconfigmodel.Setup) {
 		}
 	}
 
-	config.BindEnv("procfs_path")           //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("container_proc_root")   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("container_cgroup_root") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("container_pid_mapper")  //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.BindEnvAndSetDefault("ignore_host_etc", false)
 	config.BindEnvAndSetDefault("use_improved_cgroup_parser", false)
 	config.BindEnvAndSetDefault("proc_root", "/proc")


### PR DESCRIPTION
### What does this PR do?

Add defaults to some container platform related settings that were using bare `BindEnv`, and migrate corresponding `IsSet` calls to `IsConfigured` (or `GetString != ""` for settings with dynamic `SetDefault` overrides).

### Motivation

CONTP-1431

### Describe how you validated your changes

Unit Tests and CI
