### PR TITLE
fix(kafka_actions): pass kafka_cluster_id_override to kafka_actions

### DIFF
--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
@@ -336,5 +336,11 @@ func extractAuthFromInstanceData(instanceData integration.Data) map[string]any {
 			}
 		}
 	}
+
+	// Map kafka_consumer's kafka_cluster_id_override to kafka_actions' kafka_cluster_id
+	if v, ok := raw["kafka_cluster_id_override"]; ok {
+		out["kafka_cluster_id"] = v
+	}
+
 	return out
 }

--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
@@ -59,6 +59,19 @@ schema_registry_username: sr-user
 schema_registry_password: sr-pass
 `
 
+const kafkaConsumerConfigWithClusterIDOverride = `
+kafka_connect_str: localhost:9092
+consumer_groups:
+  - test-group
+topics:
+  - test-topic
+sasl_mechanism: PLAIN
+sasl_plain_username: user
+sasl_plain_password: pass
+security_protocol: SASL_SSL
+kafka_cluster_id_override: msk-cluster-1
+`
+
 func TestActionsController(t *testing.T) {
 	kafkaConsumerCfg := integration.Config{
 		Name:       kafkaConsumerIntegrationName,
@@ -262,4 +275,60 @@ func TestActionsControllerNoMatchingKafkaConsumer(t *testing.T) {
 	// Should fail with error
 	assert.Equal(t, state.ApplyStateError, updateStatus["config_1"].State)
 	assert.Contains(t, updateStatus["config_1"].Error, "kafka_consumer integration")
+}
+
+func TestActionsControllerClusterIDOverride(t *testing.T) {
+	kafkaConsumerCfg := integration.Config{
+		Name:       kafkaConsumerIntegrationName,
+		Instances:  []integration.Data{integration.Data(kafkaConsumerConfigWithClusterIDOverride)},
+		InitConfig: integration.Data{},
+	}
+
+	c := &actionsController{
+		ac:            getMockedAutodiscoveryActions(t, []integration.Config{kafkaConsumerCfg}),
+		rcclient:      &mockedRcClient{},
+		configChanges: make(chan integration.ConfigChanges, 10),
+	}
+
+	actions := map[string]any{
+		"read_messages": map[string]any{
+			"cluster": "msk-cluster-1",
+			"topic":   "test-topic",
+		},
+	}
+	actionsJSON, err := json.Marshal(actions)
+	require.NoError(t, err)
+
+	kafkaActionsConfig := kafkaActionsConfig{
+		Actions:          actionsJSON,
+		BootstrapServers: "localhost:9092",
+	}
+	serializedConfig, err := json.Marshal(kafkaActionsConfig)
+	require.NoError(t, err)
+
+	rcUpdate := map[string]state.RawConfig{
+		"config_1": {Config: serializedConfig, Metadata: state.Metadata{ID: "cluster_override_test"}},
+	}
+
+	updateStatus := make(map[string]state.ApplyStatus)
+	callback := func(path string, status state.ApplyStatus) {
+		updateStatus[path] = status
+	}
+
+	c.update(rcUpdate, callback)
+
+	assert.Equal(t, state.ApplyStateAcknowledged, updateStatus["config_1"].State)
+
+	updates := c.Stream(context.Background())
+	cfg := <-updates
+
+	require.Len(t, cfg.Schedule, 1)
+	var instance map[string]any
+	err = yaml.Unmarshal(cfg.Schedule[0].Instances[0], &instance)
+	require.NoError(t, err)
+
+	// kafka_cluster_id_override from kafka_consumer should be mapped to kafka_cluster_id
+	assert.Equal(t, "msk-cluster-1", instance["kafka_cluster_id"])
+	// The original field name should not be present
+	assert.Nil(t, instance["kafka_cluster_id_override"])
 }


### PR DESCRIPTION
## Summary
- Extract `kafka_cluster_id_override` from kafka_consumer instance config and map it to `kafka_cluster_id` in the kafka_actions instance
- This allows the kafka_actions check to use the overridden cluster ID for cluster verification, preventing mismatch errors when the backend creates actions using the overridden cluster ID
- Companion PR in integrations-core needed to use the field in verification

## Test plan
- [x] Added test verifying `kafka_cluster_id_override` is mapped to `kafka_cluster_id`
- [x] All existing datastreams provider tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)