### PR TITLE
Preserve trailing whitespaces in patch files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org
 
 root = true
 
@@ -11,10 +11,13 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 
+[*.patch]
+trim_trailing_whitespace = false
+
 [*.py]
 indent_style = space
 indent_size = 4
 
-[*.yml,*.tmpl]
+[*.{yml,tmpl}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
### What does this PR do?
Set `trim_trailing_whitespace = false`  for `.patch` files in `.editorconfig`.

Also fix `[*.yml,*.tmpl]` to `[*.{yml,tmpl}]` (canonical glob syntax as per https://editorconfig.org) and update the spec URL from `http` to `https`.

### Motivation
In unified diff format, every hunk line is prefixed by a single indicator character (` `, `-`, `+`); everything after it is the verbatim file content, trailing whitespaces included.

Stripping that whitespace changes what `patch`/`git apply` is told the file contains, causing context mismatches or failed hunks.

### Additional Notes
See: https://pubs.opengroup.org/onlinepubs/9799919799/utilities/diff.html