### PR TITLE
Enable `bazel`'s strict `repo_env`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,9 +17,16 @@ common --@rules_python//python/config_settings:bootstrap_impl=script # https://g
 common --check_direct_dependencies=error # Escalate any bypassed `bazel_dep` to a resolution failure
 common --enable_platform_specific_config # Supported OS identifiers are linux, macos, windows, freebsd, and openbsd
 common --experimental_disk_cache_gc_max_size=5G # Cap applied whenever --disk_cache is also set, no-op otherwise
+common --experimental_strict_repo_env # Do not leak uncontrolled environment variables into repository rules
 common --experimental_ui_max_stdouterr_bytes=1073741819 # why?
 common --http_timeout_scaling=3.0 # At least one attempt reaches 30s (3,6,12,24,30,30,30,30) instead of only 10s (1,2,4,8,10,10,10,10)
-common --incompatible_strict_action_env # Do not leak local environment variables into the build context
+common --repo_env=DEPLOY_AGENT # Keep in sync with env_vars in MODULE.bazel
+common --repo_env=FORCED_PACKAGE_COMPRESSION_LEVEL # Keep in sync with env_vars in MODULE.bazel
+common --repo_env=GOCACHE # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
+common --repo_env=GOMODCACHE # https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
+common --repo_env=PACKAGE_VERSION # Keep in sync with env_vars in MODULE.bazel
+common --repo_env=SIGN_MAC # Keep in sync with env_vars in MODULE.bazel
+common --repo_env=XDG_CACHE_HOME # https://wiki.archlinux.org/title/XDG_Base_Directory
 common --skip_incompatible_explicit_targets # Let target_compatible_with skip rather than fail
 common --test_output=errors # Print test errors to console output instead of only capturing them in buried test.log
 common --verbose_failures
@@ -44,10 +51,12 @@ common:windows --strategy=standalone # Valid values are: [dynamic_worker, standa
 # rules_python 1.9.0 transitions enable_runfiles to `true` for every py_ target on Windows. Pre-setting it here makes
 # that transition a no-op, so Bazel deduplicates python_win and avoids 2 concurrent MSBuild racing on shared resources.
 common:windows --enable_runfiles
-# Neither repo_env nor shell_executable affect action keys. It can be both an advantage and a disadvantage.
-# For instance, if we need to have some special behavior in bash we can add it, however, in some cases
-# it may lead to cache poisoning.
 common:windows --repo_env=BAZEL_SH=C:/tools/msys64/usr/bin/bash.exe # for https://github.com/bazelbuild/bazel/pull/26927
+common:windows --repo_env=PIP_CACHE_DIR # https://pip.pypa.io/en/stable/topics/caching/#default-paths
+common:windows --repo_env=SYSTEMDRIVE # needed by vswhere to locate the VS installer instance database
+common:windows --repo_env=SYSTEMROOT # used by COM to load system DLLs, needed by vswhere
+common:windows --repo_env=USERPROFILE # used by MSYS2 bash to emulate HOME, needed by git to fetch repositories
+common:windows --repo_env=VSTUDIO_ROOT # visual_studio(path_variable) in MODULE.bazel
 common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 
 # Remote cache config --------------------------------------------------------------------------------------------------

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,7 @@ env_vars(
     name = "agent_volatile",
     # Each variable needs a justification. Every time you use one, the
     # target using it is potentially uncachable.
+    # ⚠️ Keep in sync with the `--repo_env=` entries in .bazelrc
     variables = [
         # This gets set by omnibus builds in many cases. It's used in the script
         # to set things like compression, so we'll mimic that for now.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -408,8 +408,8 @@
         "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
         "recordedInputs": [
           "FILE:@@//.bazelversion 59b003a1f3465ae6084432329f8265e860cbaac0bd4a92a4f3ea6b979a6eed66",
-          "FILE:@@//tools/bazel 9e2de4e2b42cc820826732d10d5463b30849d267678fb779db876b57c3f3738d",
-          "FILE:@@//tools/bazel.bat 19e0283510e7afa8bfa3cef0e68c9129e60e61220703d04c42d95986c1fdd710",
+          "FILE:@@//tools/bazel 1dae499bda6b507adc6a400d1118c997b363267f2b697bb16452e87023d95f55",
+          "FILE:@@//tools/bazel.bat 24c80eecf763cf0f70ef5919413247b8e3dbc9eecd41dd63bc21f7c461b8a010",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],
         "generatedRepoSpecs": {}

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -408,8 +408,8 @@
         "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
         "recordedInputs": [
           "FILE:@@//.bazelversion 59b003a1f3465ae6084432329f8265e860cbaac0bd4a92a4f3ea6b979a6eed66",
-          "FILE:@@//tools/bazel d41ee01add2b1855b32212c5f9fc6481336c132c39da8c56195dc21c2325e8b9",
-          "FILE:@@//tools/bazel.bat b016bc9a1d6cb93baa5a81eedc8710ea0170aec283bcb3ca176b06ee336f4be1",
+          "FILE:@@//tools/bazel 9e2de4e2b42cc820826732d10d5463b30849d267678fb779db876b57c3f3738d",
+          "FILE:@@//tools/bazel.bat 19e0283510e7afa8bfa3cef0e68c9129e60e61220703d04c42d95986c1fdd710",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],
         "generatedRepoSpecs": {}

--- a/bazel/rules/go_fast/repo.bzl
+++ b/bazel/rules/go_fast/repo.bzl
@@ -22,7 +22,7 @@ def _impl(rctx):
     repo_utils.execute_checked(
         rctx,
         arguments = [go, "build", "-overlay", "overlay.json", "-o", out, "cmd/go"],
-        environment = {"GOPATH": None, "GOROOT": str(sdk), "GOWORK": "off"},
+        environment = {"GOROOT": str(sdk), "GOWORK": "off"},
         op = "build {}".format(out),
     )
     rctx.file(

--- a/bazel/rules/go_sdk_overrides/repo.bzl
+++ b/bazel/rules/go_sdk_overrides/repo.bzl
@@ -19,7 +19,7 @@ def _impl(rctx):
                 rctx,
                 op = "gopatch {}".format(p),
                 arguments = [go, "-C", rctx.path(rctx.attr._gopatch).dirname, "run", ".", "-p", p, rctx.path(".")],
-                environment = {"GOPATH": None, "GOROOT": None, "GOWORK": "off"},
+                environment = {"GOWORK": "off"},
             )
         else:
             rctx.patch(p, strip = 1)

--- a/bazel/rules/visual_studio.bzl
+++ b/bazel/rules/visual_studio.bzl
@@ -1,6 +1,8 @@
 """Wrapping Visual Studio and MSBuild to let Bazel track it.
 """
 
+load("@rules_python//python/private:repo_utils.bzl", "repo_utils")  # buildifier: disable=bzl-visibility
+
 def _visual_studio_impl(ctx):
     # vswhere is a tool that lets us inspect existing Visual Studio installations
     ctx.report_progress("Download vswhere.exe")
@@ -63,18 +65,19 @@ alias(
 
 def _get_vs_property(ctx, install_path, property):
     """Query a property of a VS installation using vswhere"""
-    result = ctx.execute([
-        ctx.path("vswhere.exe"),
-        "-nologo",
-        "-nocolor",
-        "-property",
-        property,
-        "-path",
-        install_path,
-    ])
-    if result.return_code:
-        fail("Failed to query property '%s' for '%s': %s" % property, install_path, result.stderr)
-
+    result = repo_utils.execute_checked(
+        ctx,
+        op = "vswhere -property {} for {}".format(property, install_path),
+        arguments = [
+            ctx.path("vswhere.exe"),
+            "-nologo",
+            "-nocolor",
+            "-property",
+            property,
+            "-path",
+            install_path,
+        ],
+    )
     return result.stdout.strip()
 
 visual_studio = repository_rule(

--- a/tools/bazel
+++ b/tools/bazel
@@ -2,15 +2,15 @@
 set -euo pipefail
 
 # Check `bazelisk` properly bootstraps `bazel` or fail with instructions
-if [ -z "${BAZEL_REAL:-}" ] || [ "${BAZELISK_SKIP_WRAPPER:-}" != true ]; then
+if [ -z "${BAZEL_REAL-}" ] || [ "${BAZELISK_SKIP_WRAPPER-}" != true ]; then
   >&2 cat "$(dirname "$0")/bazelisk.md"
   exit 2
 fi
 
 # Ensure `XDG_CACHE_HOME` denotes a directory
-if [ ! -d "${XDG_CACHE_HOME:-}" ]; then
-  if [ -n "${CI:-}" ]; then
-    >&2 echo "🔴 XDG_CACHE_HOME (${XDG_CACHE_HOME:-}) must denote a directory in CI!"
+if [ ! -d "${XDG_CACHE_HOME-}" ]; then
+  if [ -n "${CI-}" ]; then
+    >&2 echo "🔴 XDG_CACHE_HOME (${XDG_CACHE_HOME-}) must denote a directory in CI!"
     exit 2
   fi
   if [[ -e /.dockerenv || -e /run/.containerenv ]]; then
@@ -22,7 +22,7 @@ fi
 
 # Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME`
 extra_args=()
-if [ -n "${XDG_CACHE_HOME:-}" ]; then
+if [ -n "${XDG_CACHE_HOME-}" ]; then
   if [[ "$XDG_CACHE_HOME" != /* ]]; then
     >&2 echo "🔴 XDG_CACHE_HOME ($XDG_CACHE_HOME) must denote an absolute path!"
     exit 2
@@ -32,13 +32,15 @@ if [ -n "${XDG_CACHE_HOME:-}" ]; then
   extra_args+=(--disk_cache="$XDG_CACHE_HOME/bazel/disk-cache")
   # https://github.com/bazelbuild/bazel/issues/26384
   [ "$XDG_CACHE_HOME" = "$(dirname "$(dirname "$0")")/.cache" ] && extra_args+=(--repo_contents_cache=)
-  [ -n "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ] && extra_args+=(--config=ci)
+  [ -n "${CI-}" ] && [ -z "${GITHUB_ACTIONS-}" ] && extra_args+=(--config=ci)
 else
   # Without `XDG_CACHE_HOME`, fall back Go caches to official defaults so Go repo rules work under strict repo_env
-  [ -z "${GOCACHE:-}" ] && export GOCACHE=~/.cache/go-build
-  [ -n "${GOPATH:-}" ] && gp="${GOPATH%%:*}" || gp=~/go
-  export GOMODCACHE="${GOMODCACHE:-$gp/pkg/mod}"
-  unset gp
+  [ -z "${GOCACHE-}" ] && export GOCACHE=~/.cache/go-build
+  if [ -z "${GOMODCACHE:-}" ]; then
+    [ -n "${GOPATH-}" ] && gp="${GOPATH%%:*}" || gp=~/go
+    export GOMODCACHE="$gp/pkg/mod"
+    unset gp
+  fi
 fi
 
 # "--startup cmd ..." -> "--startup cmd --config=ci ..."

--- a/tools/bazel
+++ b/tools/bazel
@@ -16,24 +16,29 @@ if [ ! -d "${XDG_CACHE_HOME:-}" ]; then
   if [[ -e /.dockerenv || -e /run/.containerenv ]]; then
     >&2 echo "💡 To persist caches across restarts, please set XDG_CACHE_HOME pointing to a mounted directory, e.g.:"
     # shellcheck disable=SC2016
-    >&2 echo '    docker run --env=XDG_CACHE_HOME=/cache --volume="$HOME/.cache:/cache" ...'
+    >&2 echo '    docker run --env=XDG_CACHE_HOME=/cache --volume=~/.cache:/cache ...'
   fi
 fi
 
-# Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME` as per https://wiki.archlinux.org/title/XDG_Base_Directory
+# Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME`
 extra_args=()
 if [ -n "${XDG_CACHE_HOME:-}" ]; then
   if [[ "$XDG_CACHE_HOME" != /* ]]; then
     >&2 echo "🔴 XDG_CACHE_HOME ($XDG_CACHE_HOME) must denote an absolute path!"
     exit 2
   fi
-  unset GOCACHE                               # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
-  export GOMODCACHE="$XDG_CACHE_HOME"/go/mod  # https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
-  unset PIP_CACHE_DIR                         # https://pip.pypa.io/en/stable/topics/caching/#default-paths
+  export GOCACHE="$XDG_CACHE_HOME/go-build"
+  export GOMODCACHE="$XDG_CACHE_HOME/go/mod"
   extra_args+=(--disk_cache="$XDG_CACHE_HOME/bazel/disk-cache")
   # https://github.com/bazelbuild/bazel/issues/26384
   [ "$XDG_CACHE_HOME" = "$(dirname "$(dirname "$0")")/.cache" ] && extra_args+=(--repo_contents_cache=)
   [ -n "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ] && extra_args+=(--config=ci)
+else
+  # Without `XDG_CACHE_HOME`, fall back Go caches to official defaults so Go repo rules work under strict repo_env
+  [ -z "${GOCACHE:-}" ] && export GOCACHE=~/.cache/go-build
+  [ -n "${GOPATH:-}" ] && gp="${GOPATH%%:*}" || gp=~/go
+  export GOMODCACHE="${GOMODCACHE:-$gp/pkg/mod}"
+  unset gp
 fi
 
 # "--startup cmd ..." -> "--startup cmd --config=ci ..."
@@ -50,6 +55,4 @@ if [[ $# -gt 0 && ${#extra_args[@]} -gt 0 ]]; then
   set -- "${args[@]}"
 fi
 
-# Prevent rules_android from loading a system Android SDK - TODO(regis): replace with --experimental_strict_repo_env
-unset ANDROID_HOME
 exec "$BAZEL_REAL" "$@"

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -21,7 +21,7 @@ if not exist "%XDG_CACHE_HOME%" (
   )
 )
 
-:: Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME` as per https://wiki.archlinux.org/title/XDG_Base_Directory
+:: Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME`
 set "extra_args="
 if defined XDG_CACHE_HOME (
   set "XDG_CACHE_HOME=!XDG_CACHE_HOME:/=\!"
@@ -29,19 +29,22 @@ if defined XDG_CACHE_HOME (
     >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote an absolute path!
     exit /b 2
   )
-  :: https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
-  set "GOCACHE=%XDG_CACHE_HOME%\go-build"
-  :: https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
-  set "GOMODCACHE=%XDG_CACHE_HOME%\go\mod"
-  :: https://pip.pypa.io/en/stable/topics/caching/#default-paths
-  set "PIP_CACHE_DIR=%XDG_CACHE_HOME%\pip"
+  set "GOCACHE=!XDG_CACHE_HOME!\go-build"
+  set "GOMODCACHE=!XDG_CACHE_HOME!\go\mod"
+  set "PIP_CACHE_DIR=!XDG_CACHE_HOME!\pip"
   :: https://github.com/bazelbuild/bazel/issues/27808
-  set "bazel_home=%XDG_CACHE_HOME%\bazel"
+  set "bazel_home=!XDG_CACHE_HOME!\bazel"
   set bazel_home_startup_option="--output_user_root=!bazel_home!"
   set extra_args="--disk_cache=!bazel_home!\disk-cache"
   :: https://github.com/bazelbuild/bazel/issues/26384
   for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" set "extra_args=!extra_args! --repo_contents_cache="
   if defined CI if not defined GITHUB_ACTIONS set "extra_args=!extra_args! --config=ci"
+) else (
+  :: Without XDG_CACHE_HOME, fall back Go caches to official defaults so Go repo rules work under strict repo_env
+  if not defined GOCACHE set "GOCACHE=%LOCALAPPDATA%\go-build"
+  if defined GOPATH (for /f "tokens=1 delims=;" %%i in ("%GOPATH%") do set "gp=%%i") else set "gp=%USERPROFILE%\go"
+  if not defined GOMODCACHE set "GOMODCACHE=!gp!\pkg\mod"
+  set "gp="
 )
 
 :: Check legacy max path length of 260 characters got lifted, or fail with instructions
@@ -59,8 +62,6 @@ if not exist "!more_than_260_chars!" (
 
 set "args=%*"
 if defined args if defined extra_args call :insert_extra_args
-:: Prevent rules_android from loading a system Android SDK - TODO(regis): replace with --experimental_strict_repo_env
-set "ANDROID_HOME="
 "%BAZEL_REAL%" !bazel_home_startup_option! !args!
 exit /b !errorlevel!
 

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -42,9 +42,11 @@ if defined XDG_CACHE_HOME (
 ) else (
   :: Without XDG_CACHE_HOME, fall back Go caches to official defaults so Go repo rules work under strict repo_env
   if not defined GOCACHE set "GOCACHE=%LOCALAPPDATA%\go-build"
-  if defined GOPATH (for /f "tokens=1 delims=;" %%i in ("%GOPATH%") do set "gp=%%i") else set "gp=%USERPROFILE%\go"
-  if not defined GOMODCACHE set "GOMODCACHE=!gp!\pkg\mod"
-  set "gp="
+  if not defined GOMODCACHE (
+    if defined GOPATH (for /f "tokens=1 delims=;" %%i in ("%GOPATH%") do set "gp=%%i") else set "gp=%USERPROFILE%\go"
+    set "GOMODCACHE=!gp!\pkg\mod"
+    set "gp="
+  )
 )
 
 :: Check legacy max path length of 260 characters got lifted, or fail with instructions


### PR DESCRIPTION
### What does this PR do?
Add `--experimental_strict_repo_env` (bazelbuild/bazel#28189): only PATH (and PATHEXT on Windows) plus variables explicitly forwarded via `--repo_env` are now visible to repository rules.

Drop `--incompatible_strict_action_env`, which graduated to the default in Bazel 9 (bazelbuild/bazel#27670).

Forward `GOCACHE`, `GOMODCACHE`, and `XDG_CACHE_HOME` to all platforms via `--repo_env`, as well as `Environment values available for packaging`:
https://github.com/DataDog/datadog-agent/blob/fa38b7e14170db0f6bfed0208493b76916c04731/MODULE.bazel#L7-L23
On Windows, also forward `PIP_CACHE_DIR`, `VSTUDIO_ROOT`, `SYSTEMDRIVE` (needed by vswhere to locate the VS installer instance database), `SYSTEMROOT` (needed by COM to load system DLLs), and `USERPROFILE` (needed by git to fetch repositories).

Explicitly set `GOCACHE` in `tools/bazel[.bat]`:
- on Linux, Go derives `GOCACHE` from `XDG_CACHE_HOME` so having it unset or set to the same derived value is **neutral**,
- on macOS, Go doesn't happen to honor XDG yet, so strict `repo_env` (which strips `HOME`) exposed the gap, which is now **fixed**,
- on Windows, `GOCACHE` was already set in the XDG branch but via `%XDG_CACHE_HOME%` (parse-time expansion) rather than `!XDG_CACHE_HOME!` (delayed), yielding a path with forward slashes before `XDG_CACHE_HOME` was normalised - also **fixed**.

When `XDG_CACHE_HOME` is absent, forward `GOCACHE` and `GOMODCACHE` (to their official defaults unless explicitly set at user's discretion), so Go repo rules always receive non-empty values for both.

What's mentioned above allows to drop null environment overrides (`"GOPATH": None` from both `go_fast` and `go_sdk_overrides`, `"GOROOT": None` from `go_sdk_overrides` only): the flag already strips these from the repo-rule environment, making explicit unsetting redundant.

Switch `_get_vs_property()` in `visual_studio.bzl` from `ctx.execute()` to `repo_utils.execute_checked()`, which:
- fixes a pre-existing `fail()` format bug,
- includes `stdout` in the error message automatically (`vswhere` prints to it),
- overall brings a more actionable error output.

Finally, remove the `ANDROID_HOME` workaround from `tools/bazel[.bat]` (follow-up of #49125).

### Motivation
Without this flag, any variable set on the host leaks silently into repository rules, causing non-reproducible builds and cross-platform divergence, leading to adhoc fixes like bazelbuild/bazel#27670 or bazelbuild/bazel#28189.

We don't want that to happen again which means no variables other than explicitly allow-listed should spuriously alter repositories rules.

:bulb: Users still have the option to pass additional `--repo_env` parameters to `bazel` on their end should they need: corporate proxy, etc.

### Describe how you validated your changes
- local Windows VM,
- CI.

### Additional Notes
- bazelbuild/bazel#27670
- bazelbuild/bazel#28189
- #48032
- #49125