### PR TITLE
[procmgr] Make nix dep unix-only, add windows-sys for Windows port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "tonic-reflection",
  "tower 0.4.13",
  "uuid",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ zip = { version = "2.1", default-features = false, features = ["deflate"] }
 
 tower = "0.4"
 uuid = { version = "1", features = ["v4"] }
+windows-sys = { version = "0.59", features = [] }
 
 # dev-dependencies
 dircpy = "0.3.19"

--- a/pkg/procmgr/rust/Cargo.toml
+++ b/pkg/procmgr/rust/Cargo.toml
@@ -23,7 +23,6 @@ anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 hyper-util = { workspace = true, features = ["tokio"] }
 log.workspace = true
-nix = { workspace = true, features = ["signal", "process"] }
 prost.workspace = true
 prost-types.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -37,8 +36,22 @@ tonic-reflection.workspace = true
 tower.workspace = true
 uuid.workspace = true
 
-[dev-dependencies]
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true, features = ["signal", "process"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+    "Win32_System_Console",
+    "Win32_Security",
+] }
+
+[target.'cfg(unix)'.dev-dependencies]
 nix = { workspace = true, features = ["signal", "process", "user"] }
+
+[dev-dependencies]
 tempfile.workspace = true
 
 [build-dependencies]


### PR DESCRIPTION
### What does this PR do?

Makes the `nix` crate dependency conditional on `cfg(unix)` and adds `windows-sys` under `cfg(windows)` in the procmgr Cargo.toml. This is a no-op on Unix: the same `nix` dependency resolves as before. On Windows, the `windows-sys` crate with Win32 features (Job Objects, Console, Threading, Security) will be available for the upcoming platform abstraction layer.

### Motivation

First step in porting dd-procmgrd to Windows. The platform abstraction (next PR) needs `windows-sys` for process management APIs, and `nix` must be unix-only since it doesn't compile on Windows.

### Describe how you validated your changes

- `cargo check` passes
- `cargo test --lib` passes (131/131 tests)
- No production code changes -- only dependency wiring

### Additional Notes

Part of a series of incremental PRs to port procmgr to Windows. Each PR is independently CI-green. Next step: S02 (create `platform/` module with Unix impl + Windows stubs).