### PR TITLE
Reduce IoT agent on-disk package size

### DIFF
--- a/cmd/iot-agent/subcommands/subcommands.go
+++ b/cmd/iot-agent/subcommands/subcommands.go
@@ -14,8 +14,6 @@ import (
 	cmdcheck "github.com/DataDog/datadog-agent/cmd/agent/subcommands/check"
 	cmdconfig "github.com/DataDog/datadog-agent/cmd/agent/subcommands/config"
 	cmdconfigcheck "github.com/DataDog/datadog-agent/cmd/agent/subcommands/configcheck"
-	cmdcontrolsvc "github.com/DataDog/datadog-agent/cmd/agent/subcommands/controlsvc"
-	cmdcoverage "github.com/DataDog/datadog-agent/cmd/agent/subcommands/coverage"
 	cmddiagnose "github.com/DataDog/datadog-agent/cmd/agent/subcommands/diagnose"
 	cmddogstatsd "github.com/DataDog/datadog-agent/cmd/agent/subcommands/dogstatsd"
 	cmddogstatsdcapture "github.com/DataDog/datadog-agent/cmd/agent/subcommands/dogstatsdcapture"
@@ -25,14 +23,10 @@ import (
 	cmdhealth "github.com/DataDog/datadog-agent/cmd/agent/subcommands/health"
 	cmdhostname "github.com/DataDog/datadog-agent/cmd/agent/subcommands/hostname"
 	cmdimport "github.com/DataDog/datadog-agent/cmd/agent/subcommands/import"
-	cmdintegrations "github.com/DataDog/datadog-agent/cmd/agent/subcommands/integrations"
-	cmdjmx "github.com/DataDog/datadog-agent/cmd/agent/subcommands/jmx"
-	cmdlaunchgui "github.com/DataDog/datadog-agent/cmd/agent/subcommands/launchgui"
 	cmdremoteconfig "github.com/DataDog/datadog-agent/cmd/agent/subcommands/remoteconfig"
 	cmdrun "github.com/DataDog/datadog-agent/cmd/agent/subcommands/run"
 	cmdsecret "github.com/DataDog/datadog-agent/cmd/agent/subcommands/secret"
 	cmdsecrethelper "github.com/DataDog/datadog-agent/cmd/agent/subcommands/secrethelper"
-	cmdsnmp "github.com/DataDog/datadog-agent/cmd/agent/subcommands/snmp"
 	cmdstatus "github.com/DataDog/datadog-agent/cmd/agent/subcommands/status"
 	cmdstop "github.com/DataDog/datadog-agent/cmd/agent/subcommands/stop"
 	cmdstreamep "github.com/DataDog/datadog-agent/cmd/agent/subcommands/streamep"
@@ -58,23 +52,17 @@ func IotAgentSubcommands() []command.SubcommandFactory {
 		cmdhealth.Commands,
 		cmdhostname.Commands,
 		cmdimport.Commands,
-		cmdlaunchgui.Commands,
 		cmdanalyzelogs.Commands,
 		cmdremoteconfig.Commands,
 		cmdrun.Commands,
 		cmdsecret.Commands,
-		cmdsnmp.Commands,
+		cmdsecrethelper.Commands,
 		cmdstatus.Commands,
 		cmdstreamlogs.Commands,
 		cmdstreamep.Commands,
 		cmdtaggerlist.Commands,
 		cmdversion.Commands,
 		cmdworkloadlist.Commands,
-		cmdjmx.Commands,
-		cmdsecrethelper.Commands,
-		cmdintegrations.Commands,
 		cmdstop.Commands,
-		cmdcontrolsvc.Commands,
-		cmdcoverage.Commands,
 	}
 }

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -297,11 +297,12 @@ def render_config(ctx, env, flavor, skip_assets, build_tags, development, window
 
     generate_config(ctx, build_type=build_type, output_file="./cmd/agent/dist/datadog.yaml", env=env)
 
-    # On Linux and MacOS, render the system-probe configuration file template
-    if sys.platform != 'win32' or windows_sysprobe:
-        generate_config(ctx, build_type="system-probe", output_file="./cmd/agent/dist/system-probe.yaml", env=env)
+    if not flavor.is_iot():
+        # On Linux and MacOS, render the system-probe configuration file template
+        if sys.platform != 'win32' or windows_sysprobe:
+            generate_config(ctx, build_type="system-probe", output_file="./cmd/agent/dist/system-probe.yaml", env=env)
 
-    generate_config(ctx, build_type="security-agent", output_file="./cmd/agent/dist/security-agent.yaml", env=env)
+        generate_config(ctx, build_type="security-agent", output_file="./cmd/agent/dist/security-agent.yaml", env=env)
 
     if not skip_assets:
         refresh_assets(ctx, build_tags, development=development, flavor=flavor.name, windows_sysprobe=windows_sysprobe)
@@ -342,12 +343,12 @@ def refresh_assets(_, build_tags, development=True, flavor=AgentFlavor.base.name
         bin_ddagent = os.path.join(BIN_PATH, "dd-agent")
         shutil.move(os.path.join(dist_folder, "dd-agent"), bin_ddagent)
 
-    # System probe not supported on windows
-    if sys.platform != 'win32' or windows_sysprobe:
-        shutil.copy("./cmd/agent/dist/system-probe.yaml", os.path.join(dist_folder, "system-probe.yaml"))
-    shutil.copy("./cmd/agent/dist/datadog.yaml", os.path.join(dist_folder, "datadog.yaml"))
+    if not flavor.is_iot():
+        if sys.platform != 'win32' or windows_sysprobe:
+            shutil.copy("./cmd/agent/dist/system-probe.yaml", os.path.join(dist_folder, "system-probe.yaml"))
+        shutil.copy("./cmd/agent/dist/security-agent.yaml", os.path.join(dist_folder, "security-agent.yaml"))
 
-    shutil.copy("./cmd/agent/dist/security-agent.yaml", os.path.join(dist_folder, "security-agent.yaml"))
+    shutil.copy("./cmd/agent/dist/datadog.yaml", os.path.join(dist_folder, "datadog.yaml"))
 
     for check in AGENT_CORECHECKS if not flavor.is_iot() else IOT_AGENT_CORECHECKS:
         check_dir = os.path.join(dist_folder, f"conf.d/{check}.d/")
@@ -379,12 +380,13 @@ def refresh_assets(_, build_tags, development=True, flavor=AgentFlavor.base.name
             os.path.join(dist_folder, "conf.d/process_agent.yaml.default"),
         )
 
-    shutil.copytree(
-        "./comp/core/gui/guiimpl/views/private",
-        os.path.join(dist_folder, "views"),
-        ignore=shutil.ignore_patterns("BUILD.bazel"),
-        dirs_exist_ok=True,
-    )
+    if not flavor.is_iot():
+        shutil.copytree(
+            "./comp/core/gui/guiimpl/views/private",
+            os.path.join(dist_folder, "views"),
+            ignore=shutil.ignore_patterns("BUILD.bazel"),
+            dirs_exist_ok=True,
+        )
     if development:
         shutil.copytree("./dev/dist/", dist_folder, ignore=shutil.ignore_patterns("BUILD.bazel"), dirs_exist_ok=True)
 


### PR DESCRIPTION
The IoT agent static quality gates are failing because the package on-disk size exceeded the quota. This change applies three size reductions:

1. Skip GUI web assets (views/private) for IoT flavor (~1.4 MB) The IoT agent runs on Linux where the GUI is disabled by default (GUI_port=-1). The 1.4 MB of fonts, JavaScript, and CSS served no purpose in the package.

2. Skip system-probe.yaml and security-agent.yaml for IoT flavor The IoT agent doesn't use system-probe or security-agent, so generating and shipping their config templates is wasteful.

3. Remove unnecessary subcommands from the IoT agent binary
   - snmp: pulls in snmpscan, eventplatform, orchestrator — not an IoT feature and has no build-tag guard
   - launchgui: GUI is disabled on Linux, this command always errors
   - jmx, integrations: already compile to nil stubs without their build tags, but removing the imports is cleaner
   - controlsvc, coverage: already compile to nil stubs on Linux / without e2ecoverage tag

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
