### PR TITLE
Handle STATUS_NAME_TOO_LONG in gMSA check

### DIFF
--- a/pkg/fleet/installer/packages/user/windows/user.go
+++ b/pkg/fleet/installer/packages/user/windows/user.go
@@ -239,6 +239,13 @@ func IsServiceAccount(sid *windows.SID) (bool, error) {
 			// At this point we know the account does exist, so we won't treat this as an error and instead
 			// will assume the account is a regular domain account.
 			return false, nil
+		} else if errors.Is(err, STATUS_NAME_TOO_LONG) {
+			// This error can be returned when the domain name portion of the account name
+			// cannot be resolved, e.g. when querying a trusted/parent domain.
+			// Similar to STATUS_INVALID_ACCOUNT_NAME, at this point we know the account
+			// does exist (SID lookup succeeded), so we assume the account is a regular
+			// domain account.
+			return false, nil
 		}
 
 		// Do not add punctuation after %w, the error message already contains it.

--- a/pkg/fleet/installer/packages/user/windows/winapi.go
+++ b/pkg/fleet/installer/packages/user/windows/winapi.go
@@ -31,6 +31,7 @@ var (
 //revive:disable:var-naming match Windows status code names
 const (
 	STATUS_OBJECT_NAME_NOT_FOUND = windows.NTStatus(0xC0000034)
+	STATUS_NAME_TOO_LONG         = windows.NTStatus(0xC0000106)
 )
 
 // MSA_INFO_STATE

--- a/releasenotes/notes/windows-fleet-handle-status-name-too-long-4f3d9a6e58f1b2c7.yaml
+++ b/releasenotes/notes/windows-fleet-handle-status-name-too-long-4f3d9a6e58f1b2c7.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Windows: Fixed a remote update failure in ``datadog-installer`` when validating Agent domain accounts.
+
+    When querying some domain account names, ``NetQueryServiceAccount`` can return NTSTATUS ``0xC0000106``
+    (``STATUS_NAME_TOO_LONG``) during gMSA detection. This status is now treated like
+    ``STATUS_INVALID_ACCOUNT_NAME`` so the account is handled as a regular domain account instead of
+    incorrectly failing the update.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"cbac7a45-b65f-46a3-90f3-e7708a43f4aa","source":"chat","resourceId":"9f3abb9e-4d3c-4ebf-9d55-19802097c570","workflowId":"08895a7a-47da-42b9-b677-0a58b561bd49","codeChangeId":"08895a7a-47da-42b9-b677-0a58b561bd49","sourceType":"assistant"} -->
### What does this PR do?

Handles the `STATUS_NAME_TOO_LONG` (0xC0000106) NTSTATUS error returned by `NetQueryServiceAccount` in the Windows gMSA account check. This error can occur when the domain name portion of an account cannot be resolved, particularly when querying trusted or parent domains.

### Motivation

The Datadog installer was failing on remote updates when checking if an account is a service account. The `IsServiceAccount` function only handled `STATUS_OPEN_FAILED` and `STATUS_INVALID_ACCOUNT_NAME` errors, but `STATUS_NAME_TOO_LONG` was not handled and fell through to the generic error case, blocking updates entirely.

Since the SID lookup has already succeeded at this point, we know the account exists. Following the same logic as `STATUS_INVALID_ACCOUNT_NAME`, we can safely assume the account is a regular domain account when this error occurs.

### Describe how you validated your changes

- Added the `STATUS_NAME_TOO_LONG` constant definition to `winapi.go` to match Windows API NTSTATUS codes
- Added error handling in `IsServiceAccount` function that returns `false, nil` (indicating a regular domain account) when this error is encountered
- The fix mirrors the existing `STATUS_INVALID_ACCOUNT_NAME` handler, maintaining consistency in error handling logic
- Updated release notes to document the fix for end users

### Additional Notes

This fix allows the installer to proceed with remote updates for accounts where the domain name resolution fails during the gMSA check, since the account's existence has already been confirmed via SID lookup.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/9f3abb9e-4d3c-4ebf-9d55-19802097c570)

Comment @datadog to request changes