### PR TITLE
fix(ci): don't treat non-Go file directories as Go packages in impacted test selection

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -693,7 +693,12 @@ def get_impacted_packages(ctx, build_tags=None):
     base_branch = _get_release_json_value("base_branch")
     files = get_modified_files(ctx, base_branch=base_branch)
     print(f"Detected the following modified files: {files}")
-    modified_packages = {f"github.com/DataDog/datadog-agent/{os.path.dirname(file)}" for file in files}
+    # Only .go files directly identify their containing directory as a Go package.
+    # Non-Go files (fixtures, Cargo.toml, etc.) are resolved to the nearest
+    # ancestor Go package by the walk-up loop below.
+    modified_packages = {
+        f"github.com/DataDog/datadog-agent/{os.path.dirname(file)}" for file in files if file.endswith(".go")
+    }
 
     # Modification to go.mod and go.sum should force the tests of the whole module to run
     for file in files:
@@ -704,7 +709,8 @@ def get_impacted_packages(ctx, build_tags=None):
                 ).stdout.splitlines()
                 modified_packages.update(set(all_packages))
 
-    # Modification to fixture folders count as modification to their parent package
+    # Modification to non-Go files (fixtures, testdata, etc.) count as
+    # modification to the nearest ancestor package that contains Go sources.
     for file in files:
         if not file.endswith(".go"):
             formatted_path = Path(os.path.dirname(file)).as_posix()


### PR DESCRIPTION
### What does this PR do?

Fixes `get_impacted_packages` in `tasks/gotest.py` so that non-Go file directories (e.g. `pkg/procmgr/rust/`) are no longer blindly added as Go packages. Only `.go` files now produce direct package entries at line 696; non-Go files continue to be resolved to their nearest ancestor Go package via the existing walk-up loop (lines 712-722).

### Motivation

#48450 switched from `get_go_modified_files` to `get_modified_files` so that fixture/testdata changes trigger their parent package's tests. A side-effect is that line 696 adds `os.path.dirname(file)` for *every* modified file — including files in directories with no Go sources (e.g. Rust's `Cargo.toml`). This causes CI to invoke `go test ./pkg/procmgr/rust/...`, which fails with `go: warning: "..." matched no packages`.

The walk-up loop at lines 712-722 already handles non-Go files correctly by finding the nearest ancestor directory containing `*.go` files. This fix simply stops line 696 from also adding the raw (possibly non-Go) directory, while fully preserving the fixture-detection behavior introduced by #48450.

### Describe how you validated your changes

- Traced the code path for the motivating fixture case (`pkg/foo/testdata/data.json` → walk-up finds `pkg/foo` → tests run) — behavior preserved.
- Traced the failing case (`pkg/procmgr/rust/Cargo.toml`) — no longer produces a phantom `./pkg/procmgr/rust` test target.
- Verified existing unit tests in `tasks/unit_tests/go_tests.py` still pass (they cover `find_impacted_packages` and `should_run_all_tests`, which are not affected).

### Additional Notes

Regression introduced by #48450 (merged 2026-03-27). Only affects PRs that modify non-Go files in directories without Go sources — e.g. Rust crate files under `pkg/procmgr/rust/`.