### PR TITLE
Bump the IoT gates to enable the development

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -78,7 +78,7 @@ static_quality_gate_dogstatsd_suse_amd64:
   max_on_wire_size: 8.8 MiB
 static_quality_gate_iot_agent_deb_amd64:
   max_on_disk_size: 44.29 MiB
-  max_on_wire_size: 11.04 MiB
+  max_on_wire_size: 13.04 MiB
 static_quality_gate_iot_agent_deb_arm64:
   max_on_disk_size: 41.92 MiB
   max_on_wire_size: 11.45 MiB

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -77,17 +77,17 @@ static_quality_gate_dogstatsd_suse_amd64:
   max_on_disk_size: 30.61 MiB
   max_on_wire_size: 8.8 MiB
 static_quality_gate_iot_agent_deb_amd64:
-  max_on_disk_size: 43.29 MiB
-  max_on_wire_size: 12.04 MiB
+  max_on_disk_size: 44.29 MiB
+  max_on_wire_size: 11.04 MiB
 static_quality_gate_iot_agent_deb_arm64:
-  max_on_disk_size: 40.92 MiB
-  max_on_wire_size: 10.45 MiB
+  max_on_disk_size: 41.92 MiB
+  max_on_wire_size: 11.45 MiB
 static_quality_gate_iot_agent_deb_armhf:
-  max_on_disk_size: 41.10 MiB
-  max_on_wire_size: 10.62 MiB
+  max_on_disk_size: 42.10 MiB
+  max_on_wire_size: 11.62 MiB
 static_quality_gate_iot_agent_rpm_amd64:
-  max_on_disk_size: 43.29 MiB
-  max_on_wire_size: 12.06 MiB
+  max_on_disk_size: 44.29 MiB
+  max_on_wire_size: 13.06 MiB
 static_quality_gate_iot_agent_suse_amd64:
-  max_on_disk_size: 43.29 MiB
-  max_on_wire_size: 12.06 MiB
+  max_on_disk_size: 44.29 MiB
+  max_on_wire_size: 13.06 MiB


### PR DESCRIPTION
Giving temporary room for the IoT agent