### PR TITLE
[procmgr] Add platform abstraction module with Unix impl and Windows stubs

### DIFF
--- a/pkg/procmgr/rust/src/platform/mod.rs
+++ b/pkg/procmgr/rust/src/platform/mod.rs
@@ -3,14 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-pub mod command;
-pub mod config;
-pub mod env;
-pub mod grpc;
-pub mod manager;
-pub mod ordering;
-pub mod platform;
-pub mod process;
-pub mod shutdown;
-pub mod state;
-pub mod uuid_gen;
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use self::unix::*;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub use self::windows::*;

--- a/pkg/procmgr/rust/src/platform/unix.rs
+++ b/pkg/procmgr/rust/src/platform/unix.rs
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use anyhow::{Context, Result};
+use nix::sys::signal::{self, Signal};
+use nix::unistd::Pid;
+use std::os::unix::process::ExitStatusExt;
+
+/// Place the child in its own process group so signals don't propagate
+/// to the daemon itself and SIGTERM can target all descendants.
+pub fn configure_command(cmd: &mut tokio::process::Command) {
+    cmd.process_group(0);
+}
+
+/// Send SIGTERM to the entire process group (graceful stop).
+pub fn send_graceful_stop(pid: u32) -> Result<()> {
+    let raw = i32::try_from(pid).context("PID overflows i32")?;
+    signal::kill(Pid::from_raw(-raw), Signal::SIGTERM)
+        .with_context(|| format!("failed to send SIGTERM to pgid {pid}"))?;
+    Ok(())
+}
+
+/// Send SIGKILL to the entire process group (force kill).
+pub fn send_force_kill(pid: u32) -> Result<()> {
+    let raw = i32::try_from(pid).context("PID overflows i32")?;
+    signal::kill(Pid::from_raw(-raw), Signal::SIGKILL)
+        .with_context(|| format!("failed to send SIGKILL to pgid {pid}"))?;
+    Ok(())
+}
+
+/// Extract the signal number from an exit status, if the process was
+/// terminated by a signal.
+pub fn last_signal(status: &std::process::ExitStatus) -> Option<i32> {
+    status.signal()
+}
+
+/// Wait for a shutdown trigger (SIGTERM or SIGINT).
+pub async fn shutdown_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+    let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
+    let mut sigint = signal(SignalKind::interrupt()).expect("failed to register SIGINT handler");
+    tokio::select! {
+        _ = sigterm.recv() => { log::info!("received SIGTERM"); }
+        _ = sigint.recv() => { log::info!("received SIGINT"); }
+    }
+}

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use anyhow::Result;
+
+/// Configure the child process for Windows: create a new process group
+/// and assign to a Job Object so all descendants can be managed together.
+pub fn configure_command(_cmd: &mut tokio::process::Command) {
+    unimplemented!("Windows process group configuration not yet implemented")
+}
+
+/// Send a graceful stop signal (CTRL_BREAK_EVENT via GenerateConsoleCtrlEvent).
+pub fn send_graceful_stop(_pid: u32) -> Result<()> {
+    unimplemented!("Windows graceful stop not yet implemented")
+}
+
+/// Force-kill the process and all descendants (TerminateJobObject / TerminateProcess).
+pub fn send_force_kill(_pid: u32) -> Result<()> {
+    unimplemented!("Windows force kill not yet implemented")
+}
+
+/// On Windows, processes don't have Unix signals.
+pub fn last_signal(_status: &std::process::ExitStatus) -> Option<i32> {
+    None
+}
+
+/// Wait for a shutdown trigger (Ctrl+C or service stop event).
+pub async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to register Ctrl+C handler");
+    log::info!("received Ctrl+C");
+}


### PR DESCRIPTION
### What does this PR do?

Adds a `platform` module (`src/platform/{mod,unix,windows}.rs`) that encapsulates all OS-specific process operations behind a uniform API:

- `configure_command(cmd)` — set up process group (Unix) / job object (Windows)
- `send_graceful_stop(pid)` — SIGTERM to process group (Unix) / `GenerateConsoleCtrlEvent` (Windows)
- `send_force_kill(pid)` — SIGKILL to process group (Unix) / `TerminateProcess` (Windows)
- `last_signal(status)` — extract signal from `ExitStatus` (Unix) / always `None` (Windows)
- `shutdown_signal()` — await SIGTERM/SIGINT (Unix) / Ctrl+C (Windows)

The Unix implementation wraps the existing `nix` calls. The Windows implementation provides `unimplemented!()` stubs (except `shutdown_signal` which uses `tokio::signal::ctrl_c()`), allowing the crate to compile for Windows targets. Production code is not yet migrated to use this module — that follows in subsequent PRs.

### Motivation

Step 2 of the `dd-procmgrd` Windows port. The platform module establishes the abstraction boundary so that later steps can replace direct `nix::` calls in `process.rs` and `manager.rs` with `platform::` calls, making the daemon cross-platform.

### Describe how you validated your changes

- `cargo check` — compiles cleanly on macOS/Linux
- `cargo test --lib` — all 131 existing tests pass, no regressions
- Reviewed that Windows stubs match the Unix function signatures

### Additional Notes

Builds on #48727. Windows stubs will be replaced with real implementations in a later step (S19).