### PR TITLE
[CONTP-1050] Remove duplicate default namespace filtering from MutationFilter.

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1551,27 +1551,7 @@ func TestAutoinstrumentation(t *testing.T) {
 				unmutatedContainers: []string{"istio-proxy"},
 			},
 		},
-		"injection does not occur in the namespace where datadog is deployed": {
-			config: map[string]any{
-				"apm_config.instrumentation.enabled": true,
-				"kube_resources_namespace":           "datadog-test",
-			},
-			pod: common.FakePodSpec{
-				Name:       "test",
-				NS:         "datadog-test",
-				ParentKind: "replicaset",
-				ParentName: "deployment-123",
-			}.Create(),
-			deployments: []common.MockDeployment{
-				{
-					ContainerName:  defaultTestContainer,
-					DeploymentName: "deployment",
-					Namespace:      "datadog-test",
-				},
-			},
-			shouldMutate: false,
-		},
-		"injection does occur in the outside the datadog namespace": {
+		"injection does occur outside the datadog namespace": {
 			config: map[string]any{
 				"apm_config.instrumentation.enabled": true,
 				"kube_resources_namespace":           "datadog-test",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -49,15 +49,11 @@ type TargetMutator struct {
 // NewTargetMutator creates a new mutator for target based workload selection. We convert the targets to a more
 // efficient internal format for quick lookups.
 func NewTargetMutator(config *Config, wmeta workloadmeta.Component, imageResolver imageresolver.Resolver) (*TargetMutator, error) {
-	// Determine default disabled namespaces.
-	defaultDisabled := mutatecommon.DefaultDisabledNamespaces()
-
-	// Create a map of disabled namespaces for quick lookups.
-	disabledNamespacesMap := make(map[string]bool, len(config.Instrumentation.DisabledNamespaces)+len(defaultDisabled))
+	// Create a map of user-configured disabled namespaces for quick lookups.
+	// Default namespaces (kube-system, datadog agent namespace) are excluded at
+	// the webhook layer via namespace selectors and not duplicated here.
+	disabledNamespacesMap := make(map[string]bool, len(config.Instrumentation.DisabledNamespaces))
 	for _, ns := range config.Instrumentation.DisabledNamespaces {
-		disabledNamespacesMap[ns] = true
-	}
-	for _, ns := range defaultDisabled {
 		disabledNamespacesMap[ns] = true
 	}
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -403,13 +403,13 @@ func TestIsNamespaceEligible(t *testing.T) {
 			},
 			expected: false,
 		},
-		"a common disabled namespace is not eligible": {
+		"kube-system is eligible because default namespaces are filtered at the webhook layer": {
 			configPath: "testdata/filter_no_default.yaml",
 			in:         "kube-system",
 			namespaces: []workloadmeta.KubernetesMetadata{
 				newTestNamespace("kube-system", nil),
 			},
-			expected: false,
+			expected: true,
 		},
 	}
 
@@ -698,7 +698,7 @@ func TestGetTargetLibraries(t *testing.T) {
 				},
 			},
 		},
-		"a default disabled namespace gets no tracers": {
+		"kube-system matches target because default namespaces are filtered at the webhook layer": {
 			configPath: "testdata/filter.yaml",
 			in: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -711,7 +711,11 @@ func TestGetTargetLibraries(t *testing.T) {
 			namespaces: []workloadmeta.KubernetesMetadata{
 				newTestNamespace("kube-system", nil),
 			},
-			expected: nil,
+			expected: &targetInternal{
+				libVersions: []libInfo{
+					defaultLibInfoWithVersion(java, "v1"),
+				},
+			},
 		},
 		"enabled namespace gets converted to target": {
 			configPath: "testdata/enabled_namespaces.yaml",

--- a/pkg/clusteragent/admission/mutate/common/filter.go
+++ b/pkg/clusteragent/admission/mutate/common/filter.go
@@ -84,25 +84,21 @@ func (f *DefaultFilter) IsNamespaceEligible(ns string) bool {
 }
 
 // makeNamespaceFilter returns a filter with the provided enabled/disabled namespaces.
-// The filter excludes two namespaces by default: "kube-system" and the
-// namespace where datadog is installed.
+// Default namespaces (kube-system, datadog agent namespace) are NOT excluded here;
+// they are excluded at the webhook layer via namespace selectors.
 //
 // Cases:
-//   - No enabled namespaces and no disabled namespaces: inject in all namespaces
-//     except the 2 namespaces excluded by default.
+//   - No enabled namespaces and no disabled namespaces: inject in all namespaces.
 //   - Enabled namespaces and no disabled namespaces: inject only in the
-//     namespaces specified in the list of enabled namespaces. If one of the
-//     namespaces excluded by default is included in the list, it will be injected.
+//     namespaces specified in the list of enabled namespaces.
 //   - Disabled namespaces and no enabled namespaces: inject only in the
-//     namespaces that are not included in the list of disabled namespaces and that
-//     are not one of the ones disabled by default.
+//     namespaces that are not included in the list of disabled namespaces.
 //   - Enabled and disabled namespaces: return error.
 func makeNamespaceFilter(enabledNamespaces, disabledNamespaces []string) (*containers.Filter, error) {
 	if len(enabledNamespaces) > 0 && len(disabledNamespaces) > 0 {
 		return nil, errors.New("enabled_namespaces and disabled_namespaces configuration cannot be set together")
 	}
 
-	// Prefix the namespaces as needed by the containers.Filter.
 	prefix := containers.KubeNamespaceFilterPrefix
 	enabledNamespacesWithPrefix := make([]string, len(enabledNamespaces))
 	disabledNamespacesWithPrefix := make([]string, len(disabledNamespaces))
@@ -114,20 +110,14 @@ func makeNamespaceFilter(enabledNamespaces, disabledNamespaces []string) (*conta
 		disabledNamespacesWithPrefix[i] = prefix + fmt.Sprintf("^%s$", disabledNamespaces[i])
 	}
 
-	defaultDisabled := DefaultDisabledNamespaces()
-	disabledByDefault := make([]string, len(defaultDisabled))
-	for i := range defaultDisabled {
-		disabledByDefault[i] = prefix + fmt.Sprintf("^%s$", defaultDisabled[i])
-	}
-
 	var filterExcludeList []string
 	if len(enabledNamespacesWithPrefix) > 0 && len(disabledNamespacesWithPrefix) == 0 {
-		// In this case, we want to include only the namespaces in the enabled list.
-		// In the containers.Filter, the include list is checked before the
-		// exclude list, that's why we set the exclude list to all namespaces.
+		// Include only the namespaces in the enabled list. The containers.Filter
+		// checks the include list before the exclude list, so we set the exclude
+		// list to all namespaces.
 		filterExcludeList = []string{prefix + ".*"}
 	} else {
-		filterExcludeList = append(disabledNamespacesWithPrefix, disabledByDefault...)
+		filterExcludeList = disabledNamespacesWithPrefix
 	}
 
 	return containers.NewFilter(containers.GlobalFilter, enabledNamespacesWithPrefix, filterExcludeList)


### PR DESCRIPTION
### What does this PR do?

Remove duplicate default namespace filtering from MutationFilter.

Webhook namespace selectors already exclude kube-system and the agent namespace. Drop the redundant checks from makeNamespaceFilter and TargetMutator so namespace-level filtering lives solely in the webhook layer.

### Motivation

Remove unnecessary extra filtering.

### Describe how you validated your changes

Unit tests + E2E tests.

### Additional Notes

This is a No-Op change, making the code cleaner. Users should not see any behavior change.