### PR TITLE
[EBPF] gpu: generate table with metric metadata

### DIFF
--- a/pkg/collector/corechecks/gpu/spec/aggregations.yaml
+++ b/pkg/collector/corechecks/gpu/spec/aggregations.yaml
@@ -1,0 +1,21 @@
+aggregations:
+  relative_activity:
+    description: "Relative measure of load/activity at a given point in time"
+    time_aggregator: "avg"
+    group-aggregator: "avg"
+    granularity_aggregator: "avg"
+  absolute_usage:
+    description: "Absolute measure of load/activity at a given point in time"
+    time_aggregator: "avg"
+    group-aggregator: "sum"
+    granularity_aggregator: "avg"
+  lifetime_error:
+    description: "Consistently increasing lifetime error counters"
+    time_aggregator: "max/last"
+    group-aggregator: "sum"
+    granularity_aggregator: "max"
+  sensor_data:
+    description: "GPU sensor readings"
+    time_aggregator: "avg"
+    group-aggregator: "avg"
+    granularity_aggregator: "avg"

--- a/pkg/collector/corechecks/gpu/spec/aggregations.yaml
+++ b/pkg/collector/corechecks/gpu/spec/aggregations.yaml
@@ -2,20 +2,20 @@ aggregations:
   relative_activity:
     description: "Relative measure of load/activity at a given point in time"
     time_aggregator: "avg"
-    group-aggregator: "avg"
+    group_aggregator: "avg"
     granularity_aggregator: "avg"
   absolute_usage:
     description: "Absolute measure of load/activity at a given point in time"
     time_aggregator: "avg"
-    group-aggregator: "sum"
+    group_aggregator: "sum"
     granularity_aggregator: "avg"
   lifetime_error:
     description: "Consistently increasing lifetime error counters"
     time_aggregator: "max/last"
-    group-aggregator: "sum"
+    group_aggregator: "sum"
     granularity_aggregator: "max"
   sensor_data:
     description: "GPU sensor readings"
     time_aggregator: "avg"
-    group-aggregator: "avg"
+    group_aggregator: "avg"
     granularity_aggregator: "avg"

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -241,7 +241,8 @@ metrics:
   clock.throttle_reasons.sync_boost:
     metadata:
       metric_type: gauge
-      description: GPU clocks that are throttled to match clock speed of another GPU in the current sync boost group
+      description: GPU clocks that are throttled to match clock speed of another GPU
+        in the current sync boost group
       aggregation:
         type: sensor_data
     tagsets:
@@ -260,6 +261,7 @@ metrics:
       metric_type: gauge
       unit: core
       description: Number of GPU cores that the process/container/device has available
+      used_in_dd_ui: true
       aggregation:
         type: absolute_usage
     tagsets:
@@ -296,6 +298,7 @@ metrics:
     metadata:
       metric_type: gauge
       description: Number of GPU devices found in the host
+      used_in_dd_ui: true
       aggregation:
         type: absolute_usage
     tagsets:
@@ -381,6 +384,7 @@ metrics:
   errors.ecc.uncorrected.total:
     metadata:
       metric_type: gauge
+      used_in_dd_ui: true
       description: >-
         Uncorrectable ECC (Error Correcting Code) errors indicate GPU memory
         corruption that could not be automatically fixed. These errors can lead
@@ -472,6 +476,7 @@ metrics:
   errors.xid.total:
     metadata:
       metric_type: gauge
+      used_in_dd_ui: true
       description: >-
         XID errors are NVIDIA driver error codes that indicate GPU hardware or
         software issues like thermal throttling to hardware defects.
@@ -510,7 +515,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the time that the 16-bit floating point calculation engine was active. Only for Hopper and newer GPUs
+      description: Percentage of the time that the 16-bit floating point calculation
+        engine was active. Only for Hopper and newer GPUs
     tagsets:
       - device
     aggregation:
@@ -533,7 +539,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the time that the 32-bit floating point calculation engine was active. Only for Hopper and newer GPUs
+      description: Percentage of the time that the 32-bit floating point calculation
+        engine was active. Only for Hopper and newer GPUs
     tagsets:
       - device
     aggregation:
@@ -556,7 +563,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the time that the 64-bit floating point calculation engine was active. Only for Hopper and newer GPUs
+      description: Percentage of the time that the 64-bit floating point calculation
+        engine was active. Only for Hopper and newer GPUs
     tagsets:
       - device
     aggregation:
@@ -580,6 +588,7 @@ metrics:
       metric_type: gauge
       unit: percent
       description: Percentage of time that the graphics engine was active
+      used_in_dd_ui: true
     tagsets:
       - device
     aggregation:
@@ -595,7 +604,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the time that the integer calculation engine was active. Only for Hopper and newer GPUs
+      description: Percentage of the time that the integer calculation engine was
+        active. Only for Hopper and newer GPUs
     tagsets:
       - device
     aggregation:
@@ -685,6 +695,7 @@ metrics:
       metric_type: gauge
       unit: byte
       description: The maximum amount of memory a process/container/device could allocate
+      used_in_dd_ui: true
       aggregation:
         type: absolute_usage
     tagsets:
@@ -1345,7 +1356,8 @@ metrics:
   nvlink.plr.tx.retry_events_within_t_sec_max:
     metadata:
       metric_type: gauge
-      description: Maximum NVLink PLR TX retry events within the configured time window for the port
+      description: Maximum NVLink PLR TX retry events within the configured time
+        window for the port
     tagsets:
       - device
     custom_tags:
@@ -1531,6 +1543,7 @@ metrics:
       metric_type: gauge
       unit: kilobyte/second
       description: Total RX of all NVLINK links
+      used_in_dd_ui: true
       aggregation:
         type: absolute_usage
     tagsets:
@@ -1554,6 +1567,7 @@ metrics:
       metric_type: gauge
       unit: kilobyte/second
       description: Total TX of all NVLINK links
+      used_in_dd_ui: true
       aggregation:
         type: absolute_usage
     tagsets:
@@ -1710,6 +1724,7 @@ metrics:
       metric_type: gauge
       unit: byte/second
       description: Bytes received through PCI to the GPU device per second
+      used_in_dd_ui: true
       aggregation:
         type: absolute_usage
     tagsets:
@@ -1730,6 +1745,7 @@ metrics:
       metric_type: gauge
       unit: byte/second
       description: Bytes transmitted through PCI from the GPU device per second
+      used_in_dd_ui: true
       aggregation:
         type: absolute_usage
     tagsets:
@@ -1811,9 +1827,10 @@ metrics:
       metric_type: gauge
       unit: milliwatt
       description: >-
-        Power usage for the GPU device. On GA100 and older architectures this
-        is the instantaneous power at that moment, in newer ones it represents
-        the average power draw over one second
+        Power usage for the GPU device. On GA100 and older architectures this is
+        the instantaneous power at that moment, in newer ones it represents the
+        average power draw over one second
+      used_in_dd_ui: true
     tagsets:
       - device
     aggregation:
@@ -1828,7 +1845,9 @@ metrics:
     metadata:
       metric_type: gauge
       unit: core
-      description: Average number of GPU cores that a process was using in the interval. Only emitted when processes are active.
+      description: Average number of GPU cores that a process was using in the
+        interval. Only emitted when processes are active.
+      used_in_dd_ui: true
       aggregation:
         type: absolute_usage
     workload_only: true
@@ -1907,7 +1926,9 @@ metrics:
     metadata:
       metric_type: gauge
       unit: byte
-      description: The memory used by this process at the point the metric was given. Only emitted when processes are active.
+      description: The memory used by this process at the point the metric was given.
+        Only emitted when processes are active.
+      used_in_dd_ui: true
       aggregation:
         type: absolute_usage
     workload_only: true
@@ -1929,7 +1950,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of time the streaming multiprocessor was active for a specific process
+      description: Percentage of time the streaming multiprocessor was active for a
+        specific process
       aggregation:
         type: relative_activity
     workload_only: true
@@ -2068,6 +2090,7 @@ metrics:
       metric_type: gauge
       unit: percent
       description: Percentage of time the streaming multiprocessor was active
+      used_in_dd_ui: true
       aggregation:
         type: relative_activity
     tagsets:
@@ -2086,7 +2109,9 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the Streaming Multiprocessors that were active in the interval
+      description: Percentage of the Streaming Multiprocessors that were active in the
+        interval
+      used_in_dd_ui: true
     tagsets:
       - device
     aggregation:
@@ -2109,7 +2134,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the Streaming Multiprocessors that were in use in the interval
+      description: Percentage of the Streaming Multiprocessors that were in use in the
+        interval
     tagsets:
       - device
     aggregation:
@@ -2133,6 +2159,7 @@ metrics:
       metric_type: gauge
       unit: degree celsius
       description: Temperature of the GPU device
+      used_in_dd_ui: true
       aggregation:
         type: sensor_data
     tagsets:
@@ -2151,7 +2178,8 @@ metrics:
     metadata:
       metric_type: gauge
       unit: percent
-      description: Percentage of the time that the tensor calculation engine was active. Only for Hopper and newer GPUs
+      description: Percentage of the time that the tensor calculation engine was
+        active. Only for Hopper and newer GPUs
     tagsets:
       - device
     aggregation:

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -19,10 +19,9 @@ metrics:
       metric_type: gauge
       unit: megahertz
       description: Current clock speed for the graphics domain
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -34,10 +33,9 @@ metrics:
       metric_type: gauge
       unit: megahertz
       description: Maximum clock speed for the graphics domain
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -49,10 +47,9 @@ metrics:
       metric_type: gauge
       unit: megahertz
       description: Current clock speed for the memory
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -64,10 +61,9 @@ metrics:
       metric_type: gauge
       unit: megahertz
       description: Maximum clock speed for the memory
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -79,10 +75,9 @@ metrics:
       metric_type: gauge
       unit: megahertz
       description: Current clock speed for the Streaming Multiprocessor
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -94,10 +89,9 @@ metrics:
       metric_type: gauge
       unit: megahertz
       description: Maximum clock speed for the Streaming Multiprocessor
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -109,10 +103,9 @@ metrics:
       metric_type: gauge
       unit: megahertz
       description: Current clock speed for the video encoder/decoder
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures:
         - fermi
@@ -125,10 +118,9 @@ metrics:
       metric_type: gauge
       unit: megahertz
       description: Maximum clock speed for the video encoder/decoder
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures:
         - fermi
@@ -140,8 +132,7 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are throttled due to application settings
-      aggregation:
-        type: sensor_data
+      aggregation: sensor_data
     tagsets:
       - device
     validator:
@@ -157,8 +148,7 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are throttled due to display clock settings
-      aggregation:
-        type: sensor_data
+      aggregation: sensor_data
     tagsets:
       - device
     validator:
@@ -174,8 +164,7 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are throttled due to the GPU being idle
-      aggregation:
-        type: sensor_data
+      aggregation: sensor_data
     tagsets:
       - device
     validator:
@@ -191,8 +180,7 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are not throttled
-      aggregation:
-        type: sensor_data
+      aggregation: sensor_data
     tagsets:
       - device
     validator:
@@ -208,8 +196,7 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are throttled to avoid exceeding power limits
-      aggregation:
-        type: sensor_data
+      aggregation: sensor_data
     tagsets:
       - device
     validator:
@@ -225,8 +212,7 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are throttled to avoid exceeding temperature limits
-      aggregation:
-        type: sensor_data
+      aggregation: sensor_data
     tagsets:
       - device
     validator:
@@ -243,8 +229,7 @@ metrics:
       metric_type: gauge
       description: GPU clocks that are throttled to match clock speed of another GPU
         in the current sync boost group
-      aggregation:
-        type: sensor_data
+      aggregation: sensor_data
     tagsets:
       - device
     validator:
@@ -262,8 +247,7 @@ metrics:
       unit: core
       description: Number of GPU cores that the process/container/device has available
       used_in_dd_ui: true
-      aggregation:
-        type: absolute_usage
+      aggregation: absolute_usage
     tagsets:
       - device
       - process
@@ -283,10 +267,9 @@ metrics:
       metric_type: gauge
       unit: percent
       description: Percentage of time the decoder was active
+      aggregation: relative_activity
     tagsets:
       - device
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -299,8 +282,7 @@ metrics:
       metric_type: gauge
       description: Number of GPU devices found in the host
       used_in_dd_ui: true
-      aggregation:
-        type: absolute_usage
+      aggregation: absolute_usage
     tagsets:
       - device
     validator:
@@ -315,8 +297,7 @@ metrics:
     metadata:
       metric_type: gauge
       description: Whether the GPU device is unhealthy
-      aggregation:
-        type: absolute_usage
+      aggregation: absolute_usage
     tagsets:
       - device
     validator:
@@ -332,10 +313,9 @@ metrics:
       metric_type: gauge
       unit: percent
       description: Percentage of time the DRAM was active
+      aggregation: relative_activity
     tagsets:
       - device
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -348,10 +328,9 @@ metrics:
       metric_type: gauge
       unit: percent
       description: Percentage of time the encoder was active
+      aggregation: relative_activity
     tagsets:
       - device
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -369,12 +348,11 @@ metrics:
         recurring corrected errors can be an early sign of degrading memory or
         underlying hardware issues. The counter reports errors seen for the entire
         lifetime of the device.
+      aggregation: lifetime_error
     tagsets:
       - device
     custom_tags:
       - memory_location
-    aggregation:
-      type: lifetime_error
     support:
       unsupported_architectures: []
       device_modes:
@@ -390,12 +368,11 @@ metrics:
         corruption that could not be automatically fixed. These errors can lead
         to data corruption, application crashes, or incorrect computation
         results. The counter reports errors seen for the entire lifetime of the device.
+      aggregation: lifetime_error
     tagsets:
       - device
     custom_tags:
       - memory_location
-    aggregation:
-      type: lifetime_error
     support:
       unsupported_architectures: []
       device_modes:
@@ -483,13 +460,12 @@ metrics:
         Investigate these errors immediately as they often precede total GPU
         failures. The counter reports XID errors received since the Agent started
         collecting events for this device.
+      aggregation: lifetime_error
     tagsets:
       - device
     custom_tags:
       - origin
       - type
-    aggregation:
-      type: lifetime_error
     support:
       unsupported_architectures: []
       device_modes:
@@ -501,10 +477,9 @@ metrics:
       metric_type: gauge
       unit: percent
       description: Configured fan speed as a percentage of its maximum
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -517,10 +492,9 @@ metrics:
       unit: percent
       description: Percentage of the time that the 16-bit floating point calculation
         engine was active. Only for Hopper and newer GPUs
+      aggregation: relative_activity
     tagsets:
       - device
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -541,10 +515,9 @@ metrics:
       unit: percent
       description: Percentage of the time that the 32-bit floating point calculation
         engine was active. Only for Hopper and newer GPUs
+      aggregation: relative_activity
     tagsets:
       - device
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -565,10 +538,9 @@ metrics:
       unit: percent
       description: Percentage of the time that the 64-bit floating point calculation
         engine was active. Only for Hopper and newer GPUs
+      aggregation: relative_activity
     tagsets:
       - device
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -589,10 +561,9 @@ metrics:
       unit: percent
       description: Percentage of time that the graphics engine was active
       used_in_dd_ui: true
+      aggregation: relative_activity
     tagsets:
       - device
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -606,10 +577,9 @@ metrics:
       unit: percent
       description: Percentage of the time that the integer calculation engine was
         active. Only for Hopper and newer GPUs
+      aggregation: relative_activity
     tagsets:
       - device
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -629,10 +599,9 @@ metrics:
       metric_type: gauge
       unit: byte
       description: Unallocated BAR1 memory (in bytes)
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -645,10 +614,9 @@ metrics:
       metric_type: gauge
       unit: byte
       description: Total BAR1 memory (in bytes).
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -661,10 +629,9 @@ metrics:
       metric_type: gauge
       unit: byte
       description: Allocated used memory (in bytes)
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -677,10 +644,9 @@ metrics:
       metric_type: gauge
       unit: byte
       description: Unallocated device memory (in bytes).
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -696,8 +662,7 @@ metrics:
       unit: byte
       description: The maximum amount of memory a process/container/device could allocate
       used_in_dd_ui: true
-      aggregation:
-        type: absolute_usage
+      aggregation: absolute_usage
     tagsets:
       - device
       - process
@@ -717,10 +682,9 @@ metrics:
       metric_type: gauge
       unit: byte
       description: Device memory (in bytes) reserved for system use (driver or firmware)..
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -735,10 +699,9 @@ metrics:
       metric_type: gauge
       unit: degree celsius
       description: Temperature of the memory chip
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures:
         - fermi
@@ -756,10 +719,9 @@ metrics:
     metadata:
       metric_type: gauge
       description: Number of active nvlinks for the device
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -773,10 +735,9 @@ metrics:
     metadata:
       metric_type: gauge
       description: Number of inactive nvlinks for the device
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -790,10 +751,9 @@ metrics:
     metadata:
       metric_type: gauge
       description: Number of total nvlinks for the device
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -807,10 +767,9 @@ metrics:
     metadata:
       metric_type: gauge
       description: Effective bit error rate for all NVLINK links
+      aggregation: lifetime_error
     tagsets:
       - device
-    aggregation:
-      type: lifetime_error
     support:
       unsupported_architectures:
         - fermi
@@ -897,10 +856,9 @@ metrics:
       description: >-
         NVLink buffer overrun error counter total for all links. The counter
         reports the device lifetime total reported by NVML.
+      aggregation: lifetime_error
     tagsets:
       - device
-    aggregation:
-      type: lifetime_error
     support:
       unsupported_architectures:
         - fermi
@@ -922,10 +880,9 @@ metrics:
       description: >-
         NVLink ECC error counter total for all links. The counter reports the
         device lifetime total reported by NVML.
+      aggregation: lifetime_error
     tagsets:
       - device
-    aggregation:
-      type: lifetime_error
     validator:
       range:
         min: 0
@@ -946,10 +903,9 @@ metrics:
       description: >-
         NVLink effective error counter total for all links. The counter reports
         the device lifetime total reported by NVML.
+      aggregation: lifetime_error
     tagsets:
       - device
-    aggregation:
-      type: lifetime_error
     support:
       unsupported_architectures:
         - fermi
@@ -1039,10 +995,9 @@ metrics:
       description: >-
         NVLink replay error counter total for all links. The counter reports the
         device lifetime total reported by NVML.
+      aggregation: lifetime_error
     tagsets:
       - device
-    aggregation:
-      type: lifetime_error
     validator:
       range:
         min: 0
@@ -1153,10 +1108,9 @@ metrics:
     metadata:
       metric_type: gauge
       description: Number of NVLinks connected to the NVSwitch
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -1171,8 +1125,7 @@ metrics:
     metadata:
       metric_type: gauge
       description: NVLink PLR codes loss counter for the port
-      aggregation:
-        type: sensor_data
+      aggregation: sensor_data
     tagsets:
       - device
     custom_tags:
@@ -1407,8 +1360,7 @@ metrics:
       metric_type: gauge
       unit: megabit/second
       description: common speed of all NVLINK links
-      aggregation:
-        type: sensor_data
+      aggregation: sensor_data
     tagsets:
       - device
     validator:
@@ -1431,10 +1383,9 @@ metrics:
       description: >-
         Failed NVLink recovery events total for all links. The counter reports
         the device lifetime total reported by NVML.
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -1520,8 +1471,7 @@ metrics:
       metric_type: gauge
       unit: kilobyte/second
       description: Total TX data throughput of all NVLINK links
-      aggregation:
-        type: absolute_usage
+      aggregation: absolute_usage
     tagsets:
       - device
     validator:
@@ -1544,8 +1494,7 @@ metrics:
       unit: kilobyte/second
       description: Total RX of all NVLINK links
       used_in_dd_ui: true
-      aggregation:
-        type: absolute_usage
+      aggregation: absolute_usage
     tagsets:
       - device
     validator:
@@ -1568,8 +1517,7 @@ metrics:
       unit: kilobyte/second
       description: Total TX of all NVLINK links
       used_in_dd_ui: true
-      aggregation:
-        type: absolute_usage
+      aggregation: absolute_usage
     tagsets:
       - device
     validator:
@@ -1590,10 +1538,9 @@ metrics:
     metadata:
       metric_type: gauge
       description: NVLink transmitted discard counter total for all links
+      aggregation: lifetime_error
     tagsets:
       - device
-    aggregation:
-      type: lifetime_error
     support:
       unsupported_architectures:
         - fermi
@@ -1725,8 +1672,7 @@ metrics:
       unit: byte/second
       description: Bytes received through PCI to the GPU device per second
       used_in_dd_ui: true
-      aggregation:
-        type: absolute_usage
+      aggregation: absolute_usage
     tagsets:
       - device
     validator:
@@ -1746,8 +1692,7 @@ metrics:
       unit: byte/second
       description: Bytes transmitted through PCI from the GPU device per second
       used_in_dd_ui: true
-      aggregation:
-        type: absolute_usage
+      aggregation: absolute_usage
     tagsets:
       - device
     validator:
@@ -1797,10 +1742,9 @@ metrics:
     metadata:
       metric_type: gauge
       description: Returns the current performance state of the device
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -1812,10 +1756,9 @@ metrics:
       metric_type: gauge
       unit: milliwatt
       description: Upper boundary for the device power draw.
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures: []
       device_modes:
@@ -1831,10 +1774,9 @@ metrics:
         the instantaneous power at that moment, in newer ones it represents the
         average power draw over one second
       used_in_dd_ui: true
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures: []
       device_modes:
@@ -1848,8 +1790,7 @@ metrics:
       description: Average number of GPU cores that a process was using in the
         interval. Only emitted when processes are active.
       used_in_dd_ui: true
-      aggregation:
-        type: absolute_usage
+      aggregation: absolute_usage
     workload_only: true
     tagsets:
       - device
@@ -1870,13 +1811,12 @@ metrics:
       metric_type: gauge
       unit: percent
       description: Percentage of time the decoder was active for a specific process
+      aggregation: relative_activity
     workload_only: true
     tagsets:
       - device
       - process
       - container
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -1889,13 +1829,12 @@ metrics:
       metric_type: gauge
       unit: percent
       description: Percentage of time the DRAM was active for a specific process
+      aggregation: relative_activity
     workload_only: true
     tagsets:
       - device
       - process
       - container
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -1908,13 +1847,12 @@ metrics:
       metric_type: gauge
       unit: percent
       description: Percentage of time the encoder was active for a specific process
+      aggregation: relative_activity
     workload_only: true
     tagsets:
       - device
       - process
       - container
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -1929,8 +1867,7 @@ metrics:
       description: The memory used by this process at the point the metric was given.
         Only emitted when processes are active.
       used_in_dd_ui: true
-      aggregation:
-        type: absolute_usage
+      aggregation: absolute_usage
     workload_only: true
     tagsets:
       - device
@@ -1952,8 +1889,7 @@ metrics:
       unit: percent
       description: Percentage of time the streaming multiprocessor was active for a
         specific process
-      aggregation:
-        type: relative_activity
+      aggregation: relative_activity
     workload_only: true
     tagsets:
       - device
@@ -1975,10 +1911,9 @@ metrics:
       description: >-
         Number of rows remapped due to correctable errors. The counter reports
         the device lifetime total reported by NVML.
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     validator:
       range:
         min: 0
@@ -2001,10 +1936,9 @@ metrics:
       description: >-
         Whether row remapping has failed. This value reflects the current
         remapping status reported by NVML.
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     validator:
       values: [0, 1]
     support:
@@ -2025,10 +1959,9 @@ metrics:
       description: >-
         Whether row remapping is pending. This value reflects the current
         remapping status reported by NVML.
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     validator:
       values: [0, 1]
     support:
@@ -2049,10 +1982,9 @@ metrics:
       description: >-
         Number of rows remapped due to uncorrectable errors. The counter reports
         the device lifetime total reported by NVML.
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     validator:
       range:
         min: 0
@@ -2074,10 +2006,9 @@ metrics:
       metric_type: gauge
       unit: degree celsius
       description: Slowdown temperature
+      aggregation: sensor_data
     tagsets:
       - device
-    aggregation:
-      type: sensor_data
     support:
       unsupported_architectures:
         - fermi
@@ -2091,8 +2022,7 @@ metrics:
       unit: percent
       description: Percentage of time the streaming multiprocessor was active
       used_in_dd_ui: true
-      aggregation:
-        type: relative_activity
+      aggregation: relative_activity
     tagsets:
       - device
     validator:
@@ -2112,10 +2042,9 @@ metrics:
       description: Percentage of the Streaming Multiprocessors that were active in the
         interval
       used_in_dd_ui: true
+      aggregation: relative_activity
     tagsets:
       - device
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -2136,10 +2065,9 @@ metrics:
       unit: percent
       description: Percentage of the Streaming Multiprocessors that were in use in the
         interval
+      aggregation: relative_activity
     tagsets:
       - device
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -2160,8 +2088,7 @@ metrics:
       unit: degree celsius
       description: Temperature of the GPU device
       used_in_dd_ui: true
-      aggregation:
-        type: sensor_data
+      aggregation: sensor_data
     tagsets:
       - device
     validator:
@@ -2180,10 +2107,9 @@ metrics:
       unit: percent
       description: Percentage of the time that the tensor calculation engine was
         active. Only for Hopper and newer GPUs
+      aggregation: relative_activity
     tagsets:
       - device
-    aggregation:
-      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -2203,10 +2129,9 @@ metrics:
       metric_type: gauge
       unit: millijoule
       description: Total energy consumed by the device since the driver was reloaded
+      aggregation: absolute_usage
     tagsets:
       - device
-    aggregation:
-      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -21,6 +21,8 @@ metrics:
       description: Current clock speed for the graphics domain
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -34,6 +36,8 @@ metrics:
       description: Maximum clock speed for the graphics domain
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -47,6 +51,8 @@ metrics:
       description: Current clock speed for the memory
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -60,6 +66,8 @@ metrics:
       description: Maximum clock speed for the memory
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -73,6 +81,8 @@ metrics:
       description: Current clock speed for the Streaming Multiprocessor
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -86,6 +96,8 @@ metrics:
       description: Maximum clock speed for the Streaming Multiprocessor
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -99,6 +111,8 @@ metrics:
       description: Current clock speed for the video encoder/decoder
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures:
         - fermi
@@ -113,6 +127,8 @@ metrics:
       description: Maximum clock speed for the video encoder/decoder
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures:
         - fermi
@@ -124,6 +140,8 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are throttled due to application settings
+      aggregation:
+        type: sensor_data
     tagsets:
       - device
     validator:
@@ -139,6 +157,8 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are throttled due to display clock settings
+      aggregation:
+        type: sensor_data
     tagsets:
       - device
     validator:
@@ -154,6 +174,8 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are throttled due to the GPU being idle
+      aggregation:
+        type: sensor_data
     tagsets:
       - device
     validator:
@@ -169,6 +191,8 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are not throttled
+      aggregation:
+        type: sensor_data
     tagsets:
       - device
     validator:
@@ -184,6 +208,8 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are throttled to avoid exceeding power limits
+      aggregation:
+        type: sensor_data
     tagsets:
       - device
     validator:
@@ -199,6 +225,8 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are throttled to avoid exceeding temperature limits
+      aggregation:
+        type: sensor_data
     tagsets:
       - device
     validator:
@@ -214,6 +242,8 @@ metrics:
     metadata:
       metric_type: gauge
       description: GPU clocks that are throttled to match clock speed of another GPU in the current sync boost group
+      aggregation:
+        type: sensor_data
     tagsets:
       - device
     validator:
@@ -230,6 +260,8 @@ metrics:
       metric_type: gauge
       unit: core
       description: Number of GPU cores that the process/container/device has available
+      aggregation:
+        type: absolute_usage
     tagsets:
       - device
       - process
@@ -251,6 +283,8 @@ metrics:
       description: Percentage of time the decoder was active
     tagsets:
       - device
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -262,6 +296,8 @@ metrics:
     metadata:
       metric_type: gauge
       description: Number of GPU devices found in the host
+      aggregation:
+        type: absolute_usage
     tagsets:
       - device
     validator:
@@ -276,6 +312,8 @@ metrics:
     metadata:
       metric_type: gauge
       description: Whether the GPU device is unhealthy
+      aggregation:
+        type: absolute_usage
     tagsets:
       - device
     validator:
@@ -293,6 +331,8 @@ metrics:
       description: Percentage of time the DRAM was active
     tagsets:
       - device
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -307,6 +347,8 @@ metrics:
       description: Percentage of time the encoder was active
     tagsets:
       - device
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -328,6 +370,8 @@ metrics:
       - device
     custom_tags:
       - memory_location
+    aggregation:
+      type: lifetime_error
     support:
       unsupported_architectures: []
       device_modes:
@@ -346,6 +390,8 @@ metrics:
       - device
     custom_tags:
       - memory_location
+    aggregation:
+      type: lifetime_error
     support:
       unsupported_architectures: []
       device_modes:
@@ -437,6 +483,8 @@ metrics:
     custom_tags:
       - origin
       - type
+    aggregation:
+      type: lifetime_error
     support:
       unsupported_architectures: []
       device_modes:
@@ -450,6 +498,8 @@ metrics:
       description: Configured fan speed as a percentage of its maximum
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -463,6 +513,8 @@ metrics:
       description: Percentage of the time that the 16-bit floating point calculation engine was active. Only for Hopper and newer GPUs
     tagsets:
       - device
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -484,6 +536,8 @@ metrics:
       description: Percentage of the time that the 32-bit floating point calculation engine was active. Only for Hopper and newer GPUs
     tagsets:
       - device
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -505,6 +559,8 @@ metrics:
       description: Percentage of the time that the 64-bit floating point calculation engine was active. Only for Hopper and newer GPUs
     tagsets:
       - device
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -526,6 +582,8 @@ metrics:
       description: Percentage of time that the graphics engine was active
     tagsets:
       - device
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -540,6 +598,8 @@ metrics:
       description: Percentage of the time that the integer calculation engine was active. Only for Hopper and newer GPUs
     tagsets:
       - device
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -561,6 +621,8 @@ metrics:
       description: Unallocated BAR1 memory (in bytes)
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -575,6 +637,8 @@ metrics:
       description: Total BAR1 memory (in bytes).
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -589,6 +653,8 @@ metrics:
       description: Allocated used memory (in bytes)
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -603,6 +669,8 @@ metrics:
       description: Unallocated device memory (in bytes).
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -617,6 +685,8 @@ metrics:
       metric_type: gauge
       unit: byte
       description: The maximum amount of memory a process/container/device could allocate
+      aggregation:
+        type: absolute_usage
     tagsets:
       - device
       - process
@@ -638,6 +708,8 @@ metrics:
       description: Device memory (in bytes) reserved for system use (driver or firmware)..
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -654,6 +726,8 @@ metrics:
       description: Temperature of the memory chip
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures:
         - fermi
@@ -673,6 +747,8 @@ metrics:
       description: Number of active nvlinks for the device
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -688,6 +764,8 @@ metrics:
       description: Number of inactive nvlinks for the device
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -703,6 +781,8 @@ metrics:
       description: Number of total nvlinks for the device
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -718,6 +798,8 @@ metrics:
       description: Effective bit error rate for all NVLINK links
     tagsets:
       - device
+    aggregation:
+      type: lifetime_error
     support:
       unsupported_architectures:
         - fermi
@@ -806,6 +888,8 @@ metrics:
         reports the device lifetime total reported by NVML.
     tagsets:
       - device
+    aggregation:
+      type: lifetime_error
     support:
       unsupported_architectures:
         - fermi
@@ -829,6 +913,8 @@ metrics:
         device lifetime total reported by NVML.
     tagsets:
       - device
+    aggregation:
+      type: lifetime_error
     validator:
       range:
         min: 0
@@ -851,6 +937,8 @@ metrics:
         the device lifetime total reported by NVML.
     tagsets:
       - device
+    aggregation:
+      type: lifetime_error
     support:
       unsupported_architectures:
         - fermi
@@ -942,6 +1030,8 @@ metrics:
         device lifetime total reported by NVML.
     tagsets:
       - device
+    aggregation:
+      type: lifetime_error
     validator:
       range:
         min: 0
@@ -1054,6 +1144,8 @@ metrics:
       description: Number of NVLinks connected to the NVSwitch
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -1068,6 +1160,8 @@ metrics:
     metadata:
       metric_type: gauge
       description: NVLink PLR codes loss counter for the port
+      aggregation:
+        type: sensor_data
     tagsets:
       - device
     custom_tags:
@@ -1301,6 +1395,8 @@ metrics:
       metric_type: gauge
       unit: megabit/second
       description: common speed of all NVLINK links
+      aggregation:
+        type: sensor_data
     tagsets:
       - device
     validator:
@@ -1325,6 +1421,8 @@ metrics:
         the device lifetime total reported by NVML.
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi
@@ -1410,6 +1508,8 @@ metrics:
       metric_type: gauge
       unit: kilobyte/second
       description: Total TX data throughput of all NVLINK links
+      aggregation:
+        type: absolute_usage
     tagsets:
       - device
     validator:
@@ -1431,6 +1531,8 @@ metrics:
       metric_type: gauge
       unit: kilobyte/second
       description: Total RX of all NVLINK links
+      aggregation:
+        type: absolute_usage
     tagsets:
       - device
     validator:
@@ -1452,6 +1554,8 @@ metrics:
       metric_type: gauge
       unit: kilobyte/second
       description: Total TX of all NVLINK links
+      aggregation:
+        type: absolute_usage
     tagsets:
       - device
     validator:
@@ -1474,6 +1578,8 @@ metrics:
       description: NVLink transmitted discard counter total for all links
     tagsets:
       - device
+    aggregation:
+      type: lifetime_error
     support:
       unsupported_architectures:
         - fermi
@@ -1604,6 +1710,8 @@ metrics:
       metric_type: gauge
       unit: byte/second
       description: Bytes received through PCI to the GPU device per second
+      aggregation:
+        type: absolute_usage
     tagsets:
       - device
     validator:
@@ -1622,6 +1730,8 @@ metrics:
       metric_type: gauge
       unit: byte/second
       description: Bytes transmitted through PCI from the GPU device per second
+      aggregation:
+        type: absolute_usage
     tagsets:
       - device
     validator:
@@ -1673,6 +1783,8 @@ metrics:
       description: Returns the current performance state of the device
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures: []
       device_modes:
@@ -1686,6 +1798,8 @@ metrics:
       description: Upper boundary for the device power draw.
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures: []
       device_modes:
@@ -1702,6 +1816,8 @@ metrics:
         the average power draw over one second
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures: []
       device_modes:
@@ -1713,6 +1829,8 @@ metrics:
       metric_type: gauge
       unit: core
       description: Average number of GPU cores that a process was using in the interval. Only emitted when processes are active.
+      aggregation:
+        type: absolute_usage
     workload_only: true
     tagsets:
       - device
@@ -1738,6 +1856,8 @@ metrics:
       - device
       - process
       - container
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -1755,6 +1875,8 @@ metrics:
       - device
       - process
       - container
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -1772,6 +1894,8 @@ metrics:
       - device
       - process
       - container
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -1784,6 +1908,8 @@ metrics:
       metric_type: gauge
       unit: byte
       description: The memory used by this process at the point the metric was given. Only emitted when processes are active.
+      aggregation:
+        type: absolute_usage
     workload_only: true
     tagsets:
       - device
@@ -1804,6 +1930,8 @@ metrics:
       metric_type: gauge
       unit: percent
       description: Percentage of time the streaming multiprocessor was active for a specific process
+      aggregation:
+        type: relative_activity
     workload_only: true
     tagsets:
       - device
@@ -1827,6 +1955,8 @@ metrics:
         the device lifetime total reported by NVML.
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     validator:
       range:
         min: 0
@@ -1851,6 +1981,8 @@ metrics:
         remapping status reported by NVML.
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     validator:
       values: [0, 1]
     support:
@@ -1873,6 +2005,8 @@ metrics:
         remapping status reported by NVML.
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     validator:
       values: [0, 1]
     support:
@@ -1895,6 +2029,8 @@ metrics:
         the device lifetime total reported by NVML.
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     validator:
       range:
         min: 0
@@ -1918,6 +2054,8 @@ metrics:
       description: Slowdown temperature
     tagsets:
       - device
+    aggregation:
+      type: sensor_data
     support:
       unsupported_architectures:
         - fermi
@@ -1930,6 +2068,8 @@ metrics:
       metric_type: gauge
       unit: percent
       description: Percentage of time the streaming multiprocessor was active
+      aggregation:
+        type: relative_activity
     tagsets:
       - device
     validator:
@@ -1949,6 +2089,8 @@ metrics:
       description: Percentage of the Streaming Multiprocessors that were active in the interval
     tagsets:
       - device
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -1970,6 +2112,8 @@ metrics:
       description: Percentage of the Streaming Multiprocessors that were in use in the interval
     tagsets:
       - device
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -1989,6 +2133,8 @@ metrics:
       metric_type: gauge
       unit: degree celsius
       description: Temperature of the GPU device
+      aggregation:
+        type: sensor_data
     tagsets:
       - device
     validator:
@@ -2008,6 +2154,8 @@ metrics:
       description: Percentage of the time that the tensor calculation engine was active. Only for Hopper and newer GPUs
     tagsets:
       - device
+    aggregation:
+      type: relative_activity
     support:
       unsupported_architectures:
         - fermi
@@ -2029,6 +2177,8 @@ metrics:
       description: Total energy consumed by the device since the driver was reloaded
     tagsets:
       - device
+    aggregation:
+      type: absolute_usage
     support:
       unsupported_architectures:
         - fermi

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -1383,7 +1383,7 @@ metrics:
       description: >-
         Failed NVLink recovery events total for all links. The counter reports
         the device lifetime total reported by NVML.
-      aggregation: absolute_usage
+      aggregation: lifetime_error
     tagsets:
       - device
     support:
@@ -1407,6 +1407,7 @@ metrics:
       description: >-
         Successful NVLink recovery events total for all links. The counter
         reports the device lifetime total reported by NVML.
+      aggregation: lifetime_error
     tagsets:
       - device
     support:
@@ -1911,7 +1912,7 @@ metrics:
       description: >-
         Number of rows remapped due to correctable errors. The counter reports
         the device lifetime total reported by NVML.
-      aggregation: absolute_usage
+      aggregation: lifetime_error
     tagsets:
       - device
     validator:
@@ -1982,7 +1983,7 @@ metrics:
       description: >-
         Number of rows remapped due to uncorrectable errors. The counter reports
         the device lifetime total reported by NVML.
-      aggregation: absolute_usage
+      aggregation: lifetime_error
     tagsets:
       - device
     validator:

--- a/pkg/collector/corechecks/gpu/spec/metrics-list/.gitignore
+++ b/pkg/collector/corechecks/gpu/spec/metrics-list/.gitignore
@@ -1,0 +1,1 @@
+gpu-metrics-list

--- a/pkg/collector/corechecks/gpu/spec/metrics-list/main.go
+++ b/pkg/collector/corechecks/gpu/spec/metrics-list/main.go
@@ -1,0 +1,241 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package main generates a GPU metric list CSV from the shared spec.
+package main
+
+import (
+	"encoding/csv"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"maps"
+	"os"
+	"slices"
+	"strings"
+
+	gpuspec "github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/spec"
+)
+
+var outputHeaders = []string{
+	"Metric name",
+	"Min supported architecture",
+	"Tagset",
+	"Extra tags",
+	"MIG support",
+	"vGPU support",
+	"Aggregation type",
+	"Time aggregation",
+	"Group aggregation",
+	"Granularity aggregation",
+	"Granularity tags",
+	"Used in GPU Mon",
+}
+
+type config struct {
+	outputPath string
+}
+
+type metricRow struct {
+	metricName                   string
+	minSupportedArchitecture     string
+	tagset                       string
+	extraTags                    string
+	migSupport                   string
+	vgpuSupport                  string
+	aggregationType              string
+	timeAggregation              string
+	groupAggregation             string
+	granularityAggregation       string
+	granularityTags              string
+	usedInGPUMon                 string
+}
+
+func main() {
+	cfg := parseFlags()
+	if err := validateFlags(cfg); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "gpu metric list generation failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := writeMetricList(cfg); err != nil {
+		log.Fatalf("gpu metric list generation failed: %v", err)
+	}
+}
+
+func parseFlags() config {
+	cfg := config{}
+	flag.StringVar(&cfg.outputPath, "output-path", "", "Path to write generated metric list CSV")
+	flag.Parse()
+	return cfg
+}
+
+func validateFlags(cfg config) error {
+	if strings.TrimSpace(cfg.outputPath) == "" {
+		return errors.New("--output-path is required")
+	}
+	return nil
+}
+
+func writeMetricList(cfg config) error {
+	specs, err := gpuspec.LoadSpecs()
+	if err != nil {
+		return fmt.Errorf("load specs: %w", err)
+	}
+
+	rows, err := buildMetricRows(specs)
+	if err != nil {
+		return fmt.Errorf("build metric rows: %w", err)
+	}
+
+	file, err := os.Create(cfg.outputPath)
+	if err != nil {
+		return fmt.Errorf("create output file %q: %w", cfg.outputPath, err)
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	writer.Comma = '\t'
+	if err := writer.Write(outputHeaders); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+
+	for _, row := range rows {
+		record := []string{
+			row.metricName,
+			row.minSupportedArchitecture,
+			row.tagset,
+			row.extraTags,
+			row.migSupport,
+			row.vgpuSupport,
+			row.aggregationType,
+			row.timeAggregation,
+			row.groupAggregation,
+			row.granularityAggregation,
+			row.granularityTags,
+			row.usedInGPUMon,
+		}
+		if err := writer.Write(record); err != nil {
+			return fmt.Errorf("write row for %q: %w", row.metricName, err)
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return fmt.Errorf("flush CSV %q: %w", cfg.outputPath, err)
+	}
+
+	return nil
+}
+
+func buildMetricRows(specs *gpuspec.Specs) ([]metricRow, error) {
+	rows := make([]metricRow, 0, len(specs.Metrics.Metrics))
+	for metricName, metricSpec := range specs.Metrics.Metrics {
+		if metricSpec.Metadata == nil {
+			return nil, fmt.Errorf("metric %q missing metadata", metricName)
+		}
+
+		aggregationType := metricSpec.Metadata.Aggregation
+		if aggregationType == "" {
+			// This report is aggregation-centric; metrics without aggregation metadata are skipped.
+			continue
+		}
+
+		aggregationSpec, found := specs.Aggregations.Aggregations[aggregationType]
+		if !found {
+			return nil, fmt.Errorf("metric %q references unknown aggregation %q", metricName, aggregationType)
+		}
+
+		minSupportedArchitecture := earliestSupportedArchitecture(specs, metricSpec)
+		if minSupportedArchitecture == "" {
+			return nil, fmt.Errorf("metric %q is unsupported on all known architectures", metricName)
+		}
+
+		row := metricRow{
+			metricName:               gpuspec.PrefixedMetricName(specs, metricName),
+			minSupportedArchitecture: minSupportedArchitecture,
+			tagset:                   strings.Join(metricSpec.Tagsets, "|"),
+			extraTags:                strings.Join(metricSpec.CustomTags, "|"),
+			migSupport:               boolString(metricSpec.SupportsDeviceMode(gpuspec.DeviceModeMIG)),
+			vgpuSupport:              boolString(metricSpec.SupportsDeviceMode(gpuspec.DeviceModeVGPU)),
+			aggregationType:          aggregationType,
+			timeAggregation:          aggregationSpec.TimeAggregator,
+			groupAggregation:         aggregationSpec.GroupAggregator,
+			granularityAggregation:   aggregationSpec.GranularityAggregator,
+			granularityTags:          granularityTags(metricSpec),
+			usedInGPUMon:             boolString(metricSpec.Metadata.UsedInDDUI),
+		}
+		rows = append(rows, row)
+	}
+
+	slices.SortFunc(rows, func(a, b metricRow) int {
+		return strings.Compare(a.metricName, b.metricName)
+	})
+
+	return rows, nil
+}
+
+func granularityTags(metricSpec gpuspec.MetricSpec) string {
+	tags := []string{"gpu_uuid", "host"}
+	if slices.Contains(metricSpec.Tagsets, "process") {
+		tags = append(tags, "pid")
+	}
+	tags = append(tags, metricSpec.CustomTags...)
+	return "{" + strings.Join(tags, ",") + "}"
+}
+
+func earliestSupportedArchitecture(specs *gpuspec.Specs, metricSpec gpuspec.MetricSpec) string {
+	architectures := slices.Sorted(maps.Keys(specs.Architectures.Architectures))
+	slices.SortFunc(architectures, compareArchitectureName)
+
+	for _, arch := range architectures {
+		if metricSpec.SupportsArchitecture(arch) {
+			return arch
+		}
+	}
+	return ""
+}
+
+func compareArchitectureName(a, b string) int {
+	// Keep this mapping local so this generator remains buildable on non-Linux hosts
+	// and without NVML/test-only imports.
+	knownOrder := map[string]int{
+		// Not currently in spec/architectures.yaml, but keep full historical order
+		// to avoid accidental mis-sorting if older architectures are added later.
+		"fermi":     0,
+		"kepler":    1,
+		"maxwell":   2,
+		"pascal":    3,
+		"volta":     4,
+		"turing":    5,
+		"ampere":    6,
+		"hopper":    7,
+		"ada":       8,
+		"blackwell": 9,
+	}
+
+	aRank, aKnown := knownOrder[a]
+	bRank, bKnown := knownOrder[b]
+
+	switch {
+	case aKnown && bKnown:
+		return aRank - bRank
+	case aKnown:
+		return -1
+	case bKnown:
+		return 1
+	default:
+		return strings.Compare(a, b)
+	}
+}
+
+func boolString(v bool) string {
+	if v {
+		return "TRUE"
+	}
+	return "FALSE"
+}
+

--- a/pkg/collector/corechecks/gpu/spec/metrics-list/main.go
+++ b/pkg/collector/corechecks/gpu/spec/metrics-list/main.go
@@ -40,18 +40,18 @@ type config struct {
 }
 
 type metricRow struct {
-	metricName                   string
-	minSupportedArchitecture     string
-	tagset                       string
-	extraTags                    string
-	migSupport                   string
-	vgpuSupport                  string
-	aggregationType              string
-	timeAggregation              string
-	groupAggregation             string
-	granularityAggregation       string
-	granularityTags              string
-	usedInGPUMon                 string
+	metricName               string
+	minSupportedArchitecture string
+	tagset                   string
+	extraTags                string
+	migSupport               string
+	vgpuSupport              string
+	aggregationType          string
+	timeAggregation          string
+	groupAggregation         string
+	granularityAggregation   string
+	granularityTags          string
+	usedInGPUMon             string
 }
 
 func main() {
@@ -238,4 +238,3 @@ func boolString(v bool) string {
 	}
 	return "FALSE"
 }
-

--- a/pkg/collector/corechecks/gpu/spec/spec.go
+++ b/pkg/collector/corechecks/gpu/spec/spec.go
@@ -21,9 +21,10 @@ const (
 	metricsSpecFile       = "gpu_metrics.yaml"
 	architecturesSpecFile = "architectures.yaml"
 	tagsSpecFile          = "tags.yaml"
+	aggregationsSpecFile  = "aggregations.yaml"
 )
 
-//go:embed gpu_metrics.yaml architectures.yaml tags.yaml
+//go:embed gpu_metrics.yaml architectures.yaml tags.yaml aggregations.yaml
 var embeddedSpecs embed.FS
 
 // DeviceMode identifies the GPU device operating mode in the spec.
@@ -52,6 +53,19 @@ type MetricsSpec struct {
 type TagsSpec struct {
 	Tags    map[string]TagSpec    `yaml:"tags"`
 	Tagsets map[string]TagsetSpec `yaml:"tagsets"`
+}
+
+// AggregationsSpec is the YAML aggregation specification.
+type AggregationsSpec struct {
+	Aggregations map[string]AggregationSpec `yaml:"aggregations"`
+}
+
+// AggregationSpec defines aggregation behavior metadata.
+type AggregationSpec struct {
+	Description           string `yaml:"description"`
+	TimeAggregator        string `yaml:"time_aggregator"`
+	GroupAggregator       string `yaml:"group-aggregator"`
+	GranularityAggregator string `yaml:"granularity_aggregator"`
 }
 
 // TagSpec defines validation metadata for a reusable tag.
@@ -94,6 +108,7 @@ type MetricMetadataSpec struct {
 	MetricType  string `yaml:"metric_type,omitempty"`
 	Unit        string `yaml:"unit,omitempty"`
 	Description string `yaml:"description,omitempty"`
+	Aggregation string `yaml:"aggregation,omitempty"`
 }
 
 // UnmarshalYAML validates metric metadata values while decoding.
@@ -228,6 +243,7 @@ type Specs struct {
 	Metrics       *MetricsSpec
 	Tags          *TagsSpec
 	Architectures *ArchitecturesSpec
+	Aggregations  *AggregationsSpec
 }
 
 // ArchitectureCapabilities defines capabilities and unsupported fields.
@@ -328,6 +344,21 @@ func LoadArchitecturesSpec() (*ArchitecturesSpec, error) {
 	return &parsed, nil
 }
 
+// LoadAggregationsSpec loads the canonical GPU aggregations specification file.
+func LoadAggregationsSpec() (*AggregationsSpec, error) {
+	data, err := embeddedSpecs.ReadFile(aggregationsSpecFile)
+	if err != nil {
+		return nil, fmt.Errorf("read aggregations spec %q: %w", aggregationsSpecFile, err)
+	}
+
+	var parsed AggregationsSpec
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("unmarshal aggregations spec %q: %w", aggregationsSpecFile, err)
+	}
+
+	return &parsed, nil
+}
+
 // LoadSpecs loads all canonical GPU specification files.
 func LoadSpecs() (*Specs, error) {
 	metrics, err := LoadMetricsSpec()
@@ -345,9 +376,24 @@ func LoadSpecs() (*Specs, error) {
 		return nil, fmt.Errorf("load architectures spec: %w", err)
 	}
 
+	aggregations, err := LoadAggregationsSpec()
+	if err != nil {
+		return nil, fmt.Errorf("load aggregations spec: %w", err)
+	}
+
+	for metricName, metricSpec := range metrics.Metrics {
+		if metricSpec.Metadata == nil || metricSpec.Metadata.Aggregation == "" {
+			continue
+		}
+		if _, found := aggregations.Aggregations[metricSpec.Metadata.Aggregation]; !found {
+			return nil, fmt.Errorf("metric %q references unknown aggregation %q", metricName, metricSpec.Metadata.Aggregation)
+		}
+	}
+
 	return &Specs{
 		Metrics:       metrics,
 		Tags:          tags,
 		Architectures: architectures,
+		Aggregations:  aggregations,
 	}, nil
 }

--- a/pkg/collector/corechecks/gpu/spec/spec.go
+++ b/pkg/collector/corechecks/gpu/spec/spec.go
@@ -105,8 +105,10 @@ type TagsetSpec struct {
 
 // MetricMetadataSpec defines metadata used to generate integrations metadata.csv rows.
 type MetricMetadataSpec struct {
-	MetricType  string `yaml:"metric_type,omitempty"`
-	Unit        string `yaml:"unit,omitempty"`
+	MetricType string `yaml:"metric_type,omitempty"`
+	Unit       string `yaml:"unit,omitempty"`
+	// UsedInDDUI marks metrics surfaced in Datadog UI defaults.
+	UsedInDDUI bool   `yaml:"used_in_dd_ui,omitempty"`
 	Description string `yaml:"description,omitempty"`
 	Aggregation string `yaml:"aggregation,omitempty"`
 }

--- a/pkg/collector/corechecks/gpu/spec/spec.go
+++ b/pkg/collector/corechecks/gpu/spec/spec.go
@@ -64,7 +64,7 @@ type AggregationsSpec struct {
 type AggregationSpec struct {
 	Description           string `yaml:"description"`
 	TimeAggregator        string `yaml:"time_aggregator"`
-	GroupAggregator       string `yaml:"group-aggregator"`
+	GroupAggregator       string `yaml:"group_aggregator"`
 	GranularityAggregator string `yaml:"granularity_aggregator"`
 }
 

--- a/pkg/collector/corechecks/gpu/spec/spec.go
+++ b/pkg/collector/corechecks/gpu/spec/spec.go
@@ -108,7 +108,7 @@ type MetricMetadataSpec struct {
 	MetricType string `yaml:"metric_type,omitempty"`
 	Unit       string `yaml:"unit,omitempty"`
 	// UsedInDDUI marks metrics surfaced in Datadog UI defaults.
-	UsedInDDUI bool   `yaml:"used_in_dd_ui,omitempty"`
+	UsedInDDUI  bool   `yaml:"used_in_dd_ui,omitempty"`
 	Description string `yaml:"description,omitempty"`
 	Aggregation string `yaml:"aggregation,omitempty"`
 }

--- a/pkg/collector/corechecks/gpu/spec/spec_test.go
+++ b/pkg/collector/corechecks/gpu/spec/spec_test.go
@@ -51,6 +51,15 @@ func TestLoadSpecNotEmpty(t *testing.T) {
 			require.NotNil(t, archSpec.UnsupportedDeviceModes, "unsupported_device_modes should be present")
 		})
 	}
+
+	require.NotEmpty(t, specs.Aggregations.Aggregations, "aggregations should not be empty")
+	for aggregationName, aggregationSpec := range specs.Aggregations.Aggregations {
+		require.NotEmptyf(t, aggregationName, "aggregation name should not be empty")
+		require.NotEmptyf(t, aggregationSpec.Description, "aggregation %s should define description", aggregationName)
+		require.NotEmptyf(t, aggregationSpec.TimeAggregator, "aggregation %s should define time_aggregator", aggregationName)
+		require.NotEmptyf(t, aggregationSpec.GroupAggregator, "aggregation %s should define group-aggregator", aggregationName)
+		require.NotEmptyf(t, aggregationSpec.GranularityAggregator, "aggregation %s should define granularity_aggregator", aggregationName)
+	}
 }
 
 func TestTagSpecUnmarshalYAML(t *testing.T) {
@@ -169,6 +178,7 @@ metadata:
   metric_type: gauge
   unit: byte/second
   description: Example description
+  aggregation: absolute_usage
 tagsets:
   - device
 support:
@@ -184,6 +194,7 @@ support:
 	require.Equal(t, "gauge", spec.Metadata.MetricType)
 	require.Equal(t, "byte/second", spec.Metadata.Unit)
 	require.Equal(t, "Example description", spec.Metadata.Description)
+	require.Equal(t, "absolute_usage", spec.Metadata.Aggregation)
 }
 
 func TestMetricMetadataSpecUnmarshalYAMLRejectsInvalidMetricType(t *testing.T) {

--- a/pkg/collector/corechecks/gpu/spec/spec_test.go
+++ b/pkg/collector/corechecks/gpu/spec/spec_test.go
@@ -177,6 +177,7 @@ func TestMetricMetadataSpecUnmarshalYAML(t *testing.T) {
 metadata:
   metric_type: gauge
   unit: byte/second
+  used_in_dd_ui: true
   description: Example description
   aggregation: absolute_usage
 tagsets:
@@ -193,6 +194,7 @@ support:
 	require.NotNil(t, spec.Metadata)
 	require.Equal(t, "gauge", spec.Metadata.MetricType)
 	require.Equal(t, "byte/second", spec.Metadata.Unit)
+	require.True(t, spec.Metadata.UsedInDDUI)
 	require.Equal(t, "Example description", spec.Metadata.Description)
 	require.Equal(t, "absolute_usage", spec.Metadata.Aggregation)
 }

--- a/pkg/collector/corechecks/gpu/spec/spec_test.go
+++ b/pkg/collector/corechecks/gpu/spec/spec_test.go
@@ -57,7 +57,7 @@ func TestLoadSpecNotEmpty(t *testing.T) {
 		require.NotEmptyf(t, aggregationName, "aggregation name should not be empty")
 		require.NotEmptyf(t, aggregationSpec.Description, "aggregation %s should define description", aggregationName)
 		require.NotEmptyf(t, aggregationSpec.TimeAggregator, "aggregation %s should define time_aggregator", aggregationName)
-		require.NotEmptyf(t, aggregationSpec.GroupAggregator, "aggregation %s should define group-aggregator", aggregationName)
+		require.NotEmptyf(t, aggregationSpec.GroupAggregator, "aggregation %s should define group_aggregator", aggregationName)
 		require.NotEmptyf(t, aggregationSpec.GranularityAggregator, "aggregation %s should define granularity_aggregator", aggregationName)
 	}
 }

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -17,6 +17,9 @@ DEFAULT_ALLOWLIST_PATH = "../dd-analytics/luigiscripts/billing/usage/standard_me
 METADATA_PACKAGE = f"{SPEC_PACKAGE}/metadata"
 METADATA_BINARY = f"{METADATA_PACKAGE}/gpu-metrics-metadata"
 DEFAULT_METADATA_PATH = "../integrations-core/gpu/metadata.csv"
+METRICS_LIST_PACKAGE = f"{SPEC_PACKAGE}/metrics-list"
+METRICS_LIST_BINARY = f"{METRICS_LIST_PACKAGE}/gpu-metrics-list"
+DEFAULT_METRICS_LIST_PATH = "../integrations-core/gpu/list_of_metrics.csv"
 VALIDATOR_PACKAGE = f"{SPEC_PACKAGE}/metrics-validator"
 VALIDATOR_BINARY = f"{VALIDATOR_PACKAGE}/gpu-metrics-validator"
 VALIDATOR_SITE = "datadoghq.com"
@@ -134,4 +137,26 @@ def update_metadata(
         f"--default-interval {int(default_interval)}"
     )
     print(f"== Updating GPU metadata at {metadata_path} ==")
+    ctx.run(command)
+
+
+@task(
+    name="generate-metrics-list",
+    help={
+        "output_path": f"Path to write generated CSV (default: {DEFAULT_METRICS_LIST_PATH})",
+    },
+)
+def generate_metrics_list(
+    ctx,
+    output_path: str = DEFAULT_METRICS_LIST_PATH,
+):
+    """
+    Generate a GPU metrics list CSV from the shared GPU spec.
+    """
+    binary_path = build_binary(ctx, METRICS_LIST_PACKAGE, METRICS_LIST_BINARY, "metrics list generator")
+    command = (
+        f"{shlex.quote(binary_path)} "
+        f"--output-path {shlex.quote(output_path)}"
+    )
+    print(f"== Generating GPU metrics list CSV at {output_path} ==")
     ctx.run(command)

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -154,9 +154,6 @@ def generate_metrics_list(
     Generate a GPU metrics list CSV from the shared GPU spec.
     """
     binary_path = build_binary(ctx, METRICS_LIST_PACKAGE, METRICS_LIST_BINARY, "metrics list generator")
-    command = (
-        f"{shlex.quote(binary_path)} "
-        f"--output-path {shlex.quote(output_path)}"
-    )
+    command = f"{shlex.quote(binary_path)} " f"--output-path {shlex.quote(output_path)}"
     print(f"== Generating GPU metrics list CSV at {output_path} ==")
     ctx.run(command)

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -19,7 +19,7 @@ METADATA_BINARY = f"{METADATA_PACKAGE}/gpu-metrics-metadata"
 DEFAULT_METADATA_PATH = "../integrations-core/gpu/metadata.csv"
 METRICS_LIST_PACKAGE = f"{SPEC_PACKAGE}/metrics-list"
 METRICS_LIST_BINARY = f"{METRICS_LIST_PACKAGE}/gpu-metrics-list"
-DEFAULT_METRICS_LIST_PATH = "../integrations-core/gpu/list_of_metrics.csv"
+DEFAULT_METRICS_LIST_PATH = "gpu_metrics.tsv"
 VALIDATOR_PACKAGE = f"{SPEC_PACKAGE}/metrics-validator"
 VALIDATOR_BINARY = f"{VALIDATOR_PACKAGE}/gpu-metrics-validator"
 VALIDATOR_SITE = "datadoghq.com"
@@ -143,7 +143,7 @@ def update_metadata(
 @task(
     name="generate-metrics-list",
     help={
-        "output_path": f"Path to write generated CSV (default: {DEFAULT_METRICS_LIST_PATH})",
+        "output_path": f"Path to write generated TSV (default: {DEFAULT_METRICS_LIST_PATH})",
     },
 )
 def generate_metrics_list(
@@ -151,9 +151,9 @@ def generate_metrics_list(
     output_path: str = DEFAULT_METRICS_LIST_PATH,
 ):
     """
-    Generate a GPU metrics list CSV from the shared GPU spec.
+    Generate a GPU metrics list TSV from the shared GPU spec.
     """
     binary_path = build_binary(ctx, METRICS_LIST_PACKAGE, METRICS_LIST_BINARY, "metrics list generator")
     command = f"{shlex.quote(binary_path)} " f"--output-path {shlex.quote(output_path)}"
-    print(f"== Generating GPU metrics list CSV at {output_path} ==")
+    print(f"== Generating GPU metrics list TSV at {output_path} ==")
     ctx.run(command)


### PR DESCRIPTION
### What does this PR do?

Adds extra metadata to the metric specification that can be used to define how to aggregate the metrics and whether they are used in the UI or not.

### Motivation

Centralize metric definition and allow easy exporting to CSV/tables.

### Describe how you validated your changes

CI passing.

### Additional Notes
