### PR TITLE
[testbench] Add --config flag to specify hyperparameters

### DIFF
--- a/cmd/observer-testbench/README.md
+++ b/cmd/observer-testbench/README.md
@@ -1,15 +1,32 @@
 # Observer Test Bench
 
-A standalone tool for iterating on observer anomaly detection and correlation algorithms. Load historical scenarios and visualize analysis results in a web UI, or run headless for batch evaluation.
+A standalone tool for iterating on observer anomaly detection and correlation algorithms. Load historical scenarios and visualize analysis results in a web UI, or run headless for batch evaluation and hyperparameter optimization.
 
 ## Quick Start
 
 ```bash
-# Build the testbench
-go build -o observer-testbench ./cmd/observer-testbench
+# Build + launch backend and UI in one command (recommended)
+dda inv -- q.launch-testbench --build
 
-# Run with default settings
-./observer-testbench --scenarios-dir ./comp/observer/scenarios
+# Just launch (if already built)
+dda inv -- q.launch-testbench
+
+# Use a custom scenarios directory
+dda inv -- q.launch-testbench --scenarios-dir /path/to/scenarios
+```
+
+Then open http://localhost:5173 in your browser.
+
+The `--build` flag rebuilds the binary before launching. Omit it after the first run to skip the build step.
+
+### Manual launch
+
+```bash
+# Build only
+dda inv -- q.build-testbench
+
+# Run the backend
+./bin/observer-testbench --scenarios-dir ./comp/observer/scenarios
 
 # Start the UI (in a separate terminal)
 cd cmd/observer-testbench/ui
@@ -17,18 +34,19 @@ npm install  # first time only
 npm run dev
 ```
 
-Then open http://localhost:5173 in your browser.
-
 ## Command Line Flags
 
 ### General
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--scenarios-dir` | `./scenarios` | Directory containing scenario subdirectories |
+| `--scenarios-dir` | `./comp/observer/scenarios` | Directory containing scenario subdirectories |
 | `--http` | `:8080` | HTTP server address for the API (interactive mode only) |
 | `--enable` | _(empty)_ | Comma-separated components to enable (overrides defaults) |
 | `--disable` | _(empty)_ | Comma-separated components to disable (overrides defaults) |
+| `--only` | _(empty)_ | Enable ONLY these components (plus extractors); disable everything else. Mutually exclusive with `--enable`/`--disable`. |
+| `--config` | _(empty)_ | Path to a JSON params file controlling enabled state and hyperparameters. Takes full precedence over `--enable`/`--disable`/`--only`. See [Params File](#params-file--config). |
+
 ### Headless Mode
 
 | Flag | Default | Description |
@@ -36,76 +54,83 @@ Then open http://localhost:5173 in your browser.
 | `--headless` | _(empty)_ | Scenario subdirectory name to run in headless mode (no HTTP server) |
 | `--output` | _(empty)_ | Path for observer JSON output |
 | `--verbose` | `false` | Include full detail in JSON output (titles, member series, individual anomalies) |
+| `--memprofile` | _(empty)_ | Write a heap profile to this file after the run |
 
 ## Components
-
-Components are controlled via `--enable` and `--disable` using their names.
 
 ### Detectors
 
 | Name | Default | Description |
 |------|---------|-------------|
-| `cusum` | enabled | CUSUM change-point detector |
-| `bocpd` | enabled | Bayesian Online Change Point Detection |
+| `bocpd` | enabled | Bayesian Online Change Point Detection — streaming, per-series changepoint detector |
+| `rrcf` | enabled | Robust Random Cut Forest — multivariate anomaly detection over system metrics |
+| `cusum` | disabled | CUSUM change-point detector |
+| `scanmw` | disabled | Mann-Whitney scan statistic detector |
+| `scanwelch` | disabled | Welch t-test scan statistic detector |
 
 ### Correlators
 
 | Name | Default | Description |
 |------|---------|-------------|
 | `time_cluster` | enabled | Groups anomalies that occur close together in time |
+| `cross_signal` | disabled | Cross-signal pattern correlator (fixed known patterns) |
+| `passthrough` | disabled | Passes every anomaly through as its own correlation (for TP metric scoring) |
+
+### Extractors
+
+Extractors are always enabled and convert raw observations into timeseries:
+
+| Name | Description |
+|------|-------------|
+| `log_metrics_extractor` | Derives metrics from log patterns and JSON fields |
+| `connection_error_extractor` | Detects connection-error patterns in logs |
+| `log_pattern_extractor` | Clusters log messages into patterns |
 
 ## Examples
 
 ```bash
-# Run with all defaults
-./observer-testbench --scenarios-dir ./comp/observer/scenarios
+# Run with all defaults (bocpd + rrcf + time_cluster)
+dda inv -- q.launch-testbench
 
-# Only CUSUM + TimeCluster (disable everything else)
-./observer-testbench --scenarios-dir ./comp/observer/scenarios \
-  --disable bocpd
+# Only BOCPD + TimeCluster
+dda inv -- q.launch-testbench --only bocpd,time_cluster
+
+# Enable CUSUM on top of defaults
+dda inv -- q.launch-testbench --enable cusum
 
 # Run on a different port
-./observer-testbench --scenarios-dir ./comp/observer/scenarios \
-  --http :9090
+dda inv -- q.launch-testbench --http :9090
 ```
 
 ## Headless Mode
 
-Run a scenario without the HTTP server or UI — load data, run the full detector→correlator pipeline, write a JSON results file, and exit.
-
-The `--headless` value is the name of a subdirectory inside `--scenarios-dir`. For example, given:
-
-```
-my-scenarios/
-  ├── scenario_a/
-  │   └── parquet/
-  └── scenario_b/
-      └── parquet/
-```
-
-`--headless scenario_a --scenarios-dir ./my-scenarios` loads `./my-scenarios/scenario_a/`.
+Run a scenario without the HTTP server — load data, run the full detector→correlator pipeline, write a JSON results file, and exit.
 
 ```bash
-# Basic headless run
-./observer-testbench \
+# Via invoke (builds automatically with --build)
+dda inv -- q.launch-testbench --headless-scenario <scenario-name>
+dda inv -- q.launch-testbench --headless-scenario <scenario-name> --headless-output /tmp/out.json
+dda inv -- q.launch-testbench --headless-scenario <scenario-name> --profile  # write heap profile
+
+# Direct binary
+./bin/observer-testbench \
   --headless <scenario-name> \
   --output results.json \
-  --scenarios-dir ./path/to/scenarios
+  --scenarios-dir ./comp/observer/scenarios
 
 # Verbose output (includes anomaly detail, member series, titles)
-./observer-testbench \
+./bin/observer-testbench \
   --headless <scenario-name> \
   --output results-verbose.json \
   --verbose \
-  --scenarios-dir ./path/to/scenarios
+  --scenarios-dir ./comp/observer/scenarios
 
-# With component overrides
-./observer-testbench \
+# Only BOCPD + TimeCluster in headless mode
+./bin/observer-testbench \
   --headless <scenario-name> \
   --output results.json \
-  --scenarios-dir ./path/to/scenarios \
-  --enable cusum,time_cluster \
-  --disable bocpd
+  --scenarios-dir ./comp/observer/scenarios \
+  --only bocpd,time_cluster
 ```
 
 ### Output Format
@@ -114,29 +139,18 @@ my-scenarios/
 ```json
 {
   "metadata": {
-    "scenario": "...",
+    "scenario": "my_scenario",
     "timeline_start": 1708200000,
     "timeline_end": 1708203600,
-    "detectors_enabled": ["cusum"],
+    "detectors_enabled": ["bocpd"],
     "correlators_enabled": ["time_cluster"],
-    "total_anomaly_periods": 5
+    "total_anomaly_periods": 2
   },
   "anomaly_periods": [
     {
       "pattern": "cluster_1708201234",
       "period_start": 1708201234,
       "period_end": 1708201500
-    }
-  ],
-  "reports": [
-    {
-      "pattern": "cluster_1708201234",
-      "title": "Correlated anomalies at 1708201234",
-      "message": "...",
-      "tags": ["source:agent-q-branch-observer", "pattern:cluster_1708201234"],
-      "firstSeen": 1708201234,
-      "lastUpdated": 1708201500,
-      "formattedTime": "2024-02-17T12:00:34Z"
     }
   ]
 }
@@ -151,13 +165,13 @@ my-scenarios/
       "period_start": 1708201234,
       "period_end": 1708201500,
       "title": "Correlated anomalies at 1708201234",
-      "member_series": ["parquet|cpu.user:avg|tag1:v1"],
+      "member_series": ["parquet|cpu.user:avg|host:web-1"],
       "anomalies": [
         {
           "timestamp": 1708201234,
           "source": "cpu.user:avg",
-          "source_series_id": "parquet|cpu.user:avg|tag1:v1",
-          "detector": "cusum"
+          "source_series_id": "42:avg",
+          "detector": "bocpd_detector"
         }
       ]
     }
@@ -165,16 +179,125 @@ my-scenarios/
 }
 ```
 
+## Params File (`--config`)
+
+The `--config` flag accepts a JSON file that controls both enabled/disabled state and hyperparameters for any component. This is the recommended interface for **Bayesian hyperparameter optimization** — the optimizer writes a params file, runs the testbench in headless mode, and scores the output with `observer-scorer`.
+
+When `--config` is provided it takes full precedence over `--enable`/`--disable`/`--only`. Components not mentioned in the file use their catalog defaults.
+
+### Schema
+
+```json
+{
+  "components": {
+    "<component-name>": {
+      "enabled": true,
+      "<param>": <value>,
+      ...
+    }
+  }
+}
+```
+
+- `"enabled"` is optional — omit to use the catalog default.
+- Hyperparameter fields are optional — omitted fields keep their default values.
+
+### Example
+
+```json
+{
+  "components": {
+    "bocpd": {
+      "enabled": true,
+      "hazard": 0.08,
+      "cp_threshold": 0.55,
+      "cp_mass_threshold": 0.65,
+      "recovery_points": 8
+    },
+    "rrcf": {
+      "enabled": true,
+      "threshold_sigma": 2.5,
+      "tree_size": 128
+    },
+    "cusum": { "enabled": false },
+    "time_cluster": {
+      "enabled": true,
+      "proximity_seconds": 15,
+      "window_seconds": 180,
+      "min_cluster_size": 2
+    }
+  }
+}
+```
+
+### Available Hyperparameters
+
+#### `bocpd`
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `warmup_points` | 120 | Points used to build the initial baseline |
+| `hazard` | 0.05 | Prior P(changepoint) per time step — primary sensitivity knob |
+| `cp_threshold` | 0.6 | Posterior P(changepoint) threshold to fire — primary FP/FN knob |
+| `short_run_length` | 5 | Secondary trigger: run-length horizon k |
+| `cp_mass_threshold` | 0.7 | Secondary trigger: P(r_t ≤ k) threshold |
+| `max_run_length` | 200 | Compute cap for tracked hypotheses |
+| `prior_variance_scale` | 10.0 | Diffuseness of prior over the mean |
+| `min_variance` | 1.0 | Variance floor (numerical stability) |
+| `recovery_points` | 10 | Consecutive quiet points needed to exit alert state |
+
+#### `cusum`
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `min_points` | 5 | Minimum data points required |
+| `baseline_fraction` | 0.25 | Fraction of data used for baseline estimation |
+| `slack_factor` | 0.5 | k = slack_factor × stddev (slack parameter) |
+| `threshold_factor` | 4.0 | h = threshold_factor × stddev (detection threshold) |
+
+#### `rrcf`
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `num_trees` | 100 | Number of trees in the forest |
+| `tree_size` | 256 | Sliding window size per tree |
+| `shingle_size` | 4 | Temporal context window (consecutive samples per point) |
+| `threshold_sigma` | 3.0 | σ above score mean to flag an anomaly |
+
+#### `time_cluster`
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `proximity_seconds` | 10 | Max time gap between anomalies to consider them in the same cluster |
+| `window_seconds` | 120 | How long to keep anomalies before eviction |
+| `min_cluster_size` | 0 | Minimum cluster size to report (0 = report all) |
+
+#### `cross_signal`
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `window_seconds` | 30 | Time window for clustering anomalies |
+
 ## Scenario Directory Structure
 
-Each scenario is a subdirectory within `--scenarios-dir`. Parquet files can live in a `parquet/` subdirectory or directly in the scenario root.
+Each scenario is a subdirectory within `--scenarios-dir`. An optional `episode.json` provides ground truth for scoring.
 
 ```
 scenario-name/
-  └── parquet/
-      ├── observer-metrics-*.parquet    # Metric time series
-      ├── observer-logs-*.parquet       # Log entries
-      └── ...
+  ├── parquet/
+  │   ├── observer-metrics-*.parquet    # Metric time series
+  │   ├── observer-logs-*.parquet       # Log entries
+  │   └── ...
+  └── episode.json                      # Ground truth (disruption onset, baseline window)
+```
+
+### `episode.json` format
+
+```json
+{
+  "baseline": { "start": "2024-02-17T11:00:00Z", "end": "2024-02-17T11:30:00Z" },
+  "disruption": { "start": "2024-02-17T12:00:00Z" }
+}
 ```
 
 ## API Endpoints
@@ -194,19 +317,23 @@ These endpoints are available in interactive mode (not headless).
 | GET | `/api/anomalies` | Get all detected anomalies |
 | GET | `/api/logs` | Get loaded log entries |
 | GET | `/api/log-anomalies` | Get log anomalies |
+| GET | `/api/log-patterns` | Get log pattern clusters |
 | GET | `/api/correlations` | Get correlation outputs |
-| GET | `/api/reports` | Datadog-style report events (same payload as headless `reports` JSON) |
 | GET | `/api/correlations/compressed` | Get compressed correlation outputs |
-| GET | `/api/correlators/{name}` | Get data for a specific correlator |
+| GET | `/api/reports` | Datadog-style report events |
+| GET | `/api/score` | Gaussian F1 score against episode.json ground truth |
 | GET | `/api/stats` | Correlator statistics |
+| GET | `/api/benchmark` | Component benchmark data |
 
 ## UI Features
 
 - **Scenario Selection**: Load different scenarios from the sidebar
-- **Component Toggles**: Enable/disable detectors and correlators
+- **Component Toggles**: Enable/disable detectors and correlators live
 - **Series Tree**: Browse and select time series to visualize
 - **Aggregation Types**: Switch between avg, count, sum, min, max views
 - **Time Clusters**: View correlated anomaly groups
 - **Zoom/Pan**: Drag to zoom, middle-drag to pan on charts
 - **Split by Tag**: Split series by tag values for comparison
-- **Reports**: Datadog-style incident events on a zoomable timeline (same gestures as Logs); hover a row to highlight the span on the chart
+- **Log Patterns**: Browse detected log pattern clusters
+- **Reports**: Datadog-style incident events on a zoomable timeline
+- **Score**: Live Gaussian F1 score against episode.json ground truth

--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -29,9 +29,9 @@ import (
 )
 
 type CLIParams struct {
-	ScenariosDir string
-	HTTPAddr     string
-	Enabled      map[string]bool
+	ScenariosDir      string
+	HTTPAddr          string
+	ComponentSettings observerimpl.ComponentSettings
 
 	// Headless mode: run a scenario and exit (no HTTP server)
 	Headless   string // scenario name to run (empty = interactive mode)
@@ -49,6 +49,7 @@ func main() {
 	enableStr := flag.String("enable", "", "Comma-separated components to enable (overrides defaults)")
 	disableStr := flag.String("disable", "", "Comma-separated components to disable (overrides defaults)")
 	onlyStr := flag.String("only", "", "Enable ONLY these components (plus extractors); disable everything else. Mutually exclusive with --enable/--disable.")
+	configFile := flag.String("config", "", "Path to JSON params file for component enabled state and hyperparameters (for Bayesian optimization). Overrides --enable/--disable/--only.")
 	headless := flag.String("headless", "", "Run scenario in headless mode (no HTTP server) and exit")
 	output := flag.String("output", "", "Path for eval JSON output (headless mode only)")
 	verbose := flag.Bool("verbose", false, "Include full detail in JSON output (headless mode only)")
@@ -56,39 +57,51 @@ func main() {
 	sendAnomalyEvent := flag.String("send-anomaly-event", "", "Run scenario and send one Datadog event per correlation, then exit")
 	flag.Parse()
 
-	overrides := make(map[string]bool)
-	if *onlyStr != "" {
-		// --only: enable listed components + extractors, disable everything else.
-		onlySet := make(map[string]bool)
-		for _, name := range strings.Split(*onlyStr, ",") {
-			name = strings.TrimSpace(name)
-			if name != "" {
-				onlySet[name] = true
-			}
+	// --config takes full precedence over --enable/--disable/--only.
+	var componentSettings observerimpl.ComponentSettings
+	if *configFile != "" {
+		loaded, err := observerimpl.LoadTestbenchParams(*configFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to load config file: %v\n", err)
+			os.Exit(1)
 		}
-		for _, entry := range observerimpl.TestbenchCatalogEntries() {
-			if entry.Kind == "extractor" {
-				continue // extractors always enabled
-			}
-			overrides[entry.Name] = onlySet[entry.Name]
-		}
+		componentSettings = loaded
 	} else {
-		if *enableStr != "" {
-			for _, name := range strings.Split(*enableStr, ",") {
+		overrides := make(map[string]bool)
+		if *onlyStr != "" {
+			// --only: enable listed components + extractors, disable everything else.
+			onlySet := make(map[string]bool)
+			for _, name := range strings.Split(*onlyStr, ",") {
 				name = strings.TrimSpace(name)
 				if name != "" {
-					overrides[name] = true
+					onlySet[name] = true
+				}
+			}
+			for _, entry := range observerimpl.TestbenchCatalogEntries() {
+				if entry.Kind == "extractor" {
+					continue // extractors always enabled
+				}
+				overrides[entry.Name] = onlySet[entry.Name]
+			}
+		} else {
+			if *enableStr != "" {
+				for _, name := range strings.Split(*enableStr, ",") {
+					name = strings.TrimSpace(name)
+					if name != "" {
+						overrides[name] = true
+					}
+				}
+			}
+			if *disableStr != "" {
+				for _, name := range strings.Split(*disableStr, ",") {
+					name = strings.TrimSpace(name)
+					if name != "" {
+						overrides[name] = false
+					}
 				}
 			}
 		}
-		if *disableStr != "" {
-			for _, name := range strings.Split(*disableStr, ",") {
-				name = strings.TrimSpace(name)
-				if name != "" {
-					overrides[name] = false
-				}
-			}
-		}
+		componentSettings = observerimpl.ComponentSettings{Enabled: overrides}
 	}
 
 	if *headless == "" {
@@ -106,14 +119,14 @@ func main() {
 			LogParams:    log.ForOneShot("", "off", true),
 		}),
 		fx.Supply(CLIParams{
-			ScenariosDir:     *scenariosDir,
-			HTTPAddr:         *httpAddr,
-			Enabled:          overrides,
-			Headless:         *headless,
-			Output:           *output,
-			Verbose:          *verbose,
-			MemProfile:       *memProfile,
-			SendAnomalyEvent: *sendAnomalyEvent,
+			ScenariosDir:      *scenariosDir,
+			HTTPAddr:          *httpAddr,
+			ComponentSettings: componentSettings,
+			Headless:          *headless,
+			Output:            *output,
+			Verbose:           *verbose,
+			MemProfile:        *memProfile,
+			SendAnomalyEvent:  *sendAnomalyEvent,
 		}),
 	)
 	if err != nil {
@@ -125,14 +138,12 @@ func main() {
 func run(recorder recorderdef.Component, cfg config.Component, logger log.Component, params CLIParams) error {
 	// Create the test bench
 	tb, err := observerimpl.NewTestBench(observerimpl.TestBenchConfig{
-		ScenariosDir: params.ScenariosDir,
-		HTTPAddr:     params.HTTPAddr,
-		Recorder:     recorder,
-		Cfg:          cfg,
-		Logger:       logger,
-		ComponentSettings: observerimpl.ComponentSettings{
-			Enabled: params.Enabled,
-		},
+		ScenariosDir:      params.ScenariosDir,
+		HTTPAddr:          params.HTTPAddr,
+		Recorder:          recorder,
+		Cfg:               cfg,
+		Logger:            logger,
+		ComponentSettings: params.ComponentSettings,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create test bench: %v\n", err)

--- a/cmd/observer-testbench/ui/src/App.tsx
+++ b/cmd/observer-testbench/ui/src/App.tsx
@@ -115,7 +115,7 @@ function formatTime(isoString: string): string {
   return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
-function EpisodeInfoPanel({ info, score }: { info: EpisodeInfo; score?: ScoreResult | null }) {
+function EpisodeInfoPanel({ info, score, onShowConfig }: { info: EpisodeInfo; score?: ScoreResult | null; onShowConfig?: () => void }) {
   const [expanded, setExpanded] = useState(false);
 
   const phases: { key: string; phase: typeof info.baseline }[] = [
@@ -184,6 +184,17 @@ function EpisodeInfoPanel({ info, score }: { info: EpisodeInfo; score?: ScoreRes
         )}
 
       </div>
+
+      {/* Config button — right-aligned outside the flex-1 group */}
+      {onShowConfig && (
+        <button
+          onClick={onShowConfig}
+          title="Show active component config as JSON (for --config flag)"
+          className="shrink-0 px-2.5 py-1 rounded text-xs text-slate-400 hover:text-white hover:bg-slate-700 transition-colors font-mono border border-slate-600 hover:border-slate-500"
+        >
+          {'{ }'}
+        </button>
+      )}
     </div>
   );
 }
@@ -213,9 +224,81 @@ function ScoreDisplay({ score }: { score: ScoreResult }) {
   );
 }
 
+function ConfigModal({ components, onClose }: {
+  components: import('./api/client').ComponentInfo[];
+  onClose: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const configJSON = JSON.stringify(
+    {
+      components: Object.fromEntries(
+        components.map(c => [
+          c.name,
+          { enabled: c.enabled, ...(c.config ?? {}) },
+        ])
+      ),
+    },
+    null,
+    2
+  );
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(configJSON).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-slate-800 border border-slate-600 rounded-lg shadow-2xl w-[560px] max-h-[80vh] flex flex-col"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-slate-700">
+          <div>
+            <h2 className="text-sm font-semibold text-white">Active Config</h2>
+            <p className="text-xs text-slate-400 mt-0.5">
+              Paste into a file and pass with <code className="font-mono bg-slate-700 px-1 rounded">--config &lt;file&gt;</code>
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleCopy}
+              className={`px-3 py-1 rounded text-xs font-medium transition-colors ${
+                copied
+                  ? 'bg-green-700 text-green-200'
+                  : 'bg-slate-600 hover:bg-slate-500 text-slate-200'
+              }`}
+            >
+              {copied ? '✓ Copied' : 'Copy'}
+            </button>
+            <button
+              onClick={onClose}
+              className="text-slate-400 hover:text-white transition-colors text-lg leading-none px-1"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+        {/* Body */}
+        <pre className="overflow-auto flex-1 p-4 text-xs font-mono text-slate-200 leading-relaxed">
+          {configJSON}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
 function App() {
   const [state, actions] = useObserver();
   const [activeTab, setActiveTab] = useState<TabID>('timeseries');
+  const [showConfigModal, setShowConfigModal] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(320);
   const [requestedFocusedGroupKey, setRequestedFocusedGroupKey] = useState<string | null>(null);
   const [requestedPatternFilter, setRequestedPatternFilter] = useState<string | null>(null);
@@ -559,7 +642,13 @@ function App() {
       )}
 
       {/* Episode info panel (shown when episode.json is present) */}
-      {episodeInfo && <EpisodeInfoPanel info={episodeInfo} score={state.scoreResponse?.available ? state.scoreResponse.score : null} />}
+      {episodeInfo && (
+        <EpisodeInfoPanel
+          info={episodeInfo}
+          score={state.scoreResponse?.available ? state.scoreResponse.score : null}
+          onShowConfig={state.components?.length ? () => setShowConfigModal(true) : undefined}
+        />
+      )}
 
       <div className="flex-1 flex relative min-h-0">
         {/* Resize handle */}
@@ -630,6 +719,13 @@ function App() {
           />
         </div>
       </div>
+
+      {showConfigModal && state.components && (
+        <ConfigModal
+          components={state.components}
+          onClose={() => setShowConfigModal(false)}
+        />
+      )}
     </div>
   );
 }

--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -62,6 +62,8 @@ export interface ComponentInfo {
   displayName: string;
   category: 'detector' | 'correlator' | 'processing';
   enabled: boolean;
+  /** Active hyperparameter values, present when the component has a typed config. */
+  config?: Record<string, unknown>;
 }
 
 export interface SeriesInfo {

--- a/cmd/observer-testbench/ui/src/components/CorrelatorView.tsx
+++ b/cmd/observer-testbench/ui/src/components/CorrelatorView.tsx
@@ -26,6 +26,14 @@ export function CorrelatorView({ state, actions, sidebarWidth, timeRange, phaseM
   const correlatorStats = state.correlatorStats;
 
   const [showRawData, setShowRawData] = useState(false);
+  const [expandedConfigs, setExpandedConfigs] = useState<Set<string>>(new Set());
+  const toggleConfigPanel = (name: string) => {
+    setExpandedConfigs(prev => {
+      const next = new Set(prev);
+      next.has(name) ? next.delete(name) : next.add(name);
+      return next;
+    });
+  };
   const [tagFilterInput, setTagFilterInput] = useState('');
   const initializedScenarioRef = useRef<string | null>(null);
 
@@ -82,23 +90,46 @@ export function CorrelatorView({ state, actions, sidebarWidth, timeRange, phaseM
           <div className="space-y-1">
             {correlatorComponents.map((comp) => {
               const stats = correlatorStats?.[comp.name];
+              const configEntries = comp.config ? Object.entries(comp.config) : [];
+              const isExpanded = expandedConfigs.has(comp.name);
               return (
-                <div key={comp.name} className="flex items-center gap-2 px-2 py-1.5">
-                  <button
-                    onClick={() => actions.toggleComponent(comp.name)}
-                    className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors flex-shrink-0 ${
-                      comp.enabled ? 'bg-purple-600' : 'bg-slate-600'
-                    }`}
-                  >
-                    <span
-                      className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${
-                        comp.enabled ? 'translate-x-3.5' : 'translate-x-0.5'
+                <div key={comp.name}>
+                  <div className="flex items-center gap-2 px-2 py-1.5">
+                    <button
+                      onClick={() => actions.toggleComponent(comp.name)}
+                      className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors flex-shrink-0 ${
+                        comp.enabled ? 'bg-purple-600' : 'bg-slate-600'
                       }`}
-                    />
-                  </button>
-                  <span className="text-sm text-slate-300 flex-1">{comp.displayName}</span>
-                  {stats && (
-                    <StatsLabel stats={stats} />
+                    >
+                      <span
+                        className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${
+                          comp.enabled ? 'translate-x-3.5' : 'translate-x-0.5'
+                        }`}
+                      />
+                    </button>
+                    <span className="text-sm text-slate-300 flex-1">{comp.displayName}</span>
+                    {stats && (
+                      <StatsLabel stats={stats} />
+                    )}
+                    {configEntries.length > 0 && (
+                      <button
+                        onClick={() => toggleConfigPanel(comp.name)}
+                        title={isExpanded ? 'Hide config' : 'Show config'}
+                        className="text-slate-500 hover:text-slate-300 transition-colors text-xs leading-none"
+                      >
+                        {isExpanded ? '▴' : '▾'}
+                      </button>
+                    )}
+                  </div>
+                  {isExpanded && configEntries.length > 0 && (
+                    <div className="ml-6 mb-1 px-2 py-1.5 bg-slate-900/60 rounded border border-slate-700/50 font-mono text-xs space-y-0.5">
+                      {configEntries.map(([k, v]) => (
+                        <div key={k} className="flex gap-2">
+                          <span className="text-slate-500 shrink-0">{k}</span>
+                          <span className="text-slate-300">{String(v)}</span>
+                        </div>
+                      ))}
+                    </div>
                   )}
                 </div>
               );

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -402,6 +402,15 @@ export function MetricsView({
     actions.toggleComponent(name);
   };
 
+  const [expandedConfigs, setExpandedConfigs] = useState<Set<string>>(new Set());
+  const toggleConfigPanel = (name: string) => {
+    setExpandedConfigs(prev => {
+      const next = new Set(prev);
+      next.has(name) ? next.delete(name) : next.add(name);
+      return next;
+    });
+  };
+
   const anomalousGroupKeys = useMemo(() => {
     const keys = new Set<string>();
     metricGroups.forEach((g) => {
@@ -431,31 +440,52 @@ export function MetricsView({
               const count = allAnomalies.filter((a) => getDetectorComponent(a) === comp.name).length;
               const detectorName = detectorNameByComponent.get(comp.name);
               const color = detectorName ? getDetectorColorStable(detectorName) : null;
+              const configEntries = comp.config ? Object.entries(comp.config) : [];
+              const isExpanded = expandedConfigs.has(comp.name);
               return (
-                <label
-                  key={comp.name}
-                  className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-slate-700 cursor-pointer"
-                >
-                  <input
-                    type="checkbox"
-                    checked={enabledDetectors.has(comp.name)}
-                    onChange={() => toggleDetector(comp.name)}
-                    className="rounded border-slate-600 bg-slate-700 text-purple-600 focus:ring-purple-500"
-                  />
-                  {color ? (
-                    <span
-                      className="text-xs px-1.5 py-0.5 rounded font-medium flex-1"
-                      style={{ backgroundColor: color.fill, color: color.stroke }}
-                    >
-                      {comp.displayName}
-                    </span>
-                  ) : (
-                    <span className="text-sm text-slate-300 flex-1">{comp.displayName}</span>
+                <div key={comp.name}>
+                  <label className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-slate-700 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={enabledDetectors.has(comp.name)}
+                      onChange={() => toggleDetector(comp.name)}
+                      className="rounded border-slate-600 bg-slate-700 text-purple-600 focus:ring-purple-500"
+                    />
+                    {color ? (
+                      <span
+                        className="text-xs px-1.5 py-0.5 rounded font-medium flex-1"
+                        style={{ backgroundColor: color.fill, color: color.stroke }}
+                      >
+                        {comp.displayName}
+                      </span>
+                    ) : (
+                      <span className="text-sm text-slate-300 flex-1">{comp.displayName}</span>
+                    )}
+                    {count > 0 && (
+                      <span className="text-xs text-slate-500">{count}</span>
+                    )}
+                    {configEntries.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={e => { e.preventDefault(); toggleConfigPanel(comp.name); }}
+                        title={isExpanded ? 'Hide config' : 'Show config'}
+                        className="text-slate-500 hover:text-slate-300 transition-colors text-xs leading-none"
+                      >
+                        {isExpanded ? '▴' : '▾'}
+                      </button>
+                    )}
+                  </label>
+                  {isExpanded && configEntries.length > 0 && (
+                    <div className="ml-6 mb-1 px-2 py-1.5 bg-slate-900/60 rounded border border-slate-700/50 font-mono text-xs space-y-0.5">
+                      {configEntries.map(([k, v]) => (
+                        <div key={k} className="flex gap-2">
+                          <span className="text-slate-500 shrink-0">{k}</span>
+                          <span className="text-slate-300">{String(v)}</span>
+                        </div>
+                      ))}
+                    </div>
                   )}
-                  {count > 0 && (
-                    <span className="text-xs text-slate-500">{count}</span>
-                  )}
-                </label>
+                </div>
               );
             })}
           </div>

--- a/comp/observer/impl/anomaly_correlator_time_cluster.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster.go
@@ -18,17 +18,17 @@ type TimeClusterConfig struct {
 	// ProximitySeconds is the maximum time difference between anomaly timestamps
 	// for them to be considered part of the same cluster.
 	// Default: 10 seconds.
-	ProximitySeconds int64
+	ProximitySeconds int64 `json:"proximity_seconds"`
 
 	// WindowSeconds is how long to keep anomalies before eviction.
 	// Default: 60 seconds.
-	WindowSeconds int64
+	WindowSeconds int64 `json:"window_seconds"`
 
 	// MinClusterSize is the minimum number of anomalies a cluster must contain
 	// to be included in output (ActiveCorrelations, GetClusters).
 	// Clusters below this threshold are still tracked internally but not reported.
 	// Default: 0 (no minimum).
-	MinClusterSize int
+	MinClusterSize int `json:"min_cluster_size"`
 }
 
 // DefaultTimeClusterConfig returns a TimeClusterConfig with default values.

--- a/comp/observer/impl/anomaly_processor_correlator.go
+++ b/comp/observer/impl/anomaly_processor_correlator.go
@@ -14,7 +14,7 @@ type CorrelatorConfig struct {
 	// WindowSeconds is the time window (in seconds) for clustering anomalies.
 	// Anomalies with data timestamps older than (currentDataTime - WindowSeconds) are evicted.
 	// Default: 30 seconds.
-	WindowSeconds int64
+	WindowSeconds int64 `json:"window_seconds"`
 }
 
 // DefaultCorrelatorConfig returns a CorrelatorConfig with default values.

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -5,7 +5,11 @@
 
 package observerimpl
 
-import observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+import (
+	"encoding/json"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
 
 // componentKind distinguishes detectors from correlators in the catalog.
 type componentKind int
@@ -36,6 +40,13 @@ type componentEntry struct {
 	// populated config struct. Only components that need agent-config
 	// tuning set this; others leave it nil.
 	readConfig func(ConfigReader, string) any
+
+	// parseJSON optionally parses component hyperparameters from a JSON object
+	// (the component's sub-object from a --config params file, with "enabled"
+	// already stripped). It starts from the provided defaults and overlays JSON
+	// values, so unspecified fields keep their default. Returns the populated
+	// typed config. Nil means the component has no tunable hyperparameters.
+	parseJSON func(defaults any, raw []byte) (any, error)
 }
 
 // componentInstance tracks a component entry paired with its runtime instance and enabled state.
@@ -125,6 +136,13 @@ func defaultCatalog() *componentCatalog {
 				defaultConfig:  DefaultCUSUMConfig(),
 				factory:        func(cfg any) any { return NewCUSUMDetector(cfg.(CUSUMConfig)) },
 				defaultEnabled: false,
+				parseJSON: func(defaults any, raw []byte) (any, error) {
+					cfg := defaults.(CUSUMConfig)
+					if err := json.Unmarshal(raw, &cfg); err != nil {
+						return nil, err
+					}
+					return cfg, nil
+				},
 			},
 			{
 				name:           "bocpd",
@@ -133,6 +151,13 @@ func defaultCatalog() *componentCatalog {
 				defaultConfig:  DefaultBOCPDConfig(),
 				factory:        func(cfg any) any { return NewBOCPDDetector(cfg.(BOCPDConfig)) },
 				defaultEnabled: true,
+				parseJSON: func(defaults any, raw []byte) (any, error) {
+					cfg := defaults.(BOCPDConfig)
+					if err := json.Unmarshal(raw, &cfg); err != nil {
+						return nil, err
+					}
+					return cfg, nil
+				},
 			},
 			{
 				name:           "rrcf",
@@ -141,6 +166,13 @@ func defaultCatalog() *componentCatalog {
 				defaultConfig:  DefaultRRCFConfig(),
 				factory:        func(cfg any) any { return NewRRCFDetector(cfg.(RRCFConfig)) },
 				defaultEnabled: true,
+				parseJSON: func(defaults any, raw []byte) (any, error) {
+					cfg := defaults.(RRCFConfig)
+					if err := json.Unmarshal(raw, &cfg); err != nil {
+						return nil, err
+					}
+					return cfg, nil
+				},
 			},
 			{
 				name:           "scanmw",
@@ -164,6 +196,13 @@ func defaultCatalog() *componentCatalog {
 				defaultConfig:  DefaultCorrelatorConfig(),
 				factory:        func(cfg any) any { return NewCorrelator(cfg.(CorrelatorConfig)) },
 				defaultEnabled: false,
+				parseJSON: func(defaults any, raw []byte) (any, error) {
+					cfg := defaults.(CorrelatorConfig)
+					if err := json.Unmarshal(raw, &cfg); err != nil {
+						return nil, err
+					}
+					return cfg, nil
+				},
 			},
 			{
 				name:           "time_cluster",
@@ -173,6 +212,13 @@ func defaultCatalog() *componentCatalog {
 				factory:        func(cfg any) any { return NewTimeClusterCorrelator(cfg.(TimeClusterConfig)) },
 				defaultEnabled: true,
 				readConfig:     readTimeClusterConfig,
+				parseJSON: func(defaults any, raw []byte) (any, error) {
+					cfg := defaults.(TimeClusterConfig)
+					if err := json.Unmarshal(raw, &cfg); err != nil {
+						return nil, err
+					}
+					return cfg, nil
+				},
 			},
 			{
 				name:           "passthrough",

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -51,9 +51,10 @@ type componentEntry struct {
 
 // componentInstance tracks a component entry paired with its runtime instance and enabled state.
 type componentInstance struct {
-	entry    componentEntry
-	instance any
-	enabled  bool
+	entry        componentEntry
+	instance     any
+	enabled      bool
+	activeConfig any // config actually passed to factory (nil for parameterless components)
 }
 
 // ConfigReader provides read access to a key-value configuration source.
@@ -255,9 +256,10 @@ func (c *componentCatalog) Instantiate(settings ComponentSettings) (
 
 		instance := entry.factory(cfg)
 		ci := &componentInstance{
-			entry:    entry,
-			instance: instance,
-			enabled:  enabled,
+			entry:        entry,
+			instance:     instance,
+			enabled:      enabled,
+			activeConfig: cfg,
 		}
 		components[entry.name] = ci
 

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -61,43 +61,43 @@ type BOCPDConfig struct {
 	// WarmupPoints is the number of initial points used for baseline estimation.
 	// A longer warmup captures more of the metric's natural variability, reducing
 	// false positives from normal fluctuation. Default: 120 (~2 minutes at 1Hz).
-	WarmupPoints int
+	WarmupPoints int `json:"warmup_points"`
 
 	// Hazard is the constant changepoint hazard probability.
 	// Default: 0.05
-	Hazard float64
+	Hazard float64 `json:"hazard"`
 
 	// CPThreshold is the posterior P(changepoint at t) threshold to emit.
 	// Default: 0.6
-	CPThreshold float64
+	CPThreshold float64 `json:"cp_threshold"`
 
 	// ShortRunLength is the run-length horizon k for short-run posterior mass P(r_t <= k).
 	// Default: 5
-	ShortRunLength int
+	ShortRunLength int `json:"short_run_length"`
 
 	// CPMassThreshold is the threshold for short-run posterior mass P(r_t <= k).
 	// Default: 0.7
-	CPMassThreshold float64
+	CPMassThreshold float64 `json:"cp_mass_threshold"`
 
 	// MaxRunLength caps tracked run-length hypotheses for bounded compute.
 	// Default: 200
-	MaxRunLength int
+	MaxRunLength int `json:"max_run_length"`
 
 	// PriorVarianceScale controls prior variance over the mean relative to observed variance.
 	// Default: 10.0
-	PriorVarianceScale float64
+	PriorVarianceScale float64 `json:"prior_variance_scale"`
 
 	// MinVariance is the floor for observation variance. When warmup data has
 	// near-zero variance (e.g. constant series), this prevents pathologically
 	// sharp PDFs that would flag any tiny fluctuation as anomalous. Default: 1.0
-	MinVariance float64
+	MinVariance float64 `json:"min_variance"`
 
 	// RecoveryPoints is how many consecutive non-triggering points are needed
 	// to exit alert state. Default: 10
-	RecoveryPoints int
+	RecoveryPoints int `json:"recovery_points"`
 
 	// Aggregations to run detection on. Default: [Average, Count]
-	Aggregations []observer.Aggregate
+	Aggregations []observer.Aggregate `json:"-"`
 }
 
 // DefaultBOCPDConfig returns a BOCPDConfig with default values.

--- a/comp/observer/impl/metrics_detector_cusum.go
+++ b/comp/observer/impl/metrics_detector_cusum.go
@@ -17,21 +17,21 @@ import (
 type CUSUMConfig struct {
 	// MinPoints is the minimum number of points required for analysis.
 	// Default: 5
-	MinPoints int
+	MinPoints int `json:"min_points"`
 
 	// BaselineFraction is the fraction of points to use for baseline estimation.
 	// Default: 0.25 (first 25% of data)
-	BaselineFraction float64
+	BaselineFraction float64 `json:"baseline_fraction"`
 
 	// SlackFactor is multiplied by baseline stddev to get k (slack parameter).
 	// Higher values make detection less sensitive to small shifts.
 	// Default: 0.5
-	SlackFactor float64
+	SlackFactor float64 `json:"slack_factor"`
 
 	// ThresholdFactor is multiplied by baseline stddev to get h (threshold).
 	// Higher values require larger cumulative deviation to trigger.
 	// Default: 4.0
-	ThresholdFactor float64
+	ThresholdFactor float64 `json:"threshold_factor"`
 }
 
 // DefaultCUSUMConfig returns a CUSUMConfig with default values.

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -60,18 +60,18 @@ type RRCFMetricDef struct {
 // RRCFConfig holds configuration for the RRCF analysis.
 type RRCFConfig struct {
 	// NumTrees is the number of trees in the forest. More trees = more robust but slower.
-	NumTrees int
+	NumTrees int `json:"num_trees"`
 	// TreeSize is the maximum number of points per tree (sliding window size).
-	TreeSize int
+	TreeSize int `json:"tree_size"`
 	// ShingleSize is the number of consecutive timestamps to combine into one point.
 	// ShingleSize=4 means each "point" is 4 consecutive samples, enabling temporal pattern detection.
-	ShingleSize int
+	ShingleSize int `json:"shingle_size"`
 	// ThresholdSigma controls dynamic anomaly thresholding. A point is flagged if its
 	// CoDisp score exceeds mean + ThresholdSigma*stddev of the recent score window.
 	// Set to 0 to disable anomaly detection (scores still computed for analysis).
-	ThresholdSigma float64
+	ThresholdSigma float64 `json:"threshold_sigma"`
 	// Metrics defines which series to include. If nil, uses DefaultRRCFMetrics().
-	Metrics []RRCFMetricDef
+	Metrics []RRCFMetricDef `json:"-"`
 }
 
 // DefaultRRCFConfig returns sensible defaults for RRCF.

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -23,13 +23,17 @@ type ObserverOutput struct {
 
 // ObserverMetadata describes the scenario and pipeline configuration.
 type ObserverMetadata struct {
-	Scenario            string       `json:"scenario"`
-	TimelineStart       int64        `json:"timeline_start"`
-	TimelineEnd         int64        `json:"timeline_end"`
-	DetectorsEnabled    []string     `json:"detectors_enabled"`
-	CorrelatorsEnabled  []string     `json:"correlators_enabled"`
-	TotalAnomalyPeriods int          `json:"total_anomaly_periods"`
-	Stats               *ReplayStats `json:"stats,omitempty"`
+	Scenario            string   `json:"scenario"`
+	TimelineStart       int64    `json:"timeline_start"`
+	TimelineEnd         int64    `json:"timeline_end"`
+	DetectorsEnabled    []string `json:"detectors_enabled"`
+	CorrelatorsEnabled  []string `json:"correlators_enabled"`
+	TotalAnomalyPeriods int      `json:"total_anomaly_periods"`
+	// ComponentConfigs holds the active configuration of every component in the
+	// --config params-file format: { "bocpd": { "enabled": true, "hazard": 0.05, ... }, ... }.
+	// This can be copy-pasted into a file and passed to --config to reproduce the run.
+	ComponentConfigs map[string]map[string]any `json:"component_configs,omitempty"`
+	Stats            *ReplayStats              `json:"stats,omitempty"`
 }
 
 // ObserverCorrelation is one correlation cluster.
@@ -65,10 +69,24 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 	scenario := tb.loadedScenario
 	timelineStart, timelineEnd, hasBounds := tb.engine.Storage().TimeBounds()
 
-	// Collect enabled detector and correlator names
+	// Collect enabled detector / correlator names and build the full component config map.
 	var detectorNames []string
 	var correlatorNames []string
+	componentConfigs := make(map[string]map[string]any, len(tb.components))
 	for name, ci := range tb.components {
+		entry := map[string]any{"enabled": ci.enabled}
+		if ci.activeConfig != nil {
+			if raw, err := json.Marshal(ci.activeConfig); err == nil {
+				var fields map[string]any
+				if err := json.Unmarshal(raw, &fields); err == nil {
+					for k, v := range fields {
+						entry[k] = v
+					}
+				}
+			}
+		}
+		componentConfigs[name] = entry
+
 		if !ci.enabled {
 			continue
 		}
@@ -133,6 +151,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 			DetectorsEnabled:    detectorNames,
 			CorrelatorsEnabled:  correlatorNames,
 			TotalAnomalyPeriods: len(outCorrelations),
+			ComponentConfigs:    componentConfigs,
 			Stats:               replayStats,
 		},
 		AnomalyPeriods: outCorrelations,

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -148,10 +148,11 @@ type ScenarioInfo struct {
 
 // ComponentInfo describes a registered component.
 type ComponentInfo struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"displayName"`
-	Category    string `json:"category"` // "detector", "correlator", "processing"
-	Enabled     bool   `json:"enabled"`
+	Name        string         `json:"name"`
+	DisplayName string         `json:"displayName"`
+	Category    string         `json:"category"` // "detector", "correlator", "processing"
+	Enabled     bool           `json:"enabled"`
+	Config      map[string]any `json:"config,omitempty"` // active hyperparameter values (nil for parameterless components)
 }
 
 // StatusResponse is the response for /api/status.
@@ -861,11 +862,20 @@ func (tb *TestBench) GetComponents() []ComponentInfo {
 		if entry.kind == componentCorrelator {
 			category = "correlator"
 		}
+
+		var cfgMap map[string]any
+		if ci.activeConfig != nil {
+			if data, err := json.Marshal(ci.activeConfig); err == nil {
+				_ = json.Unmarshal(data, &cfgMap)
+			}
+		}
+
 		components = append(components, ComponentInfo{
 			Name:        entry.name,
 			DisplayName: entry.displayName,
 			Category:    category,
 			Enabled:     ci.enabled,
+			Config:      cfgMap,
 		})
 	}
 

--- a/comp/observer/impl/testbench_params.go
+++ b/comp/observer/impl/testbench_params.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// TestbenchParamsFile is the top-level structure of a --config JSON file used
+// for Bayesian optimization. Each component entry controls enabled state and
+// hyperparameters for the named component.
+//
+// Example:
+//
+//	{
+//	  "components": {
+//	    "bocpd": {
+//	      "enabled": true,
+//	      "warmup_points": 60,
+//	      "hazard": 0.08,
+//	      "cp_threshold": 0.55
+//	    },
+//	    "time_cluster": {
+//	      "enabled": true,
+//	      "proximity_seconds": 15,
+//	      "min_cluster_size": 2
+//	    },
+//	    "rrcf": { "enabled": false }
+//	  }
+//	}
+//
+// Components not listed in the file use their catalog defaults (both enabled
+// state and hyperparameters). Listed components only override the fields
+// they specify — unset hyperparameter fields keep their default values.
+type TestbenchParamsFile struct {
+	Components map[string]json.RawMessage `json:"components"`
+}
+
+// LoadTestbenchParams reads a params JSON file and returns ComponentSettings
+// suitable for passing to TestBenchConfig.ComponentSettings.
+//
+// For each component mentioned in the file:
+//   - "enabled" (if present) overrides the catalog default enabled state.
+//   - remaining fields are passed to the component's parseJSON function (if
+//     registered), overlaying the catalog default config.
+//
+// Returns an error if the file cannot be read, is invalid JSON, or references
+// an unknown component name.
+func LoadTestbenchParams(path string) (ComponentSettings, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ComponentSettings{}, fmt.Errorf("reading params file %s: %w", path, err)
+	}
+
+	var file TestbenchParamsFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return ComponentSettings{}, fmt.Errorf("parsing params file: %w", err)
+	}
+
+	catalog := defaultCatalog()
+
+	// Build name→entry index for O(1) lookup.
+	entryByName := make(map[string]componentEntry, len(catalog.entries))
+	for _, e := range catalog.entries {
+		entryByName[e.name] = e
+	}
+
+	settings := ComponentSettings{
+		Enabled: make(map[string]bool),
+		configs: make(map[string]any),
+	}
+
+	for name, raw := range file.Components {
+		entry, ok := entryByName[name]
+		if !ok {
+			return ComponentSettings{}, fmt.Errorf("unknown component %q in params file", name)
+		}
+
+		// Extract the optional "enabled" field.
+		var wrapper struct {
+			Enabled *bool `json:"enabled"`
+		}
+		if err := json.Unmarshal(raw, &wrapper); err != nil {
+			return ComponentSettings{}, fmt.Errorf("parsing \"enabled\" for component %q: %w", name, err)
+		}
+		if wrapper.Enabled != nil {
+			settings.Enabled[name] = *wrapper.Enabled
+		}
+
+		// Parse hyperparameters if the component supports it.
+		if entry.parseJSON != nil && entry.defaultConfig != nil {
+			cfg, err := entry.parseJSON(entry.defaultConfig, raw)
+			if err != nil {
+				return ComponentSettings{}, fmt.Errorf("parsing hyperparameters for component %q: %w", name, err)
+			}
+			settings.configs[name] = cfg
+		}
+	}
+
+	return settings, nil
+}

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -427,6 +427,7 @@ def launch_testbench(
     open_pprof: bool = False,
     verbose: bool = False,
     profile_path: str = "",
+    config: str = "",
 ):
     """
     Will launch both the observer-testbench backend and UI.
@@ -443,6 +444,8 @@ def launch_testbench(
     flags = ""
     if verbose:
         flags += " --verbose"
+    if config:
+        flags += f" --config {config}"
 
     if headless_scenario:
         if not headless_output:


### PR DESCRIPTION
### What does this PR do?

The goal is to prepare bayesian optimization, this adds a `--config` flag only for the testbench to change which component is enabled and to change hyper parameters as well.

We list all hyper parameters but we will tune a subset of these.

Adds:
- `--config <file>` CLI flag: loads a JSON params file that controls enabled/disabled state and hyperparameters for any component.
- `component_configs` field in the headless output `metadata` block
- UI: `{ }` button in the episode info bar to show the current active config

### Motivation

### Describe how you validated your changes

### Additional Notes

Example config:

```json
    {
      "bocpd": {
        "cp_mass_threshold": 0.7,
        "cp_threshold": 0.6,
        "enabled": true,
        "hazard": 0.05,
        "max_run_length": 200,
        "min_variance": 1,
        "prior_variance_scale": 10,
        "recovery_points": 10,
        "short_run_length": 5,
        "warmup_points": 120
      },
      "connection_error_extractor": {
        "enabled": true
      },
      "cross_signal": {
        "enabled": false,
        "window_seconds": 30
      },
      "cusum": {
        "baseline_fraction": 0.25,
        "enabled": false,
        "min_points": 5,
        "slack_factor": 0.5,
        "threshold_factor": 4
      },
      "log_metrics_extractor": {
        "MaxEvalBytes": 4096,
        "enabled": true
      },
      "log_pattern_extractor": {
        "enabled": true
      },
      "passthrough": {
        "enabled": false
      },
      "rrcf": {
        "enabled": true,
        "num_trees": 100,
        "shingle_size": 4,
        "threshold_sigma": 3,
        "tree_size": 256
      },
      "scanmw": {
        "enabled": false
      },
      "scanwelch": {
        "enabled": false
      },
      "time_cluster": {
        "enabled": true,
        "min_cluster_size": 0,
        "proximity_seconds": 10,
        "window_seconds": 120
      }
    },

```
