### PR TITLE
[SDBM-2478] Fix aurora & RDS autodiscovery not deleting services when 0 clusters/instances found

### DIFF
--- a/comp/core/autodiscovery/listeners/dbm_aurora.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora.go
@@ -114,25 +114,21 @@ func (l *DBMAuroraListener) discoverAuroraClusters() {
 		_ = log.Error(err)
 		return
 	}
+	auroraCluster, err := l.awsRdsClient.GetAuroraClusterEndpoints(ctx, ids, l.config)
+	if err != nil {
+		_ = log.Error(err)
+		return
+	}
 	discoveredServices := make(map[string]struct{})
-	if len(ids) == 0 {
-		log.Debugf("no aurora clusters found with provided tags %v", l.config.Tags)
-	} else {
-		auroraCluster, err := l.awsRdsClient.GetAuroraClusterEndpoints(ctx, ids, l.config)
-		if err != nil {
-			_ = log.Error(err)
-			return
-		}
-		for id, c := range auroraCluster {
-			for _, instance := range c.Instances {
-				if instance == nil {
-					_ = log.Warnf("received malformed instance response for cluster %s, skipping", id)
-					continue
-				}
-				entityID := instance.Digest(engineToIntegrationType[instance.Engine], id)
-				discoveredServices[entityID] = struct{}{}
-				l.createService(entityID, id, instance)
+	for id, c := range auroraCluster {
+		for _, instance := range c.Instances {
+			if instance == nil {
+				_ = log.Warnf("received malformed instance response for cluster %s, skipping", id)
+				continue
 			}
+			entityID := instance.Digest(engineToIntegrationType[instance.Engine], id)
+			discoveredServices[entityID] = struct{}{}
+			l.createService(entityID, id, instance)
 		}
 	}
 	deletedServices := findDeletedServices(l.services, discoveredServices)

--- a/comp/core/autodiscovery/listeners/dbm_aurora.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora.go
@@ -116,7 +116,6 @@ func (l *DBMAuroraListener) discoverAuroraClusters() {
 	}
 	if len(ids) == 0 {
 		log.Debugf("no aurora clusters found with provided tags %v", l.config.Tags)
-		return
 	}
 	auroraCluster, err := l.awsRdsClient.GetAuroraClusterEndpoints(ctx, ids, l.config)
 	if err != nil {

--- a/comp/core/autodiscovery/listeners/dbm_aurora.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora.go
@@ -114,6 +114,10 @@ func (l *DBMAuroraListener) discoverAuroraClusters() {
 		_ = log.Error(err)
 		return
 	}
+	if len(ids) == 0 {
+		log.Debugf("no aurora clusters found with provided tags %v", l.config.Tags)
+		return
+	}
 	auroraCluster, err := l.awsRdsClient.GetAuroraClusterEndpoints(ctx, ids, l.config)
 	if err != nil {
 		_ = log.Error(err)

--- a/comp/core/autodiscovery/listeners/dbm_aurora.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora.go
@@ -114,25 +114,25 @@ func (l *DBMAuroraListener) discoverAuroraClusters() {
 		_ = log.Error(err)
 		return
 	}
+	discoveredServices := make(map[string]struct{})
 	if len(ids) == 0 {
 		log.Debugf("no aurora clusters found with provided tags %v", l.config.Tags)
-		return
-	}
-	auroraCluster, err := l.awsRdsClient.GetAuroraClusterEndpoints(ctx, ids, l.config)
-	if err != nil {
-		_ = log.Error(err)
-		return
-	}
-	discoveredServices := make(map[string]struct{})
-	for id, c := range auroraCluster {
-		for _, instance := range c.Instances {
-			if instance == nil {
-				_ = log.Warnf("received malformed instance response for cluster %s, skipping", id)
-				continue
+	} else {
+		auroraCluster, err := l.awsRdsClient.GetAuroraClusterEndpoints(ctx, ids, l.config)
+		if err != nil {
+			_ = log.Error(err)
+			return
+		}
+		for id, c := range auroraCluster {
+			for _, instance := range c.Instances {
+				if instance == nil {
+					_ = log.Warnf("received malformed instance response for cluster %s, skipping", id)
+					continue
+				}
+				entityID := instance.Digest(engineToIntegrationType[instance.Engine], id)
+				discoveredServices[entityID] = struct{}{}
+				l.createService(entityID, id, instance)
 			}
-			entityID := instance.Digest(engineToIntegrationType[instance.Engine], id)
-			discoveredServices[entityID] = struct{}{}
-			l.createService(entityID, id, instance)
 		}
 	}
 	deletedServices := findDeletedServices(l.services, discoveredServices)

--- a/comp/core/autodiscovery/listeners/dbm_aurora_test.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora_test.go
@@ -337,6 +337,7 @@ func TestDBMAuroraListener(t *testing.T) {
 			},
 			rdsClientConfigurer: func(k *aws.MockRdsClient) {
 				k.EXPECT().GetAuroraClustersFromTags(gomock.Any(), []string{defaultADTag}).Return([]string{}, nil).AnyTimes()
+				k.EXPECT().GetAuroraClusterEndpoints(gomock.Any(), []string{}, gomock.Any()).Return(nil, nil).AnyTimes()
 			},
 			expectedServices: []*DBMAuroraService{},
 			expectedDelServices: []*DBMAuroraService{

--- a/comp/core/autodiscovery/listeners/dbm_aurora_test.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora_test.go
@@ -25,6 +25,7 @@ func TestDBMAuroraListener(t *testing.T) {
 		name                  string
 		config                aws.Config
 		numDiscoveryIntervals int
+		initialServices       map[string]Service
 		rdsClientConfigurer   mockRdsClientConfigurer
 		expectedServices      []*DBMAuroraService
 		expectedDelServices   []*DBMAuroraService
@@ -309,6 +310,52 @@ func TestDBMAuroraListener(t *testing.T) {
 			},
 			expectedDelServices: []*DBMAuroraService{},
 		},
+		{
+			name: "previously discovered services are deleted when no clusters found",
+			config: aws.Config{
+				DiscoveryInterval: 1,
+				Region:            "us-east-1",
+				Tags:              []string{defaultADTag},
+				DbmTag:            defaultDbmTag,
+			},
+			numDiscoveryIntervals: 0,
+			initialServices: map[string]Service{
+				"f7fee36c58e3da8a": &DBMAuroraService{
+					adIdentifier: dbmPostgresAuroraADIdentifier,
+					entityID:     "f7fee36c58e3da8a",
+					checkName:    "postgres",
+					clusterID:    "my-cluster-1",
+					region:       "us-east-1",
+					instance: &aws.Instance{
+						Endpoint:   "my-endpoint",
+						Port:       5432,
+						IamEnabled: true,
+						Engine:     "aurora-postgresql",
+						DbmEnabled: true,
+					},
+				},
+			},
+			rdsClientConfigurer: func(k *aws.MockRdsClient) {
+				k.EXPECT().GetAuroraClustersFromTags(gomock.Any(), []string{defaultADTag}).Return([]string{}, nil).AnyTimes()
+			},
+			expectedServices: []*DBMAuroraService{},
+			expectedDelServices: []*DBMAuroraService{
+				{
+					adIdentifier: dbmPostgresAuroraADIdentifier,
+					entityID:     "f7fee36c58e3da8a",
+					checkName:    "postgres",
+					clusterID:    "my-cluster-1",
+					region:       "us-east-1",
+					instance: &aws.Instance{
+						Endpoint:   "my-endpoint",
+						Port:       5432,
+						IamEnabled: true,
+						Engine:     "aurora-postgresql",
+						DbmEnabled: true,
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -329,6 +376,9 @@ func TestDBMAuroraListener(t *testing.T) {
 			tc.rdsClientConfigurer(mockAWSClient)
 			ticks := make(chan time.Time, 1)
 			l := newDBMAuroraListener(tc.config, mockAWSClient, ticks)
+			if tc.initialServices != nil {
+				l.(*DBMAuroraListener).services = tc.initialServices
+			}
 			l.Listen(newSvc, delSvc)
 			// execute loop
 			for i := 0; i < tc.numDiscoveryIntervals; i++ {

--- a/comp/core/autodiscovery/listeners/dbm_rds.go
+++ b/comp/core/autodiscovery/listeners/dbm_rds.go
@@ -115,9 +115,9 @@ func (l *DBMRdsListener) discoverRdsInstances() {
 	}
 	if len(instances) == 0 {
 		log.Debugf("no rds instances found with provided tags %v", l.config.Tags)
-		return
+	} else {
+		log.Debugf("found %d rds instances with provided tags %v", len(instances), l.config.Tags)
 	}
-	log.Debugf("found %d rds instances with provided tags %v", len(instances), l.config.Tags)
 	discoveredServices := make(map[string]struct{})
 	for _, instance := range instances {
 		log.Debugf("found rds instance %v", instance)

--- a/comp/core/autodiscovery/listeners/dbm_rds_test.go
+++ b/comp/core/autodiscovery/listeners/dbm_rds_test.go
@@ -27,6 +27,7 @@ func TestDBMRdsListener(t *testing.T) {
 		name                  string
 		config                map[string]interface{}
 		numDiscoveryIntervals int
+		initialServices       map[string]Service
 		rdsClientConfigurer   mockRdsClientConfigurer
 		expectedServices      []*DBMRdsService
 		expectedDelServices   []*DBMRdsService
@@ -192,6 +193,52 @@ func TestDBMRdsListener(t *testing.T) {
 			},
 			expectedDelServices: []*DBMRdsService{},
 		},
+		{
+			name: "previously discovered services are deleted when no instances found",
+			config: map[string]interface{}{
+				"discoveryInterval": 1,
+				"region":            "us-east-1",
+				"tags":              []string{defaultADTag},
+				"dbmTag":            defaultDbmTag,
+			},
+			numDiscoveryIntervals: 0,
+			initialServices: map[string]Service{
+				"36740c31448ee889": &DBMRdsService{
+					adIdentifier: dbmPostgresADIdentifier,
+					entityID:     "36740c31448ee889",
+					checkName:    "postgres",
+					region:       "us-east-1",
+					instance: &aws.Instance{
+						ID:         "my-instance-1",
+						Endpoint:   "my-endpoint",
+						Port:       5432,
+						IamEnabled: true,
+						Engine:     "postgres",
+						DbmEnabled: true,
+					},
+				},
+			},
+			rdsClientConfigurer: func(k *aws.MockRdsClient) {
+				k.EXPECT().GetRdsInstancesFromTags(gomock.Any(), gomock.Any()).Return([]aws.Instance{}, nil).AnyTimes()
+			},
+			expectedServices: []*DBMRdsService{},
+			expectedDelServices: []*DBMRdsService{
+				{
+					adIdentifier: dbmPostgresADIdentifier,
+					entityID:     "36740c31448ee889",
+					checkName:    "postgres",
+					region:       "us-east-1",
+					instance: &aws.Instance{
+						ID:         "my-instance-1",
+						Endpoint:   "my-endpoint",
+						Port:       5432,
+						IamEnabled: true,
+						Engine:     "postgres",
+						DbmEnabled: true,
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -208,6 +255,9 @@ func TestDBMRdsListener(t *testing.T) {
 			err := mapstructure.Decode(tc.config, &newRdsConfig)
 			assert.NoError(t, err)
 			l := newDBMRdsListener(newRdsConfig, mockAWSClient, ticks)
+			if tc.initialServices != nil {
+				l.(*DBMRdsListener).services = tc.initialServices
+			}
 			l.Listen(newSvc, delSvc)
 			// execute loop
 			for i := 0; i < tc.numDiscoveryIntervals; i++ {

--- a/pkg/databasemonitoring/aws/aurora.go
+++ b/pkg/databasemonitoring/aws/aurora.go
@@ -9,7 +9,6 @@ package aws
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"hash/fnv"
 	"strconv"
@@ -36,7 +35,7 @@ const (
 // requires the dbClusterIdentifier for the cluster
 func (c *Client) GetAuroraClusterEndpoints(ctx context.Context, dbClusterIdentifiers []string, config Config) (map[string]*AuroraCluster, error) {
 	if len(dbClusterIdentifiers) == 0 {
-		return nil, errors.New("at least one database cluster identifier is required")
+		return nil, nil
 	}
 	clusters := make(map[string]*AuroraCluster, 0)
 	for _, clusterID := range dbClusterIdentifiers {

--- a/pkg/databasemonitoring/aws/aurora_test.go
+++ b/pkg/databasemonitoring/aws/aurora_test.go
@@ -29,10 +29,10 @@ func TestGetAuroraClusterEndpoints(t *testing.T) {
 		expectedErr                    error
 	}{
 		{
-			name:            "no cluster ids given",
-			configureClient: func(*MockrdsService) {},
-			clusterIDs:      nil,
-			expectedErr:     errors.New("at least one database cluster identifier is required"),
+			name:                           "no cluster ids given",
+			configureClient:                func(*MockrdsService) {},
+			clusterIDs:                     nil,
+			expectedAuroraClusterEndpoints: nil,
 		},
 		{
 			name: "single cluster id returns no results from API",

--- a/releasenotes/notes/fix-aurora-autodiscovery-cluster-bug-78a34cfc10b8f955.yaml
+++ b/releasenotes/notes/fix-aurora-autodiscovery-cluster-bug-78a34cfc10b8f955.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixes a bug where autodiscovered services were not being deleted if GetAuroraClustersFromTags returned no matches. 
+    Fixes a bug where autodiscovered services were not being deleted if GetAuroraClustersFromTags or GetRdsInstancesFromTags returned no matches. 

--- a/releasenotes/notes/fix-aurora-autodiscovery-cluster-bug-78a34cfc10b8f955.yaml
+++ b/releasenotes/notes/fix-aurora-autodiscovery-cluster-bug-78a34cfc10b8f955.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug where autodiscovered services were not being deleted if GetAuroraClustersFromTags returned no matches. 


### PR DESCRIPTION
## Summary

- **Bug:** When `GetAuroraClustersFromTags` returns an empty list (e.g. customer removes the autodiscovery tag from their only cluster), `discoverAuroraClusters()` returned early before reaching `findDeletedServices`/`deleteServices`, leaving stale services in `l.services` indefinitely. This happens for autodiscovery of RDS instances as well.
- **Fix:** Remove the early return when `len(ids) == 0` and let execution fall through to the deletion logic with an empty `discoveredServices` map. This correctly identifies all existing services as deleted.
- **Test:** Added test coverage that asserts the unmatched service appears on `delSvc`.

## Test plan

- [x] Existing unit tests pass (`dda inv test --targets=./comp/core/autodiscovery/listeners --build-exclude=systemd` — 184 passed)
- [x] New test validates the auto-undiscovery scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)