### PR TITLE
Load env proxy settings regardless of core-config

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -230,6 +230,12 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 		pkgconfig.Set("proxy.https", ddc.ProxyURL, pkgconfigmodel.SourceLocalConfigProcess)
 	}
 
+	// Always load proxy env vars (DD_PROXY_HTTP, DD_PROXY_HTTPS, DD_PROXY_NO_PROXY,
+	// HTTP_PROXY, HTTPS_PROXY, NO_PROXY) regardless of whether --core-config was provided.
+	// Without this, LoadDatadog is never called when no core config is given, and proxy
+	// env vars are silently ignored.
+	pkgconfigsetup.LoadProxyFromEnv(pkgconfig)
+
 	// Apply dogtelextension config only in standalone mode. In connected mode
 	// the core agent owns these settings; we must not override them here.
 	if pkgconfig.GetBool("otel_standalone") {

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -386,6 +386,63 @@ func (suite *ConfigTestSuite) TestDDAPISiteSet() {
 	assert.Equal(t, "https://trace.agent.us3.datadoghq.com", c.Get("apm_config.apm_dd_url"))
 }
 
+func (suite *ConfigTestSuite) TestProxyDDEnvVarsWithoutCoreConfig() {
+	t := suite.T()
+	t.Setenv("DD_PROXY_HTTP", "http://dd-proxy.example.com:8080")
+	t.Setenv("DD_PROXY_HTTPS", "https://dd-proxy.example.com:8443")
+	t.Setenv("DD_PROXY_NO_PROXY", "localhost,127.0.0.1")
+
+	pkgconfig, err := NewConfigComponent(context.Background(), "", []string{"testdata/config.yaml"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "http://dd-proxy.example.com:8080", pkgconfig.GetString("proxy.http"))
+	assert.Equal(t, "https://dd-proxy.example.com:8443", pkgconfig.GetString("proxy.https"))
+	// 169.254.169.254 and 100.100.100.200 are added by default (cloud metadata endpoints)
+	assert.ElementsMatch(t, []string{"localhost", "127.0.0.1", "169.254.169.254", "100.100.100.200"}, pkgconfig.GetStringSlice("proxy.no_proxy"))
+}
+
+func (suite *ConfigTestSuite) TestProxyHTTPEnvVarsWithoutCoreConfig() {
+	t := suite.T()
+	t.Setenv("HTTP_PROXY", "http://proxy.example.com:8080")
+	t.Setenv("HTTPS_PROXY", "https://proxy.example.com:8443")
+	t.Setenv("NO_PROXY", "localhost,127.0.0.1")
+
+	pkgconfig, err := NewConfigComponent(context.Background(), "", []string{"testdata/config.yaml"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "http://proxy.example.com:8080", pkgconfig.GetString("proxy.http"))
+	assert.Equal(t, "https://proxy.example.com:8443", pkgconfig.GetString("proxy.https"))
+	// 169.254.169.254 and 100.100.100.200 are added by default (cloud metadata endpoints)
+	assert.ElementsMatch(t, []string{"localhost", "127.0.0.1", "169.254.169.254", "100.100.100.200"}, pkgconfig.GetStringSlice("proxy.no_proxy"))
+}
+
+func (suite *ConfigTestSuite) TestProxyDDEnvVarsTakePrecedenceOverHTTPEnvVars() {
+	t := suite.T()
+	t.Setenv("DD_PROXY_HTTP", "http://dd-proxy.example.com:8080")
+	t.Setenv("DD_PROXY_HTTPS", "https://dd-proxy.example.com:8443")
+	t.Setenv("HTTP_PROXY", "http://other-proxy.example.com:8080")
+	t.Setenv("HTTPS_PROXY", "https://other-proxy.example.com:8443")
+
+	pkgconfig, err := NewConfigComponent(context.Background(), "", []string{"testdata/config.yaml"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "http://dd-proxy.example.com:8080", pkgconfig.GetString("proxy.http"))
+	assert.Equal(t, "https://dd-proxy.example.com:8443", pkgconfig.GetString("proxy.https"))
+}
+
+func (suite *ConfigTestSuite) TestProxyConfigURLTakesPrecedenceOverDDEnvVars() {
+	t := suite.T()
+	t.Setenv("DD_PROXY_HTTP", "http://dd-proxy.example.com:8080")
+	t.Setenv("DD_PROXY_HTTPS", "https://dd-proxy.example.com:8443")
+
+	pkgconfig, err := NewConfigComponent(context.Background(), "", []string{"testdata/config_proxy.yaml"})
+	require.NoError(t, err)
+
+	// proxy_url from OTel exporter config should take precedence over DD_PROXY_* env vars
+	assert.Equal(t, "http://proxyurl.example.com:3128", pkgconfig.GetString("proxy.http"))
+	assert.Equal(t, "http://proxyurl.example.com:3128", pkgconfig.GetString("proxy.https"))
+}
+
 func (suite *ConfigTestSuite) TestProxyEnvVarsBoth() {
 	t := suite.T()
 	t.Setenv("HTTP_PROXY", "http://proxy.example.com:8080")

--- a/releasenotes/notes/gateway-proxy-envvars-67fbff104425c34a.yaml
+++ b/releasenotes/notes/gateway-proxy-envvars-67fbff104425c34a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    ``DD_PROXY_HTTP``, ``DD_PROXY_HTTPS``, ``HTTP_PROXY``, ``HTTPS_PROXY``,
+    ``DD_PROXY_NO_PROXY``, and ``NO_PROXY`` environment variables are now
+    respected by the standalone OTel agent without requiring ``--core-config``.


### PR DESCRIPTION
### What does this PR do?

Allow setting the HTTP proxy from standalone DDOT (e.g. gateways) without having a core config

### Motivation
[OTAGENT-947](https://datadoghq.atlassian.net/browse/OTAGENT-947?atlOrigin=eyJpIjoiMDI5Y2E1YjFjZjdhNDI3NzlhNjU3NGZjOTVmMGNhMDUiLCJwIjoiaiJ9)

### Describe how you validated your changes

Used `mitmproxy` to see traffic going through a local proxy


[OTAGENT-947]: https://datadoghq.atlassian.net/browse/OTAGENT-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ