### PR TITLE
[SMP] bump `quality_gate_idle` memory limit

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 210 MiB
+  memory_allotment: 217 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -38,7 +38,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher
-      upper_bound: "175 MiB"
+      upper_bound: "181 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
### What does this PR do?

Bumps the `quality_gate_idle` memory limit from `175 MiB` to `181 MiB` 

### Motivation

Main has been out of spec ever so slightly for a while now on this check. We have some incoming approved regressions and also optimizations.
