### PR TITLE
[NTWK-735] Fix bpffs volume reference for cilium

### DIFF
--- a/pkg/network/tracer/cilium_lb.go
+++ b/pkg/network/tracer/cilium_lb.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 	"unsafe"
@@ -28,7 +29,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/netlink"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -155,6 +155,15 @@ func newCiliumLoadBalancerConntracker(cfg *config.Config) (netlink.Conntracker, 
 	return clb, nil
 }
 
+// ciliumBPFRoot returns the root of the bpffs where cilium maps are pinned.
+// The system-probe container has a volume mounted at /sys/fs/bpf pointing directly to the host's bpffs.
+//
+// bpffs is a separate virtual filesystem, meaning that since /host is not a recursive
+// bind mount, it's not going to have /host/sys/fs/bpf, it will just be missing.
+func ciliumBPFRoot() string {
+	return "/sys/fs/bpf"
+}
+
 func loadMaps() (ctTCP, ctUDP, backends *ebpf.Map, err error) {
 	defer func() {
 		if err != nil {
@@ -164,17 +173,18 @@ func loadMaps() (ctTCP, ctUDP, backends *ebpf.Map, err error) {
 		}
 	}()
 
-	ctTCP, err = loadMap(kernel.HostSys("/fs/bpf/tc/globals/cilium_ct4_global"))
+	bpffsRoot := ciliumBPFRoot()
+	ctTCP, err = loadMap(filepath.Join(bpffsRoot, "tc/globals/cilium_ct4_global"))
 	if ctTCP == nil {
 		return nil, nil, nil, err
 	}
 
-	ctUDP, err = loadMap(kernel.HostSys("/fs/bpf/tc/globals/cilium_ct_any4_global"))
+	ctUDP, err = loadMap(filepath.Join(bpffsRoot, "tc/globals/cilium_ct_any4_global"))
 	if ctUDP == nil {
 		return nil, nil, nil, err
 	}
 
-	backends, err = loadMap(kernel.HostSys("/fs/bpf/tc/globals/cilium_lb4_backends_v3"))
+	backends, err = loadMap(filepath.Join(bpffsRoot, "tc/globals/cilium_lb4_backends_v3"))
 	if backends == nil {
 		return nil, nil, nil, err
 	}

--- a/releasenotes/notes/cnm-cilium-bpffs-f3f41971067ca658.yaml
+++ b/releasenotes/notes/cnm-cilium-bpffs-f3f41971067ca658.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes an issue where Cloud Network Monitoring would not resolve NAT'd cluster IPs when using Cilium to replace kube-proxy.


### PR DESCRIPTION
### What does this PR do?
This PR fixes the path that the agent uses to check for the presence of cilium eBPF maps.

### Motivation
Customer reported issue -- the basic problem is, `/host` is not a recursive mount so bpffs is not included.

### Describe how you validated your changes
Checked the presence of bpffs at the expected path on a cluster with Cilium replacing kube-proxy:
```
root@ip-192-168-94-113:/# ls /sys/fs/bpf/tc/globals/cilium_ct4_global
/sys/fs/bpf/tc/globals/cilium_ct4_global
root@ip-192-168-94-113:/# ls /host/sys/fs/bpf/tc/globals/cilium_ct4_global
ls: cannot access '/host/sys/fs/bpf/tc/globals/cilium_ct4_global': No such file or directory
```