### PR TITLE
[observer] Add local gensim episode runner (Kind) and status TUI --local mode

### DIFF
--- a/.claude/skills/inspect-agent-egress-traffic/SKILL.md
+++ b/.claude/skills/inspect-agent-egress-traffic/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: inspect-agent-egress-traffic
+description: >
+  Inspect what metrics/traces/logs the Datadog Agent is sending to intake by
+  running a MiTM proxy (proxy-dumper) between the agent and Datadog endpoints.
+  Use this skill when the user wants to verify intake isolation, debug metric
+  cardinality, validate that specific metrics do/don't reach intake, or inspect
+  agent egress traffic. Also trigger when the user mentions "proxy-dumper",
+  "intake isolation", "what is the agent sending", "MiTM proxy", or wants to
+  see what the forwarder is sending to Datadog.
+---
+
+# Inspect Agent Egress Traffic
+
+Run a MiTM proxy between the Datadog Agent and Datadog intake endpoints to
+inspect, filter, and validate outbound metric/trace/log payloads.
+
+## Prerequisites
+
+This skill requires the `proxy-dumper` Docker image, built from the
+`datadog-agent-benchmarks` repository (Datadog-internal only).
+
+Check if the user is a Datadog employee by testing for `ddtool` in PATH:
+
+```bash
+which ddtool >/dev/null 2>&1
+```
+
+If `ddtool` is not found, tell the user this skill requires internal Datadog
+tooling and stop.
+
+## Building proxy-dumper
+
+The source lives at `~/dd/datadog-agent-benchmarks/docker/proxy-dumper/`
+(or `$DATADOG_AGENT_BENCHMARKS_PATH/docker/proxy-dumper/`).
+
+```bash
+BENCHMARKS_PATH="${DATADOG_AGENT_BENCHMARKS_PATH:-$HOME/dd/datadog-agent-benchmarks}"
+docker build -t proxy-dumper "$BENCHMARKS_PATH/docker/proxy-dumper/"
+```
+
+If the benchmarks repo isn't found, tell the user:
+```
+git clone git@github.com:DataDog/datadog-agent-benchmarks.git ~/dd/datadog-agent-benchmarks
+```
+
+Check if the image already exists before building — `docker image inspect
+proxy-dumper >/dev/null 2>&1` skips the build if it's cached.
+
+## proxy-dumper flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `-f/--prefix <string>` | `""` (all) | Filter metrics by name prefix (e.g. `-f system.` or `-f container.`) |
+| `--points-print` | off | Include timestamps on each data point |
+| `--print-origins` | off | Show metric origin metadata (MetricSource enum) |
+| `--proxy-requests=false` | true | Capture only, don't forward to real intake (no API key needed) |
+| `--proxy-requests=true` | (default) | Forward to real intake after inspection |
+| `-l :PORT` | `:8081` | Listen address |
+| `-p/--protobuf-print` | true | Print protobuf v2 series payloads |
+| `-j/--json-print` | true | Print JSON v1 series payloads |
+| `-k/--sketch-print` | true | Print DDSketch payloads |
+
+## tmux orchestration
+
+Use a dedicated tmux session called `egress-inspect` with two windows. These
+commands are self-contained — no tmux skill dependency required.
+
+### Setup
+
+```bash
+tmux new-session -d -s egress-inspect
+tmux new-window -t egress-inspect -n proxy
+tmux new-window -t egress-inspect -n agent
+```
+
+### Start proxy-dumper
+
+```bash
+tmux send-keys -t egress-inspect:proxy \
+  "docker run --rm -p 8081:8081 proxy-dumper [FLAGS] 2>&1 | tee /tmp/proxy-dump.log" Enter
+```
+
+Replace `[FLAGS]` with the appropriate flags for the use case. Wait ~2 seconds
+and verify it started:
+
+```bash
+sleep 2
+tmux capture-pane -t egress-inspect:proxy -p | tail -5
+# Should show "Starting server" log line
+```
+
+### Start the agent
+
+Generate a temp config pointing ALL endpoints at the proxy. Note: `dd_url`
+alone only routes metrics. Event platform pipelines (container lifecycle, logs,
+container images) each need explicit `logs_dd_url` overrides due to a known
+bug (see DataDog/datadog-agent#48814).
+
+```bash
+cat > /tmp/egress-inspect-datadog.yaml << 'YAML'
+api_key: "0000001"
+dd_url: "http://localhost:8081"
+hostname: "egress-inspect"
+
+# Event platform pipelines need explicit endpoint overrides.
+# dd_url alone does not route these (bug: #48814).
+container_lifecycle:
+  enabled: true
+  logs_dd_url: "http://localhost:8081"
+container_image:
+  logs_dd_url: "http://localhost:8081"
+logs_config:
+  logs_dd_url: "http://localhost:8081"
+YAML
+```
+
+If `DDDEV_API_KEY` is set and the user wants real forwarding, use that instead
+of the dummy key. Add any additional agent config the user specifies before
+starting.
+
+```bash
+tmux send-keys -t egress-inspect:agent \
+  "sudo ./bin/agent/agent run -c /tmp/egress-inspect-datadog.yaml 2>&1 | tee /tmp/agent-egress.log" Enter
+```
+
+### Monitor
+
+```bash
+# Check proxy is receiving traffic
+tmux capture-pane -t egress-inspect:proxy -p | tail -20
+
+# Check agent is running
+tmux display-message -t egress-inspect:agent -p "#{pane_current_command}"
+
+# Read full captured traffic
+cat /tmp/proxy-dump.log
+
+# Count occurrences of a specific metric
+grep 'Metric="system.cpu.user"' /tmp/proxy-dump.log | wc -l
+```
+
+### Cleanup
+
+```bash
+tmux send-keys -t egress-inspect:agent C-c
+sleep 1
+tmux send-keys -t egress-inspect:proxy C-c
+sleep 1
+tmux kill-session -t egress-inspect
+rm -f /tmp/egress-inspect-datadog.yaml
+```
+
+## Common use cases
+
+### Verify HF metrics don't reach intake
+
+```bash
+# proxy-dumper filtering for system.* metrics, no forwarding
+docker run --rm -p 8081:8081 proxy-dumper -f system. --proxy-requests=false
+```
+
+Run the agent for 60 seconds, then count:
+
+```bash
+grep 'Metric="system.cpu.user"' /tmp/proxy-dump.log | wc -l
+```
+
+At 15s check interval, expect ~4 occurrences per minute. If you see ~60, the
+1s HF metrics are leaking through the forwarder.
+
+### Inspect container metric cardinality
+
+```bash
+docker run --rm -p 8081:8081 proxy-dumper \
+  -f container. --points-print --print-origins
+```
+
+Look for per-`container_id` tag explosion in the output.
+
+### Full traffic inspection with forwarding
+
+```bash
+docker run --rm -p 8081:8081 proxy-dumper --proxy-requests=true
+```
+
+All traffic is visible AND forwarded to real Datadog intake. Requires a valid
+`api_key` in the agent config.
+
+### Count unique metric names being sent
+
+```bash
+grep 'Metric="' /tmp/proxy-dump.log \
+  | sed 's/.*Metric="\([^"]*\)".*/\1/' \
+  | sort -u | wc -l
+```
+
+### Measure per-metric submission rate
+
+```bash
+# After running for 60 seconds:
+grep 'Metric="system.cpu.user"' /tmp/proxy-dump.log | wc -l
+# Divide by 60 for per-second rate
+```
+
+### Check metric timestamps for cadence
+
+```bash
+grep -A1 'Metric="system.cpu.user"' /tmp/proxy-dump.log | grep Timestamp
+# Look at the time gaps between consecutive entries
+```

--- a/deps/py_dev_requirements.txt
+++ b/deps/py_dev_requirements.txt
@@ -1,2 +1,3 @@
 invoke==2.2.1
+pyarrow>=17.0.0
 pyyaml==6.0.3

--- a/q_branch/gensim-status.py
+++ b/q_branch/gensim-status.py
@@ -801,8 +801,35 @@ def _probe_local() -> str:
         return "[dim]✕[/dim] unavailable"
 
 
+def _probe_aws_auth() -> str:
+    """Check AWS auth via sts get-caller-identity. Returns a short status string."""
+    try:
+        r = subprocess.run(
+            ["aws", "sts", "get-caller-identity", "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            data = json.loads(r.stdout.strip())
+            arn = data.get("Arn", "")
+            # Show just the role/user name, not the full ARN
+            short = arn.rsplit("/", 1)[-1] if "/" in arn else arn
+            return f"[green]✓[/green] {short}"
+        return "[red]✕[/red] not authenticated"
+    except FileNotFoundError:
+        return "[dim]✕[/dim] aws cli not installed"
+    except Exception:
+        return "[red]✕[/red] auth failed"
+
+
 def _probe_remote() -> str:
     """Quick synchronous probe: is a remote EKS run active? Returns status string."""
+    # First check AWS auth — everything else depends on it.
+    aws_status = _probe_aws_auth()
+    if "✕" in aws_status:
+        return f"[dim]✕[/dim] AWS: {aws_status}"
+
     kc = os.environ.get("KUBECONFIG", f"{_STACK_NAME}-kubeconfig.yaml")
     try:
         r = subprocess.run(
@@ -820,15 +847,15 @@ def _probe_remote() -> str:
                 running = sum(1 for s in statuses if s == "running")
                 done = sum(1 for s in statuses if s == "done")
                 if running:
-                    return f"[yellow]●[/yellow] {running} running, {done} done"
-                return f"[green]●[/green] {len(eps)} done"
-            return "[yellow]●[/yellow] run detected"
+                    return f"[yellow]●[/yellow] {running} running, {done} done  (AWS: {aws_status})"
+                return f"[green]●[/green] {len(eps)} done  (AWS: {aws_status})"
+            return f"[yellow]●[/yellow] run detected  (AWS: {aws_status})"
         # Check if kubeconfig exists
         if Path(kc).exists():
-            return "[dim]○[/dim] cluster reachable, no active run"
-        return "[dim]✕[/dim] no kubeconfig"
+            return f"[dim]○[/dim] no active run  (AWS: {aws_status})"
+        return f"[dim]✕[/dim] no kubeconfig  (AWS: {aws_status})"
     except Exception:
-        return "[dim]✕[/dim] unavailable"
+        return f"[dim]✕[/dim] cluster unreachable  (AWS: {aws_status})"
 
 
 class ModeOption(Static):

--- a/q_branch/gensim-status.py
+++ b/q_branch/gensim-status.py
@@ -32,6 +32,7 @@ import asyncio
 import json
 import os
 import re
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -39,8 +40,9 @@ from typing import Any
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal
+from textual.containers import Horizontal, Vertical
 from textual.reactive import reactive
+from textual.screen import Screen
 from textual.widgets import Footer, Header, Static
 
 # ---------------------------------------------------------------------------
@@ -48,37 +50,46 @@ from textual.widgets import Footer, Header, Static
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
-# Mode detection: --local flag switches to Kind cluster, skips Pulumi/EKS
+# Mode config — mutable globals, set by mode selection screen or --local flag
 # ---------------------------------------------------------------------------
 LOCAL_MODE = "--local" in sys.argv
 
-# Auto-detect stack name from the user prefix (matches e2e framework convention).
 _USER = os.environ.get("USER", "unknown").replace(".", "-")
 _STACK_NAME = os.environ.get("GENSIM_STACK_NAME", f"{_USER}-gensim-eks")
-
-if LOCAL_MODE:
-    _LOCAL_CLUSTER = os.environ.get("LOCAL_CLUSTER_NAME", "observer-local")
-    KUBECONFIG = os.path.expanduser("~/.kube/config")
-    PULUMI_STATE = "/dev/null"  # no Pulumi for local
-    EKS_CLUSTER_NAME = ""
-    LOCAL_EPISODE_LOG = "/tmp/local-episode-runner.log"
-else:
-    _LOCAL_CLUSTER = ""
-    LOCAL_EPISODE_LOG = ""
-    # All paths derived from stack name -- override via env vars if needed.
-    KUBECONFIG = os.environ.get("KUBECONFIG", f"{_STACK_NAME}-kubeconfig.yaml")
-    PULUMI_STATE = os.path.expanduser(os.environ.get("PULUMI_STATE", f"~/.pulumi/stacks/{_STACK_NAME}.json"))
-    EKS_CLUSTER_NAME = os.environ.get("EKS_CLUSTER_NAME", _STACK_NAME)
-
+_LOCAL_CLUSTER = os.environ.get("LOCAL_CLUSTER_NAME", "observer-local")
 EKS_REGION = os.environ.get("EKS_REGION", "us-east-1")
 
-KUBECTL_ENV = {**os.environ, "KUBECONFIG": KUBECONFIG}
+# These are reconfigured by _apply_mode() after selection.
+KUBECONFIG = ""
+PULUMI_STATE = ""
+EKS_CLUSTER_NAME = ""
+LOCAL_EPISODE_LOG = ""
+KUBECTL_ENV: dict[str, str] = {}
+
+
+def _apply_mode(local: bool) -> None:
+    """Configure global variables for the selected mode."""
+    global LOCAL_MODE, KUBECONFIG, PULUMI_STATE, EKS_CLUSTER_NAME, LOCAL_EPISODE_LOG, KUBECTL_ENV
+    LOCAL_MODE = local
+    if local:
+        KUBECONFIG = os.path.expanduser("~/.kube/config")
+        PULUMI_STATE = "/dev/null"
+        EKS_CLUSTER_NAME = ""
+        LOCAL_EPISODE_LOG = "/tmp/local-episode-runner.log"
+        KUBECTL_ENV = {**os.environ, "KUBECONFIG": KUBECONFIG, "KUBECTL_CONTEXT": f"kind-{_LOCAL_CLUSTER}"}
+    else:
+        KUBECONFIG = os.environ.get("KUBECONFIG", f"{_STACK_NAME}-kubeconfig.yaml")
+        PULUMI_STATE = os.path.expanduser(os.environ.get("PULUMI_STATE", f"~/.pulumi/stacks/{_STACK_NAME}.json"))
+        EKS_CLUSTER_NAME = os.environ.get("EKS_CLUSTER_NAME", _STACK_NAME)
+        LOCAL_EPISODE_LOG = ""
+        KUBECTL_ENV = {**os.environ, "KUBECONFIG": KUBECONFIG}
+
+
+# Apply immediately if --local was passed (skip the selection screen).
 if LOCAL_MODE:
-    # For Kind, we need the context in all kubectl calls. The easiest way is to
-    # set KUBECTL_CONTEXT which some helpers use, and inject --context into
-    # fetch_configmap. For the generic kubectl calls (pods, nodes) that go via
-    # run_cmd, we just set the current-context in KUBECTL_ENV.
-    KUBECTL_ENV["KUBECTL_CONTEXT"] = f"kind-{_LOCAL_CLUSTER}"
+    _apply_mode(True)
+else:
+    _apply_mode(False)
 
 # Phase durations (seconds) extracted from typical gensim orchestrator defaults.
 PHASE_DURATIONS: dict[str, int] = {
@@ -739,12 +750,190 @@ class PodLogsWidget(Static):
 
 
 # ---------------------------------------------------------------------------
+# Mode selection screen
+# ---------------------------------------------------------------------------
+
+
+def _probe_local() -> str:
+    """Quick synchronous probe: is a local Kind run active? Returns status string."""
+    try:
+        r = subprocess.run(
+            [
+                "kubectl",
+                "--context",
+                f"kind-{_LOCAL_CLUSTER}",
+                "get",
+                "configmap",
+                "gensim-run-status",
+                "-o",
+                "jsonpath={.data.status}",
+                "-n",
+                "default",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={**os.environ, "KUBECONFIG": os.path.expanduser("~/.kube/config")},
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            data = json.loads(r.stdout.strip())
+            eps = data.get("episodes", [])
+            if eps:
+                ep = eps[0]
+                status = ep.get("status", "?")
+                phase = ep.get("phase", "")
+                name = ep.get("episode", "?")
+                if status == "done":
+                    return f"[green]●[/green] {name}: done"
+                return f"[yellow]●[/yellow] {name}: {status} ({phase})"
+            return "[yellow]●[/yellow] run detected"
+        # Check if cluster exists at all
+        r2 = subprocess.run(
+            ["kind", "get", "clusters"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if _LOCAL_CLUSTER in (r2.stdout or ""):
+            return "[dim]○[/dim] cluster exists, no active run"
+        return "[dim]✕[/dim] no cluster"
+    except Exception:
+        return "[dim]✕[/dim] unavailable"
+
+
+def _probe_remote() -> str:
+    """Quick synchronous probe: is a remote EKS run active? Returns status string."""
+    kc = os.environ.get("KUBECONFIG", f"{_STACK_NAME}-kubeconfig.yaml")
+    try:
+        r = subprocess.run(
+            ["kubectl", "get", "configmap", "gensim-run-status", "-o", "jsonpath={.data.status}", "-n", "default"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={**os.environ, "KUBECONFIG": kc},
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            data = json.loads(r.stdout.strip())
+            eps = data.get("episodes", [])
+            if eps:
+                statuses = [e.get("status", "?") for e in eps]
+                running = sum(1 for s in statuses if s == "running")
+                done = sum(1 for s in statuses if s == "done")
+                if running:
+                    return f"[yellow]●[/yellow] {running} running, {done} done"
+                return f"[green]●[/green] {len(eps)} done"
+            return "[yellow]●[/yellow] run detected"
+        # Check if kubeconfig exists
+        if Path(kc).exists():
+            return "[dim]○[/dim] cluster reachable, no active run"
+        return "[dim]✕[/dim] no kubeconfig"
+    except Exception:
+        return "[dim]✕[/dim] unavailable"
+
+
+class ModeOption(Static):
+    """A selectable mode option in the picker."""
+
+    def __init__(self, label: str, status: str, is_local: bool, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.label = label
+        self.status = status
+        self.is_local = is_local
+        self.selected = False
+
+    def render(self) -> str:
+        arrow = "[bold cyan]▸[/bold cyan] " if self.selected else "  "
+        return f"{arrow}[bold]{self.label}[/bold]\n    {self.status}"
+
+
+class ModeSelectScreen(Screen):
+    """Startup screen to pick local or remote mode."""
+
+    BINDINGS = [
+        Binding("up", "move_up", "Up", show=False),
+        Binding("down", "move_down", "Down", show=False),
+        Binding("k", "move_up", "Up", show=False),
+        Binding("j", "move_down", "Down", show=False),
+        Binding("enter", "select", "Select"),
+        Binding("q", "quit", "Quit"),
+    ]
+
+    CSS = """
+    ModeSelectScreen {
+        align: center middle;
+    }
+    #mode-box {
+        width: 60;
+        height: auto;
+        padding: 1 2;
+        border: round $accent;
+    }
+    #mode-title {
+        text-align: center;
+        text-style: bold;
+        margin-bottom: 1;
+    }
+    ModeOption {
+        height: 3;
+        margin: 0 1;
+    }
+    #mode-hint {
+        text-align: center;
+        margin-top: 1;
+        color: $text-muted;
+    }
+    """
+
+    def __init__(self, local_status: str, remote_status: str, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._local_status = local_status
+        self._remote_status = remote_status
+        self._selected = 0  # 0 = local, 1 = remote
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="mode-box"):
+            yield Static("Gensim Status Monitor", id="mode-title")
+            yield ModeOption("Local (Kind)", self._local_status, is_local=True, id="opt-local")
+            yield ModeOption("Remote (EKS)", self._remote_status, is_local=False, id="opt-remote")
+            yield Static("↑↓ to select, Enter to confirm", id="mode-hint")
+
+    def on_mount(self) -> None:
+        self._update_selection()
+
+    def action_move_up(self) -> None:
+        self._selected = 0
+        self._update_selection()
+
+    def action_move_down(self) -> None:
+        self._selected = 1
+        self._update_selection()
+
+    def action_select(self) -> None:
+        is_local = self._selected == 0
+        _apply_mode(is_local)
+        self.app.title = "Gensim Local Monitor" if is_local else "Gensim EKS Monitor"
+        self.app.pop_screen()
+        self.app._start_monitoring()  # noqa: SLF001
+
+    def action_quit(self) -> None:
+        self.app.exit()
+
+    def _update_selection(self) -> None:
+        local_opt = self.query_one("#opt-local", ModeOption)
+        remote_opt = self.query_one("#opt-remote", ModeOption)
+        local_opt.selected = self._selected == 0
+        remote_opt.selected = self._selected == 1
+        local_opt.refresh()
+        remote_opt.refresh()
+
+
+# ---------------------------------------------------------------------------
 # App
 # ---------------------------------------------------------------------------
 
 
 class GensimStatusApp(App):
-    """Gensim EKS evaluation run monitor."""
+    """Gensim evaluation run monitor."""
 
     CSS = """
     #top-row {
@@ -752,7 +941,7 @@ class GensimStatusApp(App):
     }
     """
 
-    TITLE = "Gensim Local Monitor" if LOCAL_MODE else "Gensim EKS Monitor"
+    TITLE = "Gensim Status Monitor"
     BINDINGS = [
         Binding("q", "quit", "Quit"),
         Binding("r", "refresh", "Refresh now"),
@@ -785,6 +974,18 @@ class GensimStatusApp(App):
         yield Footer()
 
     def on_mount(self) -> None:
+        if "--local" in sys.argv or "--remote" in sys.argv:
+            # Mode was specified on CLI — skip the picker.
+            self._start_monitoring()
+        else:
+            # Probe both and show the picker.
+            local_status = _probe_local()
+            remote_status = _probe_remote()
+            self.push_screen(ModeSelectScreen(local_status, remote_status))
+
+    def _start_monitoring(self) -> None:
+        """Begin polling after mode has been selected."""
+        self.title = "Gensim Local Monitor" if LOCAL_MODE else "Gensim EKS Monitor"
         self.call_later(self.action_refresh)
         if not LOCAL_MODE:
             self.set_interval(5, self._poll_pulumi)
@@ -887,7 +1088,9 @@ class GensimStatusApp(App):
 
 if __name__ == "__main__":
     headless = "--headless" in sys.argv
+    if "--remote" in sys.argv:
+        _apply_mode(False)
     # Strip custom flags before Textual sees argv
-    sys.argv = [a for a in sys.argv if a not in ("--local", "--headless")]
+    sys.argv = [a for a in sys.argv if a not in ("--local", "--remote", "--headless")]
     app = GensimStatusApp()
     app.run(headless=headless)

--- a/q_branch/gensim-status.py
+++ b/q_branch/gensim-status.py
@@ -15,15 +15,15 @@ Real-time TUI that tracks a gensim-eks evaluation run by polling:
   - AWS EKS cluster status (optional)
 
 Usage:
-    # 1. Submit an evaluation run
-    dda inv aws.eks.gensim.submit --image=<agent-image> --episodes=<ep:scenario> --mode=record-parquet
-
-    # 2. Monitor it live with this TUI (run under aws-vault for EKS status)
+    # Remote (EKS) — monitor an evaluation run on gensim-eks
     aws-vault exec sso-agent-sandbox-account-admin -- uv run q_branch/gensim-status.py
 
+    # Local (Kind) — monitor a local episode run
+    uv run q_branch/gensim-status.py --local
+
     # Other useful commands
-    dda inv aws.eks.gensim.status    # Quick non-interactive status check
-    dda inv aws.eks.gensim.destroy   # Tear down the EKS cluster
+    dda inv aws.eks.gensim.status    # Quick non-interactive status check (EKS)
+    dda inv q.run-local-episode ...  # Start a local episode run
 """
 
 from __future__ import annotations
@@ -32,6 +32,7 @@ import asyncio
 import json
 import os
 import re
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -46,17 +47,38 @@ from textual.widgets import Footer, Header, Static
 # Config
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Mode detection: --local flag switches to Kind cluster, skips Pulumi/EKS
+# ---------------------------------------------------------------------------
+LOCAL_MODE = "--local" in sys.argv
+
 # Auto-detect stack name from the user prefix (matches e2e framework convention).
 _USER = os.environ.get("USER", "unknown").replace(".", "-")
 _STACK_NAME = os.environ.get("GENSIM_STACK_NAME", f"{_USER}-gensim-eks")
 
-# All paths derived from stack name -- override via env vars if needed.
-KUBECONFIG = os.environ.get("KUBECONFIG", f"{_STACK_NAME}-kubeconfig.yaml")
-PULUMI_STATE = os.path.expanduser(os.environ.get("PULUMI_STATE", f"~/.pulumi/stacks/{_STACK_NAME}.json"))
-EKS_CLUSTER_NAME = os.environ.get("EKS_CLUSTER_NAME", _STACK_NAME)
+if LOCAL_MODE:
+    _LOCAL_CLUSTER = os.environ.get("LOCAL_CLUSTER_NAME", "observer-local")
+    KUBECONFIG = os.path.expanduser("~/.kube/config")
+    PULUMI_STATE = "/dev/null"  # no Pulumi for local
+    EKS_CLUSTER_NAME = ""
+    LOCAL_EPISODE_LOG = "/tmp/local-episode-runner.log"
+else:
+    _LOCAL_CLUSTER = ""
+    LOCAL_EPISODE_LOG = ""
+    # All paths derived from stack name -- override via env vars if needed.
+    KUBECONFIG = os.environ.get("KUBECONFIG", f"{_STACK_NAME}-kubeconfig.yaml")
+    PULUMI_STATE = os.path.expanduser(os.environ.get("PULUMI_STATE", f"~/.pulumi/stacks/{_STACK_NAME}.json"))
+    EKS_CLUSTER_NAME = os.environ.get("EKS_CLUSTER_NAME", _STACK_NAME)
+
 EKS_REGION = os.environ.get("EKS_REGION", "us-east-1")
 
 KUBECTL_ENV = {**os.environ, "KUBECONFIG": KUBECONFIG}
+if LOCAL_MODE:
+    # For Kind, we need the context in all kubectl calls. The easiest way is to
+    # set KUBECTL_CONTEXT which some helpers use, and inject --context into
+    # fetch_configmap. For the generic kubectl calls (pods, nodes) that go via
+    # run_cmd, we just set the current-context in KUBECTL_ENV.
+    KUBECTL_ENV["KUBECTL_CONTEXT"] = f"kind-{_LOCAL_CLUSTER}"
 
 # Phase durations (seconds) extracted from typical gensim orchestrator defaults.
 PHASE_DURATIONS: dict[str, int] = {
@@ -114,16 +136,17 @@ async def fetch_pulumi_state() -> dict[str, Any]:
 async def fetch_configmap() -> dict[str, Any] | None:
     """Fetch the gensim-run-status configmap."""
     raw = await run_cmd(
-        [
-            "kubectl",
-            "get",
-            "configmap",
-            "gensim-run-status",
-            "-o",
-            "jsonpath={.data.status}",
-            "-n",
-            "default",
-        ],
+        _kubectl_cmd(
+            [
+                "get",
+                "configmap",
+                "gensim-run-status",
+                "-o",
+                "jsonpath={.data.status}",
+                "-n",
+                "default",
+            ]
+        ),
         env=KUBECTL_ENV,
     )
     if not raw:
@@ -135,7 +158,17 @@ async def fetch_configmap() -> dict[str, Any] | None:
 
 
 async def fetch_logs() -> str:
-    """Fetch recent orchestrator logs."""
+    """Fetch recent orchestrator logs (or local episode log in --local mode)."""
+    if LOCAL_MODE:
+        try:
+            path = Path(LOCAL_EPISODE_LOG)
+            if not path.exists():
+                return ""
+            text = await asyncio.to_thread(path.read_text)
+            # Return last 80 lines to match the kubectl tail behavior
+            return "\n".join(text.splitlines()[-80:])
+        except Exception:
+            return ""
     return await run_cmd(
         [
             "kubectl",
@@ -172,14 +205,22 @@ async def fetch_eks_status() -> str:
     )
 
 
+def _kubectl_cmd(args: list[str]) -> list[str]:
+    """Build a kubectl command, injecting --context for local mode."""
+    cmd = ["kubectl"]
+    if LOCAL_MODE:
+        cmd += ["--context", f"kind-{_LOCAL_CLUSTER}"]
+    return cmd + args
+
+
 async def fetch_node_pod_counts() -> tuple[str, str]:
     """Fetch node and pod ready counts."""
     nodes_raw = await run_cmd(
-        ["kubectl", "get", "nodes", "-o", "json"],
+        _kubectl_cmd(["get", "nodes", "-o", "json"]),
         env=KUBECTL_ENV,
     )
     pods_raw = await run_cmd(
-        ["kubectl", "get", "pods", "-A", "-o", "json"],
+        _kubectl_cmd(["get", "pods", "-A", "-o", "json"]),
         env=KUBECTL_ENV,
     )
 
@@ -213,16 +254,17 @@ async def fetch_node_pod_counts() -> tuple[str, str]:
 async def fetch_pod_list() -> list[dict[str, str]]:
     """Fetch pod names and statuses in default namespace using lightweight output."""
     raw = await run_cmd(
-        [
-            "kubectl",
-            "get",
-            "pods",
-            "-n",
-            "default",
-            "--no-headers",
-            "-o",
-            "custom-columns=NAME:.metadata.name,STATUS:.status.phase,READY:.status.containerStatuses[*].ready,RESTARTS:.status.containerStatuses[*].restartCount",
-        ],
+        _kubectl_cmd(
+            [
+                "get",
+                "pods",
+                "-n",
+                "default",
+                "--no-headers",
+                "-o",
+                "custom-columns=NAME:.metadata.name,STATUS:.status.phase,READY:.status.containerStatuses[*].ready,RESTARTS:.status.containerStatuses[*].restartCount",
+            ]
+        ),
         env=KUBECTL_ENV,
     )
     if not raw:
@@ -316,6 +358,18 @@ def build_episode_markup(
     remaining: int | None,
 ) -> str:
     if cm is None:
+        if LOCAL_MODE:
+            return (
+                "[bold]No active local run detected.[/bold]\n"
+                "\n"
+                "Start one with:\n"
+                "  [bold cyan]dda inv q.run-local-episode \\\\[/bold cyan]\n"
+                "    [cyan]--episode=food-delivery-redis \\\\[/cyan]\n"
+                "    [cyan]--image=<agent-image> \\\\[/cyan]\n"
+                "    [cyan]--mode=live-and-record[/cyan]\n"
+                "\n"
+                "[dim]This TUI will auto-refresh when a run starts.[/dim]"
+            )
         return (
             "[bold]No active gensim run detected.[/bold]\n"
             "\n"
@@ -698,7 +752,7 @@ class GensimStatusApp(App):
     }
     """
 
-    TITLE = "Gensim EKS Monitor"
+    TITLE = "Gensim Local Monitor" if LOCAL_MODE else "Gensim EKS Monitor"
     BINDINGS = [
         Binding("q", "quit", "Quit"),
         Binding("r", "refresh", "Refresh now"),
@@ -732,12 +786,13 @@ class GensimStatusApp(App):
 
     def on_mount(self) -> None:
         self.call_later(self.action_refresh)
-        self.set_interval(5, self._poll_pulumi)
+        if not LOCAL_MODE:
+            self.set_interval(5, self._poll_pulumi)
+            self.set_interval(60, self._poll_eks)
         self.set_interval(10, self._poll_configmap)
         self.set_interval(5, self._poll_logs)
         self.set_interval(30, self._poll_infra_kube)
         self.set_interval(30, self._poll_pods)
-        self.set_interval(60, self._poll_eks)
         self._update_pod_logs_visibility()
 
     def on_resize(self) -> None:
@@ -829,8 +884,8 @@ class GensimStatusApp(App):
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    import sys
-
     headless = "--headless" in sys.argv
+    # Strip custom flags before Textual sees argv
+    sys.argv = [a for a in sys.argv if a not in ("--local", "--headless")]
     app = GensimStatusApp()
     app.run(headless=headless)

--- a/q_branch/gensim-status.py
+++ b/q_branch/gensim-status.py
@@ -811,14 +811,16 @@ class GensimStatusApp(App):
 
     async def action_refresh(self) -> None:
         """Manual refresh all data sources."""
-        await asyncio.gather(
-            self._poll_pulumi(),
+        pollers = [
             self._poll_configmap(),
             self._poll_logs(),
             self._poll_infra_kube(),
             self._poll_pods(),
-            self._poll_eks(),
-        )
+        ]
+        if not LOCAL_MODE:
+            pollers.append(self._poll_pulumi())
+            pollers.append(self._poll_eks())
+        await asyncio.gather(*pollers)
 
     async def _poll_pulumi(self) -> None:
         self._pulumi_data = await fetch_pulumi_state()

--- a/q_branch/gensim-status.py
+++ b/q_branch/gensim-status.py
@@ -772,7 +772,7 @@ def _probe_local() -> str:
             ],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=1,
             env={**os.environ, "KUBECONFIG": os.path.expanduser("~/.kube/config")},
         )
         if r.returncode == 0 and r.stdout.strip():
@@ -792,7 +792,7 @@ def _probe_local() -> str:
             ["kind", "get", "clusters"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=1,
         )
         if _LOCAL_CLUSTER in (r2.stdout or ""):
             return "[dim]○[/dim] cluster exists, no active run"
@@ -808,7 +808,7 @@ def _probe_aws_auth() -> str:
             ["aws", "sts", "get-caller-identity", "--output", "json"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=1,
         )
         if r.returncode == 0 and r.stdout.strip():
             data = json.loads(r.stdout.strip())
@@ -836,7 +836,7 @@ def _probe_remote() -> str:
             ["kubectl", "get", "configmap", "gensim-run-status", "-o", "jsonpath={.data.status}", "-n", "default"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=1,
             env={**os.environ, "KUBECONFIG": kc},
         )
         if r.returncode == 0 and r.stdout.strip():

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -2212,6 +2212,77 @@ def _run_episode_phases(
     print(color_message(f"{'=' * 60}", Color.GREEN))
 
 
+# --- Parquet utilities ---
+
+
+@task
+def compact_parquets(ctx, parquet_dir: str = "", scenario: str = "food_delivery_redis"):
+    """
+    Combines per-flush parquet files into one file per type (logs, metrics,
+    trace-stats, traces). Dramatically reduces size on disk thanks to larger
+    row groups and shared dictionary encoding.
+
+    Example:
+        dda inv q.compact-parquets --scenario=food_delivery_redis
+        dda inv q.compact-parquets --parquet-dir=/tmp/my-parquets
+    """
+    if not parquet_dir:
+        parquet_dir = os.path.join("comp", "observer", "scenarios", scenario, "parquet")
+
+    if not os.path.isdir(parquet_dir):
+        raise FileNotFoundError(f"Parquet directory not found: {parquet_dir}")
+
+    prefixes = ["observer-logs", "observer-metrics", "observer-trace-stats", "observer-traces"]
+
+    before_size = sum(
+        os.path.getsize(os.path.join(parquet_dir, f)) for f in os.listdir(parquet_dir) if f.endswith(".parquet")
+    )
+    before_count = sum(1 for f in os.listdir(parquet_dir) if f.endswith(".parquet"))
+
+    for prefix in prefixes:
+        parts = sorted(glob.glob(os.path.join(parquet_dir, f"{prefix}-*.parquet")))
+        if len(parts) <= 1:
+            print(f"  {prefix}: {len(parts)} file(s), skipping")
+            continue
+
+        combined_path = os.path.join(parquet_dir, f"{prefix}.parquet")
+        print(color_message(f"  {prefix}: combining {len(parts)} files...", Color.BLUE))
+
+        # Use uv run to get pyarrow without polluting the dda venv.
+        parts_repr = repr(parts)
+        result = ctx.run(
+            f"uv run --with pyarrow python3 -c "
+            f"'import pyarrow as pa, pyarrow.parquet as pq; "
+            f"pq.write_table(pa.concat_tables([pq.read_table(f) for f in {parts_repr}]), "
+            f"{combined_path!r}, compression=\"zstd\")'",
+            warn=True,
+            hide=True,
+        )
+
+        if result.ok and os.path.exists(combined_path) and os.path.getsize(combined_path) > 0:
+            for p in parts:
+                os.unlink(p)
+            combined_size = os.path.getsize(combined_path)
+            print(color_message(f"    → {combined_size / 1024 / 1024:.1f}MB", Color.GREEN))
+        else:
+            print(color_message("    ✕ combine failed, keeping originals", Color.RED))
+
+    after_size = sum(
+        os.path.getsize(os.path.join(parquet_dir, f)) for f in os.listdir(parquet_dir) if f.endswith(".parquet")
+    )
+    after_count = sum(1 for f in os.listdir(parquet_dir) if f.endswith(".parquet"))
+
+    ratio = (1 - after_size / before_size) * 100 if before_size > 0 else 0
+    print(
+        color_message(
+            f"\n  {before_count} files ({before_size / 1024 / 1024:.0f}MB) → "
+            f"{after_count} files ({after_size / 1024 / 1024:.0f}MB) "
+            f"({ratio:.0f}% reduction)",
+            Color.GREEN,
+        )
+    )
+
+
 # --- Benchmarks ---
 
 

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -1779,14 +1779,20 @@ def _update_run_status(ctx, kube_ctx, run_id, image, episodes, started_at=None, 
     if completed_at:
         status["completedAt"] = completed_at
 
-    status_json = json.dumps(status).replace('"', '\\"')
-    ctx.run(
-        f'kubectl --context {kube_ctx} create configmap gensim-run-status '
-        f'--from-literal=status="{status_json}" '
-        f'--dry-run=client -o yaml | kubectl --context {kube_ctx} apply -f -',
-        hide=True,
-        warn=True,
-    )
+    # Write JSON to a temp file to avoid shell-escaping issues with --from-literal.
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as sf:
+        json.dump(status, sf)
+        status_path = sf.name
+    try:
+        ctx.run(
+            f"kubectl --context {kube_ctx} create configmap gensim-run-status "
+            f"--from-file=status={status_path} "
+            f"--dry-run=client -o yaml | kubectl --context {kube_ctx} apply -f -",
+            hide=True,
+            warn=True,
+        )
+    finally:
+        os.unlink(status_path)
 
 
 def _ensure_kind_cluster(ctx, cluster_name):
@@ -2001,6 +2007,66 @@ def run_local_episode(
         _build_and_load_episode_images(ctx, episode_dir, cluster_name)
     _load_agent_image(ctx, image, cluster_name)
 
+    # Wrap phases 3-7 in try/finally so helm releases and secrets are cleaned up on failure.
+    try:
+        _run_episode_phases(
+            ctx,
+            kube_ctx,
+            release_name,
+            namespace,
+            dd_env,
+            api_key,
+            app_key,
+            episode_dir,
+            scenario,
+            image,
+            mode,
+            cluster_name,
+            output_dir,
+            run_id,
+            ep_status,
+            started_at,
+            _set_phase,
+            skip_teardown,
+        )
+    except Exception:
+        if not skip_teardown:
+            print(color_message("\nCleaning up after failure...", Color.RED))
+            ctx.run(
+                f"helm --kube-context {kube_ctx} uninstall {release_name} --wait 2>/dev/null || true",
+                warn=True,
+                hide=True,
+            )
+            ctx.run(
+                f"helm --kube-context {kube_ctx} uninstall datadog-agent --wait 2>/dev/null || true",
+                warn=True,
+                hide=True,
+            )
+        raise
+
+
+def _run_episode_phases(
+    ctx,
+    kube_ctx,
+    release_name,
+    namespace,
+    dd_env,
+    api_key,
+    app_key,
+    episode_dir,
+    scenario,
+    image,
+    mode,
+    cluster_name,
+    output_dir,
+    run_id,
+    ep_status,
+    started_at,
+    _set_phase,
+    skip_teardown,
+):
+    """Inner function for phases 3-7, wrapped in try/finally by the caller."""
+
     # Phase 3: Create secrets
     print(color_message("\n[Phase 3/7] Creating K8s secrets...", Color.BLUE))
     ctx.run(
@@ -2018,15 +2084,21 @@ def run_local_episode(
     print(color_message("\n[Phase 4/7] Installing episode chart...", Color.BLUE))
     chart_dir = os.path.join(episode_dir, "chart")
     ctx.run(f"helm --kube-context {kube_ctx} uninstall {release_name} --wait 2>/dev/null || true", warn=True, hide=True)
-    ctx.run(
-        f"helm --kube-context {kube_ctx} install {release_name} {chart_dir} "
-        f"--set agent.enabled=false "
-        f"--set namespace={namespace} "
-        f"--set datadog.env={dd_env} "
-        f"--set datadog.apiKey={api_key} "
-        f"--set datadog.appKey={app_key} "
-        f"--timeout 5m --wait"
-    )
+    # Use a temp values file for credentials to avoid leaking keys in process list.
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as ef:
+        ef.write(
+            f"agent:\n  enabled: false\n"
+            f"namespace: {namespace}\n"
+            f"datadog:\n  env: {dd_env}\n  apiKey: {api_key}\n  appKey: {app_key}\n"
+        )
+        episode_values_path = ef.name
+    try:
+        ctx.run(
+            f"helm --kube-context {kube_ctx} install {release_name} {chart_dir} "
+            f"-f {episode_values_path} --timeout 5m --wait"
+        )
+    finally:
+        os.unlink(episode_values_path)
 
     # Phase 5: Install Datadog Agent
     _set_phase("running", "agent-install")
@@ -2071,13 +2143,15 @@ def run_local_episode(
     }
 
     # Pre-flight: verify API credentials work before starting the long episode.
+    # Use env vars for the curl headers to avoid leaking keys in the process list.
     print(color_message("  Validating Datadog API credentials...", Color.BLUE))
     preflight = ctx.run(
-        f'curl -s -o /dev/null -w "%{{http_code}}" '
-        f'-X GET "https://api.datadoghq.com/api/v1/validate" '
-        f'-H "DD-API-KEY: {api_key}" '
-        f'-H "DD-APPLICATION-KEY: {app_key}"',
+        'curl -s -o /dev/null -w "%{http_code}" '
+        '-X GET "https://api.datadoghq.com/api/v1/validate" '
+        '-H "DD-API-KEY: ${DD_API_KEY}" '
+        '-H "DD-APPLICATION-KEY: ${DD_APP_KEY}"',
         hide=True,
+        env=episode_env,
     )
     if preflight.stdout.strip() != "200":
         raise RuntimeError(
@@ -2121,6 +2195,8 @@ def run_local_episode(
         ctx.run(
             f"helm --kube-context {kube_ctx} uninstall datadog-agent --wait 2>/dev/null || true", warn=True, hide=True
         )
+
+    import datetime as _dt
 
     ep_status[0]["parquetFiles"] = len(glob.glob(os.path.join(output_dir, "*.parquet")))
     _set_phase("done", "")

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -1746,6 +1746,396 @@ def fetch_k8s_observer_parquet(ctx, dest: str = "/tmp/k8s-observer-metrics"):
     print(color_message(f"Fetched observer parquet files to {dest}", Color.GREEN))
 
 
+# --- Local Episode Runner ---
+
+_DEFAULT_GENSIM_PATH = os.path.expanduser("~/dd/gensim-episodes")
+_DEFAULT_CLUSTER_NAME = "observer-local"
+
+# Maps short episode names to their directory under gensim-episodes
+_EPISODE_PATHS = {
+    "food-delivery-redis": "synthetics/food-delivery-redis-cpu-saturation",
+}
+
+# Maps short episode names to their default scenario file (without .yaml)
+_EPISODE_DEFAULT_SCENARIOS = {
+    "food-delivery-redis": "redis-cpu-saturation",
+}
+
+
+_LOCAL_EPISODE_LOG = "/tmp/local-episode-runner.log"
+
+
+def _update_run_status(ctx, kube_ctx, run_id, image, episodes, started_at=None, completed_at=None):
+    """Creates or updates the gensim-run-status ConfigMap with the same schema
+    as the EKS orchestrator, so gensim-status.py can display local runs."""
+    import datetime as _dt
+
+    status = {
+        "runId": run_id,
+        "image": image,
+        "startedAt": started_at or _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "episodes": episodes,
+    }
+    if completed_at:
+        status["completedAt"] = completed_at
+
+    status_json = json.dumps(status).replace('"', '\\"')
+    ctx.run(
+        f'kubectl --context {kube_ctx} create configmap gensim-run-status '
+        f'--from-literal=status="{status_json}" '
+        f'--dry-run=client -o yaml | kubectl --context {kube_ctx} apply -f -',
+        hide=True,
+        warn=True,
+    )
+
+
+def _ensure_kind_cluster(ctx, cluster_name):
+    """Creates a Kind cluster if it doesn't already exist."""
+    result = ctx.run(f"kind get clusters 2>/dev/null | grep -q '^{cluster_name}$'", warn=True, hide=True)
+    if result.ok:
+        print(color_message(f"Kind cluster '{cluster_name}' already exists", Color.GREEN))
+        return
+
+    print(color_message(f"Creating Kind cluster '{cluster_name}'...", Color.BLUE))
+    kind_config = """
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+"""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        f.write(kind_config)
+        f.flush()
+        ctx.run(f"kind create cluster --name {cluster_name} --config {f.name}")
+    os.unlink(f.name)
+    print(color_message(f"Kind cluster '{cluster_name}' created", Color.GREEN))
+
+
+def _build_and_load_episode_images(ctx, episode_dir, cluster_name):
+    """Builds episode service images and loads them into Kind."""
+    compose_file = os.path.join(episode_dir, "docker-compose.yaml")
+    if not os.path.exists(compose_file):
+        print(color_message("No docker-compose.yaml, skipping service image build", Color.BLUE))
+        return
+
+    print(color_message("Building episode service images...", Color.BLUE))
+    ctx.run(f"docker compose -f {compose_file} build", env={"DOCKER_BUILDKIT": "1"})
+
+    # Parse image names from docker-compose.yaml and load each into Kind
+    import yaml as pyyaml
+
+    with open(compose_file) as f:
+        compose = pyyaml.safe_load(f)
+
+    images = [svc.get("image") for svc in compose.get("services", {}).values() if svc.get("image")]
+    for img in images:
+        print(color_message(f"  Loading {img} into Kind...", Color.BLUE))
+        ctx.run(f"kind load docker-image {img} --name {cluster_name}")
+
+    print(color_message(f"Loaded {len(images)} service images into Kind", Color.GREEN))
+
+
+def _load_agent_image(ctx, image, cluster_name):
+    """Pulls (if needed) and loads the agent image into Kind."""
+    # Pull if not already present
+    result = ctx.run(f"docker image inspect {image} >/dev/null 2>&1", warn=True, hide=True)
+    if not result.ok:
+        print(color_message(f"Pulling {image}...", Color.BLUE))
+        ctx.run(f"docker pull {image}")
+
+    print(color_message("Loading agent image into Kind...", Color.BLUE))
+    ctx.run(f"kind load docker-image {image} --name {cluster_name}")
+
+
+def _generate_agent_values(image, mode, cluster_name):
+    """Generates Helm values YAML for the Datadog Agent with observer config."""
+    repo, tag = image.rsplit(":", 1) if ":" in image else (image, "latest")
+
+    env_vars = [
+        ("DD_OBSERVER_RECORDING_ENABLED", "true"),
+        ("DD_OBSERVER_RECORDING_PARQUET_OUTPUT_DIR", "/tmp/observer-parquet"),
+        ("DD_OBSERVER_RECORDING_PARQUET_FLUSH_INTERVAL", "30s"),
+        ("DD_OBSERVER_RECORDING_PARQUET_RETENTION", "24h"),
+        ("DD_OBSERVER_HIGH_FREQUENCY_SYSTEM_CHECKS_ENABLED", "true"),
+        ("DD_OBSERVER_HIGH_FREQUENCY_CONTAINER_CHECKS_ENABLED", "true"),
+    ]
+
+    if mode in ("live-anomaly-detection", "live-and-record"):
+        env_vars.append(("DD_OBSERVER_ANALYSIS_ENABLED", "true"))
+        env_vars.append(("DD_OBSERVER_EVENT_REPORTER_SENDING_ENABLED", "true"))
+
+    if mode in ("live-anomaly-detection",):
+        # Disable recording for live-only mode
+        env_vars = [(k, v) for k, v in env_vars if "RECORDING" not in k]
+
+    env_block = "\n".join(f"  - name: {k}\n    value: \"{v}\"" for k, v in env_vars)
+
+    return f"""datadog:
+  apiKeyExistingSecret: "datadog-secret"
+  clusterName: "{cluster_name}"
+  logLevel: "INFO"
+  apm:
+    instrumentation:
+      enabled: true
+  logs:
+    enabled: true
+    containerCollectAll: true
+  processAgent:
+    enabled: true
+    processCollection: true
+  kubelet:
+    tlsVerify: false
+  clusterChecks:
+    enabled: true
+  env:
+{env_block}
+
+agents:
+  image:
+    pullPolicy: "IfNotPresent"
+    repository: "{repo}"
+    tag: "{tag}"
+    doNotCheckTag: true
+
+clusterAgent:
+  enabled: true
+  replicas: 1
+"""
+
+
+@task
+def run_local_episode(
+    ctx,
+    episode: str = "food-delivery-redis",
+    scenario: str = "",
+    image: str = "datadog/agent-dev:sopell-hf-container-checks-full",
+    mode: str = "live-and-record",
+    gensim_path: str = "",
+    cluster_name: str = "",
+    output_dir: str = "",
+    skip_build: bool = False,
+    skip_teardown: bool = False,
+):
+    """
+    Runs a gensim episode locally on a Kind cluster with the observer agent.
+
+    This is the local equivalent of `dda inv aws.eks.gensim.submit` — it builds
+    episode service images, deploys them to Kind alongside the observer agent,
+    executes the episode's play-episode.sh, collects parquet recordings, and
+    optionally tears down. Output is compatible with q.eval-scenarios.
+
+    Example:
+        dda inv q.run-local-episode \\
+            --episode=food-delivery-redis \\
+            --image=datadog/agent-dev:sopell-hf-container-checks-full \\
+            --mode=live-and-record
+    """
+    # Resolve paths and defaults
+    gensim_path = gensim_path or os.environ.get("GENSIM_REPO_PATH", _DEFAULT_GENSIM_PATH)
+    cluster_name = cluster_name or _DEFAULT_CLUSTER_NAME
+
+    if episode not in _EPISODE_PATHS:
+        raise ValueError(f"Unknown episode '{episode}'. Known: {list(_EPISODE_PATHS.keys())}")
+
+    episode_dir = os.path.join(gensim_path, _EPISODE_PATHS[episode])
+    if not os.path.isdir(episode_dir):
+        raise FileNotFoundError(f"Episode directory not found: {episode_dir}")
+
+    scenario = scenario or _EPISODE_DEFAULT_SCENARIOS.get(episode, "")
+    if not scenario:
+        raise ValueError(f"No default scenario for episode '{episode}', specify --scenario")
+
+    scenario_file = os.path.join(episode_dir, "episodes", f"{scenario}.yaml")
+    if not os.path.exists(scenario_file):
+        raise FileNotFoundError(f"Scenario file not found: {scenario_file}")
+
+    if not output_dir:
+        # Map to scenario directory compatible with q.eval-scenarios
+        short_name = {v: k for k, v in SCENARIO_EPISODE_NAMES.items()}.get(os.path.basename(episode_dir), episode)
+        output_dir = os.path.join("comp", "observer", "scenarios", short_name, "parquet")
+
+    release_name = f"gensim-{episode}"
+    namespace = "default"
+    dd_env = f"local-{episode}-{os.getpid()}"
+    run_id = f"local-{episode}-{os.getpid()}"
+
+    # Validate credentials
+    api_key = os.environ.get("DDDEV_API_KEY") or os.environ.get("DD_API_KEY", "")
+    app_key = os.environ.get("DDDEV_APP_KEY") or os.environ.get("DD_APP_KEY", "")
+    if not api_key:
+        raise RuntimeError("DDDEV_API_KEY or DD_API_KEY must be set")
+
+    print(color_message(f"{'=' * 60}", Color.BLUE))
+    print(color_message("Local Episode Runner", Color.BLUE))
+    print(color_message(f"  Episode:  {episode} ({scenario})", Color.BLUE))
+    print(color_message(f"  Image:    {image}", Color.BLUE))
+    print(color_message(f"  Mode:     {mode}", Color.BLUE))
+    print(color_message(f"  Cluster:  {cluster_name}", Color.BLUE))
+    print(color_message(f"  Output:   {output_dir}", Color.BLUE))
+    print(color_message(f"{'=' * 60}", Color.BLUE))
+
+    kube_ctx = f"kind-{cluster_name}"
+
+    # Episode status tracking (mirrors gensim-run-status ConfigMap schema)
+    import datetime as _dt
+
+    ep_status = [{"episode": episode, "scenario": scenario, "status": "queued", "phase": ""}]
+    started_at = _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+    def _set_phase(status, phase=""):
+        ep_status[0]["status"] = status
+        ep_status[0]["phase"] = phase
+        _update_run_status(ctx, kube_ctx, run_id, image, ep_status, started_at)
+
+    # Phase 1: Ensure Kind cluster
+    print(color_message("\n[Phase 1/7] Ensuring Kind cluster...", Color.BLUE))
+    _ensure_kind_cluster(ctx, cluster_name)
+
+    _set_phase("running", "cluster-setup")
+
+    # Phase 2: Build and load images
+    print(color_message("\n[Phase 2/7] Building and loading images...", Color.BLUE))
+    _set_phase("running", "image-build")
+    if not skip_build:
+        _build_and_load_episode_images(ctx, episode_dir, cluster_name)
+    _load_agent_image(ctx, image, cluster_name)
+
+    # Phase 3: Create secrets
+    print(color_message("\n[Phase 3/7] Creating K8s secrets...", Color.BLUE))
+    ctx.run(
+        f"kubectl --context {kube_ctx} delete secret datadog-secret --ignore-not-found",
+        hide=True,
+        warn=True,
+    )
+    ctx.run(
+        f"kubectl --context {kube_ctx} create secret generic datadog-secret "
+        f"--from-literal api-key={api_key} --from-literal app-key={app_key}",
+    )
+
+    # Phase 4: Install episode chart
+    _set_phase("running", "episode-install")
+    print(color_message("\n[Phase 4/7] Installing episode chart...", Color.BLUE))
+    chart_dir = os.path.join(episode_dir, "chart")
+    ctx.run(f"helm --kube-context {kube_ctx} uninstall {release_name} --wait 2>/dev/null || true", warn=True, hide=True)
+    ctx.run(
+        f"helm --kube-context {kube_ctx} install {release_name} {chart_dir} "
+        f"--set agent.enabled=false "
+        f"--set namespace={namespace} "
+        f"--set datadog.env={dd_env} "
+        f"--set datadog.apiKey={api_key} "
+        f"--set datadog.appKey={app_key} "
+        f"--timeout 5m --wait"
+    )
+
+    # Phase 5: Install Datadog Agent
+    _set_phase("running", "agent-install")
+    print(color_message("\n[Phase 5/7] Installing Datadog Agent...", Color.BLUE))
+    values_yaml = _generate_agent_values(image, mode, cluster_name)
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        f.write(values_yaml)
+        values_path = f.name
+
+    try:
+        ctx.run("helm repo add datadog https://helm.datadoghq.com 2>/dev/null || true", hide=True, warn=True)
+        ctx.run("helm repo update datadog", hide=True, warn=True)
+        ctx.run(
+            f"helm --kube-context {kube_ctx} uninstall datadog-agent --wait 2>/dev/null || true", warn=True, hide=True
+        )
+        ctx.run(
+            f"helm --kube-context {kube_ctx} install datadog-agent datadog/datadog "
+            f"-f {values_path} --timeout 5m --wait"
+        )
+    finally:
+        os.unlink(values_path)
+
+    # Wait for agent pod to be ready
+    print(color_message("  Waiting for agent pod readiness...", Color.BLUE))
+    ctx.run(
+        f"kubectl --context {kube_ctx} wait --for=condition=ready pod " f"-l app=datadog-agent --timeout=120s",
+        warn=True,
+    )
+
+    # Phase 6: Run episode
+    print(color_message(f"\n[Phase 6/7] Running episode ({scenario})...", Color.BLUE))
+    print(color_message("  This will take ~34 minutes (warmup + baseline + disruption + cooldown)", Color.BLUE))
+
+    episode_env = {
+        "DD_API_KEY": api_key,
+        "DD_APP_KEY": app_key,
+        "DD_ENV": dd_env,
+        "DD_SITE": "datadoghq.com",
+        "KUBE_NAMESPACE": namespace,
+        "KUBECONFIG": os.path.expanduser("~/.kube/config"),
+        "KUBECTL_CONTEXT": kube_ctx,
+    }
+
+    # Pre-flight: verify API credentials work before starting the long episode.
+    print(color_message("  Validating Datadog API credentials...", Color.BLUE))
+    preflight = ctx.run(
+        f'curl -s -o /dev/null -w "%{{http_code}}" '
+        f'-X GET "https://api.datadoghq.com/api/v1/validate" '
+        f'-H "DD-API-KEY: {api_key}" '
+        f'-H "DD-APPLICATION-KEY: {app_key}"',
+        hide=True,
+    )
+    if preflight.stdout.strip() != "200":
+        raise RuntimeError(
+            f"Datadog API credential validation failed (HTTP {preflight.stdout.strip()}). "
+            f"Check that DDDEV_API_KEY and DDDEV_APP_KEY are correct."
+        )
+    print(color_message("  API credentials validated OK", Color.GREEN))
+
+    _set_phase("running", "episode-running")
+
+    play_script = os.path.join(episode_dir, "play-episode.sh")
+    # Pipe episode output to a log file so gensim-status.py can tail it.
+    ctx.run(
+        f"bash {shlex.quote(play_script)} run-episode {shlex.quote(scenario)} " f"2>&1 | tee {_LOCAL_EPISODE_LOG}",
+        env=episode_env,
+    )
+
+    # Phase 7: Collect parquet
+    _set_phase("running", "collecting-parquet")
+    print(color_message("\n[Phase 7/7] Collecting parquet recordings...", Color.BLUE))
+    os.makedirs(output_dir, exist_ok=True)
+
+    agent_pod = ctx.run(
+        f"kubectl --context {kube_ctx} get pod -l app=datadog-agent " f"-o jsonpath='{{.items[0].metadata.name}}'",
+        hide=True,
+    ).stdout.strip()
+
+    if agent_pod:
+        ctx.run(f"kubectl --context {kube_ctx} cp {agent_pod}:/tmp/observer-parquet/ {output_dir}/", warn=True)
+        parquet_count = len(glob.glob(os.path.join(output_dir, "*.parquet")))
+        print(color_message(f"  Collected {parquet_count} parquet files to {output_dir}", Color.GREEN))
+    else:
+        print(color_message("  WARNING: Agent pod not found, could not collect parquets", Color.RED))
+
+    # Teardown (episode + agent, but leave cluster)
+    if not skip_teardown:
+        print(color_message("\nTearing down episode and agent...", Color.BLUE))
+        ctx.run(
+            f"helm --kube-context {kube_ctx} uninstall {release_name} --wait 2>/dev/null || true", warn=True, hide=True
+        )
+        ctx.run(
+            f"helm --kube-context {kube_ctx} uninstall datadog-agent --wait 2>/dev/null || true", warn=True, hide=True
+        )
+
+    ep_status[0]["parquetFiles"] = len(glob.glob(os.path.join(output_dir, "*.parquet")))
+    _set_phase("done", "")
+    completed_at = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    _update_run_status(ctx, kube_ctx, run_id, image, ep_status, started_at, completed_at)
+
+    print(color_message(f"\n{'=' * 60}", Color.GREEN))
+    print(color_message("Episode complete!", Color.GREEN))
+    print(color_message(f"  Parquets: {output_dir}", Color.GREEN))
+    print(color_message("", Color.GREEN))
+    print(color_message("  Next steps:", Color.GREEN))
+    print(color_message("    dda inv q.eval-scenarios --scenario=food_delivery_redis", Color.GREEN))
+    print(color_message(f"{'=' * 60}", Color.GREEN))
+
+
 # --- Benchmarks ---
 
 

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -1751,15 +1751,21 @@ def fetch_k8s_observer_parquet(ctx, dest: str = "/tmp/k8s-observer-metrics"):
 _DEFAULT_GENSIM_PATH = os.path.expanduser("~/dd/gensim-episodes")
 _DEFAULT_CLUSTER_NAME = "observer-local"
 
-# Maps short episode names to their directory under gensim-episodes
-_EPISODE_PATHS = {
-    "food-delivery-redis": "synthetics/food-delivery-redis-cpu-saturation",
-}
+# Subdirectories to search for episodes within the gensim-episodes repo.
+_EPISODE_SUBDIRS = ["postmortems", "synthetics"]
 
-# Maps short episode names to their default scenario file (without .yaml)
-_EPISODE_DEFAULT_SCENARIOS = {
-    "food-delivery-redis": "redis-cpu-saturation",
-}
+
+def _find_episode_dir(gensim_path, ep_name):
+    """Find an episode directory by searching known subdirectories."""
+    direct = os.path.join(gensim_path, ep_name)
+    if os.path.isdir(direct):
+        return direct
+    for subdir in _EPISODE_SUBDIRS:
+        candidate = os.path.join(gensim_path, subdir, ep_name)
+        if os.path.isdir(candidate):
+            return candidate
+    checked = [direct] + [os.path.join(gensim_path, s, ep_name) for s in _EPISODE_SUBDIRS]
+    raise FileNotFoundError(f"Episode '{ep_name}' not found. Checked: {', '.join(checked)}")
 
 
 _LOCAL_EPISODE_LOG = "/tmp/local-episode-runner.log"
@@ -1913,9 +1919,10 @@ clusterAgent:
 @task
 def run_local_episode(
     ctx,
-    episode: str = "food-delivery-redis",
+    episode: str = "",
     scenario: str = "",
-    image: str = "datadog/agent-dev:sopell-hf-container-checks-full",
+    episode_manifest: str = "",
+    image: str = "",
     mode: str = "live-and-record",
     gensim_path: str = "",
     cluster_name: str = "",
@@ -1931,34 +1938,101 @@ def run_local_episode(
     executes the episode's play-episode.sh, collects parquet recordings, and
     optionally tears down. Output is compatible with q.eval-scenarios.
 
+    Episode can be specified by name (--episode) or via a manifest file
+    (--episode-manifest). The manifest uses the same format as
+    q_branch/gensim-eval-scenarios.json.
+
     Example:
         dda inv q.run-local-episode \\
             --episode=food-delivery-redis \\
-            --image=datadog/agent-dev:sopell-hf-container-checks-full \\
+            --image=datadog/agent-dev:my-tag \\
             --mode=live-and-record
+
+        dda inv q.run-local-episode \\
+            --episode-manifest=q_branch/gensim-eval-scenarios.json \\
+            --image=datadog/agent-dev:my-tag
     """
+    if not image:
+        raise ValueError("--image is required")
+
     # Resolve paths and defaults
     gensim_path = gensim_path or os.environ.get("GENSIM_REPO_PATH", _DEFAULT_GENSIM_PATH)
     cluster_name = cluster_name or _DEFAULT_CLUSTER_NAME
 
-    if episode not in _EPISODE_PATHS:
-        raise ValueError(f"Unknown episode '{episode}'. Known: {list(_EPISODE_PATHS.keys())}")
+    # Build episode list from --episode or --episode-manifest
+    if episode and episode_manifest:
+        raise ValueError("--episode and --episode-manifest are mutually exclusive.")
+    if not episode and not episode_manifest:
+        episode = "food-delivery-redis"  # default
 
-    episode_dir = os.path.join(gensim_path, _EPISODE_PATHS[episode])
-    if not os.path.isdir(episode_dir):
-        raise FileNotFoundError(f"Episode directory not found: {episode_dir}")
+    episode_pairs = []
+    if episode_manifest:
+        with open(episode_manifest) as f:
+            entries = json.load(f)
+        for entry in entries:
+            ep_name = entry.get("episode", "").strip()
+            scen_name = entry.get("scenario", "").strip()
+            if ep_name and scen_name:
+                episode_pairs.append((ep_name, scen_name))
+        if not episode_pairs:
+            raise ValueError(f"No valid episodes in manifest: {episode_manifest}")
+    else:
+        # Single episode — resolve scenario from the episodes/ directory
+        episode_dir = _find_episode_dir(gensim_path, episode)
+        if scenario:
+            episode_pairs.append((episode, scenario))
+        else:
+            # Auto-detect: use the first .yaml in episodes/
+            episodes_dir = os.path.join(episode_dir, "episodes")
+            if os.path.isdir(episodes_dir):
+                yamls = sorted(f[:-5] for f in os.listdir(episodes_dir) if f.endswith(".yaml"))
+                if yamls:
+                    episode_pairs.append((episode, yamls[0]))
+            if not episode_pairs:
+                raise ValueError(f"No scenario found for episode '{episode}', specify --scenario")
 
-    scenario = scenario or _EPISODE_DEFAULT_SCENARIOS.get(episode, "")
-    if not scenario:
-        raise ValueError(f"No default scenario for episode '{episode}', specify --scenario")
+    # Run each episode sequentially
+    for ep_name, scen_name in episode_pairs:
+        _run_single_episode(
+            ctx,
+            ep_name,
+            scen_name,
+            image,
+            mode,
+            gensim_path,
+            cluster_name,
+            output_dir,
+            skip_build,
+            skip_teardown,
+        )
+        # After the first episode, images are already loaded
+        skip_build = True
+
+
+def _run_single_episode(
+    ctx,
+    episode,
+    scenario,
+    image,
+    mode,
+    gensim_path,
+    cluster_name,
+    output_dir,
+    skip_build,
+    skip_teardown,
+):
+    """Run a single episode. Extracted so run_local_episode can loop over a manifest."""
+    episode_dir = _find_episode_dir(gensim_path, episode)
 
     scenario_file = os.path.join(episode_dir, "episodes", f"{scenario}.yaml")
     if not os.path.exists(scenario_file):
         raise FileNotFoundError(f"Scenario file not found: {scenario_file}")
 
     if not output_dir:
-        # Map to scenario directory compatible with q.eval-scenarios
-        short_name = {v: k for k, v in SCENARIO_EPISODE_NAMES.items()}.get(os.path.basename(episode_dir), episode)
+        # Map to scenario directory compatible with q.eval-scenarios.
+        # Try SCENARIO_EPISODE_NAMES reverse lookup first, fall back to episode basename.
+        basename = os.path.basename(episode_dir)
+        short_name = {v: k for k, v in SCENARIO_EPISODE_NAMES.items()}.get(basename, basename)
         output_dir = os.path.join("comp", "observer", "scenarios", short_name, "parquet")
 
     release_name = f"gensim-{episode}"

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -2239,6 +2239,9 @@ def compact_parquets(ctx, parquet_dir: str = "", scenario: str = "food_delivery_
     )
     before_count = sum(1 for f in os.listdir(parquet_dir) if f.endswith(".parquet"))
 
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
     for prefix in prefixes:
         parts = sorted(glob.glob(os.path.join(parquet_dir, f"{prefix}-*.parquet")))
         if len(parts) <= 1:
@@ -2248,24 +2251,16 @@ def compact_parquets(ctx, parquet_dir: str = "", scenario: str = "food_delivery_
         combined_path = os.path.join(parquet_dir, f"{prefix}.parquet")
         print(color_message(f"  {prefix}: combining {len(parts)} files...", Color.BLUE))
 
-        # Use uv run to get pyarrow without polluting the dda venv.
-        parts_repr = repr(parts)
-        result = ctx.run(
-            f"uv run --with pyarrow python3 -c "
-            f"'import pyarrow as pa, pyarrow.parquet as pq; "
-            f"pq.write_table(pa.concat_tables([pq.read_table(f) for f in {parts_repr}]), "
-            f"{combined_path!r}, compression=\"zstd\")'",
-            warn=True,
-            hide=True,
-        )
+        tables = [pq.read_table(f) for f in parts]
+        pq.write_table(pa.concat_tables(tables), combined_path, compression='zstd')
 
-        if result.ok and os.path.exists(combined_path) and os.path.getsize(combined_path) > 0:
+        if os.path.exists(combined_path) and os.path.getsize(combined_path) > 0:
             for p in parts:
                 os.unlink(p)
             combined_size = os.path.getsize(combined_path)
             print(color_message(f"    → {combined_size / 1024 / 1024:.1f}MB", Color.GREEN))
         else:
-            print(color_message("    ✕ combine failed, keeping originals", Color.RED))
+            print(color_message("    ✕ produced empty file, keeping originals", Color.RED))
 
     after_size = sum(
         os.path.getsize(os.path.join(parquet_dir, f)) for f in os.listdir(parquet_dir) if f.endswith(".parquet")

--- a/tasks/q/datadog-values.template.yaml
+++ b/tasks/q/datadog-values.template.yaml
@@ -38,8 +38,10 @@ datadog:
   # Agent capture to parquet
   - name: DD_OBSERVER_CAPTURE_METRICS_ENABLED
     value: "true"
-  - name: DD_OBSERVER_HIGH_FREQUENCY_INTERVAL
-    value: "1s"
+  - name: DD_OBSERVER_HIGH_FREQUENCY_SYSTEM_CHECKS_ENABLED
+    value: "true"
+  - name: DD_OBSERVER_HIGH_FREQUENCY_CONTAINER_CHECKS_ENABLED
+    value: "true"
   - name: DD_OBSERVER_PARQUET_OUTPUT_DIR
     value: "/tmp/observer-metrics"
   - name: DD_OBSERVER_PARQUET_FLUSH_INTERVAL


### PR DESCRIPTION
## Summary

Adds `dda inv q.run-local-episode` — a local equivalent of the EKS gensim submission pipeline, running episodes on a Kind cluster.

**7-phase workflow**: ensure Kind cluster → build/load images → create K8s secrets → install episode chart → install Datadog Agent → run play-episode.sh → collect parquet. Output is compatible with `q.eval-scenarios`.

**gensim-status.py --local**: monitor local runs with the same TUI used for EKS, reading from Kind cluster and local log file.

**datadog-values.template.yaml**: updated to use new HF config keys (`DD_OBSERVER_HIGH_FREQUENCY_SYSTEM_CHECKS_ENABLED`, `DD_OBSERVER_HIGH_FREQUENCY_CONTAINER_CHECKS_ENABLED`).

## Usage

```bash
# Run episode locally
dda inv q.run-local-episode \
  --episode=food-delivery-redis \
  --image=datadog/agent-dev:sopell-hf-container-checks-full \
  --mode=live-and-record

# Monitor in another terminal
uv run q_branch/gensim-status.py --local

# Score results
dda inv q.eval-scenarios --scenario=food_delivery_redis
```

## Test plan

- [x] Full food-delivery-redis episode completed successfully on Kind
- [x] 258 parquet files collected, compatible with eval pipeline
- [x] Monitor lifecycle OK→Alert→OK verified during disruption phase
- [x] Observer detected 2702 anomalies including HF system/container metrics

🤖 Generated with [Claude Code](https://claude.ai/claude-code)