### PR TITLE
dyninst/object: remove loud log line

### DIFF
--- a/pkg/dyninst/object/disk_cache.go
+++ b/pkg/dyninst/object/disk_cache.go
@@ -17,7 +17,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"strconv"
 	"sync"
 	"syscall"
@@ -189,7 +188,6 @@ func (c *DiskCache) releaseSpace(toRelease uint64) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	log.Infof("releaseSpace: releasing %s, total bytes: %s: %s", humanize.IBytes(toRelease), humanize.IBytes(c.mu.totalBytes), debug.Stack())
 	if toRelease > c.mu.totalBytes {
 		log.Errorf(
 			"releaseSpace: invariant violation: total size underflow: %s > %s (delta: %s)",


### PR DESCRIPTION
This was a debug log line that fortunately isn't really ever hit. It's only hit on error paths where the DiskFile is closed. Most DiskFile objects end up being converted IntoMMap.
