### PR TITLE
[ntp] renames `ntp.offset{source:intake}` to `ntp.intake_offset`

### DIFF
--- a/pkg/collector/corechecks/net/ntp/ntp.go
+++ b/pkg/collector/corechecks/net/ntp/ntp.go
@@ -248,7 +248,7 @@ func (c *NTPCheck) Run() error {
 		serviceCheckStatus = servicecheck.ServiceCheckOK
 	}
 
-	_ = sender.GaugeWithTimestamp("ntp.offset", clockOffset, "", []string{"source:ntp"}, ts)
+	_ = sender.GaugeWithTimestamp("ntp.offset", clockOffset, "", nil, ts)
 	ntpExpVar.Set(clockOffset)
 	tlmNtpOffset.Set(clockOffset)
 

--- a/pkg/collector/corechecks/net/ntp/ntp.go
+++ b/pkg/collector/corechecks/net/ntp/ntp.go
@@ -226,7 +226,7 @@ func (c *NTPCheck) Run() error {
 				currentTime := time.Now()
 				intakeServerTime := currentTime.Add(time.Duration(intakeOffset * float64(time.Second)))
 				intakeTS := float64(intakeServerTime.UnixNano()) / 1e9
-				_ = sender.GaugeWithTimestamp("ntp.offset", intakeOffset, "", []string{"source:intake"}, intakeTS)
+				_ = sender.GaugeWithTimestamp("ntp.intake_offset", intakeOffset, "", nil, intakeTS)
 			}
 		}
 	}

--- a/pkg/collector/corechecks/net/ntp/ntp_test.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_test.go
@@ -98,7 +98,7 @@ func TestNTPOK(t *testing.T) {
 			"ntp.offset",
 			float64(offset),
 			"",
-			[]string{"source:ntp"},
+			[]string(nil),
 			mock.AnythingOfType("float64"),
 		).Return().Times(1)
 	// ntp.intake_offset may or may not be submitted depending on whether it's been set
@@ -155,7 +155,7 @@ func TestNTPCritical(t *testing.T) {
 			"ntp.offset",
 			float64(offset),
 			"",
-			[]string{"source:ntp"},
+			[]string(nil),
 			mock.AnythingOfType("float64"),
 		).Return().Times(1)
 	// ntp.intake_offset may or may not be submitted depending on whether it's been set
@@ -296,7 +296,7 @@ func TestNTPNegativeOffsetCritical(t *testing.T) {
 			"ntp.offset",
 			float64(offset),
 			"",
-			[]string{"source:ntp"},
+			[]string(nil),
 			mock.AnythingOfType("float64"),
 		).Return().Times(1)
 	// ntp.intake_offset may or may not be submitted depending on whether it's been set
@@ -361,7 +361,7 @@ hosts:
 			"ntp.offset",
 			float64(2),
 			"",
-			[]string{"source:ntp"},
+			[]string(nil),
 			mock.AnythingOfType("float64"),
 		).Return().Times(1)
 	// ntp.intake_offset may or may not be submitted depending on whether it's been set
@@ -426,7 +426,7 @@ hosts:
 			"ntp.offset",
 			float64(offset),
 			"",
-			[]string{"source:ntp"},
+			[]string(nil),
 			mock.AnythingOfType("float64"),
 		).Return().Times(1)
 	// ntp.intake_offset may or may not be submitted depending on whether it's been set
@@ -669,7 +669,7 @@ func TestNTPUsesResponseTimestamp(t *testing.T) {
 			"ntp.offset",
 			float64(offset),
 			"",
-			[]string{"source:ntp"},
+			[]string(nil),
 			mock.MatchedBy(func(ts float64) bool {
 				actualTS = ts
 				return true

--- a/pkg/collector/corechecks/net/ntp/ntp_test.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_test.go
@@ -101,12 +101,12 @@ func TestNTPOK(t *testing.T) {
 			[]string{"source:ntp"},
 			mock.AnythingOfType("float64"),
 		).Return().Times(1)
-	// Intake offset may or may not be submitted depending on whether it's been set
+	// ntp.intake_offset may or may not be submitted depending on whether it's been set
 	mockSender.On("GaugeWithTimestamp",
-		"ntp.offset",
+		"ntp.intake_offset",
 		mock.AnythingOfType("float64"),
 		"",
-		[]string{"source:intake"},
+		[]string(nil),
 		mock.AnythingOfType("float64")).Return().Maybe()
 	mockSender.On("ServiceCheck",
 		"ntp.in_sync",
@@ -119,7 +119,7 @@ func TestNTPOK(t *testing.T) {
 	ntpCheck.Run()
 
 	mockSender.AssertExpectations(t)
-	// 1 NTP offset + 0 or 1 intake offset
+	// 1 ntp.offset + 0 or 1 ntp.intake_offset
 	gaugeCalls := 0
 	for _, c := range mockSender.Calls {
 		if c.Method == "GaugeWithTimestamp" {
@@ -158,12 +158,12 @@ func TestNTPCritical(t *testing.T) {
 			[]string{"source:ntp"},
 			mock.AnythingOfType("float64"),
 		).Return().Times(1)
-	// Intake offset may or may not be submitted depending on whether it's been set
+	// ntp.intake_offset may or may not be submitted depending on whether it's been set
 	mockSender.On("GaugeWithTimestamp",
-		"ntp.offset",
+		"ntp.intake_offset",
 		mock.AnythingOfType("float64"),
 		"",
-		[]string{"source:intake"},
+		[]string(nil),
 		mock.AnythingOfType("float64")).Return().Maybe()
 	mockSender.On("ServiceCheck",
 		"ntp.in_sync",
@@ -177,7 +177,7 @@ func TestNTPCritical(t *testing.T) {
 	ntpCheck.Run()
 
 	mockSender.AssertExpectations(t)
-	// 1 NTP offset + 0 or 1 intake offset
+	// 1 ntp.offset + 0 or 1 ntp.intake_offset
 	gaugeCalls := 0
 	for _, c := range mockSender.Calls {
 		if c.Method == "GaugeWithTimestamp" {
@@ -202,12 +202,12 @@ func TestNTPError(t *testing.T) {
 	ntpCheck.Configure(senderManager, integration.FakeConfigHash, ntpCfg, ntpInitCfg, "test", "provider")
 
 	mockSender := mocksender.NewMockSenderWithSenderManager(ntpCheck.ID(), senderManager)
-	// Intake offset may or may not be submitted depending on whether expvar is set
+	// ntp.intake_offset may or may not be submitted depending on whether expvar is set
 	mockSender.On("GaugeWithTimestamp",
-		"ntp.offset",
+		"ntp.intake_offset",
 		mock.AnythingOfType("float64"),
 		"",
-		[]string{"source:intake"},
+		[]string(nil),
 		mock.AnythingOfType("float64")).Return().Maybe()
 	mockSender.On("ServiceCheck",
 		"ntp.in_sync",
@@ -220,7 +220,7 @@ func TestNTPError(t *testing.T) {
 	err := ntpCheck.Run()
 
 	mockSender.AssertExpectations(t)
-	// 0 NTP offset (NTP failed), 0 or 1 intake offset
+	// 0 ntp.offset (NTP failed), 0 or 1 ntp.intake_offset
 	gaugeCalls := 0
 	for _, c := range mockSender.Calls {
 		if c.Method == "GaugeWithTimestamp" {
@@ -246,12 +246,12 @@ func TestNTPInvalid(t *testing.T) {
 	ntpCheck.Configure(senderManager, integration.FakeConfigHash, ntpCfg, ntpInitCfg, "test", "provider")
 
 	mockSender := mocksender.NewMockSenderWithSenderManager(ntpCheck.ID(), senderManager)
-	// Intake offset may or may not be submitted depending on whether expvar is set
+	// ntp.intake_offset may or may not be submitted depending on whether expvar is set
 	mockSender.On("GaugeWithTimestamp",
-		"ntp.offset",
+		"ntp.intake_offset",
 		mock.AnythingOfType("float64"),
 		"",
-		[]string{"source:intake"},
+		[]string(nil),
 		mock.AnythingOfType("float64")).Return().Maybe()
 	mockSender.On("ServiceCheck",
 		"ntp.in_sync",
@@ -264,7 +264,7 @@ func TestNTPInvalid(t *testing.T) {
 	err := ntpCheck.Run()
 
 	mockSender.AssertExpectations(t)
-	// 0 NTP offset (invalid stratum), 0 or 1 intake offset
+	// 0 ntp.offset (invalid stratum), 0 or 1 ntp.intake_offset
 	gaugeCalls := 0
 	for _, c := range mockSender.Calls {
 		if c.Method == "GaugeWithTimestamp" {
@@ -299,12 +299,12 @@ func TestNTPNegativeOffsetCritical(t *testing.T) {
 			[]string{"source:ntp"},
 			mock.AnythingOfType("float64"),
 		).Return().Times(1)
-	// Intake offset may or may not be submitted depending on whether it's been set
+	// ntp.intake_offset may or may not be submitted depending on whether it's been set
 	mockSender.On("GaugeWithTimestamp",
-		"ntp.offset",
+		"ntp.intake_offset",
 		mock.AnythingOfType("float64"),
 		"",
-		[]string{"source:intake"},
+		[]string(nil),
 		mock.AnythingOfType("float64")).Return().Maybe()
 	mockSender.On("ServiceCheck",
 		"ntp.in_sync",
@@ -318,7 +318,7 @@ func TestNTPNegativeOffsetCritical(t *testing.T) {
 	ntpCheck.Run()
 
 	mockSender.AssertExpectations(t)
-	// 1 NTP offset + 0 or 1 intake offset
+	// 1 ntp.offset + 0 or 1 ntp.intake_offset
 	gaugeCalls := 0
 	for _, c := range mockSender.Calls {
 		if c.Method == "GaugeWithTimestamp" {
@@ -364,12 +364,12 @@ hosts:
 			[]string{"source:ntp"},
 			mock.AnythingOfType("float64"),
 		).Return().Times(1)
-	// Intake offset may or may not be submitted depending on whether it's been set
+	// ntp.intake_offset may or may not be submitted depending on whether it's been set
 	mockSender.On("GaugeWithTimestamp",
-		"ntp.offset",
+		"ntp.intake_offset",
 		mock.AnythingOfType("float64"),
 		"",
-		[]string{"source:intake"},
+		[]string(nil),
 		mock.AnythingOfType("float64")).Return().Maybe()
 	mockSender.On("ServiceCheck",
 		"ntp.in_sync",
@@ -382,7 +382,7 @@ hosts:
 	ntpCheck.Run()
 
 	mockSender.AssertExpectations(t)
-	// 1 NTP offset + 0 or 1 intake offset
+	// 1 ntp.offset + 0 or 1 ntp.intake_offset
 	gaugeCalls := 0
 	for _, c := range mockSender.Calls {
 		if c.Method == "GaugeWithTimestamp" {
@@ -429,12 +429,12 @@ hosts:
 			[]string{"source:ntp"},
 			mock.AnythingOfType("float64"),
 		).Return().Times(1)
-	// Intake offset may or may not be submitted depending on whether it's been set
+	// ntp.intake_offset may or may not be submitted depending on whether it's been set
 	mockSender.On("GaugeWithTimestamp",
-		"ntp.offset",
+		"ntp.intake_offset",
 		mock.AnythingOfType("float64"),
 		"",
-		[]string{"source:intake"},
+		[]string(nil),
 		mock.AnythingOfType("float64")).Return().Maybe()
 	mockSender.On("ServiceCheck",
 		"ntp.in_sync",
@@ -448,7 +448,7 @@ hosts:
 	ntpCheck.Run()
 
 	mockSender.AssertExpectations(t)
-	// 1 NTP offset + 0 or 1 intake offset
+	// 1 ntp.offset + 0 or 1 ntp.intake_offset
 	gaugeCalls := 0
 	for _, c := range mockSender.Calls {
 		if c.Method == "GaugeWithTimestamp" {
@@ -676,12 +676,12 @@ func TestNTPUsesResponseTimestamp(t *testing.T) {
 			}),
 		).Return().Once()
 
-	// Intake offset may or may not be submitted depending on whether it's been set
+	// ntp.intake_offset may or may not be submitted depending on whether it's been set
 	mockSender.On("GaugeWithTimestamp",
-		"ntp.offset",
+		"ntp.intake_offset",
 		mock.AnythingOfType("float64"),
 		"",
-		[]string{"source:intake"},
+		[]string(nil),
 		mock.AnythingOfType("float64")).Return().Maybe()
 
 	mockSender.

--- a/releasenotes/notes/ntp-rename-intake-offset-metric-27e70692cdd78479.yaml
+++ b/releasenotes/notes/ntp-rename-intake-offset-metric-27e70692cdd78479.yaml
@@ -1,0 +1,20 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    The NTP check no longer submits ``ntp.offset`` with the tag ``source:intake``.
+    The intake-derived clock offset is now reported as a separate metric,
+    ``ntp.intake_offset``, with no source tag.
+
+    If you have monitors or dashboards querying ``ntp.offset{source:intake}``,
+    update them to use ``ntp.intake_offset`` instead.
+
+    This change was made because emitting both ``ntp.offset{source:ntp}`` and
+    ``ntp.offset{source:intake}`` caused monitors on the untagged ``ntp.offset``
+    metric to aggregate over two series, skewing values and triggering false alerts.

--- a/releasenotes/notes/ntp-rename-intake-offset-metric-27e70692cdd78479.yaml
+++ b/releasenotes/notes/ntp-rename-intake-offset-metric-27e70692cdd78479.yaml
@@ -6,21 +6,9 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-upgrade:
+fixes:
   - |
-    The NTP check reverts ``ntp.offset`` to its pre-7.77.0 behavior: it is
-    submitted without any ``source`` tag, as a single untagged series.
-
-    Two changes introduced in 7.77.0 are rolled back or replaced:
-
-    - The ``source:ntp`` tag on ``ntp.offset`` has been removed.
-    - The ``ntp.offset{source:intake}`` metric has been replaced by a new
-      dedicated metric ``ntp.intake_offset`` (no tags).
-
-    If you have monitors or dashboards querying ``ntp.offset{source:intake}``,
-    update them to use ``ntp.intake_offset`` instead.
-    Queries on ``ntp.offset{source:ntp}`` should be updated to ``ntp.offset``.
-
-    This change was made because tagging ``ntp.offset`` with ``source`` caused
-    monitors on the untagged metric to aggregate over two series, skewing values
-    and triggering false alerts.
+    NTP: renames ``ntp.offset`` with the tag ``source:intake`` to ``ntp.intake_offset``
+    and removes the ``source:ntp`` tag from ``ntp.offset``, restoring it to its
+    pre-7.77.0 single-series behavior. This fixes false alerts on existing monitors
+    querying ``ntp.offset`` without a tag filter.

--- a/releasenotes/notes/ntp-rename-intake-offset-metric-27e70692cdd78479.yaml
+++ b/releasenotes/notes/ntp-rename-intake-offset-metric-27e70692cdd78479.yaml
@@ -8,13 +8,19 @@
 ---
 upgrade:
   - |
-    The NTP check no longer submits ``ntp.offset`` with the tag ``source:intake``.
-    The intake-derived clock offset is now reported as a separate metric,
-    ``ntp.intake_offset``, with no source tag.
+    The NTP check reverts ``ntp.offset`` to its pre-7.77.0 behavior: it is
+    submitted without any ``source`` tag, as a single untagged series.
+
+    Two changes introduced in 7.77.0 are rolled back or replaced:
+
+    - The ``source:ntp`` tag on ``ntp.offset`` has been removed.
+    - The ``ntp.offset{source:intake}`` metric has been replaced by a new
+      dedicated metric ``ntp.intake_offset`` (no tags).
 
     If you have monitors or dashboards querying ``ntp.offset{source:intake}``,
     update them to use ``ntp.intake_offset`` instead.
+    Queries on ``ntp.offset{source:ntp}`` should be updated to ``ntp.offset``.
 
-    This change was made because emitting both ``ntp.offset{source:ntp}`` and
-    ``ntp.offset{source:intake}`` caused monitors on the untagged ``ntp.offset``
-    metric to aggregate over two series, skewing values and triggering false alerts.
+    This change was made because tagging ``ntp.offset`` with ``source`` caused
+    monitors on the untagged metric to aggregate over two series, skewing values
+    and triggering false alerts.


### PR DESCRIPTION
### What does this PR do?

- Renames the intake-derived clock offset metric from ntp.offset (tagged source:intake) to a distinct metric ntp.intake_offset (no source tag).
- All unit test expectations updated to match the new metric name
agent status Clocks display is unchanged — it reads from the corechecks_net_ntp_intake_time_offset expvar directly

### Motivation

- PR #45664 introduced ntp.offset{source:intake} alongside the existing ntp.offset{source:ntp}. Existing monitors querying ntp.offset without a tag filter began aggregating over two time series instead of one, shifting the average and triggering false alerts.
- Using a separate metric name (ntp.intake_offset) fully decouples intake-based clock monitoring from NTP-based monitoring, leaving existing ntp.offset monitors unaffected.

### Describe how you validated your changes

- Verified all modified packages compile successfully
- Confirmed agent status Clocks section continues to display both NTP offset and Intake offset (expvar-based, unaffected by metric rename)

### Additional Notes

- Fixes #48789