### PR TITLE
[bazel] Migrate more L3 packages

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -424,8 +424,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/util/gpu
 # gazelle:exclude pkg/util/grpc
 # gazelle:exclude pkg/util/hostinfo
-# gazelle:exclude pkg/util/hostname
-# gazelle:exclude pkg/util/hostname/validate
 # gazelle:exclude pkg/util/http
 # gazelle:exclude pkg/util/input
 # gazelle:exclude pkg/util/installinfo

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -162,7 +162,9 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/syntheticstestscheduler
 # gazelle:exclude comp/systray
 # gazelle:exclude comp/trace-telemetry
-# gazelle:exclude comp/trace/agent
+# gazelle:exclude comp/trace/agent/fx
+# gazelle:exclude comp/trace/agent/fx-mock
+# gazelle:exclude comp/trace/agent/impl
 # gazelle:exclude comp/trace/compression/fx-gzip
 # gazelle:exclude comp/trace/compression/fx-zstd
 # gazelle:exclude comp/trace/config

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -58,7 +58,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/core/log/impl
 # gazelle:exclude comp/core/log/impl-systemprobe
 # gazelle:exclude comp/core/log/impl-trace
-# gazelle:exclude comp/core/log/mock
 # gazelle:exclude comp/core/log/rust
 # gazelle:exclude comp/core/lsof
 # gazelle:exclude comp/core/pid

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -457,7 +457,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/util/tmplvar
 # gazelle:exclude pkg/util/trie
 # gazelle:exclude pkg/util/trivy
-# gazelle:exclude pkg/util/uuid
 # gazelle:exclude pkg/util/winutil
 # gazelle:exclude pkg/util/workqueue
 # gazelle:exclude pkg/util/xc

--- a/comp/core/log/mock/BUILD.bazel
+++ b/comp/core/log/mock/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "mock",
+    srcs = [
+        "docs.go",
+        "mock.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/core/log/mock",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/log/def",
+        "//pkg/util/log",
+    ],
+)

--- a/comp/trace/agent/def/BUILD.bazel
+++ b/comp/trace/agent/def/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "def",
+    srcs = ["component.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/trace/agent/def",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/opentelemetry-mapping-go/otlp/attributes",
+        "//pkg/opentelemetry-mapping-go/otlp/attributes/source",
+        "//pkg/proto/pbgo/trace",
+        "@io_opentelemetry_go_collector_pdata//ptrace",
+    ],
+)

--- a/pkg/util/hostname/BUILD.bazel
+++ b/pkg/util/hostname/BUILD.bazel
@@ -1,0 +1,1 @@
+# gazelle:ignore

--- a/pkg/util/hostname/validate/BUILD.bazel
+++ b/pkg/util/hostname/validate/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "validate",
+    srcs = [
+        "normalize.go",
+        "validate.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/util/hostname/validate",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/util/log"],
+)
+
+go_test(
+    name = "validate_test",
+    srcs = [
+        "normalize_test.go",
+        "validate_test.go",
+    ],
+    embed = [":validate"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/pkg/util/uuid/BUILD.bazel
+++ b/pkg/util/uuid/BUILD.bazel
@@ -1,0 +1,81 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "uuid",
+    srcs = [
+        "uuid.go",
+        "uuid_nix.go",
+        "uuid_windows.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/util/uuid",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/cache",
+    ] + select({
+        "@rules_go//go/platform:aix": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:android": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:js": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:osx": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:plan9": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:qnx": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//host",
+        ],
+        "@rules_go//go/platform:windows": [
+            "//pkg/util/log",
+            "@org_golang_x_sys//windows",
+        ],
+        "//conditions:default": [],
+    }),
+)


### PR DESCRIPTION
### What does this PR do?

Migrate:
* `comp/core/log/mock`
* `pkg/util/hostname/validate`
* `comp/trace/agent/def`
* `pkg/util/uuid`

### Motivation

https://datadoghq.atlassian.net/browse/ABLD-425

### Describe how you validated your changes

Local gazelle & `bazel test //pkg/... //comp/...` invocation

### Additional Notes

This is based on top of https://github.com/DataDog/datadog-agent/pull/48618/changes since `comp/trace/agent/def` depends on some OTLP packages migrated in this PR