### PR TITLE
[observer] Improve reports

### DIFF
--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -634,6 +634,13 @@ type StorageReader interface {
 	// Uses binary search for efficiency. Returns 0 if the series is not found.
 	PointCountUpTo(handle SeriesRef, endTime int64) int
 
+	// SumRange returns the sum of the specified aggregate over all points with
+	// timestamp in (start, end] without allocating any intermediate slices.
+	// Returns 0 if the series is not found or the range is empty.
+	// This is more efficient than ForEachPoint when only the aggregate total
+	// is needed (e.g. computing an average rate over a window).
+	SumRange(handle SeriesRef, start, end int64, agg Aggregate) float64
+
 	// WriteGeneration returns a per-series counter that increments on every
 	// write to that series, including same-bucket merges. Use this to detect
 	// updates to an existing series even when its point count does not change.

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -11,6 +11,11 @@ import (
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
+// LogPatternExtractorName is the canonical name for the log pattern extractor.
+// It is used as the storage namespace for emitted metrics, as the component
+// name in the catalog, and in notify formatting for log-derived anomalies.
+const LogPatternExtractorName = "log_pattern_extractor"
+
 // defaultMinClusterSizeBeforeEmitMetrics is the minimum number of logs
 // inside a cluster (pattern) before we emit a metric.
 const defaultMinClusterSizeBeforeEmitMetrics = 5

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -283,19 +284,23 @@ func buildChangeMessage(c observerdef.ActiveCorrelation, storage observerdef.Sto
 	lines = append(lines, fmt.Sprintf("Correlated behavior change detected: %d anomalies in pattern %q", len(c.Anomalies), c.Pattern))
 	lines = append(lines, "")
 
+	anomalyLines := []string{}
 	for _, a := range c.Anomalies {
 		if isLogDerivedAnomaly(a) {
-			lines = append(lines, "- "+logDerivedDescription(a, storage))
+			anomalyLines = append(anomalyLines, "- "+logDerivedDescription(a, storage))
 		} else if a.DebugInfo != nil {
 			display := anomalyDisplayKey(a)
-			lines = append(lines, fmt.Sprintf("- %s: %.2f (baseline mean: %.2f, %.1f sigma)", display, a.DebugInfo.CurrentValue, a.DebugInfo.BaselineMean, a.DebugInfo.DeviationSigma))
+			anomalyLines = append(anomalyLines, fmt.Sprintf("- %s: %.2f (baseline mean: %.2f, %.1f sigma)", display, a.DebugInfo.CurrentValue, a.DebugInfo.BaselineMean, a.DebugInfo.DeviationSigma))
 		} else if a.Description != "" {
-			lines = append(lines, "- "+a.Description)
+			anomalyLines = append(anomalyLines, "- "+a.Description)
 		} else {
-			lines = append(lines, "- "+anomalyDisplayKey(a))
+			anomalyLines = append(anomalyLines, "- "+anomalyDisplayKey(a))
 		}
 	}
 
+	// Ensure anomalies are unique and sorted (could be duplicate if 2 anomalies on the same series at a similar timestamp)
+	slices.Sort(anomalyLines)
+	lines = append(lines, slices.Compact(anomalyLines)...)
 	text := strings.Join(lines, "\n")
 	const maxLen = 4000
 	if len(text) > maxLen {
@@ -327,14 +332,13 @@ func isLogDerivedAnomaly(a observerdef.Anomaly) bool {
 func logDerivedDescription(a observerdef.Anomaly, storage observerdef.StorageReader) string {
 	pattern := strings.TrimSpace(a.Context.Pattern)
 	var example string
-	if a.Context.Example != "" {
-		example = "\tlog example: " + strings.TrimSpace(a.Context.Example)
+	// Don't display example if it's the same as the pattern
+	if a.Context.Example != "" && strings.TrimSpace(a.Context.Example) != pattern {
+		example = "\n\texample: " + strings.TrimSpace(a.Context.Example)
 	}
 	var ratePart string
 	if rate, ok := logPatternRate(a, storage); ok {
-		ratePart = fmt.Sprintf("\tavg rate (60s): %.1flog/s", rate)
-	} else {
-		ratePart = "\tavg rate (60s): unknown"
+		ratePart = fmt.Sprintf("\n\trate: %.1flog/s", rate)
 	}
 	var tagsPart string
 	if len(a.Context.SplitTags) > 0 {
@@ -345,10 +349,10 @@ func logDerivedDescription(a observerdef.Anomaly, storage observerdef.StorageRea
 			}
 		}
 		if len(parts) > 0 {
-			tagsPart = "\t[" + strings.Join(parts, ", ") + "]"
+			tagsPart = "\n\ttags: " + strings.Join(parts, ", ")
 		}
 	}
-	return fmt.Sprintf("Log pattern change rate detected: %s%s%s%s", pattern, example, ratePart, tagsPart)
+	return fmt.Sprintf("Log pattern change rate detected:\n\tpattern: %s%s%s%s", pattern, example, ratePart, tagsPart)
 }
 
 // sendCorrelationEvents sends one event per correlation.

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -73,67 +73,6 @@ func logPatternRate(a observerdef.Anomaly, storage observerdef.StorageReader) (r
 	return 0, false
 }
 
-// correlationMessage builds the event message body for a correlation.
-func correlationMessage(c observerdef.ActiveCorrelation, storage observerdef.StorageReader) string {
-	var metricLines, logLines []string
-	for _, a := range c.Anomalies {
-		if a.Description == "" {
-			continue
-		}
-		if a.Type == observerdef.AnomalyTypeLog {
-			logLines = append(logLines, "- "+a.Description)
-		} else {
-			var pattern string
-			if a.Context != nil {
-				pattern = strings.TrimSpace(a.Context.Pattern)
-			}
-			// If this metric is a log related one, find its pattern and create a custom message
-			// TODO(celian): Be sure that we don't have twice (pattern, tags) tuples
-			if a.Source.Namespace == LogPatternExtractorName && pattern != "" {
-				var tagsPart string
-				if len(a.Context.SplitTags) > 0 {
-					var parts []string
-					for _, k := range splitTagKeyOrder {
-						if v, ok := a.Context.SplitTags[k]; ok {
-							parts = append(parts, k+"="+v)
-						}
-					}
-					if len(parts) > 0 {
-						tagsPart = "\t[" + strings.Join(parts, ", ") + "]"
-					}
-				}
-				var example string
-				if a.Context.Example != "" {
-					example = "\tlog example: " + strings.TrimSpace(a.Context.Example)
-				}
-				var ratePart string
-				if rate, ok := logPatternRate(a, storage); ok {
-					ratePart = fmt.Sprintf("\tavg rate (60s): %.1flog/s", rate)
-				} else {
-					ratePart = "\tavg rate (60s): unknown"
-				}
-				logDescription := fmt.Sprintf("Log pattern change rate detected: %s%s%s%s", pattern, example, ratePart, tagsPart)
-				logLines = append(logLines, "- "+logDescription)
-			} else {
-				metricLines = append(metricLines, "- "+a.Description)
-			}
-		}
-	}
-	var sections []string
-	if len(metricLines) > 0 {
-		sections = append(sections, fmt.Sprintf("Metric anomalies (%d):\n%s", len(metricLines), strings.Join(metricLines, "\n")))
-	}
-	if len(logLines) > 0 {
-		sections = append(sections, fmt.Sprintf("Log anomalies (%d):\n%s", len(logLines), strings.Join(logLines, "\n")))
-	}
-	const maxLen = 4000
-	text := "The following anomalies were detected and are likely related:\n\n" + strings.Join(sections, "\n\n")
-	if len(text) > maxLen {
-		text = text[:maxLen-3] + "..."
-	}
-	return text
-}
-
 // send formats a correlation into a change event and either prints or posts it.
 func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 	msg := buildChangeMessage(c, s.storage)
@@ -337,7 +276,8 @@ func buildChangeMetadata(c observerdef.ActiveCorrelation) map[string]interface{}
 	return meta
 }
 
-// buildChangeMessage creates a compact human-readable summary for the change event message.
+// buildChangeMessage creates a compact human-readable summary for a correlation (Datadog
+// change events, testbench JSON output, and replay-reported events).
 func buildChangeMessage(c observerdef.ActiveCorrelation, storage observerdef.StorageReader) string {
 	var lines []string
 	lines = append(lines, fmt.Sprintf("Correlated behavior change detected: %d anomalies in pattern %q", len(c.Anomalies), c.Pattern))
@@ -396,7 +336,19 @@ func logDerivedDescription(a observerdef.Anomaly, storage observerdef.StorageRea
 	} else {
 		ratePart = "\tavg rate (60s): unknown"
 	}
-	return fmt.Sprintf("Log pattern change rate detected: %s%s%s", pattern, example, ratePart)
+	var tagsPart string
+	if len(a.Context.SplitTags) > 0 {
+		var parts []string
+		for _, k := range splitTagKeyOrder {
+			if v, ok := a.Context.SplitTags[k]; ok {
+				parts = append(parts, k+"="+v)
+			}
+		}
+		if len(parts) > 0 {
+			tagsPart = "\t[" + strings.Join(parts, ", ") + "]"
+		}
+	}
+	return fmt.Sprintf("Log pattern change rate detected: %s%s%s%s", pattern, example, ratePart, tagsPart)
 }
 
 // sendCorrelationEvents sends one event per correlation.

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -22,19 +22,25 @@ import (
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
+// logPatternRateWindowSec is the window (seconds) for averaging log pattern
+// rates shown in reports and event messages.
+const logPatternRateWindowSec = 60
+
 // eventSender formats and dispatches one Datadog event per correlation.
 // When api is nil, send prints to stdout (dry-run mode) instead of calling the API.
 type eventSender struct {
-	api    *datadogV2.EventsApi
-	ctx    context.Context
-	logger log.Component
+	api     *datadogV2.EventsApi
+	ctx     context.Context
+	logger  log.Component
+	storage observerdef.StorageReader
 }
 
 // newEventSender creates an eventSender. It reads observer.event_reporter.sending_enabled
 // from cfg; when false, api is left nil and events are only logged (dry-run mode).
-func newEventSender(cfg config.Component, logger log.Component) (*eventSender, error) {
+// storage is used to compute windowed log rates for display in event messages.
+func newEventSender(cfg config.Component, logger log.Component, storage observerdef.StorageReader) (*eventSender, error) {
 	if !cfg.GetBool("observer.event_reporter.sending_enabled") {
-		return &eventSender{logger: logger}, nil
+		return &eventSender{logger: logger, storage: storage}, nil
 	}
 	apiKey := cfg.GetString("api_key")
 	if apiKey == "" {
@@ -46,14 +52,29 @@ func newEventSender(cfg config.Component, logger log.Component) (*eventSender, e
 		map[string]datadog.APIKey{"apiKeyAuth": {Key: apiKey}},
 	)
 	return &eventSender{
-		api:    datadogV2.NewEventsApi(datadog.NewAPIClient(datadog.NewConfiguration())),
-		ctx:    ctx,
-		logger: logger,
+		api:     datadogV2.NewEventsApi(datadog.NewAPIClient(datadog.NewConfiguration())),
+		ctx:     ctx,
+		logger:  logger,
+		storage: storage,
 	}, nil
 }
 
+// logPatternRate returns the average log/s over the last logPatternRateWindowSec seconds
+// for the given anomaly. It uses SumRange on storage when a series ref is available,
+// otherwise falls back to DebugInfo.CurrentValue.
+func logPatternRate(a observerdef.Anomaly, storage observerdef.StorageReader) (rate float64, ok bool) {
+	if a.SourceRef != nil && storage != nil {
+		total := storage.SumRange(a.SourceRef.Ref, a.Timestamp-logPatternRateWindowSec, a.Timestamp, observerdef.AggregateCount)
+		return total / logPatternRateWindowSec, true
+	}
+	if a.DebugInfo != nil {
+		return a.DebugInfo.CurrentValue, true
+	}
+	return 0, false
+}
+
 // correlationMessage builds the event message body for a correlation.
-func correlationMessage(c observerdef.ActiveCorrelation) string {
+func correlationMessage(c observerdef.ActiveCorrelation, storage observerdef.StorageReader) string {
 	var metricLines, logLines []string
 	for _, a := range c.Anomalies {
 		if a.Description == "" {
@@ -68,7 +89,7 @@ func correlationMessage(c observerdef.ActiveCorrelation) string {
 			}
 			// If this metric is a log related one, find its pattern and create a custom message
 			// TODO(celian): Be sure that we don't have twice (pattern, tags) tuples
-			if a.Source.Namespace == "log_pattern_extractor" && pattern != "" {
+			if a.Source.Namespace == LogPatternExtractorName && pattern != "" {
 				var tagsPart string
 				if len(a.Context.SplitTags) > 0 {
 					var parts []string
@@ -86,10 +107,10 @@ func correlationMessage(c observerdef.ActiveCorrelation) string {
 					example = "\tlog example: " + strings.TrimSpace(a.Context.Example)
 				}
 				var ratePart string
-				if a.DebugInfo != nil {
-					ratePart = fmt.Sprintf("\tcurrent rate: %.1flog/s", a.DebugInfo.CurrentValue)
+				if rate, ok := logPatternRate(a, storage); ok {
+					ratePart = fmt.Sprintf("\tavg rate (60s): %.1flog/s", rate)
 				} else {
-					ratePart = "\tcurrent rate: unknown"
+					ratePart = "\tavg rate (60s): unknown"
 				}
 				logDescription := fmt.Sprintf("Log pattern change rate detected: %s%s%s%s", pattern, example, ratePart, tagsPart)
 				logLines = append(logLines, "- "+logDescription)
@@ -115,7 +136,7 @@ func correlationMessage(c observerdef.ActiveCorrelation) string {
 
 // send formats a correlation into a change event and either prints or posts it.
 func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
-	msg := buildChangeMessage(c)
+	msg := buildChangeMessage(c, s.storage)
 	ts := time.Unix(c.FirstSeen, 0).UTC().Format(time.RFC3339)
 	aggKey := "observer:" + c.Pattern
 
@@ -317,14 +338,14 @@ func buildChangeMetadata(c observerdef.ActiveCorrelation) map[string]interface{}
 }
 
 // buildChangeMessage creates a compact human-readable summary for the change event message.
-func buildChangeMessage(c observerdef.ActiveCorrelation) string {
+func buildChangeMessage(c observerdef.ActiveCorrelation, storage observerdef.StorageReader) string {
 	var lines []string
 	lines = append(lines, fmt.Sprintf("Correlated behavior change detected: %d anomalies in pattern %q", len(c.Anomalies), c.Pattern))
 	lines = append(lines, "")
 
 	for _, a := range c.Anomalies {
 		if isLogDerivedAnomaly(a) {
-			lines = append(lines, "- "+logDerivedDescription(a))
+			lines = append(lines, "- "+logDerivedDescription(a, storage))
 		} else if a.DebugInfo != nil {
 			display := anomalyDisplayKey(a)
 			lines = append(lines, fmt.Sprintf("- %s: %.2f (baseline mean: %.2f, %.1f sigma)", display, a.DebugInfo.CurrentValue, a.DebugInfo.BaselineMean, a.DebugInfo.DeviationSigma))
@@ -356,24 +377,24 @@ func anomalyDisplayKey(a observerdef.Anomaly) string {
 // pattern/example/rate context rather than raw metric descriptions.
 func isLogDerivedAnomaly(a observerdef.Anomaly) bool {
 	return a.Type != observerdef.AnomalyTypeLog &&
-		a.Source.Namespace == "log_pattern_extractor" &&
+		a.Source.Namespace == LogPatternExtractorName &&
 		a.Context != nil &&
 		strings.TrimSpace(a.Context.Pattern) != ""
 }
 
 // logDerivedDescription builds a human-readable description for a log-derived
-// metric anomaly, including pattern, example, and current rate.
-func logDerivedDescription(a observerdef.Anomaly) string {
+// metric anomaly, including pattern, example, and windowed average rate.
+func logDerivedDescription(a observerdef.Anomaly, storage observerdef.StorageReader) string {
 	pattern := strings.TrimSpace(a.Context.Pattern)
 	var example string
 	if a.Context.Example != "" {
 		example = "\tlog example: " + strings.TrimSpace(a.Context.Example)
 	}
 	var ratePart string
-	if a.DebugInfo != nil {
-		ratePart = fmt.Sprintf("\tcurrent rate: %.1flog/s", a.DebugInfo.CurrentValue)
+	if rate, ok := logPatternRate(a, storage); ok {
+		ratePart = fmt.Sprintf("\tavg rate (60s): %.1flog/s", rate)
 	} else {
-		ratePart = "\tcurrent rate: unknown"
+		ratePart = "\tavg rate (60s): unknown"
 	}
 	return fmt.Sprintf("Log pattern change rate detected: %s%s%s", pattern, example, ratePart)
 }

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -286,7 +286,7 @@ func NewComponent(deps Requires) Provides {
 
 	// Optionally add the event reporter when sending is enabled via config.
 	if cfg.GetBool("observer.event_reporter.sending_enabled") {
-		if sender, err := newEventSender(deps.Config, deps.Log); err != nil {
+		if sender, err := newEventSender(deps.Config, deps.Log, eng.Storage()); err != nil {
 			deps.Log.Warnf("[observer] event_reporter disabled: %v", err)
 		} else {
 			eventReporter := &EventReporter{sender: sender, logger: deps.Log}
@@ -429,9 +429,9 @@ type observerImpl struct {
 	// fetcher pulls traces/profiles from remote trace-agents
 	fetcher *observerFetcher
 
-	telemetryHandler    *telemetryHandler
-	digestCleanup      func() // flushes detect digest recording file
-	advanceLogCleanup  func() // flushes advance log recording file
+	telemetryHandler  *telemetryHandler
+	digestCleanup     func() // flushes detect digest recording file
+	advanceLogCleanup func() // flushes advance log recording file
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -638,9 +638,9 @@ func (o *observerImpl) DumpMetrics(path string) error {
 // handle is the lightweight observation interface passed to other components.
 // It only holds a channel and source name - all processing happens in the observer.
 type handle struct {
-	ch         chan<- observation
-	source     string
-	dropCount  *atomic.Int64 // shared counter for channel-full drops (nil = don't track)
+	ch        chan<- observation
+	source    string
+	dropCount *atomic.Int64 // shared counter for channel-full drops (nil = don't track)
 }
 
 // ObserveMetric observes a DogStatsD metric sample.

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -119,7 +119,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 
 		if verbose {
 			oc.Title = corr.Title
-			oc.Message = correlationMessage(corr, tb.engine.Storage())
+			oc.Message = buildChangeMessage(corr, tb.engine.Storage())
 			oc.Tags = []string{"source:agent-q-branch-observer", "pattern:" + corr.Pattern}
 			oc.MemberSeries = make([]string, len(corr.Members))
 			for j, m := range corr.Members {

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -119,7 +119,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 
 		if verbose {
 			oc.Title = corr.Title
-			oc.Message = correlationMessage(corr)
+			oc.Message = correlationMessage(corr, tb.engine.Storage())
 			oc.Tags = []string{"source:agent-q-branch-observer", "pattern:" + corr.Pattern}
 			oc.MemberSeries = make([]string, len(corr.Members))
 			for j, m := range corr.Members {

--- a/comp/observer/impl/reporter_testbench.go
+++ b/comp/observer/impl/reporter_testbench.go
@@ -33,6 +33,7 @@ type ReportedEvent struct {
 type replayReporter struct {
 	seenPatterns map[string]bool
 	events       []ReportedEvent
+	storage      observerdef.StorageReader
 }
 
 // Name satisfies observerdef.Reporter.
@@ -52,7 +53,7 @@ func (r *replayReporter) Report(output observerdef.ReportOutput) {
 
 	for _, ac := range output.ActiveCorrelations {
 		if !r.seenPatterns[ac.Pattern] {
-			msg := correlationMessage(ac)
+			msg := correlationMessage(ac, r.storage)
 			tags := []string{"source:agent-q-branch-observer", "pattern:" + ac.Pattern}
 			r.events = append(r.events, ReportedEvent{
 				Pattern:       ac.Pattern,

--- a/comp/observer/impl/reporter_testbench.go
+++ b/comp/observer/impl/reporter_testbench.go
@@ -53,7 +53,7 @@ func (r *replayReporter) Report(output observerdef.ReportOutput) {
 
 	for _, ac := range output.ActiveCorrelations {
 		if !r.seenPatterns[ac.Pattern] {
-			msg := correlationMessage(ac, r.storage)
+			msg := buildChangeMessage(ac, r.storage)
 			tags := []string{"source:agent-q-branch-observer", "pattern:" + ac.Pattern}
 			r.events = append(r.events, ReportedEvent{
 				Pattern:       ac.Pattern,

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -981,6 +981,51 @@ func (s *timeSeriesStorage) ForEachPoint(
 	return true
 }
 
+// SumRange returns the aggregate total over the time range (start, end] without
+// allocating any intermediate slices. It operates directly on the columnar
+// data arrays, using binary search to locate the range boundaries.
+// Returns 0 if the series is not found or the range is empty.
+func (s *timeSeriesStorage) SumRange(ref observer.SeriesRef, start, end int64, agg Aggregate) float64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	stats := s.resolveByID(ref)
+	if stats == nil {
+		return 0
+	}
+
+	lo := searchAfter(stats.timestamps, start)
+	hi := searchAfter(stats.timestamps, end)
+	if lo >= hi {
+		return 0
+	}
+
+	var total float64
+	switch agg {
+	case AggregateSum:
+		for _, v := range stats.sums[lo:hi] {
+			total += v
+		}
+	case AggregateCount:
+		for _, c := range stats.counts[lo:hi] {
+			total += float64(c)
+		}
+	case AggregateMin:
+		for _, v := range stats.mins[lo:hi] {
+			total += v
+		}
+	case AggregateMax:
+		for _, v := range stats.maxes[lo:hi] {
+			total += v
+		}
+	default: // AggregateAverage
+		for i := lo; i < hi; i++ {
+			total += stats.aggregateAt(i, agg)
+		}
+	}
+	return total
+}
+
 // snapshotRange copies points for a time range into buf under the read lock.
 // Returns the series metadata, the (potentially grown) buffer, and whether the
 // series was found.

--- a/comp/observer/impl/storage_instrumented.go
+++ b/comp/observer/impl/storage_instrumented.go
@@ -81,12 +81,16 @@ func newCallHasher() *callHasher {
 	return &callHasher{h: fnv.New64a()}
 }
 
-func (c *callHasher) mixBytes(data []byte)  { c.h.Write(data) }
-func (c *callHasher) mixString(v string)    { c.h.Write([]byte(v)) }
-func (c *callHasher) mixUint64(v uint64)    { var b [8]byte; binary.LittleEndian.PutUint64(b[:], v); c.h.Write(b[:]) }
-func (c *callHasher) mixInt64(v int64)      { c.mixUint64(uint64(v)) }
-func (c *callHasher) mixFloat64(v float64)  { c.mixUint64(math.Float64bits(v)) }
-func (c *callHasher) sum() uint64           { return c.h.Sum64() }
+func (c *callHasher) mixBytes(data []byte) { c.h.Write(data) }
+func (c *callHasher) mixString(v string)   { c.h.Write([]byte(v)) }
+func (c *callHasher) mixUint64(v uint64) {
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], v)
+	c.h.Write(b[:])
+}
+func (c *callHasher) mixInt64(v int64)     { c.mixUint64(uint64(v)) }
+func (c *callHasher) mixFloat64(v float64) { c.mixUint64(math.Float64bits(v)) }
+func (c *callHasher) sum() uint64          { return c.h.Sum64() }
 
 func (c *callHasher) mixSeriesIdentity(namespace, name string, tags []string) {
 	c.mixString(namespace)
@@ -206,6 +210,21 @@ func (s *instrumentedStorage) PointCountUpTo(ref observerdef.SeriesRef, endTime 
 	ch.mixString("PointCountUpTo")
 	ch.mixInt64(endTime)
 	ch.mixInt64(int64(result))
+	s.callHashes = append(s.callHashes, ch.sum())
+	return result
+}
+
+func (s *instrumentedStorage) SumRange(ref observerdef.SeriesRef, start, end int64, agg observerdef.Aggregate) float64 {
+	s.readCount++
+	result := s.inner.SumRange(ref, start, end, agg)
+
+	ch := newCallHasher()
+	ch.mixString("SumRange")
+	ch.mixInt64(int64(ref))
+	ch.mixInt64(start)
+	ch.mixInt64(end)
+	ch.mixInt64(int64(agg))
+	ch.mixFloat64(result)
 	s.callHashes = append(s.callHashes, ch.sum())
 	return result
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -714,7 +714,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	// Register a replay reporter before the run so it captures events exactly as
 	// EventReporter would in live mode: one event per pattern appearance, with
 	// patterns eligible to re-fire after going inactive.
-	replay := &replayReporter{}
+	replay := &replayReporter{storage: tb.engine.Storage()}
 	unsub := tb.engine.Subscribe(&reporterEventSink{
 		reporters: []observerdef.Reporter{replay},
 		state:     tb.engine.StateView(),
@@ -1377,7 +1377,7 @@ func (tb *TestBench) RunSendAnomalyEvents(scenario string) error {
 
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
-	sender, err := newEventSender(tb.config.Cfg, tb.config.Logger)
+	sender, err := newEventSender(tb.config.Cfg, tb.config.Logger, tb.engine.Storage())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

- Unifies observer correlation message (was split into 2 functions)
- Computes log-pattern `avg rate (60s)` from storage over a 60s window instead of 1s
- Improves report description for readability

### Motivation

### Describe how you validated your changes

`dda inv test --targets=./comp/observer/impl/...`

### Additional Notes
