### PR TITLE
[workloadmeta] Always mark entities as complete when not running in Node Agent

### DIFF
--- a/comp/core/workloadmeta/impl/workloadmeta.go
+++ b/comp/core/workloadmeta/impl/workloadmeta.go
@@ -99,7 +99,7 @@ func NewWorkloadMeta(deps Dependencies) Provider {
 		eventCh:               make(chan []wmdef.CollectorEvent, eventChBufferSize),
 		ongoingPulls:          make(map[string]time.Time),
 		collectorsInitialized: wmdef.CollectorsNotStarted,
-		expectedSources:       initExpectedSources(),
+		expectedSources:       initExpectedSources(deps.Params.AgentType),
 	}
 
 	deps.Lc.Append(compdef.Hook{OnStart: func(_ context.Context) error {
@@ -160,10 +160,16 @@ func (w *workloadmeta) writeResponse(writer http.ResponseWriter, r *http.Request
 // TODO: This will be handled later.
 // - Kubernetes Deployments: reported by the kubeapiserver collector and
 // language detection code. Completeness tracking is not needed for deployments.
-func initExpectedSources() map[wmdef.Kind][]wmdef.Source {
+func initExpectedSources(agentType wmdef.AgentType) map[wmdef.Kind][]wmdef.Source {
 	expectedSources := make(map[wmdef.Kind][]wmdef.Source)
 
 	if !env.IsFeaturePresent(env.Kubernetes) {
+		return expectedSources
+	}
+
+	// Only the Node Agent runs multiple collectors that need to report
+	// for an entity to be complete
+	if agentType != wmdef.NodeAgent {
 		return expectedSources
 	}
 

--- a/comp/core/workloadmeta/impl/workloadmeta_test.go
+++ b/comp/core/workloadmeta/impl/workloadmeta_test.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workloadmetaimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	wmdef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
+)
+
+func TestInitExpectedSources(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentType wmdef.AgentType
+		features  []env.Feature
+		expected  map[wmdef.Kind][]wmdef.Source
+	}{
+		{
+			name:      "not kubernetes",
+			agentType: wmdef.NodeAgent,
+			features:  nil, // No kubernetes
+			expected:  map[wmdef.Kind][]wmdef.Source{},
+		},
+		{
+			name:      "kubernetes cluster agent",
+			agentType: wmdef.ClusterAgent,
+			features: []env.Feature{
+				env.Kubernetes,
+			},
+			expected: map[wmdef.Kind][]wmdef.Source{},
+		},
+		{
+			name:      "kubernetes node agent with runtime accessible",
+			agentType: wmdef.NodeAgent,
+			features: []env.Feature{
+				env.Kubernetes,
+				env.Containerd,
+			},
+			expected: map[wmdef.Kind][]wmdef.Source{
+				wmdef.KindKubernetesPod: {
+					wmdef.SourceNodeOrchestrator,
+					wmdef.SourceClusterOrchestrator,
+				},
+				wmdef.KindContainer: {
+					wmdef.SourceRuntime,
+					wmdef.SourceNodeOrchestrator,
+				},
+			},
+		},
+		{
+			name:      "kubernetes node agent with no runtime accessible",
+			agentType: wmdef.NodeAgent,
+			features:  []env.Feature{env.Kubernetes},
+			expected: map[wmdef.Kind][]wmdef.Source{
+				wmdef.KindKubernetesPod: {
+					wmdef.SourceNodeOrchestrator,
+					wmdef.SourceClusterOrchestrator,
+				},
+				wmdef.KindContainer: {
+					wmdef.SourceNodeOrchestrator,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.features != nil {
+				env.SetFeatures(t, test.features...)
+			}
+
+			result := initExpectedSources(test.agentType)
+
+			assert.Equal(t, len(test.expected), len(result))
+			for kind, expectedSources := range test.expected {
+				assert.ElementsMatch(t, expectedSources, result[kind])
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the entity completeness detection code in workloadmeta.

The code incorrectly assumed that when running on Kubernetes, pod entity information comes from two sources: the node orchestrator and the cluster orchestrator. This is true for the Node Agent, but not for the Cluster Agent. In the Cluster Agent, there's a single collector for pods: kubeapiserver. As a result, pods in the Cluster Agent were always marked as incomplete.

This bug doesn't impact any functionality because completeness information is not yet used in the Cluster Agent. But it could be in the future, so it needs to be fixed.


### Describe how you validated your changes

New unit tests. Also, deployed locally with some debug logs in the tagger to verify that pods in the Cluster Agent are now reported as complete.
