### PR TITLE
[observer] Log pattern extractor hyperparameters

### DIFF
--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -125,8 +125,16 @@ func defaultCatalog() *componentCatalog {
 				name:           "log_pattern_extractor",
 				displayName:    "Log Pattern Extractor",
 				kind:           componentExtractor,
-				factory:        func(any) any { return NewLogPatternExtractor() },
+				defaultConfig:  DefaultLogPatternExtractorConfig(),
+				factory:        func(cfg any) any { return NewLogPatternExtractor(cfg.(LogPatternExtractorConfig)) },
 				defaultEnabled: true,
+				parseJSON: func(defaults any, raw []byte) (any, error) {
+					cfg := defaults.(LogPatternExtractorConfig)
+					if err := json.Unmarshal(raw, &cfg); err != nil {
+						return nil, err
+					}
+					return cfg, nil
+				},
 			},
 			// ---- Detectors ----
 			{

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -316,8 +316,8 @@ func TestSetExtractorsRefreshesContextProviders(t *testing.T) {
 }
 
 func TestEnrichAnomalyWithRealLogPatternExtractorUsesStoredSeriesTags(t *testing.T) {
-	extractor := NewLogPatternExtractor()
-	extractor.MinPatternsBeforeEmit = 1
+	extractor := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
+	extractor.config.MinClusterSizeBeforeEmit = 1
 	e := newEngine(engineConfig{
 		storage:          newTimeSeriesStorage(),
 		extractors:       []observerdef.LogMetricsExtractor{extractor},

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+	"github.com/DataDog/datadog-agent/comp/observer/impl/patterns"
 )
 
 // LogPatternExtractorName is the canonical name for the log pattern extractor.
@@ -16,9 +17,40 @@ import (
 // name in the catalog, and in notify formatting for log-derived anomalies.
 const LogPatternExtractorName = "log_pattern_extractor"
 
-// defaultMinClusterSizeBeforeEmitMetrics is the minimum number of logs
-// inside a cluster (pattern) before we emit a metric.
-const defaultMinClusterSizeBeforeEmitMetrics = 5
+// LogPatternExtractorConfig holds hyperparameters for the log pattern extractor.
+type LogPatternExtractorConfig struct {
+	// MinClusterSizeBeforeEmit is the minimum number of logs matching a pattern
+	// before emitting metrics. Zero means the default from DefaultLogPatternExtractorConfig.
+	MinClusterSizeBeforeEmit int `json:"min_cluster_size_before_emit,omitempty"`
+	// MaxTokenizedStringLength caps input length before tokenization (0 = patterns default).
+	MaxTokenizedStringLength int `json:"max_tokenized_string_length,omitempty"`
+	// MaxNumTokens caps token count per message (0 = patterns default).
+	MaxNumTokens int `json:"max_num_tokens,omitempty"`
+	// ParseHexDump controls hex-dump recognition in the tokenizer. When nil, the
+	// patterns package default applies (true).
+	ParseHexDump *bool `json:"parse_hex_dump,omitempty"`
+}
+
+// DefaultLogPatternExtractorConfig returns defaults aligned with the patterns package.
+func DefaultLogPatternExtractorConfig() LogPatternExtractorConfig {
+	return LogPatternExtractorConfig{
+		MinClusterSizeBeforeEmit: 5,
+	}
+}
+
+func tokenizerFromConfig(cfg LogPatternExtractorConfig) *patterns.Tokenizer {
+	t := patterns.NewTokenizer()
+	if cfg.MaxTokenizedStringLength > 0 {
+		t.MaxStringLen = cfg.MaxTokenizedStringLength
+	}
+	if cfg.MaxNumTokens > 0 {
+		t.MaxTokens = cfg.MaxNumTokens
+	}
+	if cfg.ParseHexDump != nil {
+		t.ParseHexDump = *cfg.ParseHexDump
+	}
+	return t
+}
 
 // PatternKeyInfo contains what can identify a pattern.
 type PatternKeyInfo struct {
@@ -32,9 +64,8 @@ type LogPatternExtractor struct {
 	taggedClusterer *TaggedPatternClusterer
 	registry        *TagGroupByKeyRegistry
 	patternContext  map[string]patternMetricContext
-	// MinPatternsBeforeEmit is the minimum number of distinct patterns (clusters)
-	// before emitting metrics. Zero means defaultMinPatternsBeforeEmitMetrics.
-	MinPatternsBeforeEmit int
+	// config is the resolved hyperparameters (MinClusterSizeBeforeEmit is never zero after init).
+	config LogPatternExtractorConfig
 }
 
 var _ observerdef.LogMetricsExtractor = (*LogPatternExtractor)(nil)
@@ -46,12 +77,21 @@ type patternMetricContext struct {
 }
 
 // NewLogPatternExtractor creates a new LogPatternExtractor.
-func NewLogPatternExtractor() *LogPatternExtractor {
+// A zero-value cfg is accepted; zero fields fall back to DefaultLogPatternExtractorConfig values.
+func NewLogPatternExtractor(cfg LogPatternExtractorConfig) *LogPatternExtractor {
+	defaults := DefaultLogPatternExtractorConfig()
+	if cfg.MinClusterSizeBeforeEmit <= 0 {
+		cfg.MinClusterSizeBeforeEmit = defaults.MinClusterSizeBeforeEmit
+	}
 	registry := NewTagGroupByKeyRegistry()
+	tok := tokenizerFromConfig(cfg)
+	newSub := func() *patterns.PatternClusterer {
+		return patterns.NewPatternClustererWithTokenizer(tok)
+	}
 	return &LogPatternExtractor{
-		taggedClusterer:       NewTaggedPatternClusterer(registry),
-		registry:              registry,
-		MinPatternsBeforeEmit: defaultMinClusterSizeBeforeEmitMetrics,
+		taggedClusterer: NewTaggedPatternClustererWithFactory(registry, newSub),
+		registry:        registry,
+		config:          cfg,
 	}
 }
 
@@ -119,9 +159,9 @@ func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) observerdef.Lo
 	}
 	// Not enough patterns yet, don't emit metric.
 	// It's not directly a new pattern but the first time we reach the threshold and we emit a metric.
-	if cluster.Count == e.MinPatternsBeforeEmit {
+	if cluster.Count == e.config.MinClusterSizeBeforeEmit {
 		telemetry = append(telemetry, newTelemetryCounter([]string{"detector:" + e.Name()}, telemetryLogPatternExtractorPatternCount, 1, log.GetTimestampUnixMilli()/1000))
-	} else if cluster.Count < e.MinPatternsBeforeEmit {
+	} else if cluster.Count < e.config.MinClusterSizeBeforeEmit {
 		return observerdef.LogMetricsExtractorOutput{}
 	}
 

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -29,6 +29,10 @@ type LogPatternExtractorConfig struct {
 	// ParseHexDump controls hex-dump recognition in the tokenizer. When nil, the
 	// patterns package default applies (true).
 	ParseHexDump *bool `json:"parse_hex_dump,omitempty"`
+	// MinTokenMatchRatio is the minimum fraction of token positions (by value)
+	// that must match for two log lines to merge into one pattern. Range (0,1];
+	// zero means the default 0.5 (Drain-style).
+	MinTokenMatchRatio float64 `json:"min_token_match_ratio,omitempty"`
 }
 
 // DefaultLogPatternExtractorConfig returns defaults aligned with the patterns package.
@@ -86,7 +90,7 @@ func NewLogPatternExtractor(cfg LogPatternExtractorConfig) *LogPatternExtractor 
 	registry := NewTagGroupByKeyRegistry()
 	tok := tokenizerFromConfig(cfg)
 	newSub := func() *patterns.PatternClusterer {
-		return patterns.NewPatternClustererWithTokenizer(tok)
+		return patterns.NewPatternClustererWithTokenizer(tok, cfg.MinTokenMatchRatio)
 	}
 	return &LogPatternExtractor{
 		taggedClusterer: NewTaggedPatternClustererWithFactory(registry, newSub),

--- a/comp/observer/impl/log_pattern_extractor_test.go
+++ b/comp/observer/impl/log_pattern_extractor_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestLogPatternExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
-	e := NewLogPatternExtractor()
-	e.MinPatternsBeforeEmit = 1
+	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
+	e.config.MinClusterSizeBeforeEmit = 1
 
 	log := &mockLogView{
 		content: []byte("GET /users/123 returned 500"),
@@ -36,8 +36,8 @@ func TestLogPatternExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
 }
 
 func TestLogPatternExtractor_DifferentTagGroupsProduceDifferentMetricNames(t *testing.T) {
-	e := NewLogPatternExtractor()
-	e.MinPatternsBeforeEmit = 1
+	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
+	e.config.MinClusterSizeBeforeEmit = 1
 
 	// 1 pattern per service (same pattern strings but different IDs)
 	logA := &mockLogView{
@@ -84,8 +84,8 @@ func TestLogPatternExtractor_DifferentTagGroupsProduceDifferentMetricNames(t *te
 }
 
 func TestLogPatternExtractor_DifferentHostnamesProduceDifferentMetricNamesWhenNoHostTag(t *testing.T) {
-	e := NewLogPatternExtractor()
-	e.MinPatternsBeforeEmit = 1
+	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
+	e.config.MinClusterSizeBeforeEmit = 1
 
 	msg := []byte("GET /users/123 returned 500")
 	tags := []string{"service:api", "env:prod"}
@@ -119,8 +119,8 @@ func TestLogPatternExtractor_DifferentHostnamesProduceDifferentMetricNamesWhenNo
 }
 
 func TestLogPatternExtractor_ResetClearsContext(t *testing.T) {
-	e := NewLogPatternExtractor()
-	e.MinPatternsBeforeEmit = 1
+	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
+	e.config.MinClusterSizeBeforeEmit = 1
 
 	log := &mockLogView{
 		content: []byte("GET /users/123 returned 500"),
@@ -141,7 +141,7 @@ func TestLogPatternExtractor_ResetClearsContext(t *testing.T) {
 }
 
 func TestLogPatternExtractor_SkipsBelowWarnSeverity(t *testing.T) {
-	e := NewLogPatternExtractor()
+	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
 
 	out := e.ProcessLog(&mockLogView{
 		content: []byte("INFO: routine request completed"),
@@ -153,7 +153,7 @@ func TestLogPatternExtractor_SkipsBelowWarnSeverity(t *testing.T) {
 }
 
 func TestLogPatternExtractor_DeferredEmitUntilMinPatterns(t *testing.T) {
-	e := NewLogPatternExtractor()
+	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
 	status := "warn"
 	tags := []string{"service:api"}
 

--- a/comp/observer/impl/log_tagged_pattern_clusterer.go
+++ b/comp/observer/impl/log_tagged_pattern_clusterer.go
@@ -148,16 +148,27 @@ func globalClusterHash(groupHash uint64, clusterID int64) string {
 //
 // NOT thread-safe: all calls must be made from the same goroutine.
 type TaggedPatternClusterer struct {
-	registry      *TagGroupByKeyRegistry
-	subClusterers map[uint64]*patterns.PatternClusterer
+	registry            *TagGroupByKeyRegistry
+	subClusterers       map[uint64]*patterns.PatternClusterer
+	newPatternClusterer func() *patterns.PatternClusterer
 }
 
 // NewTaggedPatternClusterer creates a TaggedPatternClusterer that writes group
 // hashes into registry.
 func NewTaggedPatternClusterer(registry *TagGroupByKeyRegistry) *TaggedPatternClusterer {
+	return NewTaggedPatternClustererWithFactory(registry, patterns.NewPatternClusterer)
+}
+
+// NewTaggedPatternClustererWithFactory is like NewTaggedPatternClusterer but uses newPC
+// to construct each per-tag-group sub-clusterer (e.g. to plug tokenizer hyperparameters).
+func NewTaggedPatternClustererWithFactory(registry *TagGroupByKeyRegistry, newPC func() *patterns.PatternClusterer) *TaggedPatternClusterer {
+	if newPC == nil {
+		newPC = patterns.NewPatternClusterer
+	}
 	return &TaggedPatternClusterer{
-		registry:      registry,
-		subClusterers: make(map[uint64]*patterns.PatternClusterer),
+		registry:            registry,
+		subClusterers:       make(map[uint64]*patterns.PatternClusterer),
+		newPatternClusterer: newPC,
 	}
 }
 
@@ -169,7 +180,7 @@ func (tc *TaggedPatternClusterer) Process(tags []string, message string) (uint64
 
 	sub, exists := tc.subClusterers[groupHash]
 	if !exists {
-		sub = patterns.NewPatternClusterer()
+		sub = tc.newPatternClusterer()
 		tc.subClusterers[groupHash] = sub
 	}
 

--- a/comp/observer/impl/patterns/cluster.go
+++ b/comp/observer/impl/patterns/cluster.go
@@ -135,9 +135,18 @@ type PatternClusterer struct {
 }
 
 func NewPatternClusterer() *PatternClusterer {
+	return NewPatternClustererWithTokenizer(NewTokenizer())
+}
+
+// NewPatternClustererWithTokenizer creates a PatternClusterer that uses the given tokenizer.
+// If t is nil, a default Tokenizer is used.
+func NewPatternClustererWithTokenizer(t *Tokenizer) *PatternClusterer {
+	if t == nil {
+		t = NewTokenizer()
+	}
 	return &PatternClusterer{
 		clustersBySignature: make(map[string][]*Cluster),
-		tokenizer:           NewTokenizer(),
+		tokenizer:           t,
 		IgnoreEmpty:         true,
 	}
 }

--- a/comp/observer/impl/patterns/cluster.go
+++ b/comp/observer/impl/patterns/cluster.go
@@ -132,15 +132,20 @@ type PatternClusterer struct {
 	tokenizer           *Tokenizer
 	IgnoreEmpty         bool
 	nextID              int64
+	// minTokenMatchRatio is the effective minimum fraction of token positions that must
+	// match by value for an incoming line to merge into an existing cluster. Set at
+	// construction from rawMinTokenMatchRatio via effectiveMinTokenMatchRatio.
+	minTokenMatchRatio float64
 }
 
 func NewPatternClusterer() *PatternClusterer {
-	return NewPatternClustererWithTokenizer(NewTokenizer())
+	return NewPatternClustererWithTokenizer(NewTokenizer(), 0)
 }
 
 // NewPatternClustererWithTokenizer creates a PatternClusterer that uses the given tokenizer.
-// If t is nil, a default Tokenizer is used.
-func NewPatternClustererWithTokenizer(t *Tokenizer) *PatternClusterer {
+// If t is nil, a default Tokenizer is used. rawMinTokenMatchRatio is normalized once at
+// construction (≤0 → 0.5, >1 → 1); pass 0 for the library default.
+func NewPatternClustererWithTokenizer(t *Tokenizer, rawMinTokenMatchRatio float64) *PatternClusterer {
 	if t == nil {
 		t = NewTokenizer()
 	}
@@ -148,6 +153,7 @@ func NewPatternClustererWithTokenizer(t *Tokenizer) *PatternClusterer {
 		clustersBySignature: make(map[string][]*Cluster),
 		tokenizer:           t,
 		IgnoreEmpty:         true,
+		minTokenMatchRatio:  effectiveMinTokenMatchRatio(rawMinTokenMatchRatio),
 	}
 }
 
@@ -171,7 +177,7 @@ func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) (*Clus
 	// Try within same signature group first
 	clusters := pc.clustersBySignature[sig]
 	for _, c := range clusters {
-		if canMergeTokenLists(c.Pattern, tokens) {
+		if pc.canMergeTokenLists(c.Pattern, tokens) {
 			mergeTokenLists(c.Pattern, tokens)
 			c.Count++
 			return c, true
@@ -185,7 +191,7 @@ func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) (*Clus
 			continue
 		}
 		for _, c := range otherClusters {
-			if canMergeTokenLists(c.Pattern, tokens) {
+			if pc.canMergeTokenLists(c.Pattern, tokens) {
 				mergeTokenLists(c.Pattern, tokens)
 				c.Count++
 				return c, true
@@ -221,10 +227,27 @@ func (pc *PatternClusterer) GetCluster(id int64) (*Cluster, error) {
 	return nil, fmt.Errorf("cluster %d not found", id)
 }
 
+func effectiveMinTokenMatchRatio(r float64) float64 {
+	switch {
+	case r <= 0:
+		return 0.5
+	case r > 1:
+		return 1
+	default:
+		return r
+	}
+}
+
 // canMergeTokenLists checks if two token lists can be merged.
-// It requires that all token pairs be type-compatible AND that at least
-// half of the tokens match by value (Drain-style similarity threshold).
-func canMergeTokenLists(pattern, incoming []Token) bool {
+// It requires that all token pairs be type-compatible AND that the fraction of
+// positions with equal values is at least pc.minTokenMatchRatio (set at construction).
+func (pc *PatternClusterer) canMergeTokenLists(pattern, incoming []Token) bool {
+	return canMergeTokenListsWithRatio(pattern, incoming, pc.minTokenMatchRatio)
+}
+
+// canMergeTokenListsWithRatio is the merge predicate parameterized by an already-resolved
+// minRatio. Used by tests and PatternClusterer.canMergeTokenLists.
+func canMergeTokenListsWithRatio(pattern, incoming []Token, minRatio float64) bool {
 	if len(pattern) != len(incoming) {
 		return false
 	}
@@ -237,7 +260,10 @@ func canMergeTokenLists(pattern, incoming []Token) bool {
 			matching++
 		}
 	}
-	return matching*2 >= len(pattern)
+	if len(pattern) == 0 {
+		return true
+	}
+	return float64(matching) >= minRatio*float64(len(pattern))
 }
 
 func canMergeTokens(a, b Token) bool {
@@ -330,7 +356,7 @@ func (pc *PatternClusterer) Classify(message string) *Cluster {
 
 	if clusters, ok := pc.clustersBySignature[sig]; ok {
 		for _, c := range clusters {
-			if canMergeTokenLists(c.Pattern, tokens) {
+			if pc.canMergeTokenLists(c.Pattern, tokens) {
 				return c
 			}
 		}
@@ -341,7 +367,7 @@ func (pc *PatternClusterer) Classify(message string) *Cluster {
 			continue
 		}
 		for _, c := range clusters {
-			if canMergeTokenLists(c.Pattern, tokens) {
+			if pc.canMergeTokenLists(c.Pattern, tokens) {
 				return c
 			}
 		}

--- a/comp/observer/impl/patterns/cluster_test.go
+++ b/comp/observer/impl/patterns/cluster_test.go
@@ -390,7 +390,7 @@ func TestMergeTokensWhitespace(t *testing.T) {
 func TestMergeTokenListsSameLength(t *testing.T) {
 	a := []Token{WordToken("hello"), WhitespaceToken(1), WordToken("world")}
 	b := []Token{WordToken("hello"), WhitespaceToken(1), WordToken("earth")}
-	if !canMergeTokenLists(a, b) {
+	if !canMergeTokenListsWithRatio(a, b, 0.5) {
 		t.Error("token lists with same structure should be mergeable")
 	}
 }
@@ -398,8 +398,20 @@ func TestMergeTokenListsSameLength(t *testing.T) {
 func TestMergeTokenListsDifferentLength(t *testing.T) {
 	a := []Token{WordToken("hello")}
 	b := []Token{WordToken("hello"), WhitespaceToken(1)}
-	if canMergeTokenLists(a, b) {
+	if canMergeTokenListsWithRatio(a, b, 0.5) {
 		t.Error("token lists with different lengths should not be mergeable")
+	}
+}
+
+func TestMergeTokenListsStricterRatio(t *testing.T) {
+	// Four tokens, two value matches (50%) — merge at default 0.5, not at 0.8.
+	a := []Token{WordToken("a"), WhitespaceToken(1), WordToken("b"), WordToken("c")}
+	b := []Token{WordToken("a"), WhitespaceToken(1), WordToken("x"), WordToken("y")}
+	if !canMergeTokenListsWithRatio(a, b, 0.5) {
+		t.Error("expected merge at default ratio 0.5")
+	}
+	if canMergeTokenListsWithRatio(a, b, 0.8) {
+		t.Error("expected no merge at 0.8 min ratio")
 	}
 }
 

--- a/comp/observer/impl/testbench_api_test.go
+++ b/comp/observer/impl/testbench_api_test.go
@@ -95,7 +95,7 @@ func TestHandleSeriesListMarksLogPatternExtractorSeriesAsVirtual(t *testing.T) {
 	require.NoError(t, err)
 	api := NewTestBenchAPI(tb)
 	if ext := tb.getLogPatternExtractor(); ext != nil {
-		ext.MinPatternsBeforeEmit = 1
+		ext.config.MinClusterSizeBeforeEmit = 1
 	}
 
 	_, _ = tb.engine.IngestLog("test-source", &logObs{

--- a/comp/observer/impl/testbench_params.go
+++ b/comp/observer/impl/testbench_params.go
@@ -32,7 +32,8 @@ import (
 //	    },
 //	    "log_pattern_extractor": {
 //	      "min_cluster_size_before_emit": 5,
-//	      "max_tokenized_string_length": 8000
+//	      "max_tokenized_string_length": 8000,
+//	      "min_token_match_ratio": 0.5
 //	    },
 //	    "rrcf": { "enabled": false }
 //	  }

--- a/comp/observer/impl/testbench_params.go
+++ b/comp/observer/impl/testbench_params.go
@@ -30,6 +30,10 @@ import (
 //	      "proximity_seconds": 15,
 //	      "min_cluster_size": 2
 //	    },
+//	    "log_pattern_extractor": {
+//	      "min_cluster_size_before_emit": 5,
+//	      "max_tokenized_string_length": 8000
+//	    },
 //	    "rrcf": { "enabled": false }
 //	  }
 //	}


### PR DESCRIPTION
### What does this PR do?

Adds JSON hyperparameters for `log_pattern_extractor` (tokenizer limits, emit threshold, hex-dump parsing, `min_token_match_ratio` for merge similarity).

`min_token_match_ratio` is a new hyper-parameter to change the way we merge two different logs into the same pattern.

### Motivation

### Describe how you validated your changes

### Additional Notes
