### PR TITLE
Use current milestone instead of last stable

### DIFF
--- a/.gitlab/distribute/deploy_containers_a7.yml
+++ b/.gitlab/distribute/deploy_containers_a7.yml
@@ -174,7 +174,7 @@ deploy_containers-a7-fips_internal:
   stage: deploy_containers
   dependencies: []
   before_script:
-    - 'if [[ "$VERSION" == "" ]]; then VERSION=$(sed -n ''s/.*"current_milestone": "\([^"]*\)".*/\1/p'' release.json | head -1); fi'
+    - if [[ "$VERSION" == "" ]]; then VERSION=$(yq -r '.current_milestone' release.json); fi
     - export IMG_SOURCES="${SRC_DDOT_EBPF}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64"
     - export IMG_DESTINATIONS="ddot-ebpf:${VERSION}-preview-host-profiler-${PREVIEW_NUMBER}"
 

--- a/.gitlab/distribute/deploy_containers_a7.yml
+++ b/.gitlab/distribute/deploy_containers_a7.yml
@@ -186,4 +186,4 @@ deploy_containers-host-profiler-preview:
       allow_failure: true
   # Update manually in branches that trigger preview image.
   variables:
-    PREVIEW_NUMBER: ""
+    PREVIEW_NUMBER: "0.2"

--- a/.gitlab/distribute/deploy_containers_a7.yml
+++ b/.gitlab/distribute/deploy_containers_a7.yml
@@ -186,4 +186,4 @@ deploy_containers-host-profiler-preview:
       allow_failure: true
   # Update manually in branches that trigger preview image.
   variables:
-    PREVIEW_NUMBER: "0.2"
+    PREVIEW_NUMBER: ""

--- a/.gitlab/distribute/deploy_containers_a7.yml
+++ b/.gitlab/distribute/deploy_containers_a7.yml
@@ -174,7 +174,7 @@ deploy_containers-a7-fips_internal:
   stage: deploy_containers
   dependencies: []
   before_script:
-    - 'if [[ "$VERSION" == "" ]]; then VERSION=$(sed -n ''s/.*"7": "\([^"]*\)".*/\1/p'' release.json | head -1); fi'
+    - 'if [[ "$VERSION" == "" ]]; then VERSION=$(sed -n ''s/.*"current_milestone": "\([^"]*\)".*/\1/p'' release.json | head -1); fi'
     - export IMG_SOURCES="${SRC_DDOT_EBPF}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64"
     - export IMG_DESTINATIONS="ddot-ebpf:${VERSION}-preview-host-profiler-${PREVIEW_NUMBER}"
 


### PR DESCRIPTION
### What does this PR do?
Custom builds are from main which reflects current milestone more than last stable.

### Motivation

### Describe how you validated your changes

### Additional Notes
