### PR TITLE
[CWS] Stop EBPFProbe goroutines before reporter channels are closed

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2300,17 +2300,22 @@ func (p *EBPFProbe) Walk(callback func(*model.ProcessCacheEntry)) {
 // Stop the probe
 func (p *EBPFProbe) Stop() {
 	_ = p.Manager.StopReaders(manager.CleanAll)
+
+	// Cancel the context and wait for all goroutines to exit before proceeding.
+	// This must happen before event consumers are stopped
+	// and reporter channels are closed, to avoid sending on a closed channel.
+	p.cancelFnc()
+	// wait for the following goroutines to exit:
+	// - the perfmap reorderer (if used/enabled)
+	// - the perfmap reorderer monitor (if used/enabled)
+	// - the security profile manager
+	// - the process killer goroutine
+	// - the startSysCtlSnapshotLoop goroutine
+	p.wg.Wait()
 }
 
 // Close the probe
 func (p *EBPFProbe) Close() error {
-	// Cancelling the context will stop the reorderer = we won't dequeue events anymore and new events from the
-	// perf map reader are ignored
-	p.cancelFnc()
-
-	// we wait until both the reorderer and the monitor are stopped
-	p.wg.Wait()
-
 	if p.rawPacketFilterCollection != nil {
 		p.rawPacketFilterCollection.Close()
 	}


### PR DESCRIPTION
### What does this PR do?

Moves context cancellation and goroutine wait from `EBPFProbe.Close()` to `EBPFProbe.Stop()`.

### Motivation

During shutdown, `EventMonitor.Close()` calls `Probe.Stop()` (which calls `EBPFProbe.Stop()`), then `CWSConsumer.Stop()` (which closes reporter pipeline channels), then `Probe.Close()` (which calls `EBPFProbe.Close()`).

`EBPFProbe` goroutines like `startSysCtlSnapshotLoop` dispatch events through the reporter pipeline. Previously, the context cancellation and goroutine wait lived in `EBPFProbe.Close()`, which runs *after* the channels are closed. This left a window where a goroutine could send on a closed channel:

```
panic: send on closed channel
goroutine 983 [running]:
github.com/DataDog/datadog-agent/pkg/security/reporter.(*RuntimeReporter).ReportRaw(...)
    pkg/security/reporter/reporter.go:39
```

By moving the cancellation to `EBPFProbe.Stop()`, all goroutines are guaranteed to exit before `CWSConsumer.Stop()` tears down the pipeline.

### Describe how you validated your changes

Verified the shutdown sequence ensures `EBPFProbe.Stop()` (step 1) completes before `APIServer.Stop()` (step 2) closes channels.

### Additional Notes

`Close()` now only handles resource teardown (eBPF programs, ERPC, resolvers), while `Stop()` handles goroutine lifecycle — consistent with the intended `Stop`/`Close` contract.