### PR TITLE
Migrating static security-agent example to the example dir

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -488,7 +488,6 @@ variables:
     paths:
       - omnibus/**/*
       - pkg/config/config_template.yaml
-      - pkg/config/security-agent_template.yaml
       - pkg/config/system-probe_template.yaml
     compare_to: $COMPARE_TO_BRANCH
 

--- a/cmd/agent/dist/BUILD.bazel
+++ b/cmd/agent/dist/BUILD.bazel
@@ -6,7 +6,6 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_fil
 pkg_files(
     name = "all_files",
     srcs = [
-        "//pkg/config:security_agent_config",
         "//pkg/config:system_probe_config",
     ] + select({
         "//packages/agent:iot_flavor": [

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -241,7 +241,7 @@ build do
     else
       copy 'bin/security-agent/security-agent', "#{install_dir}/embedded/bin"
     end
-    move 'bin/agent/dist/security-agent.yaml', "#{conf_dir}/security-agent.yaml.example"
+    move 'pkg/config/example/security-agent.yaml.example', "#{conf_dir}/security-agent.yaml.example"
   end
 
   # CWS Instrumentation

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -19,13 +19,6 @@ agent_config(
 )
 
 agent_config(
-    name = "security_agent_config",
-    out = "security-agent.yaml",
-    build_type = "security-agent",
-    template = "security-agent_template.yaml",
-)
-
-agent_config(
     name = "system_probe_config",
     out = "system-probe.yaml",
     build_type = "system-probe",

--- a/pkg/config/example/security-agent.yaml.example
+++ b/pkg/config/example/security-agent.yaml.example
@@ -11,11 +11,13 @@
 #
 #   enabled: false
 
-#   # @param socket - string - optional - default: {{ if (eq .OS "windows") }}localhost:3334{{else}}/opt/datadog-agent/run/runtime-security.sock{{end}}
-#   # On Windows: the local address and port where the security runtime module is accessed.
-#   # On Unix: the full path to the location of the unix socket where security runtime module is accessed.
+#   # @param socket - string - optional
+#   # On Windows: the local address and port where the security runtime module is accessed and defaults to "localhost:3334".
+#   #
+#   # On Unix: the full path to the location of the unix socket where security runtime module is accessed and defaults
+#   # to "/opt/datadog-agent/run/runtime-security.sock".
 #
-#   socket: {{ if (eq .OS "windows") }}localhost:3334{{else}}/opt/datadog-agent/run/runtime-security.sock{{end}}
+#   socket: ""
 
 ##########################################
 ## Compliance monitoring configuration  ##

--- a/pkg/config/render_config/render_config.go
+++ b/pkg/config/render_config/render_config.go
@@ -104,11 +104,6 @@ func mkContext(buildType string, osName string) context {
 			ClusterChecks: true,
 			CloudFoundry:  true,
 		}
-	// security-agent and system-probe use their own templating file, they only require OS
-	case "security-agent":
-		return context{
-			OS: osName,
-		}
 	case "system-probe":
 		return context{
 			OS: osName,
@@ -139,13 +134,12 @@ func render(destFile string, tplFile string, component string, osName string) {
 
 func renderAll(destFolder string, tplFolder string) {
 	for component, templateName := range map[string]string{
-		"agent-py3":      "config_template.yaml",
-		"iot-agent":      "config_template.yaml",
-		"dogstatsd":      "config_template.yaml",
-		"dca":            "config_template.yaml",
-		"dcacf":          "config_template.yaml",
-		"system-probe":   "system-probe_template.yaml",
-		"security-agent": "security-agent_template.yaml",
+		"agent-py3":    "config_template.yaml",
+		"iot-agent":    "config_template.yaml",
+		"dogstatsd":    "config_template.yaml",
+		"dca":          "config_template.yaml",
+		"dcacf":        "config_template.yaml",
+		"system-probe": "system-probe_template.yaml",
 	} {
 		for _, osName := range []string{"windows", "darwin", "linux"} {
 			destFile := filepath.Join(destFolder, component+"_"+osName+".yaml")

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -301,8 +301,6 @@ def render_config(ctx, env, flavor, skip_assets, build_tags, development, window
     if sys.platform != 'win32' or windows_sysprobe:
         generate_config(ctx, build_type="system-probe", output_file="./cmd/agent/dist/system-probe.yaml", env=env)
 
-    generate_config(ctx, build_type="security-agent", output_file="./cmd/agent/dist/security-agent.yaml", env=env)
-
     if not skip_assets:
         refresh_assets(ctx, build_tags, development=development, flavor=flavor.name, windows_sysprobe=windows_sysprobe)
 
@@ -346,8 +344,6 @@ def refresh_assets(_, build_tags, development=True, flavor=AgentFlavor.base.name
     if sys.platform != 'win32' or windows_sysprobe:
         shutil.copy("./cmd/agent/dist/system-probe.yaml", os.path.join(dist_folder, "system-probe.yaml"))
     shutil.copy("./cmd/agent/dist/datadog.yaml", os.path.join(dist_folder, "datadog.yaml"))
-
-    shutil.copy("./cmd/agent/dist/security-agent.yaml", os.path.join(dist_folder, "security-agent.yaml"))
 
     for check in AGENT_CORECHECKS if not flavor.is_iot() else IOT_AGENT_CORECHECKS:
         check_dir = os.path.join(dist_folder, f"conf.d/{check}.d/")

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -16,7 +16,6 @@ from invoke.tasks import task
 
 import tasks.libs.cws.backend_doc_gen as backend_doc_gen
 import tasks.libs.cws.secl_doc_gen as secl_doc_gen
-from tasks.agent import generate_config
 from tasks.build_tags import get_default_build_tags
 from tasks.flavor import AgentFlavor
 from tasks.go import run_golangci_lint
@@ -113,17 +112,6 @@ def build(
         check_deadcode=os.getenv("DEPLOY_AGENT") == "true",
         coverage=os.getenv("E2E_COVERAGE_PIPELINE") == "true",
     )
-
-    render_config(ctx, env=env, skip_assets=skip_assets)
-
-
-def render_config(ctx, env, skip_assets=False):
-    if not skip_assets:
-        dist_folder = os.path.join(BIN_DIR, "agent", "dist")
-        generate_config(ctx, build_type="security-agent", output_file="./cmd/agent/dist/security-agent.yaml", env=env)
-        if not os.path.exists(dist_folder):
-            os.makedirs(dist_folder)
-        shutil.copy("./cmd/agent/dist/security-agent.yaml", os.path.join(dist_folder, "security-agent.yaml"))
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

Migrating static security-agent example to the example dir. It's a static file, no need for templating.

### Describe how you validated your changes

Test that the `security-agent.yaml.example` is still created.