### PR TITLE
Fix kafka actions bootstrap_servers matching for long broker lists

### DIFF
--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
@@ -53,6 +53,13 @@ var legacyTagReplacer = regexp.MustCompile(`[,+*\-/()\[\]{}\s]`)
 var multipleUnderscoreCleanup = regexp.MustCompile(`_+`)
 var dotUnderscoreCleanup = regexp.MustCompile(`\._`)
 
+// maxTagLen is the maximum length of a Datadog metric tag (key:value).
+// Tags exceeding this limit are truncated by the backend.
+const maxTagLen = 200
+
+// bootstrapServersTagKey is the tag key used by the kafka_consumer Python check.
+const bootstrapServersTagKey = "bootstrap_servers:"
+
 func normalizeBootstrapServers(servers string) string {
 	if servers == "" {
 		return ""
@@ -62,6 +69,13 @@ func normalizeBootstrapServers(servers string) string {
 	s = multipleUnderscoreCleanup.ReplaceAllString(s, "_")
 	s = dotUnderscoreCleanup.ReplaceAllString(s, ".")
 	s = strings.Trim(s, "_")
+	// The backend truncates tags to maxTagLen characters (key:value combined).
+	// Truncate the value to match so comparisons against backend-supplied
+	// bootstrap_servers values succeed even for long broker lists.
+	maxValueLen := maxTagLen - len(bootstrapServersTagKey)
+	if len(s) > maxValueLen {
+		s = s[:maxValueLen]
+	}
 	return s
 }
 

--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
@@ -217,6 +217,14 @@ func TestNormalizeBootstrapServers(t *testing.T) {
 			input:    "-broker.example.com:9092-",
 			expected: "broker.example.com:9092",
 		},
+		{
+			name:  "long broker list truncated to backend tag limit",
+			input: "b-1.demosumuseast1main.l4fk14.c6.kafka.us-east-1.amazonaws.com:9096,b-2.demosumuseast1main.l4fk14.c6.kafka.us-east-1.amazonaws.com:9096,b-3.demosumuseast1main.l4fk14.c6.kafka.us-east-1.amazonaws.com:9096",
+			// Full normalized value would be 202 chars, but the backend truncates
+			// the tag "bootstrap_servers:<value>" to 200 chars total, leaving
+			// 200 - len("bootstrap_servers:") = 182 chars for the value.
+			expected: "b_1.demosumuseast1main.l4fk14.c6.kafka.us_east_1.amazonaws.com:9096_b_2.demosumuseast1main.l4fk14.c6.kafka.us_east_1.amazonaws.com:9096_b_3.demosumuseast1main.l4fk14.c6.kafka.us_east",
+		},
 	}
 
 	for _, tt := range tests {

--- a/releasenotes/notes/fix-kafka-actions-bootstrap-servers-truncation-8f740730c2893663.yaml
+++ b/releasenotes/notes/fix-kafka-actions-bootstrap-servers-truncation-8f740730c2893663.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed kafka actions failing to match the local kafka_consumer integration
+    when the ``bootstrap_servers`` tag exceeds the 200-character backend tag
+    limit. Long broker lists (e.g. 3+ MSK brokers) are now truncated to match
+    the backend's tag normalization.


### PR DESCRIPTION
## Summary
- The Datadog backend truncates metric tags to 200 characters (`key:value` combined). When `kafka_connect_str` contains multiple long broker hostnames (e.g. 3 MSK brokers), the `bootstrap_servers` tag exceeds this limit and gets truncated.
- The kafka actions provider compares the truncated value from remote config against the full normalized value from local config, causing a mismatch and "kafka_consumer integration with bootstrap_servers=... not found" errors.
- Fix: truncate the normalized value in `normalizeBootstrapServers()` to account for the 200-char backend tag limit (`200 - len("bootstrap_servers:") = 182` chars for the value).

## Test plan
- [x] Added test case for long broker list truncation in `TestNormalizeBootstrapServers`
- [x] Existing normalization tests still pass
- [ ] Verify on a cluster with 3+ long MSK broker hostnames that kafka actions match correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)