### PR TITLE
fix(report-merged): Remove need of environment

### DIFF
--- a/.github/workflows/report-merged-pr.yml
+++ b/.github/workflows/report-merged-pr.yml
@@ -12,8 +12,6 @@ permissions: {}
 jobs:
   report_merged_pr:
     runs-on: ubuntu-latest
-    environment:
-      name: main
     permissions:
       id-token: write # This is required for getting the required OIDC token from GitHub
     steps:


### PR DESCRIPTION
### What does this PR do?
The `environment:main` was used only to get access to the API_KEY secret. As this secret is fetched with `dd-sts` now this is not needed anymore

### Motivation
Fix current failures: 
The workflow uses `environment: main` (line 16 of report-merged-pr.yml), which causes GitHub to set the sub claim to `repo:DataDog/datadog-agent:environment:main` instead of `repo:DataDog/datadog-agent:ref:refs/heads/main`.

### Describe how you validated your changes
n/a

### Additional Notes
