### PR TITLE
[CXP-3401][agent][windows] Fix remote process collector missing from Windows build

### DIFF
--- a/comp/core/workloadmeta/collectors/catalog-core/options_nosbom.go
+++ b/comp/core/workloadmeta/collectors/catalog-core/options_nosbom.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/nvml"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/podman"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/process"
+	remoteprocesscollector "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/processcollector"
 	remotesbomcollector "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/sbomcollector"
 )
 
@@ -37,6 +38,7 @@ func getCollectorOptions() []fx.Option {
 		kubelet.GetFxOptions(),
 		kubemetadata.GetFxOptions(),
 		podman.GetFxOptions(),
+		remoteprocesscollector.GetFxOptions(),
 		remotesbomcollector.GetFxOptions(),
 		nvml.GetFxOptions(),
 		process.GetFxOptions(),

--- a/test/new-e2e/tests/process/config/language_detection.yaml
+++ b/test/new-e2e/tests/process/config/language_detection.yaml
@@ -1,0 +1,7 @@
+process_config:
+  process_collection:
+    enabled: true
+  intervals:
+    process: 1
+language_detection:
+  enabled: true

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -42,6 +42,9 @@ var coreAgentRefreshStr string
 //go:embed config/process_agent_refresh_win.yaml
 var processAgentWinRefreshStr string
 
+//go:embed config/language_detection.yaml
+var languageDetectionConfigStr string
+
 // AgentStatus is a subset of the agent's status response for asserting the process-agent runtime
 type AgentStatus struct {
 	ProcessAgentStatus struct {

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -339,31 +339,37 @@ func (s *windowsTestSuite) TestLanguageDetectionWindows() {
 		`(Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*time.sleep(300)*' } | Select-Object -First 1).ProcessId`,
 	))
 
-	// Verify language detection via the remote_process_collector source in workload-list.
-	// The header may contain multiple sources (e.g. "[remote_process_collector process_collector]"),
-	// so match by substring.
-	idSuffix := fmt.Sprintf(" id: %s ===", pid)
+	// Verify language detection via workload-list JSON output.
+	// Parse structured JSON to avoid flaky text parsing.
+	type workloadProcess struct {
+		Kind     string `json:"Kind"`
+		ID       string `json:"ID"`
+		Language *struct {
+			Name string `json:"Name"`
+		} `json:"Language"`
+	}
+	type workloadResponse struct {
+		Entities map[string][]workloadProcess `json:"Entities"`
+	}
+
+	var lastOutput string
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
-		wl := s.Env().RemoteHost.MustExecute(`& "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" workload-list`)
-		lines := strings.Split(wl, "\n")
-		var inBlock bool
-		for _, line := range lines {
-			if strings.HasPrefix(line, "=== Entity process ") && strings.Contains(line, "remote_process_collector") && strings.HasSuffix(strings.TrimSpace(line), idSuffix) {
-				inBlock = true
-				continue
-			}
-			if inBlock {
-				if strings.HasPrefix(line, "=== Entity") {
-					break
-				}
-				if strings.HasPrefix(line, "Language: ") {
-					assert.Equal(c, "python", strings.TrimSpace(line[len("Language: "):]))
-					return
-				}
+		lastOutput = s.Env().RemoteHost.MustExecute(`& "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" workload-list --json`)
+		var resp workloadResponse
+		if !assert.NoError(c, json.Unmarshal([]byte(lastOutput), &resp), "failed to parse workload-list JSON") {
+			return
+		}
+		processes := resp.Entities["process"]
+		for _, p := range processes {
+			if p.ID == pid && p.Language != nil && p.Language.Name == "python" {
+				return
 			}
 		}
-		assert.Fail(c, "python process not found in workload-list with remote_process_collector source")
+		assert.Fail(c, fmt.Sprintf("process pid=%s with language=python not found in workload-list", pid))
 	}, 2*time.Minute, 5*time.Second)
+	if s.T().Failed() {
+		s.T().Logf("Last workload-list --json output:\n%s", lastOutput)
+	}
 }
 
 // Runs Diskspd in another ssh session

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -334,13 +334,22 @@ func (s *windowsTestSuite) TestLanguageDetectionWindows() {
 		_ = stdin.Close()
 	})
 
-	// Get the PID of the exact python process we started, identified by its command line
-	pid := strings.TrimSpace(s.Env().RemoteHost.MustExecute(
-		`(Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*time.sleep(300)*' } | Select-Object -First 1).ProcessId`,
-	))
+	// Poll for the PID of the exact python process we started, identified by its command line.
+	// Get-CimInstance may briefly return no match while process metadata catches up.
+	var pid string
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		out, err := s.Env().RemoteHost.Execute(
+			`(Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*time.sleep(300)*' } | Select-Object -First 1).ProcessId`,
+		)
+		if !assert.NoError(c, err, "failed to query process") {
+			return
+		}
+		pid = strings.TrimSpace(out)
+		assert.NotEmpty(c, pid, "python process PID not yet available")
+	}, 30*time.Second, 1*time.Second)
 
 	// Verify language detection via workload-list JSON output.
-	// Parse structured JSON to avoid flaky text parsing.
+	// Use Execute (not MustExecute) so transient agent startup errors are retried.
 	type workloadProcess struct {
 		Kind     string `json:"Kind"`
 		ID       string `json:"ID"`
@@ -354,7 +363,11 @@ func (s *windowsTestSuite) TestLanguageDetectionWindows() {
 
 	var lastOutput string
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
-		lastOutput = s.Env().RemoteHost.MustExecute(`& "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" workload-list --json`)
+		out, err := s.Env().RemoteHost.Execute(`& "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" workload-list --json`)
+		if !assert.NoError(c, err, "workload-list command failed") {
+			return
+		}
+		lastOutput = out
 		var resp workloadResponse
 		if !assert.NoError(c, json.Unmarshal([]byte(lastOutput), &resp), "failed to parse workload-list JSON") {
 			return

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -308,6 +308,64 @@ func (s *windowsTestSuite) TestManualUnprotectedProcessCheckWithIO() {
 	}, 1*time.Minute, 5*time.Second)
 }
 
+func (s *windowsTestSuite) TestLanguageDetectionWindows() {
+	// Enable language detection on the agent
+	s.UpdateEnv(awshost.Provisioner(
+		awshost.WithRunOptions(
+			ec2.WithEC2InstanceOptions(ec2.WithOS(os.WindowsServerDefault)),
+			ec2.WithAgentOptions(agentparams.WithAgentConfig(languageDetectionConfigStr)),
+		),
+	))
+
+	// Install Python via chocolatey (already installed in SetupSuite)
+	stdout, err := s.Env().RemoteHost.Execute(`C:\ProgramData\chocolatey\bin\choco.exe install -y python3 --no-progress`)
+	require.NoErrorf(s.T(), err, "Failed to install python: %s", stdout)
+
+	// Resolve the full python path since SSH sessions don't inherit choco's PATH update
+	pythonPath := strings.TrimSpace(s.Env().RemoteHost.MustExecute(
+		`$env:Path = [System.Environment]::GetEnvironmentVariable('Path','Machine'); (Get-Command python).Source`,
+	))
+
+	// Start Python in a persistent SSH session so it stays alive
+	session, stdin, _, err := s.Env().RemoteHost.Start(pythonPath + ` -c "import time; time.sleep(300)"`)
+	require.NoError(s.T(), err, "Failed to start python")
+	s.T().Cleanup(func() {
+		_ = session.Close()
+		_ = stdin.Close()
+	})
+
+	// Get the PID of the exact python process we started, identified by its command line
+	pid := strings.TrimSpace(s.Env().RemoteHost.MustExecute(
+		`(Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*time.sleep(300)*' } | Select-Object -First 1).ProcessId`,
+	))
+
+	// Verify language detection via the remote_process_collector source in workload-list.
+	// The header may contain multiple sources (e.g. "[remote_process_collector process_collector]"),
+	// so match by substring.
+	idSuffix := fmt.Sprintf(" id: %s ===", pid)
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		wl := s.Env().RemoteHost.MustExecute(`& "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" workload-list`)
+		lines := strings.Split(wl, "\n")
+		var inBlock bool
+		for _, line := range lines {
+			if strings.HasPrefix(line, "=== Entity process ") && strings.Contains(line, "remote_process_collector") && strings.HasSuffix(strings.TrimSpace(line), idSuffix) {
+				inBlock = true
+				continue
+			}
+			if inBlock {
+				if strings.HasPrefix(line, "=== Entity") {
+					break
+				}
+				if strings.HasPrefix(line, "Language: ") {
+					assert.Equal(c, "python", strings.TrimSpace(line[len("Language: "):]))
+					return
+				}
+			}
+		}
+		assert.Fail(c, "python process not found in workload-list with remote_process_collector source")
+	}, 2*time.Minute, 5*time.Second)
+}
+
 // Runs Diskspd in another ssh session
 // https://github.com/Microsoft/diskspd/wiki/Command-line-and-parameters
 // diskspd is an unprotected process, so we can capture the command line


### PR DESCRIPTION
## Summary
- Fixes remote process collector missing from Windows build, restoring language detection
- Adds a Windows E2E test for language detection via the `remote_process_collector` to the existing `windowsTestSuite`

## What's broken
PR #46219 split the workloadmeta catalog into `trivy` / `!trivy` variants but only included `remoteprocesscollector` in the `trivy`-gated file (`options.go`). Since `trivy` is in `LINUX_ONLY_TAGS`, Windows always uses the `!trivy` build (`options_nosbom.go`) — which is missing the remote process collector. This broke language detection on Windows since March 20. More details in jira ticket: https://datadoghq.atlassian.net/browse/CXP-3401

## Evidence
- [Diff that introduced the regression](https://github.com/DataDog/datadog-agent/commit/20aa50f06ce0005768aac23362775879da0ef3ca) — `options_nosbom.go` created without `remoteprocesscollector`
- [LINUX_ONLY_TAGS includes trivy](https://github.com/DataDog/datadog-agent/blob/main/tasks/build_tags.py) — confirms Windows never gets the `trivy` build
- Validated on Windows Server EC2 running agent 7.78.0-rc.5:
  - `agent workload-list --json` returns `{"Entities":{}}`
  - Agent logs show no `remote-process-collector` among workloadmeta collector candidates
  - Config confirms `language_detection.enabled: true`

## Why the test lives in `tests/process/` instead of `tests/language-detection/`
The test is added to the existing `windowsTestSuite` in `tests/process/windows_test.go` to reuse the same Windows EC2 instance already provisioned by the `new-e2e-process-windows` CI job for efficiency rather than logical organization. Placing it in `tests/language-detection/` would require a separate Windows CI job and provision an additional Windows instance, adding ~10 min of extra CI time. 

## Test plan
- [x] CI passes
- [x] E2E test confirms regression (fails against 7.78.0-rc.5 with `{"Entities":{}}`) (details in jira comment: https://datadoghq.atlassian.net/browse/CXP-3401?focusedCommentId=3134649)


🤖 Generated with [Claude Code](https://claude.com/claude-code)