### PR TITLE
test/new-e2e/tests/autoscaling/spot: add spot scheduling local kind cluster e2e tests

### DIFF
--- a/test/new-e2e/BUILD.bazel
+++ b/test/new-e2e/BUILD.bazel
@@ -69,6 +69,7 @@
 # gazelle:exclude tests/agent-subcommands/flare/fixtures
 # gazelle:exclude tests/agent-subcommands/status
 # gazelle:exclude tests/agent-subcommands/status/fixtures
+# gazelle:exclude tests/autoscaling/spot
 # gazelle:exclude tests/apm
 # gazelle:exclude tests/containers
 # gazelle:exclude tests/containers/fixtures

--- a/test/new-e2e/tests/autoscaling/spot/README.md
+++ b/test/new-e2e/tests/autoscaling/spot/README.md
@@ -1,0 +1,64 @@
+# Spot Scheduling E2E Tests
+
+Integration tests for the cluster-agent spot scheduler using a local kind cluster.
+
+## Prerequisites
+
+1. **Docker** and **kind** installed locally
+2. A locally-built cluster-agent image
+
+## Build the cluster-agent image
+
+The cluster-agent must be built for Linux inside a devenv container (macOS binaries won't run in kind):
+
+```bash
+./build-cluster-agent-image.sh [image] [arch]
+# defaults: image=${USER}/cluster-agent:test  arch=arm64
+```
+
+This produces `${USER}/cluster-agent:test` in the local Docker daemon.
+
+## Run the tests
+
+Run from the **repo root**. The test creates the kind cluster automatically and loads the image into it.
+
+```bash
+DD_TEST_CLUSTER_AGENT_IMAGE=${USER}/cluster-agent:test \
+  PULUMI_CONFIG_PASSPHRASE=dummy \
+  dda inv new-e2e-tests.run --targets=./tests/autoscaling/spot/... \
+  -e "-test.timeout 10m"
+```
+
+If `DD_TEST_CLUSTER_AGENT_IMAGE` is not set, tests are skipped.
+
+## How it works
+
+1. `localkubernetes.Provisioner` creates a 3-node kind cluster via Pulumi:
+   - 1 control-plane node
+   - 1 worker labeled `karpenter.sh/capacity-type=on-demand`
+   - 1 worker labeled `karpenter.sh/capacity-type=spot` with a `autoscaling.datadoghq.com/capacity-type=interruptible:NoSchedule` taint
+2. The cluster-agent image is loaded into kind via `WithKindLoadImage`.
+3. The cluster-agent is deployed via Helm with spot scheduling enabled and short timeouts.
+4. Tests create Deployments, observe pod placement via the k8s API, and verify spot/on-demand ratios.
+
+## Debug
+
+Use `E2E_DEV_MODE=true` to keep the kind cluster alive after test failures so you can inspect pod state directly:
+
+```bash
+DD_TEST_CLUSTER_AGENT_IMAGE=${USER}/cluster-agent:test \
+  PULUMI_CONFIG_PASSPHRASE=dummy \
+  E2E_DEV_MODE=true \
+  dda inv new-e2e-tests.run --targets=./tests/autoscaling/spot/...
+```
+
+After inspecting, destroy the stack — this deletes the kind cluster and removes all Pulumi state:
+
+```bash
+# 1. Find the workspace for the spot scheduling stack
+$TMPDIR/pulumi-workspace/*/*spotschedulingsuite*
+
+# 2. Destroy resources (deletes the kind cluster) and remove the stack
+PULUMI_CONFIG_PASSPHRASE=dummy pulumi destroy --cwd <workspace> --yes
+PULUMI_CONFIG_PASSPHRASE=dummy pulumi stack rm  --cwd <workspace> --yes
+```

--- a/test/new-e2e/tests/autoscaling/spot/build-cluster-agent-image.sh
+++ b/test/new-e2e/tests/autoscaling/spot/build-cluster-agent-image.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Builds the cluster-agent image for Linux inside a devenv container.
+# macOS binaries won't run in kind, so the build must happen inside Docker.
+#
+# Usage: ./build-cluster-agent-image.sh [image] [arch]
+#   image  Docker image name (default: ${USER}/cluster-agent:test)
+#   arch   arm64 or amd64 (default: arm64)
+set -euo pipefail
+
+CLUSTER_AGENT_IMAGE="${1:-${USER}/cluster-agent:test}"
+DEVENV_ARCH="${2:-arm64}"
+REPO_DIR="$(cd "$(dirname "$0")/../../../../.." && pwd)"
+
+DEVENV_IMAGE="registry.ddbuild.io/ci/datadog-agent-devenv:1-${DEVENV_ARCH}"
+
+echo "Building ${CLUSTER_AGENT_IMAGE} (linux/${DEVENV_ARCH}) from ${REPO_DIR}"
+
+exec docker run --rm \
+    --platform "linux/${DEVENV_ARCH}" \
+    --cap-add=SYS_PTRACE \
+    --security-opt seccomp=unconfined \
+    -w "/workspaces/datadog-agent" \
+    -v "${REPO_DIR}:/workspaces/datadog-agent" \
+    -v "/var/run/docker.sock:/var/run/docker.sock" \
+    -v "${GOPATH:-${HOME}/go}/pkg/mod:/home/datadog/go/pkg/mod" \
+    -v "${HOME}/.ssh:/home/datadog/.ssh" \
+    --user datadog \
+    "${DEVENV_IMAGE}" \
+    bash -xc "
+        git config --global --add safe.directory /workspaces/datadog-agent && \
+        dda inv -e cluster-agent.build && \
+        dda inv -e cws-instrumentation.build && \
+        dda inv -e cluster-agent.image-build --arch ${DEVENV_ARCH} -t ${CLUSTER_AGENT_IMAGE}
+    "

--- a/test/new-e2e/tests/autoscaling/spot/deployment_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/deployment_test.go
@@ -1,0 +1,361 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package spot
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type spotConfig struct {
+	spotPercentage      int
+	minOnDemandReplicas int
+}
+
+// TestDeploymentSinglePodMinOnDemand: 1 replica with minOnDemand=2 → pod goes on-demand.
+func (s *spotSchedulingSuite) TestDeploymentSinglePodMinOnDemand() {
+	s.createDeployment("nginx", 1, &spotConfig{spotPercentage: 100, minOnDemandReplicas: 2})
+
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+
+		require.Len(c, pods, 1)
+		s.expectRunningOnDemand(c, pods, 1)
+	})
+}
+
+// TestDeploymentSpotPercentage: 10 replicas at 60% spot, minOnDemand=2 → 6 spot, 4 on-demand.
+func (s *spotSchedulingSuite) TestDeploymentSpotPercentage() {
+	s.createDeployment("nginx", 10, &spotConfig{spotPercentage: 60, minOnDemandReplicas: 2})
+
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+
+		require.Len(c, pods, 10)
+		s.expectRunningSpot(c, pods, 6)
+		s.expectRunningOnDemand(c, pods, 4)
+	})
+}
+
+// TestDeploymentNonEligiblePodsNotModified: Deployment without spot label → pods go on-demand, no spot assignment.
+func (s *spotSchedulingSuite) TestDeploymentNonEligiblePodsNotModified() {
+	s.createDeployment("nginx", 3, nil)
+
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+
+		require.Len(c, pods, 3)
+		s.expectRunningOnDemand(c, pods, 3)
+		for _, p := range pods {
+			require.NotContains(c, p.Labels, spotAssignedLabel,
+				"pod %s should not have spot-assigned label: deployment is not spot-eligible", p.Name)
+		}
+	})
+}
+
+// TestDeploymentFallbackWhenSpotUnavailable: cordon spot node so spot-assigned pods stay Pending,
+// verify the scheduler disables spot and re-creates pods on on-demand.
+// Then uncordon node and verify pods re-balanced to spot node.
+func (s *spotSchedulingSuite) TestDeploymentFallbackWhenSpotUnavailable() {
+	// Cordon spot node so spot-assigned pods (which have nodeSelector=spot) stay Pending.
+	s.cordonNode(s.spotNode)
+
+	s.createDeployment("nginx", 10, &spotConfig{spotPercentage: 60, minOnDemandReplicas: 2})
+
+	// Do not wait for 4 on-demand pods Running + 6 spot-assigned pods Pending.
+	// as there is a race between Deployment creation and Webhook such that
+	// all pods may land to on-demand nodes initially.
+	// Scheduler will rebalance this Deployment by evicting one pod at a time and
+	// replacement pod will be assigned to spot and become Pending.
+	// Therefore it may never reach 6 Pending spot pods before on-demand fallback kicks in so
+	// wait for the fallback marker instead.
+
+	// After ScheduleTimeout (30s), the scheduler should:
+	// 1. Set spot-disabled-until annotation on Deployment
+	// 2. Evict pending spot pods
+	// 3. New pods from ReplicaSet go to on-demand node
+	s.eventually(func(c *assert.CollectT) {
+		deploy, err := s.kubeClient.AppsV1().Deployments(s.testNamespace).Get(s.T().Context(), "nginx", metav1.GetOptions{})
+		require.NoError(c, err)
+		require.NotEmpty(c, deploy.Annotations[spotDisabledUntilAnnotation],
+			"spot-disabled-until annotation should be set on Deployment after fallback")
+	})
+
+	// Wait for all 10 pods to run on on-demand (fallback mode).
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+
+		require.Len(c, pods, 10)
+		s.expectRunningOnDemand(c, pods, 10)
+	})
+
+	// Uncordon and wait for all 10 pods to run on spot and on-demand due to rebalancing.
+	s.uncordonNode(s.spotNode)
+
+	const spotPods = 6 // 60% of 10 replicas
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+
+		require.Len(c, pods, 10)
+		s.expectRunningSpot(c, pods, spotPods)
+		s.expectRunningOnDemand(c, pods, 4)
+	}, fallbackDuration+rebalancingTimeout(spotPods), 5*time.Second)
+}
+
+// TestDeploymentOptIn: create a deployment without the spot label, wait for all pods
+// to run on-demand, then opt in by adding the spot-enabled label and annotations.
+// Verify the deployment converges to the desired spot ratio via rebalancing.
+func (s *spotSchedulingSuite) TestDeploymentOptIn() {
+	const replicas = 10
+
+	// Step 1: create deployment without spot label — all pods go on-demand.
+	s.createDeployment("nginx", replicas, nil)
+
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+
+		require.Len(c, pods, replicas)
+		s.expectRunningOnDemand(c, pods, replicas)
+	})
+
+	// Step 2: opt in to spot scheduling.
+	s.updateDeployment("nginx", &spotConfig{spotPercentage: 60, minOnDemandReplicas: 2})
+
+	// Step 3: expect rebalancing to converge to 6 spot / 4 on-demand.
+	// Budget: one rebalance cycle per spot pod to be evicted and replaced.
+	const spotPods = 6 // 60% of 10 replicas
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+
+		require.Len(c, pods, replicas)
+		s.expectRunningSpot(c, pods, spotPods)
+		s.expectRunningOnDemand(c, pods, replicas-spotPods)
+	}, rebalancingTimeout(spotPods), 5*time.Second)
+}
+
+// TestDeploymentRebalancingAfterScaleDown: after scaling down a deployment, verify the rebalancer
+// evicts excess pods to restore the correct spot/on-demand ratio.
+func (s *spotSchedulingSuite) TestDeploymentRebalancingAfterScaleDown() {
+	s.createDeployment("nginx", 10, &spotConfig{spotPercentage: 60, minOnDemandReplicas: 2})
+
+	// Wait for initial 6 spot / 4 on-demand.
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+
+		require.Len(c, pods, 10)
+		s.expectRunningSpot(c, pods, 6)
+		s.expectRunningOnDemand(c, pods, 4)
+	})
+
+	// Scale the Deployment down to 5 replicas.
+	s.scaleDeployment("nginx", 5)
+
+	// Wait for rebalancing.
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+
+		require.Len(c, pods, 5)
+		s.expectRunningSpot(c, pods, 3)
+		s.expectRunningOnDemand(c, pods, 2)
+	})
+}
+
+// TestDeploymentRollingUpdatePreservesRatio: after triggering a rolling update the new
+// ReplicaSet's pods must converge to the same spot/on-demand ratio.
+func (s *spotSchedulingSuite) TestDeploymentRollingUpdatePreservesRatio() {
+	const replicas = 10
+
+	s.createDeployment("nginx", replicas, &spotConfig{spotPercentage: 60, minOnDemandReplicas: 2})
+
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+		require.Len(c, pods, replicas)
+		s.expectRunningSpot(c, pods, 6)
+		s.expectRunningOnDemand(c, pods, 4)
+	})
+
+	// Trigger a rolling update by bumping the pod-template annotation.
+	s.rolloutRestart("nginx")
+
+	// After the rollout the new ReplicaSet's pods should also converge to 6 spot / 4 on-demand.
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+		require.Len(c, pods, replicas)
+		s.expectRunningSpot(c, pods, 6)
+		s.expectRunningOnDemand(c, pods, 4)
+	})
+}
+
+// TestDeploymentScaleUpPreservesRatio: scaling up from 5 to 10 replicas must maintain
+// the configured spot/on-demand ratio for the additional pods.
+func (s *spotSchedulingSuite) TestDeploymentScaleUpPreservesRatio() {
+	s.createDeployment("nginx", 5, &spotConfig{spotPercentage: 60, minOnDemandReplicas: 2})
+
+	// Initial: minOnDemand=2 → 2 on-demand, 3 spot (60% of 5).
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+		require.Len(c, pods, 5)
+		s.expectRunningSpot(c, pods, 3)
+		s.expectRunningOnDemand(c, pods, 2)
+	})
+
+	// Scale up to 10 replicas: expect 6 spot / 4 on-demand.
+	s.scaleDeployment("nginx", 10)
+
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+		require.Len(c, pods, 10)
+		s.expectRunningSpot(c, pods, 6)
+		s.expectRunningOnDemand(c, pods, 4)
+	})
+}
+
+// TestDeploymentOptOut: remove the spot-enabled label and restart the Deployment;
+// all replacement pods must land on the on-demand node with no spot-assigned label.
+func (s *spotSchedulingSuite) TestDeploymentOptOut() {
+	const replicas = 10
+
+	// Step 1: opt in — wait for 6 spot / 4 on-demand.
+	s.createDeployment("nginx", replicas, &spotConfig{spotPercentage: 60, minOnDemandReplicas: 2})
+
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+		require.Len(c, pods, replicas)
+		s.expectRunningSpot(c, pods, 6)
+		s.expectRunningOnDemand(c, pods, 4)
+	})
+
+	// Step 2: remove spot label to opt out, then restart to replace existing pods.
+	s.removeDeploymentLabel("nginx", spotEnabledLabelKey)
+	s.rolloutRestart("nginx")
+
+	// Step 3: all pods should land on on-demand without the spot-assigned label.
+	s.eventually(func(c *assert.CollectT) {
+		pods := s.listPods("deployment=nginx")
+		require.Len(c, pods, replicas)
+		s.expectRunningOnDemand(c, pods, replicas)
+		for _, p := range pods {
+			require.NotContains(c, p.Labels, spotAssignedLabel,
+				"pod %s should not have spot-assigned label after opt-out", p.Name)
+		}
+	})
+}
+
+// createDeployment creates a Deployment with a pause container and a "deployment=name" selector
+// label on the pod template. If config is non-nil, the spot-enabled label and spot-config
+// annotation are added to opt the deployment in to spot scheduling.
+func (s *spotSchedulingSuite) createDeployment(name string, replicas int32, config *spotConfig) {
+	s.T().Helper()
+
+	podSelector := map[string]string{"deployment": name}
+
+	deployLabels := map[string]string{"deployment": name}
+	var annotations map[string]string
+	if config != nil {
+		deployLabels[spotEnabledLabelKey] = spotEnabledLabelValue
+		annotations = map[string]string{
+			spotConfigAnnotation: fmt.Sprintf(`{"percentage":%d,"minOnDemandReplicas":%d}`, config.spotPercentage, config.minOnDemandReplicas),
+		}
+	}
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   s.testNamespace,
+			Labels:      deployLabels,
+			Annotations: annotations,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: podSelector,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podSelector,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "registry.k8s.io/pause",
+					}},
+				},
+			},
+		},
+	}
+	_, err := s.kubeClient.AppsV1().Deployments(s.testNamespace).Create(s.T().Context(), deploy, metav1.CreateOptions{})
+	s.Require().NoError(err)
+}
+
+// updateDeployment reads an existing Deployment, merges in the spot-enabled label and
+// spot-config annotation from config, and updates it.
+func (s *spotSchedulingSuite) updateDeployment(name string, config *spotConfig) {
+	s.T().Helper()
+	ctx := s.T().Context()
+
+	deploy, err := s.kubeClient.AppsV1().Deployments(s.testNamespace).Get(ctx, name, metav1.GetOptions{})
+	s.Require().NoError(err)
+
+	if config != nil {
+		if deploy.Labels == nil {
+			deploy.Labels = make(map[string]string)
+		}
+		deploy.Labels[spotEnabledLabelKey] = spotEnabledLabelValue
+
+		if deploy.Annotations == nil {
+			deploy.Annotations = make(map[string]string)
+		}
+		deploy.Annotations[spotConfigAnnotation] = fmt.Sprintf(`{"percentage":%d,"minOnDemandReplicas":%d}`, config.spotPercentage, config.minOnDemandReplicas)
+	}
+
+	_, err = s.kubeClient.AppsV1().Deployments(s.testNamespace).Update(ctx, deploy, metav1.UpdateOptions{})
+	s.Require().NoError(err)
+}
+
+// scaleDeployment updates the replica count of a Deployment in s.testNamespace.
+func (s *spotSchedulingSuite) scaleDeployment(name string, replicas int32) {
+	s.T().Helper()
+	ctx := s.T().Context()
+
+	deploy, err := s.kubeClient.AppsV1().Deployments(s.testNamespace).Get(ctx, name, metav1.GetOptions{})
+	s.Require().NoError(err)
+
+	deploy.Spec.Replicas = &replicas
+	_, err = s.kubeClient.AppsV1().Deployments(s.testNamespace).Update(ctx, deploy, metav1.UpdateOptions{})
+	s.Require().NoError(err)
+}
+
+// rolloutRestart triggers a rolling update by patching the pod-template restart annotation.
+func (s *spotSchedulingSuite) rolloutRestart(name string) {
+	s.T().Helper()
+	ctx := s.T().Context()
+
+	patch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":%q}}}}}`, time.Now().UTC().Format(time.RFC3339))
+
+	_, err := s.kubeClient.AppsV1().Deployments(s.testNamespace).Patch(ctx, name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+	s.Require().NoError(err)
+}
+
+// removeDeploymentLabel removes a single label key from a Deployment.
+func (s *spotSchedulingSuite) removeDeploymentLabel(name, key string) {
+	s.T().Helper()
+	ctx := s.T().Context()
+
+	// JSON Pointer (RFC 6901) requires escaping: ~ → ~0, / → ~1.
+	escaped := strings.NewReplacer("~", "~0", "/", "~1").Replace(key)
+	patch := fmt.Sprintf(`[{"op":"remove","path":"/metadata/labels/%s"}]`, escaped)
+
+	_, err := s.kubeClient.AppsV1().Deployments(s.testNamespace).Patch(ctx, name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
+	s.Require().NoError(err)
+}

--- a/test/new-e2e/tests/autoscaling/spot/suite_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/suite_test.go
@@ -1,0 +1,298 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package spot contains end-to-end tests for the cluster-agent spot scheduler.
+// Tests run against a real kind cluster with 1 control-plane, 1 on-demand worker,
+// and 1 spot worker. The full cluster-agent is deployed via Helm; no mocking is used.
+//
+// Prerequisites: build the cluster-agent image and export DD_TEST_CLUSTER_AGENT_IMAGE
+// pointing to it (see README.md).
+package spot
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "k8s.io/client-go/kubernetes"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	kubeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	localkubernetes "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/local/kubernetes"
+)
+
+// Spot scheduling label/annotation constants — mirror pkg/clusteragent/autoscaling/cluster/spot/const.go
+// (defined here to avoid a cross-module dependency on a kubeapiserver-tagged package).
+const (
+	spotEnabledLabelKey         = "autoscaling.datadoghq.com/spot-enabled"
+	spotEnabledLabelValue       = "true"
+	spotAssignedLabel           = "autoscaling.datadoghq.com/spot-assigned"
+	spotConfigAnnotation        = "autoscaling.datadoghq.com/spot-config"
+	spotDisabledUntilAnnotation = "autoscaling.datadoghq.com/spot-disabled-until"
+	karpenterCapacityTypeLabel  = "karpenter.sh/capacity-type"
+	karpenterCapacityTypeSpot   = "spot"
+
+	// kindClusterName is the provisioner name; the kind cluster name is derived from it.
+	kindClusterName = "spot-test"
+)
+
+// Cluster-agent spot scheduler timeouts used both in Helm values and in test assertions.
+// fallbackDuration is 2× scheduleTimeout so the test can observe all pods on-demand
+// and uncordon the spot node before the fallback is re-triggered.
+const (
+	scheduleTimeout              = 30 * time.Second
+	fallbackDuration             = 2 * scheduleTimeout
+	rebalanceStabilizationPeriod = 10 * time.Second
+)
+
+var helmValues = fmt.Sprintf(`
+clusterAgent:
+  enabled: true
+  image:
+    # pre-loaded into kind via WithKindLoadImage; Never prevents pulling from a registry
+    pullPolicy: Never
+  admissionController:
+    enabled: true
+    mutateUnlabelled: false
+  env:
+    - name: DD_LOG_LEVEL
+      value: "DEBUG"
+    - name: DD_AUTOSCALING_CLUSTER_SPOT_ENABLED
+      value: "true"
+    - name: DD_AUTOSCALING_CLUSTER_SPOT_DEFAULTS_PERCENTAGE
+      value: "100"
+    - name: DD_AUTOSCALING_CLUSTER_SPOT_DEFAULTS_MIN_ON_DEMAND_REPLICAS
+      value: "0"
+    - name: DD_AUTOSCALING_CLUSTER_SPOT_SCHEDULE_TIMEOUT
+      value: "%v"
+    - name: DD_AUTOSCALING_CLUSTER_SPOT_FALLBACK_DURATION
+      value: "%v"
+    - name: DD_AUTOSCALING_CLUSTER_SPOT_REBALANCE_STABILIZATION_PERIOD
+      value: "%v"
+# node-agent DaemonSet not needed; only the cluster-agent runs the spot scheduler
+agents:
+  enabled: false
+# cluster check runners not needed for spot scheduling
+clusterChecksRunner:
+  enabled: false
+datadog:
+  kubeStateMetricsCore:
+    # the framework sets this to true by default, which unconditionally enables the
+    # cluster checks runner deployment regardless of clusterChecksRunner.enabled
+    useClusterCheckRunners: false
+`, scheduleTimeout, fallbackDuration, rebalanceStabilizationPeriod)
+
+// rebalancingTimeout returns the expected duration to rebalance given number of spot pods.
+func rebalancingTimeout(spotPods int) time.Duration {
+	return time.Duration(spotPods)*2*rebalanceStabilizationPeriod + 30*time.Second
+}
+
+type spotSchedulingSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+	kubeClient    k8sclient.Interface
+	spotNode      string
+	onDemandNode  string
+	testNamespace string // namespace for the current test, set by SetupTest
+}
+
+// TestSpotSchedulingKind runs spot scheduling integration tests on a local kind cluster.
+// Requires DD_TEST_CLUSTER_AGENT_IMAGE to be set to the locally-built cluster-agent image
+// (see README.md for build instructions).
+func TestSpotSchedulingKind(t *testing.T) {
+	image := os.Getenv("DD_TEST_CLUSTER_AGENT_IMAGE")
+	if image == "" {
+		t.Skip("DD_TEST_CLUSTER_AGENT_IMAGE not set; skipping spot scheduling e2e tests")
+	}
+
+	workerNodes := []kubeComp.KindWorkerNode{
+		{
+			Labels: []kubeComp.Label{{Key: "karpenter.sh/capacity-type", Value: "on-demand"}},
+		},
+		{
+			Labels: []kubeComp.Label{{Key: "karpenter.sh/capacity-type", Value: "spot"}},
+			Taints: []kubeComp.Taint{{Key: "autoscaling.datadoghq.com/capacity-type", Value: "interruptible", Effect: "NoSchedule"}},
+		},
+	}
+
+	e2e.Run(t, &spotSchedulingSuite{}, e2e.WithProvisioner(
+		localkubernetes.Provisioner(
+			localkubernetes.WithName(kindClusterName),
+			localkubernetes.WithKindWorkerNodes(workerNodes...),
+			localkubernetes.WithoutFakeIntake(),
+			localkubernetes.WithKindLoadImage(image),
+			localkubernetes.WithAgentOptions(
+				kubernetesagentparams.WithClusterAgentFullImagePath(image),
+				kubernetesagentparams.WithHelmValues(helmValues),
+			),
+		),
+	))
+}
+
+func (s *spotSchedulingSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure()
+
+	s.kubeClient = s.Env().KubernetesCluster.Client()
+	s.identifyNodes()
+	s.waitForWebhook()
+	// The cluster-agent ClusterRole is missing pods/eviction — a known issue to be fixed
+	// in the next Helm chart release.
+	s.patchClusterAgentEvictionRole()
+}
+
+func (s *spotSchedulingSuite) SetupTest() {
+	s.createTestNamespace()
+}
+
+func (s *spotSchedulingSuite) TearDownTest() {
+	s.deleteTestNamespace()
+}
+
+// listPods returns active (non-terminating) pods matching selector in s.testNamespace.
+// Excludes terminating pods to avoid counting stale entries.
+func (s *spotSchedulingSuite) listPods(selector string) []corev1.Pod {
+	list, err := s.kubeClient.CoreV1().Pods(s.testNamespace).List(s.T().Context(), metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	s.Require().NoError(err)
+	var active []corev1.Pod
+	for _, p := range list.Items {
+		if p.DeletionTimestamp == nil {
+			active = append(active, p)
+		}
+	}
+	return active
+}
+
+// eventually retries fn until it passes, with a 1-minute timeout and 5-second polling interval.
+func (s *spotSchedulingSuite) eventually(fn func(c *assert.CollectT)) {
+	s.EventuallyWithT(fn, 1*time.Minute, 5*time.Second)
+}
+
+// expectRunningSpot asserts that exactly count pods are Running on the spot node with spot-assigned label.
+func (s *spotSchedulingSuite) expectRunningSpot(c *assert.CollectT, pods []corev1.Pod, count int) {
+	actual := 0
+	for _, p := range pods {
+		if p.Status.Phase == corev1.PodRunning && p.Spec.NodeName == s.spotNode {
+			require.Contains(c, p.Labels, spotAssignedLabel, "pod %s on spot node should have spot-assigned label", p.Name)
+			actual++
+		}
+	}
+	require.Equal(c, count, actual, "expected %d running spot pods", count)
+}
+
+// expectRunningOnDemand asserts that exactly count pods are Running on the on-demand node without spot-assigned label.
+func (s *spotSchedulingSuite) expectRunningOnDemand(c *assert.CollectT, pods []corev1.Pod, count int) {
+	actual := 0
+	for _, p := range pods {
+		if p.Status.Phase == corev1.PodRunning && p.Spec.NodeName == s.onDemandNode {
+			require.NotContains(c, p.Labels, spotAssignedLabel, "pod %s on on-demand node should not have spot-assigned label", p.Name)
+			actual++
+		}
+	}
+	require.Equal(c, count, actual, "expected %d running on-demand pods", count)
+}
+
+// identifyNodes finds the spot and on-demand worker nodes by karpenter.sh/capacity-type label.
+func (s *spotSchedulingSuite) identifyNodes() {
+	s.T().Helper()
+	nodes, err := s.kubeClient.CoreV1().Nodes().List(s.T().Context(), metav1.ListOptions{})
+	s.Require().NoError(err)
+	for _, node := range nodes.Items {
+		switch node.Labels[karpenterCapacityTypeLabel] {
+		case karpenterCapacityTypeSpot:
+			s.spotNode = node.Name
+		default:
+			s.onDemandNode = node.Name
+		}
+	}
+	s.Require().NotEmpty(s.spotNode, "no node with %s=spot found; check WithKindWorkerNodes", karpenterCapacityTypeLabel)
+	s.Require().NotEmpty(s.onDemandNode, "no node without %s=spot found; check WithKindWorkerNodes", karpenterCapacityTypeLabel)
+}
+
+// waitForWebhook polls MutatingWebhookConfigurations until the spot scheduling webhook is registered.
+func (s *spotSchedulingSuite) waitForWebhook() {
+	s.T().Helper()
+	s.Require().Eventually(func() bool {
+		whList, err := s.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(s.T().Context(), metav1.ListOptions{})
+		if err != nil {
+			return false
+		}
+		for _, wh := range whList.Items {
+			for _, webhook := range wh.Webhooks {
+				if webhook.Name == "datadog.webhook.spot.scheduling" {
+					return true
+				}
+			}
+		}
+		return false
+	}, 5*time.Minute, 5*time.Second, "spot scheduling webhook not registered; is the cluster-agent running?")
+}
+
+func (s *spotSchedulingSuite) createTestNamespace() {
+	name := s.T().Name()
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		name = name[i+1:]
+	}
+	s.testNamespace = strings.ToLower(name)
+	if len(s.testNamespace) > 63 {
+		s.testNamespace = s.testNamespace[:63]
+	}
+	_, err := s.kubeClient.CoreV1().Namespaces().Create(s.T().Context(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: s.testNamespace},
+	}, metav1.CreateOptions{})
+	s.Require().NoError(err)
+}
+
+func (s *spotSchedulingSuite) deleteTestNamespace() {
+	err := s.kubeClient.CoreV1().Namespaces().Delete(context.Background(), s.testNamespace, metav1.DeleteOptions{})
+	s.Require().NoError(err)
+}
+
+// patchClusterAgentEvictionRole adds pods/eviction create permission to the cluster-agent
+// ClusterRole. This is needed because the Helm chart omits this rule; it will be fixed
+// in the next operator release.
+func (s *spotSchedulingSuite) patchClusterAgentEvictionRole() {
+	patch := []byte(`[{"op":"add","path":"/rules/-","value":{"apiGroups":[""],"resources":["pods/eviction"],"verbs":["create"]}}]`)
+	_, err := s.kubeClient.RbacV1().ClusterRoles().Patch(
+		s.T().Context(),
+		"dda-linux-datadog-cluster-agent",
+		types.JSONPatchType,
+		patch,
+		metav1.PatchOptions{},
+	)
+	s.Require().NoError(err)
+}
+
+// cordonNode marks a node as unschedulable and registers an uncordon cleanup.
+func (s *spotSchedulingSuite) cordonNode(name string) {
+	s.T().Helper()
+	_, err := s.kubeClient.CoreV1().Nodes().Patch(s.T().Context(), name,
+		types.StrategicMergePatchType,
+		[]byte(`{"spec":{"unschedulable":true}}`),
+		metav1.PatchOptions{})
+	s.Require().NoError(err)
+	s.T().Cleanup(func() { s.uncordonNode(name) })
+}
+
+// uncordonNode marks a node as schedulable.
+func (s *spotSchedulingSuite) uncordonNode(name string) {
+	s.T().Helper()
+	_, err := s.kubeClient.CoreV1().Nodes().Patch(context.Background(), name,
+		types.StrategicMergePatchType,
+		[]byte(`{"spec":{"unschedulable":false}}`),
+		metav1.PatchOptions{})
+	s.Require().NoError(err)
+}


### PR DESCRIPTION
### What does this PR do?

Add spot scheduling e2e test suite using a locally-built cluster-agent image loaded into kind.
In the subsequent steps I plan to expand it into CI-compatible test in EKS cluster.

### Motivation

Verify spot scheduling works.

### Describe how you validated your changes

See README.md

### Additional Notes

Updates https://datadoghq.atlassian.net/browse/CASCL-1222

Exclude test package from bazel build for now similra to other e2e packages.

