### PR TITLE
[SDBM-2478] Fix autodiscovery non-hashed field updates

### DIFF
--- a/comp/core/autodiscovery/listeners/dbm_aurora.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora.go
@@ -139,8 +139,12 @@ func (l *DBMAuroraListener) discoverAuroraClusters() {
 }
 
 func (l *DBMAuroraListener) createService(entityID, clusterID string, instance *aws.Instance) {
-	if _, present := l.services[entityID]; present {
-		return
+	if existing, present := l.services[entityID]; present {
+		if existingSvc, ok := existing.(*DBMAuroraService); ok && reflect.DeepEqual(existingSvc.instance, instance) {
+			return
+		}
+		l.delService <- existing
+		delete(l.services, entityID)
 	}
 	svc := &DBMAuroraService{
 		adIdentifier: engineToAuroraADIdentifier[instance.Engine],

--- a/comp/core/autodiscovery/listeners/dbm_aurora.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora.go
@@ -139,13 +139,6 @@ func (l *DBMAuroraListener) discoverAuroraClusters() {
 }
 
 func (l *DBMAuroraListener) createService(entityID, clusterID string, instance *aws.Instance) {
-	if existing, present := l.services[entityID]; present {
-		if existingSvc, ok := existing.(*DBMAuroraService); ok && reflect.DeepEqual(existingSvc.instance, instance) {
-			return
-		}
-		l.delService <- existing
-		delete(l.services, entityID)
-	}
 	svc := &DBMAuroraService{
 		adIdentifier: engineToAuroraADIdentifier[instance.Engine],
 		entityID:     entityID,
@@ -153,6 +146,15 @@ func (l *DBMAuroraListener) createService(entityID, clusterID string, instance *
 		instance:     instance,
 		region:       l.config.Region,
 		clusterID:    clusterID,
+	}
+	if existing, present := l.services[entityID]; present {
+		if existingSvc, ok := existing.(*DBMAuroraService); ok && existingSvc.Equal(svc) {
+			return
+		}
+		// If the cached service is not equal to the new service then metadata has changed
+		// Delete the cached service first and then send the updated one to the newSvc channel.
+		l.delService <- existing
+		delete(l.services, entityID)
 	}
 	l.services[entityID] = svc
 	l.newService <- svc

--- a/comp/core/autodiscovery/listeners/dbm_aurora_test.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora_test.go
@@ -357,6 +357,95 @@ func TestDBMAuroraListener(t *testing.T) {
 				},
 			},
 		},
+		{
+			// When an instance's non-hashed fields change (DbmEnabled, DbName,
+			// GlobalViewDb), the listener should detect the change and emit a
+			// delete + re-create so autodiscovery picks up the new configuration.
+			name: "changed non-hashed instance fields are picked up on rediscovery",
+			config: aws.Config{
+				DiscoveryInterval: 1,
+				Region:            "us-east-1",
+				Tags:              []string{defaultADTag},
+				DbmTag:            defaultDbmTag,
+			},
+			numDiscoveryIntervals: 0,
+			initialServices: map[string]Service{
+				"f7fee36c58e3da8a": &DBMAuroraService{
+					adIdentifier: dbmPostgresAuroraADIdentifier,
+					entityID:     "f7fee36c58e3da8a",
+					checkName:    "postgres",
+					clusterID:    "my-cluster-1",
+					region:       "us-east-1",
+					instance: &aws.Instance{
+						Endpoint:   "my-endpoint",
+						Port:       5432,
+						IamEnabled: true,
+						Engine:     "aurora-postgresql",
+						DbmEnabled: true,
+						DbName:     "",
+					},
+				},
+			},
+			rdsClientConfigurer: func(k *aws.MockRdsClient) {
+				k.EXPECT().GetAuroraClustersFromTags(gomock.Any(), []string{defaultADTag}).Return([]string{"my-cluster-1"}, nil).AnyTimes()
+				k.EXPECT().GetAuroraClusterEndpoints(gomock.Any(), []string{"my-cluster-1"}, aws.Config{
+					DiscoveryInterval: 1,
+					Region:            "us-east-1",
+					Tags:              []string{defaultADTag},
+					DbmTag:            defaultDbmTag,
+				}).Return(
+					map[string]*aws.AuroraCluster{
+						"my-cluster-1": {
+							Instances: []*aws.Instance{
+								{
+									Endpoint:   "my-endpoint",
+									Port:       5432,
+									IamEnabled: true,
+									Engine:     "aurora-postgresql",
+									DbmEnabled: false,
+									DbName:     "mydb",
+								},
+							},
+						},
+					}, nil).AnyTimes()
+			},
+			// Only the updated service should be emitted as new
+			expectedServices: []*DBMAuroraService{
+				{
+					adIdentifier: dbmPostgresAuroraADIdentifier,
+					entityID:     "f7fee36c58e3da8a",
+					checkName:    "postgres",
+					clusterID:    "my-cluster-1",
+					region:       "us-east-1",
+					instance: &aws.Instance{
+						Endpoint:   "my-endpoint",
+						Port:       5432,
+						IamEnabled: true,
+						Engine:     "aurora-postgresql",
+						DbmEnabled: false,
+						DbName:     "mydb",
+					},
+				},
+			},
+			// The original service should be deleted
+			expectedDelServices: []*DBMAuroraService{
+				{
+					adIdentifier: dbmPostgresAuroraADIdentifier,
+					entityID:     "f7fee36c58e3da8a",
+					checkName:    "postgres",
+					clusterID:    "my-cluster-1",
+					region:       "us-east-1",
+					instance: &aws.Instance{
+						Endpoint:   "my-endpoint",
+						Port:       5432,
+						IamEnabled: true,
+						Engine:     "aurora-postgresql",
+						DbmEnabled: true,
+						DbName:     "",
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/comp/core/autodiscovery/listeners/dbm_rds.go
+++ b/comp/core/autodiscovery/listeners/dbm_rds.go
@@ -131,15 +131,21 @@ func (l *DBMRdsListener) discoverRdsInstances() {
 }
 
 func (l *DBMRdsListener) createService(entityID string, instance aws.Instance) {
-	if _, present := l.services[entityID]; present {
-		return
-	}
 	svc := &DBMRdsService{
 		adIdentifier: engineToRdsADIdentifier[instance.Engine],
 		entityID:     entityID,
 		checkName:    engineToIntegrationType[instance.Engine],
 		instance:     &instance,
 		region:       l.config.Region,
+	}
+	if existing, present := l.services[entityID]; present {
+		if existingSvc, ok := existing.(*DBMRdsService); ok && existingSvc.Equal(svc) {
+			return
+		}
+		// If the cached service is not equal to the new service then metadata has changed
+		// Delete the cached service first and then send the updated one to the newSvc channel.
+		l.delService <- existing
+		delete(l.services, entityID)
 	}
 	l.services[entityID] = svc
 	l.newService <- svc

--- a/comp/core/autodiscovery/listeners/dbm_rds_test.go
+++ b/comp/core/autodiscovery/listeners/dbm_rds_test.go
@@ -239,6 +239,106 @@ func TestDBMRdsListener(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "changed non-hashed instance fields are picked up on rediscovery",
+			config: map[string]interface{}{
+				"discoveryInterval": 1,
+				"region":            "us-east-1",
+				"tags":              []string{defaultADTag},
+				"dbmTag":            defaultDbmTag,
+			},
+			numDiscoveryIntervals: 0,
+			initialServices: map[string]Service{
+				"36740c31448ee889": &DBMRdsService{
+					adIdentifier: dbmPostgresADIdentifier,
+					entityID:     "36740c31448ee889",
+					checkName:    "postgres",
+					region:       "us-east-1",
+					instance: &aws.Instance{
+						ID: "my-instance-1", Endpoint: "my-endpoint", Port: 5432,
+						IamEnabled: true, Engine: "postgres", DbmEnabled: true, DbName: "",
+					},
+				},
+			},
+			rdsClientConfigurer: func(k *aws.MockRdsClient) {
+				// Discovery returns same instance with changed non-hashed fields
+				k.EXPECT().GetRdsInstancesFromTags(gomock.Any(), gomock.Any()).Return(
+					[]aws.Instance{
+						{
+							ID: "my-instance-1", Endpoint: "my-endpoint", Port: 5432,
+							IamEnabled: true, Engine: "postgres", DbmEnabled: false, DbName: "mydb",
+						},
+					}, nil).AnyTimes()
+			},
+			// Only the updated service should be emitted as new
+			expectedServices: []*DBMRdsService{
+				{
+					adIdentifier: dbmPostgresADIdentifier, entityID: "36740c31448ee889",
+					checkName: "postgres", region: "us-east-1",
+					instance: &aws.Instance{
+						ID: "my-instance-1", Endpoint: "my-endpoint", Port: 5432,
+						IamEnabled: true, Engine: "postgres", DbmEnabled: false, DbName: "mydb",
+					},
+				},
+			},
+			// The original service should be deleted
+			expectedDelServices: []*DBMRdsService{
+				{
+					adIdentifier: dbmPostgresADIdentifier, entityID: "36740c31448ee889",
+					checkName: "postgres", region: "us-east-1",
+					instance: &aws.Instance{
+						ID: "my-instance-1", Endpoint: "my-endpoint", Port: 5432,
+						IamEnabled: true, Engine: "postgres", DbmEnabled: true, DbName: "",
+					},
+				},
+			},
+		},
+		{
+			name: "previously discovered services are deleted when no instances found",
+			config: map[string]interface{}{
+				"discoveryInterval": 1,
+				"region":            "us-east-1",
+				"tags":              []string{defaultADTag},
+				"dbmTag":            defaultDbmTag,
+			},
+			numDiscoveryIntervals: 0,
+			initialServices: map[string]Service{
+				"36740c31448ee889": &DBMRdsService{
+					adIdentifier: dbmPostgresADIdentifier,
+					entityID:     "36740c31448ee889",
+					checkName:    "postgres",
+					region:       "us-east-1",
+					instance: &aws.Instance{
+						ID:         "my-instance-1",
+						Endpoint:   "my-endpoint",
+						Port:       5432,
+						IamEnabled: true,
+						Engine:     "postgres",
+						DbmEnabled: true,
+					},
+				},
+			},
+			rdsClientConfigurer: func(k *aws.MockRdsClient) {
+				k.EXPECT().GetRdsInstancesFromTags(gomock.Any(), gomock.Any()).Return([]aws.Instance{}, nil).AnyTimes()
+			},
+			expectedServices: []*DBMRdsService{},
+			expectedDelServices: []*DBMRdsService{
+				{
+					adIdentifier: dbmPostgresADIdentifier,
+					entityID:     "36740c31448ee889",
+					checkName:    "postgres",
+					region:       "us-east-1",
+					instance: &aws.Instance{
+						ID:         "my-instance-1",
+						Endpoint:   "my-endpoint",
+						Port:       5432,
+						IamEnabled: true,
+						Engine:     "postgres",
+						DbmEnabled: true,
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/releasenotes/notes/fix-dbm-autodiscovery-updates-c3936a96c45e811c.yaml
+++ b/releasenotes/notes/fix-dbm-autodiscovery-updates-c3936a96c45e811c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug where cached services would not be updated with new metadata.

--- a/releasenotes/notes/fix-dbm-autodiscovery-updates-c3936a96c45e811c.yaml
+++ b/releasenotes/notes/fix-dbm-autodiscovery-updates-c3936a96c45e811c.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixes a bug where cached services would not be updated with new metadata.
+    Fixes a caching bug in dbm rds instance and aurora cluster autodiscovery. When service metatadata changed (DbName for example) the service check would not be updated with the new metadata if the service was already in the cache. Now the cached service is deleted and the updated service is added as a new check.


### PR DESCRIPTION
## Summary
- Add support for detecting and updating non-hashed instance field changes (e.g. `DbmEnabled`, `DbName`) on rediscovery, triggering delete + re-create of the service

## Test plan
- [x] Added test: changed non-hashed instance fields are picked up on rediscovery (RDS + Aurora)
- [x] Run full `dda inv test --targets=./comp/core/autodiscovery/listeners` — RDS tests pass, Aurora rediscovery test needs listener implementation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)