### PR TITLE
[observer] Ingest container lifecycle events from workloadmeta

### DIFF
--- a/comp/anomalydetection/recorder/impl/jsonl_lifecycle_writer.go
+++ b/comp/anomalydetection/recorder/impl/jsonl_lifecycle_writer.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package recorderimpl
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+const lifecycleFileName = "observer-lifecycle.jsonl"
+
+// lifecycleRecord is the JSON structure written as one line per event.
+type lifecycleRecord struct {
+	Timestamp     int64  `json:"ts"`
+	EventType     string `json:"type"`
+	ContainerID   string `json:"container_id"`
+	ExitCode      *int32 `json:"exit_code,omitempty"`
+	ContainerName string `json:"container_name"`
+	Image         string `json:"image"`
+	Runtime       string `json:"runtime"`
+}
+
+// lifecycleJSONLWriter appends container lifecycle events as JSON Lines.
+// It is safe for concurrent use by multiple goroutines.
+type lifecycleJSONLWriter struct {
+	mu   sync.Mutex
+	file *os.File
+}
+
+// newLifecycleJSONLWriter opens (or creates) the lifecycle JSONL file in outputDir.
+// The file is opened in append mode so existing data is preserved across restarts.
+func newLifecycleJSONLWriter(outputDir string) (*lifecycleJSONLWriter, error) {
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return nil, fmt.Errorf("creating output directory: %w", err)
+	}
+
+	path := filepath.Join(outputDir, lifecycleFileName)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("opening lifecycle file: %w", err)
+	}
+
+	return &lifecycleJSONLWriter{file: f}, nil
+}
+
+// WriteEvent serializes a LifecycleView as a single JSON line and appends it to
+// the file. For non-delete events the exit_code field is omitted.
+func (w *lifecycleJSONLWriter) WriteEvent(event observer.LifecycleView) error {
+	rec := lifecycleRecord{
+		Timestamp:     event.GetTimestampUnix(),
+		EventType:     event.GetEventType(),
+		ContainerID:   event.GetContainerID(),
+		ExitCode:      event.GetExitCode(),
+		ContainerName: event.GetContainerName(),
+		Image:         event.GetImage(),
+		Runtime:       event.GetRuntime(),
+	}
+
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshaling lifecycle event: %w", err)
+	}
+	data = append(data, '\n')
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if _, err := w.file.Write(data); err != nil {
+		return fmt.Errorf("writing lifecycle event: %w", err)
+	}
+	return nil
+}
+
+// Close closes the underlying file.
+func (w *lifecycleJSONLWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.file.Close()
+}

--- a/comp/anomalydetection/recorder/impl/recorder.go
+++ b/comp/anomalydetection/recorder/impl/recorder.go
@@ -93,6 +93,14 @@ func NewComponent(req Requires) (Provides, error) {
 	r.traceStatsParquetWriter = traceStatsWriter
 	pkglog.Infof("Recorder trace stats writer started: dir=%s", parquetDir)
 
+	// Initialize lifecycle JSONL writer (always enabled when recording is on)
+	lcWriter, err := newLifecycleJSONLWriter(parquetDir)
+	if err != nil {
+		return Provides{Comp: r}, pkglog.Errorf("Failed to create lifecycle JSONL writer: %v", err)
+	}
+	r.lifecycleWriter = lcWriter
+	pkglog.Infof("Recorder lifecycle writer started: dir=%s", parquetDir)
+
 	return Provides{Comp: r}, nil
 }
 
@@ -104,6 +112,7 @@ type recorderImpl struct {
 	profileParquetWriter    *profileParquetWriter
 	logParquetWriter        *logParquetWriter
 	traceStatsParquetWriter *traceStatsParquetWriter
+	lifecycleWriter         *lifecycleJSONLWriter
 }
 
 // GetHandle wraps the provided HandleFunc with recording capability.
@@ -347,6 +356,17 @@ func (h *recordingHandle) ObserveProfile(profile observer.ProfileView) {
 		profile.GetRawData(),
 		mapToTagSlice(profile.GetTags()),
 	)
+}
+
+// ObserveLifecycle forwards the lifecycle event to the inner handle and records it.
+func (h *recordingHandle) ObserveLifecycle(event observer.LifecycleView) {
+	h.inner.ObserveLifecycle(event)
+
+	if h.recorder.lifecycleWriter != nil {
+		if err := h.recorder.lifecycleWriter.WriteEvent(event); err != nil {
+			pkglog.Warnf("recorder: failed to write lifecycle event: %v", err)
+		}
+	}
 }
 
 // mapToTagSlice converts a map to a slice of "key:value" strings.

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -45,6 +45,31 @@ type Handle interface {
 
 	// ObserveProfile observes a profiling sample.
 	ObserveProfile(profile ProfileView)
+
+	// ObserveLifecycle observes a container lifecycle event (create, start, delete).
+	ObserveLifecycle(event LifecycleView)
+}
+
+// LifecycleView provides read-only access to a container lifecycle event.
+//
+// Events are pushed from workloadmeta subscriptions and include both creation
+// and deletion events. The observer stores these alongside metrics/logs/traces
+// for correlation during anomaly analysis.
+type LifecycleView interface {
+	// GetContainerID returns the container ID.
+	GetContainerID() string
+	// GetEventType returns the lifecycle event type: "create", "start", or "delete".
+	GetEventType() string
+	// GetTimestampUnix returns the event timestamp in Unix seconds.
+	GetTimestampUnix() int64
+	// GetExitCode returns the container exit code, or nil for non-delete events.
+	GetExitCode() *int32
+	// GetContainerName returns the human-readable container name.
+	GetContainerName() string
+	// GetImage returns the container image name (e.g. "alpine:latest").
+	GetImage() string
+	// GetRuntime returns the container runtime ("docker", "containerd", "cri-o").
+	GetRuntime() string
 }
 
 // HandleFunc is a function that returns a handle for a named source.

--- a/comp/observer/fx/fx.go
+++ b/comp/observer/fx/fx.go
@@ -23,5 +23,9 @@ func Module() fxutil.Module {
 			observerimpl.NewComponent,
 		),
 		fxutil.ProvideOptional[observerdef.Component](),
+		// option.Option[workloadmeta.Component], option.Option[workloadfilter.Component],
+		// and option.Option[tagger.Component] are already provided by their respective
+		// fx modules (workloadmeta/fx, workloadfilter/fx, tagger/fx). The observer's
+		// Requires fields pick them up automatically when those modules are in the graph.
 	)
 }

--- a/comp/observer/fx/fx.go
+++ b/comp/observer/fx/fx.go
@@ -23,9 +23,5 @@ func Module() fxutil.Module {
 			observerimpl.NewComponent,
 		),
 		fxutil.ProvideOptional[observerdef.Component](),
-		// option.Option[workloadmeta.Component], option.Option[workloadfilter.Component],
-		// and option.Option[tagger.Component] are already provided by their respective
-		// fx modules (workloadmeta/fx, workloadfilter/fx, tagger/fx). The observer's
-		// Requires fields pick them up automatically when those modules are in the graph.
 	)
 }

--- a/comp/observer/impl/hfrunner/runner.go
+++ b/comp/observer/impl/hfrunner/runner.go
@@ -15,6 +15,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 
+	taggerdef "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	workloadfilterdef "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadmetadef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/generic"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/net/network"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/cpu/cpu"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/cpu/load"
@@ -35,10 +39,13 @@ const (
 	// maxBackoff caps the retry wait to avoid long silences.
 	maxBackoff = 60 * time.Second
 
-	// hfSource is the observer handle source name for HF system check metrics.
+	// HFSource is the observer handle source name for HF system check metrics.
 	// Using a distinct name from "all-metrics" lets the observer suppress the
 	// lower-frequency 15s versions of these metrics when HF mode is active.
 	HFSource = "system-checks-hf"
+
+	// HFContainerSource is the observer handle source name for HF container metrics.
+	HFContainerSource = "container-checks-hf"
 )
 
 // checkEntry tracks a single check instance and its retry state.
@@ -108,6 +115,57 @@ func New(handle observerdef.Handle) *Runner {
 	}
 
 	log.Infof("[observer/hfrunner] initialized %d system checks for high-frequency collection", len(entries))
+	return &Runner{entries: entries, stopCh: make(chan struct{})}
+}
+
+// ContainerDeps holds the components required to run the generic container check.
+// All three must be non-nil; NewContainer returns nil if any are missing.
+type ContainerDeps struct {
+	WMeta       workloadmetadef.Component
+	FilterStore workloadfilterdef.Component
+	Tagger      taggerdef.Component
+}
+
+// NewContainer creates a Runner that collects container metrics (cpu, memory, io,
+// network) at 1-second intervals via the generic container check. The runner uses
+// the same observerSender pattern as New — metrics flow directly into the observer
+// pipeline and never touch the aggregator or forwarder.
+//
+// Returns nil if any dep in ContainerDeps is nil, logging a warning.
+func NewContainer(handle observerdef.Handle, deps ContainerDeps) *Runner {
+	if deps.WMeta == nil || deps.FilterStore == nil || deps.Tagger == nil {
+		log.Warn("[observer/hfrunner] container check deps incomplete, skipping container HF runner")
+		return nil
+	}
+
+	mgr := newObserverSenderManager(handle)
+
+	type factoryEntry struct {
+		name    string
+		factory option.Option[func() check.Check]
+	}
+
+	factories := []factoryEntry{
+		{"container", generic.Factory(deps.WMeta, deps.FilterStore, deps.Tagger)},
+	}
+
+	var entries []*checkEntry
+	for _, fe := range factories {
+		factory, ok := fe.factory.Get()
+		if !ok {
+			log.Debugf("[observer/hfrunner] %s check not available on this platform, skipping", fe.name)
+			continue
+		}
+		ch := factory()
+		err := ch.Configure(mgr, 0, integration.Data("{}"), integration.Data("{}"), "hf-container-runner", "hf-container-runner")
+		if err != nil {
+			log.Warnf("[observer/hfrunner] failed to configure %s check, skipping: %v", fe.name, err)
+			continue
+		}
+		entries = append(entries, &checkEntry{name: fe.name, ch: ch})
+	}
+
+	log.Infof("[observer/hfrunner] initialized %d container checks for high-frequency collection", len(entries))
 	return &Runner{entries: entries, stopCh: make(chan struct{})}
 }
 

--- a/comp/observer/impl/lifecycle_metrics.go
+++ b/comp/observer/impl/lifecycle_metrics.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+	"time"
+)
+
+// lifecycleMetricsExtractor converts container lifecycle events into counter
+// metrics that the existing detector pipeline can analyze.
+//
+// Each lifecycle event becomes a single metric point:
+//
+//	observer.container.lifecycle{type:create|start|delete,image:alpine,runtime:docker} = 1
+//
+// For delete events, an exit_code tag is added:
+//
+//	observer.container.lifecycle{type:delete,exit_code:137,image:alpine,runtime:docker} = 1
+//
+// The count aggregation in the observer's time series storage gives detectors a
+// "container deaths per second" signal that BOCPD can detect changepoints on —
+// a spike in exit_code:137 events correlates with OOM kills or forced restarts.
+type lifecycleMetricsExtractor struct{}
+
+const lifecycleMetricName = "observer.container.lifecycle"
+
+// processLifecycleEvent converts a lifecycle observation into metric samples
+// and stores them in the engine's time series storage.
+func (e *lifecycleMetricsExtractor) processLifecycleEvent(eng *engine, source string, lc *lifecycleObs) {
+	tags := []string{
+		"type:" + lc.eventType,
+		"image:" + lc.image,
+		"runtime:" + lc.runtime,
+	}
+	if lc.exitCode != nil {
+		tags = append(tags, fmt.Sprintf("exit_code:%d", *lc.exitCode))
+	}
+
+	ts := lc.timestamp
+	if ts == 0 {
+		ts = time.Now().Unix()
+	}
+
+	eng.storage.Add(source, lifecycleMetricName, 1.0, ts, tags)
+}
+
+// lifecycleObs getter methods and LifecycleView assertion are in observer.go.

--- a/comp/observer/impl/lifecycle_watcher.go
+++ b/comp/observer/impl/lifecycle_watcher.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"time"
+
+	workloadmetadef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// containerMeta caches container metadata from Set events so it's available
+// when the Unset (delete) event arrives — Unset only carries the EntityID.
+type containerMeta struct {
+	name       string
+	image      string
+	runtime    string
+	finishedAt int64  // from last Set event before Unset
+	exitCode   *int64 // from last Set event before Unset (workloadmeta uses int64)
+}
+
+// lifecycleWatcher subscribes to workloadmeta container events and pushes
+// lifecycle observations (create, start, delete) into the observer pipeline.
+type lifecycleWatcher struct {
+	wmeta  workloadmetadef.Component
+	handle observerdef.Handle
+	stopCh chan struct{}
+	cache  map[string]containerMeta // keyed by container ID
+}
+
+// newLifecycleWatcher creates a new lifecycleWatcher.
+func newLifecycleWatcher(wmeta workloadmetadef.Component, handle observerdef.Handle) *lifecycleWatcher {
+	return &lifecycleWatcher{
+		wmeta:  wmeta,
+		handle: handle,
+		stopCh: make(chan struct{}),
+		cache:  make(map[string]containerMeta),
+	}
+}
+
+// Start launches a goroutine that subscribes to workloadmeta container events
+// and forwards them as lifecycle observations.
+func (w *lifecycleWatcher) Start() {
+	filter := workloadmetadef.NewFilterBuilder().AddKind(workloadmetadef.KindContainer).Build()
+	ch := w.wmeta.Subscribe("observer-lifecycle", workloadmetadef.NormalPriority, filter)
+
+	go func() {
+		defer w.wmeta.Unsubscribe(ch)
+
+		for {
+			select {
+			case <-w.stopCh:
+				return
+			case eventBundle, ok := <-ch:
+				if !ok {
+					return
+				}
+				eventBundle.Acknowledge()
+
+				for _, event := range eventBundle.Events {
+					w.processEvent(event)
+				}
+			}
+		}
+	}()
+}
+
+// Stop signals the watcher goroutine to exit.
+func (w *lifecycleWatcher) Stop() {
+	close(w.stopCh)
+}
+
+// processEvent converts a workloadmeta event into a lifecycle observation.
+func (w *lifecycleWatcher) processEvent(event workloadmetadef.Event) {
+	switch event.Type {
+	case workloadmetadef.EventTypeSet:
+		container, ok := event.Entity.(*workloadmetadef.Container)
+		if !ok {
+			return
+		}
+		w.handleSetEvent(container)
+
+	case workloadmetadef.EventTypeUnset:
+		// Unset only carries EntityID — use cached metadata from the Set event.
+		entityID := event.Entity.GetID()
+		cached := w.cache[entityID.ID]
+		delete(w.cache, entityID.ID)
+		var exitCode *int32
+		if cached.exitCode != nil {
+			ec := int32(*cached.exitCode)
+			exitCode = &ec
+		}
+		ts := cached.finishedAt
+		if ts == 0 {
+			ts = time.Now().Unix()
+		}
+		w.handle.ObserveLifecycle(&lifecycleEvent{
+			containerID:   entityID.ID,
+			eventType:     "delete",
+			timestamp:     ts,
+			exitCode:      exitCode,
+			containerName: cached.name,
+			image:         cached.image,
+			runtime:       cached.runtime,
+		})
+
+	default:
+		pkglog.Debugf("lifecycle_watcher: ignoring unknown event type %d", event.Type)
+	}
+}
+
+// handleSetEvent emits a "start" or "create" lifecycle event from a container entity.
+func (w *lifecycleWatcher) handleSetEvent(container *workloadmetadef.Container) {
+	var imageName string
+	if container.Image.Name != "" {
+		imageName = container.Image.Name
+	}
+
+	// Cache metadata so delete events have full context.
+	w.cache[container.EntityID.ID] = containerMeta{
+		name:    container.Name,
+		image:   imageName,
+		runtime: string(container.Runtime),
+	}
+
+	// Cache exit info too — the last Set event before Unset has FinishedAt/ExitCode.
+	if !container.State.FinishedAt.IsZero() {
+		ts := container.State.FinishedAt.Unix()
+		meta := w.cache[container.EntityID.ID]
+		meta.finishedAt = ts
+		meta.exitCode = container.State.ExitCode
+		w.cache[container.EntityID.ID] = meta
+	}
+
+	if container.State.Running && !container.State.StartedAt.IsZero() {
+		w.handle.ObserveLifecycle(&lifecycleEvent{
+			containerID:   container.EntityID.ID,
+			eventType:     "start",
+			timestamp:     container.State.StartedAt.Unix(),
+			containerName: container.Name,
+			image:         imageName,
+			runtime:       string(container.Runtime),
+		})
+	} else if !container.State.CreatedAt.IsZero() {
+		w.handle.ObserveLifecycle(&lifecycleEvent{
+			containerID:   container.EntityID.ID,
+			eventType:     "create",
+			timestamp:     container.State.CreatedAt.Unix(),
+			containerName: container.Name,
+			image:         imageName,
+			runtime:       string(container.Runtime),
+		})
+	}
+}
+
+// lifecycleEvent implements observerdef.LifecycleView for events produced by
+// the lifecycle watcher.
+type lifecycleEvent struct {
+	containerID   string
+	eventType     string // "create", "start", "delete"
+	timestamp     int64
+	exitCode      *int32
+	containerName string
+	image         string
+	runtime       string
+}
+
+// Ensure lifecycleEvent implements observerdef.LifecycleView.
+var _ observerdef.LifecycleView = (*lifecycleEvent)(nil)
+
+func (e *lifecycleEvent) GetContainerID() string   { return e.containerID }
+func (e *lifecycleEvent) GetEventType() string     { return e.eventType }
+func (e *lifecycleEvent) GetTimestampUnix() int64  { return e.timestamp }
+func (e *lifecycleEvent) GetExitCode() *int32      { return e.exitCode }
+func (e *lifecycleEvent) GetContainerName() string { return e.containerName }
+func (e *lifecycleEvent) GetImage() string         { return e.image }
+func (e *lifecycleEvent) GetRuntime() string       { return e.runtime }

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -77,11 +77,12 @@ type Provides struct {
 
 // observation is a message sent from handles to the observer.
 type observation struct {
-	source  string
-	metric  *metricObs
-	log     *logObs
-	trace   *traceObs
-	profile *profileObs
+	source    string
+	metric    *metricObs
+	log       *logObs
+	trace     *traceObs
+	profile   *profileObs
+	lifecycle *lifecycleObs
 }
 
 // metricObs contains copied metric data and implements observerdef.MetricView.
@@ -171,6 +172,28 @@ type profileObs struct {
 	rawData      []byte
 	externalPath string
 }
+
+// lifecycleObs contains copied container lifecycle event data and implements observerdef.LifecycleView.
+type lifecycleObs struct {
+	containerID   string
+	eventType     string
+	timestamp     int64
+	exitCode      *int32
+	containerName string
+	image         string
+	runtime       string
+}
+
+// Ensure lifecycleObs implements observerdef.LifecycleView
+var _ observerdef.LifecycleView = (*lifecycleObs)(nil)
+
+func (l *lifecycleObs) GetContainerID() string   { return l.containerID }
+func (l *lifecycleObs) GetEventType() string     { return l.eventType }
+func (l *lifecycleObs) GetTimestampUnix() int64  { return l.timestamp }
+func (l *lifecycleObs) GetExitCode() *int32      { return l.exitCode }
+func (l *lifecycleObs) GetContainerName() string { return l.containerName }
+func (l *lifecycleObs) GetImage() string         { return l.image }
+func (l *lifecycleObs) GetRuntime() string       { return l.runtime }
 
 // Ensure logObs implements observerdef.LogView
 var _ observerdef.LogView = (*logObs)(nil)
@@ -382,6 +405,22 @@ func NewComponent(deps Requires) Provides {
 		}
 	}
 
+	// Start lifecycle watcher if workloadmeta is available.
+	// Subscribes to container create/start/delete events and pushes them into
+	// the observer pipeline via ObserveLifecycle.
+	if wmeta, wmetaOk := deps.WMeta.Get(); wmetaOk {
+		lcHandle := obs.GetHandle("lifecycle-watcher")
+		lcWatcher := newLifecycleWatcher(wmeta, lcHandle)
+		lcWatcher.Start()
+		pkglog.Info("[observer] container lifecycle watcher started")
+		deps.Lifecycle.Append(fx.Hook{
+			OnStop: func(_ context.Context) error {
+				lcWatcher.Stop()
+				return nil
+			},
+		})
+	}
+
 	// Start periodic metric dump if configured
 	dumpPath := cfg.GetString("observer.debug_dump_path")
 	dumpInterval := cfg.GetDuration("observer.debug_dump_interval")
@@ -558,6 +597,11 @@ func (o *observerImpl) run() {
 		}
 		if obs.profile != nil {
 			o.processProfile(obs.source, obs.profile)
+		}
+		if obs.lifecycle != nil {
+			// Convert lifecycle event into a counter metric for the detector pipeline.
+			lme := &lifecycleMetricsExtractor{}
+			lme.processLifecycleEvent(o.engine, obs.source, obs.lifecycle)
 		}
 		for _, req := range requests {
 			result := o.engine.advanceWithReason(req.upToSec, req.reason)
@@ -783,6 +827,9 @@ func (f *hfFilteredHandle) ObserveTraceStats(s observerdef.TraceStatsView) {
 	f.inner.ObserveTraceStats(s)
 }
 func (f *hfFilteredHandle) ObserveProfile(p observerdef.ProfileView) { f.inner.ObserveProfile(p) }
+func (f *hfFilteredHandle) ObserveLifecycle(e observerdef.LifecycleView) {
+	f.inner.ObserveLifecycle(e)
+}
 
 // noopHandle returns a handle that discards all observations.
 // Used when analysis is disabled so the analysis pipeline is not started.
@@ -798,6 +845,7 @@ func (h *noopObserveHandle) ObserveLog(_ observerdef.LogView)               {}
 func (h *noopObserveHandle) ObserveTrace(_ observerdef.TraceView)           {}
 func (h *noopObserveHandle) ObserveTraceStats(_ observerdef.TraceStatsView) {}
 func (h *noopObserveHandle) ObserveProfile(_ observerdef.ProfileView)       {}
+func (h *noopObserveHandle) ObserveLifecycle(_ observerdef.LifecycleView)   {}
 
 // DumpMetrics writes all stored metrics to the specified file as JSON.
 func (o *observerImpl) DumpMetrics(path string) error {
@@ -963,6 +1011,40 @@ func (h *handle) ObserveProfile(profile observerdef.ProfileView) {
 			contentType:  profile.GetContentType(),
 			rawData:      copyBytes(profile.GetRawData()),
 			externalPath: profile.GetExternalPath(),
+		},
+	}
+
+	// Non-blocking send - drop if channel is full.
+	select {
+	case h.ch <- obs:
+	default:
+		if h.dropCount != nil {
+			h.dropCount.Add(1)
+		}
+		if h.dropCounter != nil {
+			h.dropCounter.Add(1, h.source)
+		}
+	}
+}
+
+// ObserveLifecycle observes a container lifecycle event.
+func (h *handle) ObserveLifecycle(event observerdef.LifecycleView) {
+	var exitCodeCopy *int32
+	if ec := event.GetExitCode(); ec != nil {
+		v := *ec
+		exitCodeCopy = &v
+	}
+
+	obs := observation{
+		source: h.source,
+		lifecycle: &lifecycleObs{
+			containerID:   event.GetContainerID(),
+			eventType:     event.GetEventType(),
+			timestamp:     event.GetTimestampUnix(),
+			exitCode:      exitCodeCopy,
+			containerName: event.GetContainerName(),
+			image:         event.GetImage(),
+			runtime:       event.GetRuntime(),
 		},
 	}
 

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -366,6 +366,10 @@ func NewComponent(deps Requires) Provides {
 			if obs.hfContainerRunner != nil {
 				obs.hfContainerRunner.Start()
 				pkglog.Info("[observer] high-frequency container check runner started (1s interval)")
+				// Only suppress 15s container metrics now that the HF replacement is confirmed running.
+				for src := range containerCheckSources {
+					obs.hfFilterSources[src] = struct{}{}
+				}
 				deps.Lifecycle.Append(fx.Hook{
 					OnStop: func(_ context.Context) error {
 						obs.hfContainerRunner.Stop()
@@ -743,12 +747,13 @@ var systemCheckSources = map[metrics.MetricSource]struct{}{
 }
 
 // containerCheckSources is the set of MetricSource values produced by the
-// container checks that the HF container runner executes.
+// container checks that the HF container runner executes. Only MetricSourceContainer
+// is included because the HF runner uses the generic container check (check name
+// "container"), which maps to MetricSourceContainer regardless of runtime.
+// The legacy per-runtime checks (containerd, cri, docker) have their own
+// MetricSource values but are not run by the HF runner.
 var containerCheckSources = map[metrics.MetricSource]struct{}{
-	metrics.MetricSourceContainer:  {},
-	metrics.MetricSourceContainerd: {},
-	metrics.MetricSourceCri:        {},
-	metrics.MetricSourceDocker:     {},
+	metrics.MetricSourceContainer: {},
 }
 
 // hfFilteredHandle wraps a Handle and drops metrics whose source is in the

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -22,8 +22,11 @@ import (
 	config "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
+	taggerdef "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
+	workloadfilterdef "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadmetadef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/DataDog/datadog-agent/comp/observer/impl/hfrunner"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -50,6 +53,14 @@ type Requires struct {
 	// RemoteAgentRegistry enables fetching traces/profiles
 	// from remote trace-agents via the ObserverProvider gRPC service.
 	RemoteAgentRegistry remoteagentregistry.Component
+
+	// WMeta, FilterStore, Tagger are optional — required only when
+	// observer.high_frequency_container_checks.enabled is true.
+	// Using option.Option so the observer can start without them (e.g. in tests
+	// or agent binaries that don't include container infrastructure).
+	WMeta       option.Option[workloadmetadef.Component]
+	FilterStore option.Option[workloadfilterdef.Component]
+	Tagger      option.Option[taggerdef.Component]
 }
 
 type AgentInternalLogTapConfig struct {
@@ -247,16 +258,22 @@ func NewComponent(deps Requires) Provides {
 	}
 
 	hfSystemEnabled := cfg.GetBool("observer.high_frequency_system_checks.enabled")
+	hfContainerEnabled := cfg.GetBool("observer.high_frequency_container_checks.enabled")
 	th := newTelemetryHandler(telemetryComp)
 
+	// Build the set of MetricSource values to suppress from the "all-metrics"
+	// pipeline. Sources are added later, only after their respective HF runners
+	// are confirmed started, to avoid suppressing 15s metrics when the HF
+	// replacement can't start.
+	hfFilterSources := make(map[metrics.MetricSource]struct{})
+
 	obs := &observerImpl{
-		engine:           eng,
-		obsCh:            make(chan observation, 1000),
-		telemetryHandler: th,
-		dropCounter:      th.telemetryCounters[telemetryObsChannelDropped],
-		// hfEnabled is set to true only AFTER the runner starts successfully,
-		// so the 15s system.* stream is not suppressed when the HF runner
-		// fails to start (e.g. check configuration errors).
+		engine:             eng,
+		obsCh:              make(chan observation, 1000),
+		telemetryHandler:   th,
+		dropCounter:        th.telemetryCounters[telemetryObsChannelDropped],
+		hfContainerEnabled: hfContainerEnabled,
+		hfFilterSources:    hfFilterSources,
 	}
 
 	// Set up handle function based on recording and analysis configuration.
@@ -319,7 +336,10 @@ func NewComponent(deps Requires) Provides {
 		hfHandle := obs.GetHandle(hfrunner.HFSource)
 		obs.hfRunner = hfrunner.New(hfHandle)
 		obs.hfRunner.Start()
-		obs.hfEnabled = true // Activate 15s suppression only after runner is confirmed started.
+		obs.hfEnabled = true
+		for src := range systemCheckSources {
+			obs.hfFilterSources[src] = struct{}{}
+		}
 		pkglog.Info("[observer] high-frequency system check runner started (1s interval)")
 		deps.Lifecycle.Append(fx.Hook{
 			OnStop: func(_ context.Context) error {
@@ -327,6 +347,35 @@ func NewComponent(deps Requires) Provides {
 				return nil
 			},
 		})
+	}
+
+	// Start high-frequency container check runner if enabled.
+	// Uses the generic container check with WLM + tagger for full per-container
+	// cardinality. Metrics route via "container-checks-hf" and never reach intake.
+	if hfContainerEnabled {
+		wmeta, wmetaOk := deps.WMeta.Get()
+		filterStore, filterOk := deps.FilterStore.Get()
+		tagger, taggerOk := deps.Tagger.Get()
+		if wmetaOk && filterOk && taggerOk {
+			containerHandle := obs.GetHandle(hfrunner.HFContainerSource)
+			obs.hfContainerRunner = hfrunner.NewContainer(containerHandle, hfrunner.ContainerDeps{
+				WMeta:       wmeta,
+				FilterStore: filterStore,
+				Tagger:      tagger,
+			})
+			if obs.hfContainerRunner != nil {
+				obs.hfContainerRunner.Start()
+				pkglog.Info("[observer] high-frequency container check runner started (1s interval)")
+				deps.Lifecycle.Append(fx.Hook{
+					OnStop: func(_ context.Context) error {
+						obs.hfContainerRunner.Stop()
+						return nil
+					},
+				})
+			}
+		} else {
+			pkglog.Warn("[observer] high_frequency_container_checks.enabled=true but WMeta/FilterStore/Tagger not available; skipping")
+		}
 	}
 
 	// Start periodic metric dump if configured
@@ -471,8 +520,19 @@ type observerImpl struct {
 	// hfRunner is the high-frequency system check runner, non-nil when enabled.
 	hfRunner *hfrunner.Runner
 
+	// hfContainerRunner is the high-frequency container check runner, non-nil when enabled.
+	hfContainerRunner *hfrunner.Runner
+
+	// hfFilterSources is the combined set of MetricSource values to suppress from
+	// the "all-metrics" pipeline when their HF counterpart is active. Built at
+	// construction time from whichever HF flags are enabled.
+	hfFilterSources map[metrics.MetricSource]struct{}
+
 	// hfEnabled is true when high-frequency system check collection is active.
 	hfEnabled bool
+
+	// hfContainerEnabled is true when high-frequency container check collection is active.
+	hfContainerEnabled bool
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -650,13 +710,13 @@ func (o *observerImpl) GetHandle(name string) observerdef.Handle {
 }
 
 // innerHandle creates the base handle without any middleware wrapping.
-// When HF system check collection is enabled, the "all-metrics" handle is
-// wrapped to suppress system.* metrics — the scorer should only see those
-// from the higher-resolution "system-checks-hf" source instead.
+// When any HF check collection is enabled, the "all-metrics" handle is wrapped
+// with hfFilteredHandle to suppress 15s samples for checks that have a 1s HF
+// counterpart active — the scorer should only see the higher-resolution stream.
 func (o *observerImpl) innerHandle(name string) observerdef.Handle {
 	h := &handle{ch: o.obsCh, source: name, dropCount: &o.engine.droppedObs, dropCounter: o.dropCounter}
-	if o.hfEnabled && name == "all-metrics" {
-		return &systemFilteredHandle{inner: h}
+	if len(o.hfFilterSources) > 0 && name == "all-metrics" {
+		return &hfFilteredHandle{inner: h, sources: o.hfFilterSources}
 	}
 	return h
 }
@@ -682,32 +742,42 @@ var systemCheckSources = map[metrics.MetricSource]struct{}{
 	metrics.MetricSourceFileHandle: {},
 }
 
-// systemFilteredHandle wraps a Handle and drops system check metrics so that
-// the 15-second pipeline samples do not compete with the 1-second HF runner
-// stream in the scorer.
+// containerCheckSources is the set of MetricSource values produced by the
+// container checks that the HF container runner executes.
+var containerCheckSources = map[metrics.MetricSource]struct{}{
+	metrics.MetricSourceContainer:  {},
+	metrics.MetricSourceContainerd: {},
+	metrics.MetricSourceCri:        {},
+	metrics.MetricSourceDocker:     {},
+}
+
+// hfFilteredHandle wraps a Handle and drops metrics whose source is in the
+// provided sources set, so that 15s pipeline samples do not compete with their
+// 1s HF counterparts in the scorer.
 //
 // Filtering uses a MetricSource enum map lookup via a type assertion to
 // sourceProvider. Samples that do not implement sourceProvider pass through
 // unchanged — absence of metadata is not sufficient grounds to drop.
-type systemFilteredHandle struct {
-	inner observerdef.Handle
+type hfFilteredHandle struct {
+	inner   observerdef.Handle
+	sources map[metrics.MetricSource]struct{}
 }
 
-func (f *systemFilteredHandle) ObserveMetric(sample observerdef.MetricView) {
+func (f *hfFilteredHandle) ObserveMetric(sample observerdef.MetricView) {
 	if sp, ok := sample.(sourceProvider); ok {
-		if _, isSystemCheck := systemCheckSources[sp.GetSource()]; isSystemCheck {
+		if _, suppressed := f.sources[sp.GetSource()]; suppressed {
 			return
 		}
 	}
 	f.inner.ObserveMetric(sample)
 }
 
-func (f *systemFilteredHandle) ObserveLog(msg observerdef.LogView)       { f.inner.ObserveLog(msg) }
-func (f *systemFilteredHandle) ObserveTrace(trace observerdef.TraceView) { f.inner.ObserveTrace(trace) }
-func (f *systemFilteredHandle) ObserveTraceStats(s observerdef.TraceStatsView) {
+func (f *hfFilteredHandle) ObserveLog(msg observerdef.LogView)       { f.inner.ObserveLog(msg) }
+func (f *hfFilteredHandle) ObserveTrace(trace observerdef.TraceView) { f.inner.ObserveTrace(trace) }
+func (f *hfFilteredHandle) ObserveTraceStats(s observerdef.TraceStatsView) {
 	f.inner.ObserveTraceStats(s)
 }
-func (f *systemFilteredHandle) ObserveProfile(p observerdef.ProfileView) { f.inner.ObserveProfile(p) }
+func (f *hfFilteredHandle) ObserveProfile(p observerdef.ProfileView) { f.inner.ObserveProfile(p) }
 
 // noopHandle returns a handle that discards all observations.
 // Used when analysis is disabled so the analysis pipeline is not started.

--- a/comp/observer/impl/system_filter_test.go
+++ b/comp/observer/impl/system_filter_test.go
@@ -97,11 +97,15 @@ func TestHFFilteredHandle_ContainerSources(t *testing.T) {
 		sample   observerdef.MetricView
 		wantDrop bool
 	}{
-		// Container check sources — all must be dropped when container HF is active.
+		// Generic container check source — dropped when container HF is active.
+		// Only MetricSourceContainer is suppressed because the HF runner uses the
+		// generic "container" check, not the legacy per-runtime checks.
 		{"container dropped", &sampleWithSource{"container.cpu.usage", metrics.MetricSourceContainer}, true},
-		{"containerd dropped", &sampleWithSource{"container.mem.usage", metrics.MetricSourceContainerd}, true},
-		{"cri dropped", &sampleWithSource{"container.io.read", metrics.MetricSourceCri}, true},
-		{"docker dropped", &sampleWithSource{"docker.cpu.usage", metrics.MetricSourceDocker}, true},
+
+		// Legacy per-runtime sources are NOT suppressed (not run by HF runner).
+		{"containerd passes", &sampleWithSource{"container.mem.usage", metrics.MetricSourceContainerd}, false},
+		{"cri passes", &sampleWithSource{"container.io.read", metrics.MetricSourceCri}, false},
+		{"docker passes", &sampleWithSource{"docker.cpu.usage", metrics.MetricSourceDocker}, false},
 
 		// Non-container sources must pass through.
 		{"dogstatsd passes", &sampleWithSource{"my.custom.metric", metrics.MetricSourceDogstatsd}, false},

--- a/comp/observer/impl/system_filter_test.go
+++ b/comp/observer/impl/system_filter_test.go
@@ -45,13 +45,17 @@ func (h *countingHandle) ObserveTrace(_ observerdef.TraceView)           {}
 func (h *countingHandle) ObserveTraceStats(_ observerdef.TraceStatsView) {}
 func (h *countingHandle) ObserveProfile(_ observerdef.ProfileView)       {}
 
-func TestSystemFilteredHandle(t *testing.T) {
+func makeHFHandle(sources map[metrics.MetricSource]struct{}) *hfFilteredHandle {
+	return &hfFilteredHandle{inner: &countingHandle{}, sources: sources}
+}
+
+func TestHFFilteredHandle_SystemSources(t *testing.T) {
 	tests := []struct {
 		name     string
 		sample   observerdef.MetricView
 		wantDrop bool
 	}{
-		// System check sources — all must be dropped.
+		// System check sources — all must be dropped when system HF is active.
 		{"cpu dropped", &sampleWithSource{"system.cpu.user", metrics.MetricSourceCPU}, true},
 		{"load dropped", &sampleWithSource{"system.load.1", metrics.MetricSourceLoad}, true},
 		{"memory dropped", &sampleWithSource{"system.mem.used", metrics.MetricSourceMemory}, true},
@@ -61,33 +65,88 @@ func TestSystemFilteredHandle(t *testing.T) {
 		{"uptime dropped", &sampleWithSource{"system.uptime", metrics.MetricSourceUptime}, true},
 		{"filehandle dropped", &sampleWithSource{"system.fs.file_handles.used", metrics.MetricSourceFileHandle}, true},
 
-		// Non-system sources with source metadata — must pass through.
+		// Non-system sources must pass through.
 		{"dogstatsd passes", &sampleWithSource{"my.custom.metric", metrics.MetricSourceDogstatsd}, false},
 		{"k8s passes", &sampleWithSource{"kubernetes_state.pod.ready", metrics.MetricSourceKubernetesStateCore}, false},
+		// Container source not in system filter set — passes through.
 		{"container passes", &sampleWithSource{"container.cpu.usage", metrics.MetricSourceContainer}, false},
 
-		// MetricSourceUnknown with source metadata — must pass through.
-		// Dropping on unknown source would be overly aggressive.
+		// MetricSourceUnknown and no-sourceProvider must always pass through.
 		{"unknown source passes", &sampleWithSource{"system.cpu.user", metrics.MetricSourceUnknown}, false},
-
-		// No sourceProvider at all — must pass through.
-		// There is no string-prefix fallback; absence of metadata means we
-		// cannot confidently identify the source, so we let it through.
 		{"no source metadata passes", &sampleNoSource{"system.cpu.user"}, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inner := &countingHandle{}
-			f := &systemFilteredHandle{inner: inner}
+			f := makeHFHandle(systemCheckSources)
 			f.ObserveMetric(tt.sample)
-
+			inner := f.inner.(*countingHandle)
 			if tt.wantDrop && inner.received != 0 {
-				t.Errorf("expected metric to be dropped, but inner handle received %d observation(s)", inner.received)
+				t.Errorf("expected drop, got %d observation(s)", inner.received)
 			}
 			if !tt.wantDrop && inner.received != 1 {
-				t.Errorf("expected metric to pass through, but inner handle received %d observation(s)", inner.received)
+				t.Errorf("expected pass-through, got %d observation(s)", inner.received)
 			}
 		})
+	}
+}
+
+func TestHFFilteredHandle_ContainerSources(t *testing.T) {
+	tests := []struct {
+		name     string
+		sample   observerdef.MetricView
+		wantDrop bool
+	}{
+		// Container check sources — all must be dropped when container HF is active.
+		{"container dropped", &sampleWithSource{"container.cpu.usage", metrics.MetricSourceContainer}, true},
+		{"containerd dropped", &sampleWithSource{"container.mem.usage", metrics.MetricSourceContainerd}, true},
+		{"cri dropped", &sampleWithSource{"container.io.read", metrics.MetricSourceCri}, true},
+		{"docker dropped", &sampleWithSource{"docker.cpu.usage", metrics.MetricSourceDocker}, true},
+
+		// Non-container sources must pass through.
+		{"dogstatsd passes", &sampleWithSource{"my.custom.metric", metrics.MetricSourceDogstatsd}, false},
+		// System source not in container filter set — passes through.
+		{"cpu passes", &sampleWithSource{"system.cpu.user", metrics.MetricSourceCPU}, false},
+		{"unknown passes", &sampleWithSource{"container.cpu.usage", metrics.MetricSourceUnknown}, false},
+		{"no source passes", &sampleNoSource{"container.cpu.usage"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := makeHFHandle(containerCheckSources)
+			f.ObserveMetric(tt.sample)
+			inner := f.inner.(*countingHandle)
+			if tt.wantDrop && inner.received != 0 {
+				t.Errorf("expected drop, got %d observation(s)", inner.received)
+			}
+			if !tt.wantDrop && inner.received != 1 {
+				t.Errorf("expected pass-through, got %d observation(s)", inner.received)
+			}
+		})
+	}
+}
+
+func TestHFFilteredHandle_BothEnabled(t *testing.T) {
+	// When both flags are active the combined source set suppresses both categories.
+	combined := make(map[metrics.MetricSource]struct{})
+	for src := range systemCheckSources {
+		combined[src] = struct{}{}
+	}
+	for src := range containerCheckSources {
+		combined[src] = struct{}{}
+	}
+
+	f := makeHFHandle(combined)
+
+	// System source dropped.
+	f.ObserveMetric(&sampleWithSource{"system.cpu.user", metrics.MetricSourceCPU})
+	// Container source dropped.
+	f.ObserveMetric(&sampleWithSource{"container.cpu.usage", metrics.MetricSourceContainer})
+	// DogStatsD passes through.
+	f.ObserveMetric(&sampleWithSource{"my.metric", metrics.MetricSourceDogstatsd})
+
+	inner := f.inner.(*countingHandle)
+	if inner.received != 1 {
+		t.Errorf("expected 1 observation (dogstatsd only), got %d", inner.received)
 	}
 }

--- a/comp/observer/impl/system_filter_test.go
+++ b/comp/observer/impl/system_filter_test.go
@@ -44,6 +44,7 @@ func (h *countingHandle) ObserveLog(_ observerdef.LogView)               {}
 func (h *countingHandle) ObserveTrace(_ observerdef.TraceView)           {}
 func (h *countingHandle) ObserveTraceStats(_ observerdef.TraceStatsView) {}
 func (h *countingHandle) ObserveProfile(_ observerdef.ProfileView)       {}
+func (h *countingHandle) ObserveLifecycle(_ observerdef.LifecycleView)   {}
 
 func makeHFHandle(sources map[metrics.MetricSource]struct{}) *hfFilteredHandle {
 	return &hfFilteredHandle{inner: &countingHandle{}, sources: sources}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -575,6 +575,7 @@ func (h *storageHandle) ObserveLog(_ observerdef.LogView)               {}
 func (h *storageHandle) ObserveTrace(_ observerdef.TraceView)           {}
 func (h *storageHandle) ObserveTraceStats(_ observerdef.TraceStatsView) {}
 func (h *storageHandle) ObserveProfile(_ observerdef.ProfileView)       {}
+func (h *storageHandle) ObserveLifecycle(_ observerdef.LifecycleView)   {}
 
 // parquetTraceStatsView adapts a slice of TraceStatsData (sharing the same AgentHostname/AgentEnv)
 // to the TraceStatsView interface for use with processStatsView.

--- a/pkg/aggregator/sender/aggregating_sender_test.go
+++ b/pkg/aggregator/sender/aggregating_sender_test.go
@@ -30,6 +30,7 @@ func (h *capturingHandle) ObserveLog(_ observerdef.LogView)               {}
 func (h *capturingHandle) ObserveTrace(_ observerdef.TraceView)           {}
 func (h *capturingHandle) ObserveTraceStats(_ observerdef.TraceStatsView) {}
 func (h *capturingHandle) ObserveProfile(_ observerdef.ProfileView)       {}
+func (h *capturingHandle) ObserveLifecycle(_ observerdef.LifecycleView)   {}
 
 // noopSender satisfies Sender and discards everything.
 type noopSender struct{}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -368,6 +368,11 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// These high-frequency samples are never forwarded to Datadog intake.
 	// The normal 15-second system check pipeline is unaffected.
 	config.BindEnvAndSetDefault("observer.high_frequency_system_checks.enabled", false)
+	// When true, the observer runs the generic container check at 1-second intervals
+	// with HighCardinality tags (container_id, image, etc.) and feeds metrics directly
+	// into the anomaly detection pipeline. Requires workloadmeta and tagger.
+	// These high-frequency samples are never forwarded to Datadog intake.
+	config.BindEnvAndSetDefault("observer.high_frequency_container_checks.enabled", false)
 	config.BindEnvAndSetDefault("observer.event_reporter.sending_enabled", false)
 
 	// Observer component toggles — values must match catalog defaults in


### PR DESCRIPTION
## Summary

Adds container lifecycle event ingestion to the observer pipeline. The observer subscribes to workloadmeta container events (create/start/delete) in real-time and processes them through three paths:

1. **JSONL recording** — `observer-lifecycle.jsonl` alongside parquet files
2. **Counter metrics** — `observer.container.lifecycle{type,image,runtime,exit_code}` fed into the detector pipeline so BOCPD can detect changepoints in container death rate
3. **Handle interface** — `ObserveLifecycle(LifecycleView)` on the Handle, same pattern as metrics/logs/traces

## Architecture

```
workloadmeta (real-time push)
  → lifecycleWatcher (subscribes to KindContainer, caches metadata)
    → handle.ObserveLifecycle(event)
      → run() loop:
          → lifecycleMetricsExtractor → storage (detector pipeline)
          → recorder → JSONL writer
```

## Validated locally

- Start events captured with container_name, image, runtime, timestamp
- Delete events captured with cached metadata from the Set event
- `time.Now()` fallback when FinishedAt unavailable
- Metrics appear in observer storage as `observer.container.lifecycle` series
- JSONL file written alongside parquets

🤖 Generated with [Claude Code](https://claude.ai/claude-code)