### PR TITLE
fix TestNPMEnabled to mock core config for EUDM env var

### DIFF
--- a/pkg/system-probe/config/config_linux_bpf_test.go
+++ b/pkg/system-probe/config/config_linux_bpf_test.go
@@ -108,6 +108,7 @@ func TestNPMEnabled(t *testing.T) {
 		{true, true, true, false, true, false, true},
 	}
 
+	mock.New(t)
 	mock.NewSystemProbe(t)
 	for _, te := range tests {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Adds `mock.New(t)` alongside `mock.NewSystemProbe(t)` in `TestNPMEnabled` so the core Datadog config is properly mocked.

### Motivation

### Describe how you validated your changes
Ran `TestNPMEnabled` locally in a Linux container — all 18 subtests pass.

### Additional Notes