### PR TITLE
[bazel] migrate /pkg/gohai

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -251,7 +251,7 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/eventmonitor
 # gazelle:exclude pkg/flare
 # gazelle:exclude pkg/fleet
-# gazelle:exclude pkg/gohai
+# gazelle:exclude pkg/gohai/cpu
 # gazelle:exclude pkg/gpu
 # gazelle:exclude pkg/hosttags
 # gazelle:exclude pkg/inventory

--- a/pkg/gohai/BUILD.bazel
+++ b/pkg/gohai/BUILD.bazel
@@ -1,0 +1,1 @@
+# gazelle:ignore

--- a/pkg/gohai/filesystem/BUILD.bazel
+++ b/pkg/gohai/filesystem/BUILD.bazel
@@ -1,0 +1,65 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "filesystem",
+    srcs = [
+        "filesystem.go",
+        "filesystem_nix.go",
+        "filesystem_windows.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/gohai/filesystem",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "//pkg/util/log",
+            "@com_github_moby_sys_mountinfo//:mountinfo",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//pkg/util/log",
+            "@com_github_moby_sys_mountinfo//:mountinfo",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//pkg/util/log",
+            "@com_github_moby_sys_mountinfo//:mountinfo",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/util/log",
+            "@com_github_moby_sys_mountinfo//:mountinfo",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:windows": [
+            "@org_golang_x_sys//windows",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "filesystem_test",
+    srcs = [
+        "filesystem_nix_test.go",
+        "filesystem_test.go",
+    ],
+    embed = [":filesystem"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "@com_github_moby_sys_mountinfo//:mountinfo",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "@com_github_moby_sys_mountinfo//:mountinfo",
+        ],
+        "@rules_go//go/platform:ios": [
+            "@com_github_moby_sys_mountinfo//:mountinfo",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_moby_sys_mountinfo//:mountinfo",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/pkg/gohai/memory/BUILD.bazel
+++ b/pkg/gohai/memory/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "memory",
+    srcs = [
+        "memory.go",
+        "memory_darwin.go",
+        "memory_linux.go",
+        "memory_windows.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/gohai/memory",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/gohai/utils",
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:ios": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:windows": [
+            "@org_golang_x_sys//windows",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "memory_test",
+    srcs = [
+        "memory_linux_test.go",
+        "memory_test.go",
+    ],
+    embed = [":memory"],
+    gotags = ["test"],
+    deps = [
+        "//pkg/gohai/utils",
+        "@com_github_stretchr_testify//assert",
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/pkg/gohai/network/BUILD.bazel
+++ b/pkg/gohai/network/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "network",
+    srcs = ["network.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/gohai/network",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/gohai/utils"],
+)
+
+go_test(
+    name = "network_test",
+    srcs = ["network_test.go"],
+    embed = [":network"],
+    deps = [
+        "//pkg/gohai/utils",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/gohai/platform/BUILD.bazel
+++ b/pkg/gohai/platform/BUILD.bazel
@@ -1,0 +1,71 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "platform",
+    srcs = [
+        "platform.go",
+        "platform_darwin.go",
+        "platform_linux.go",
+        "platform_windows.go",
+        "platform_windows_386.go",
+        "platform_windows_amd64.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/gohai/platform",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/gohai/utils",
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//pkg/util/log",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//pkg/util/log",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:windows": [
+            "@org_golang_x_sys//windows",
+            "@org_golang_x_sys//windows/registry",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "platform_test",
+    srcs = [
+        "platform_darwin_test.go",
+        "platform_linux_test.go",
+        "platform_test.go",
+    ],
+    embed = [":platform"],
+    gotags = ["test"],
+    deps = [
+        "//pkg/gohai/utils",
+        "@com_github_stretchr_testify//assert",
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "@com_github_stretchr_testify//require",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "@com_github_stretchr_testify//require",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:ios": [
+            "@com_github_stretchr_testify//require",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//require",
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/pkg/gohai/processes/BUILD.bazel
+++ b/pkg/gohai/processes/BUILD.bazel
@@ -1,0 +1,52 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "processes",
+    srcs = [
+        "processes.go",
+        "processes_nix.go",
+        "processes_windows.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/gohai/processes",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "//pkg/gohai/processes/gops",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//pkg/gohai/processes/gops",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//pkg/gohai/processes/gops",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/gohai/processes/gops",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "processes_test",
+    srcs = ["processes_test.go"],
+    embed = [":processes"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:ios": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/pkg/gohai/processes/gops/BUILD.bazel
+++ b/pkg/gohai/processes/gops/BUILD.bazel
@@ -1,0 +1,65 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "gops",
+    srcs = [
+        "gops.go",
+        "process_group.go",
+        "process_info.go",
+        "process_info_darwin.go",
+        "process_info_linux.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/gohai/processes/gops",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//mem",
+            "@com_github_shirou_gopsutil_v4//process",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//mem",
+            "@com_github_shirou_gopsutil_v4//process",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//mem",
+            "@com_github_shirou_gopsutil_v4//process",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/util/log",
+            "@com_github_shirou_gopsutil_v4//mem",
+            "@com_github_shirou_gopsutil_v4//process",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "gops_test",
+    srcs = [
+        "process_group_test.go",
+        "process_info_test.go",
+    ],
+    embed = [":gops"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:ios": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/pkg/gohai/utils/BUILD.bazel
+++ b/pkg/gohai/utils/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "utils",
+    srcs = [
+        "common.go",
+        "helpers.go",
+        "test_helpers.go",
+        "value.go",
+        "value_helpers.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/gohai/utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)
+
+go_test(
+    name = "utils_test",
+    srcs = [
+        "common_test.go",
+        "value_test.go",
+    ],
+    embed = [":utils"],
+    gotags = ["test"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/util/hostinfo/BUILD.bazel
+++ b/pkg/util/hostinfo/BUILD.bazel
@@ -73,9 +73,9 @@ go_library(
             "@com_github_shirou_gopsutil_v4//host",
         ],
         "@rules_go//go/platform:windows": [
+            "//pkg/gohai/platform",
             "//pkg/util/uuid",
             "//pkg/util/winutil",
-            "@com_github_datadog_datadog_agent_pkg_gohai//platform",
             "@com_github_shirou_w32//:w32",
             "@org_golang_x_sys//windows",
         ],
@@ -184,9 +184,9 @@ go_test(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:windows": [
+            "//pkg/gohai/platform",
             "//pkg/util/cache",
             "//pkg/util/winutil",
-            "@com_github_datadog_datadog_agent_pkg_gohai//platform",
             "@com_github_stretchr_testify//assert",
         ],
         "//conditions:default": [],


### PR DESCRIPTION
### What does this PR do?

Migrate packages in `pkg/gohai` to bazel

### Motivation

Migrating go code to bazel (ABLD-425)

### Describe how you validated your changes

Local gazelle runs & `bazel test //comp/... //pkg/...`

### Additional Notes

This PR also removes a stray exclusion for `comp/core/tagger/telemetry` which was already migrated

:warning: This is the first cgo test migrated for windows, it appears to need `libgcc.dll` which isn't available for now.
I added `-static-libgcc` to the `go_test` ldflags as a quick getaway, but I'd rather discuss this more thoroughly with the team first