### PR TITLE
Add back chocolatey ...

### DIFF
--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -60,6 +60,10 @@ func (s *windowsTestSuite) SetupSuite() {
 
 	// Start an antivirus scan to use as process for testing
 	s.Env().RemoteHost.MustExecute("Start-MpScan -ScanType FullScan -AsJob")
+	// Install chocolatey - https://chocolatey.org/install
+	// This may be due to choco rate limits - https://datadoghq.atlassian.net/browse/ADXT-950
+	stdout, err := s.Env().RemoteHost.Execute("Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iwr https://community.chocolatey.org/install.ps1 -UseBasicParsing | iex")
+	require.NoErrorf(s.T(), err, "Failed to install chocolatey: %s, err: %s", stdout, err)
 	// DiskSpd for IO tests: zip on E2E artifact host at processes/DiskSpd.zip (see diskspd.go).
 	require.NoError(s.T(), setupDiskSpd(s.Env().RemoteHost))
 }


### PR DESCRIPTION
### What does this PR do?

Chocolatey was removed in: https://github.com/DataDog/datadog-agent/pull/48688
But a later PR update a test to use it again, hence it breaks with the conflict.

Adds back chocolatey to buy some time properly fixing the test.
https://github.com/DataDog/datadog-agent/pull/48833

### Motivation

### Describe how you validated your changes

### Additional Notes
