### PR TITLE
[NDM] Fix SNMP autodiscovery default ping timeout

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4062,7 +4062,7 @@ api_key:
 #
 #       enabled: false
 
-#       # @param timeout - integer - optional - default: 5
+#       # @param timeout - integer - optional - default: 3000
 #       # @env DD_NETWORK_DEVICES_AUTODISCOVERY_PING_TIMEOUT - integer - optional - default: 3000
 #       # Timeout in milliseconds
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4063,7 +4063,7 @@ api_key:
 #       enabled: false
 
 #       # @param timeout - integer - optional - default: 5
-#       # @env DD_NETWORK_DEVICES_AUTODISCOVERY_PING_TIMEOUT - integer - optional - default: 5
+#       # @env DD_NETWORK_DEVICES_AUTODISCOVERY_PING_TIMEOUT - integer - optional - default: 3000
 #       # Timeout in milliseconds
 #
 #       timeout: 3000

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -216,7 +216,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_devices.autodiscovery.ping.enabled", false)
 	config.BindEnvAndSetDefault("network_devices.autodiscovery.ping.count", 2)
 	config.BindEnvAndSetDefault("network_devices.autodiscovery.ping.interval", 10)
-	config.BindEnvAndSetDefault("network_devices.autodiscovery.ping.timeout", 5)
+	config.BindEnvAndSetDefault("network_devices.autodiscovery.ping.timeout", 3000)
 	config.BindEnvAndSetDefault("network_devices.autodiscovery.ping.linux.use_raw_socket", false)
 	config.BindEnvAndSetDefault("network_devices.autodiscovery.use_deduplication", false)
 	config.BindEnvAndSetDefault("network_devices.autodiscovery.collect_vpn", false)


### PR DESCRIPTION
### What does this PR do?
The SNMP autodiscovery default ping timeout was incorrectly set to 5ms. This PR updates it to 3s

### Motivation

### Describe how you validated your changes

### Additional Notes
