### PR TITLE
fix: Fix create-vm -p flag

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -96,6 +96,7 @@ from tasks.e2e_framework import azure as e2e_azure
 from tasks.e2e_framework import gcp as e2e_gcp
 from tasks.e2e_framework import localpodman as e2e_localpodman
 from tasks.e2e_framework import test as e2e_test
+from tasks.e2e_framework.deploy import check_s3_image_exists
 from tasks.e2e_framework.setup import setup as e2e_setup
 from tasks.fuzz import fuzz
 from tasks.fuzz_infra import build_and_upload_fuzz
@@ -281,8 +282,9 @@ ns.add_collection(e2e_localpodman.collection, "localpodman")
 e2e_ns = Collection("e2e")
 e2e_ns.add_collection(e2e_setup)
 e2e_ns.add_collection(e2e_test)
-ns.add_collection(e2e_ns)
+e2e_ns.add_task(check_s3_image_exists)
 
+ns.add_collection(e2e_ns)
 ns.configure(
     {
         "run": {

--- a/tasks/e2e_framework/aws/deploy.py
+++ b/tasks/e2e_framework/aws/deploy.py
@@ -67,7 +67,7 @@ def deploy(
 
     # Verify image deployed and not outdated in s3
     if deploy_job is not None and pipeline_id is not None:
-        cmd = f"inv -e check-s3-image-exists --pipeline-id={pipeline_id} --deploy-job={deploy_job}"
+        cmd = f"inv -e e2e.check-s3-image-exists --pipeline-id={pipeline_id} --deploy-job={deploy_job}"
         cmd = tool.get_aws_wrapper(aws_account) + cmd
         output = ctx.run(cmd, warn=True)
 


### PR DESCRIPTION
### What does this PR do?

After updating the tasks to live in the root of datadog-agent, the `-p` flag on `create-vm` was raising an error when checking for the pipeline package availability. Fix that issue

### Motivation

### Describe how you validated your changes

### Additional Notes
