### PR TITLE
feat(host-profiler): switch OTLP export compression to zstd

### DIFF
--- a/cmd/host-profiler/docker-compose.yml
+++ b/cmd/host-profiler/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - /proc/:/host/proc/:ro
       - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
       - agent-ipc:/etc/datadog-agent:rw
-      - ../../dev/dist/datadog.yaml:/etc/datadog-agent/datadog.yaml:ro
     secrets:
       - dd-api-key
     entrypoint: [ '/bin/sh', '-c', 'export DD_API_KEY=$$(cat /run/secrets/dd-api-key) ; /bin/entrypoint.sh' ]
@@ -39,7 +38,6 @@ services:
       - ../..:/app
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - agent-ipc:/etc/datadog-agent:ro
-      - ../../dev/dist/datadog.yaml:/etc/datadog-agent/datadog.yaml:ro
     secrets:
       - dd-api-key
       - dd-app-key

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -64,6 +64,7 @@ func buildExporters(conf confMap, agent configManager) []any {
 		return confMap{
 			"profiles_endpoint": fmt.Sprintf(profilesEndpointFormat, site),
 			"metrics_endpoint":  fmt.Sprintf(metricsEndpointFormat, site),
+			"compression":       "zstd",
 			"headers":           headers,
 		}
 	}

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
@@ -2,6 +2,7 @@ exporters:
     debug:
         verbosity: detailed
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.eu_0:
+        compression: zstd
         headers:
             dd-api-key: eu_key_1
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-disabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-disabled/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-enabled/otel.yaml
@@ -2,6 +2,7 @@ exporters:
     debug:
         verbosity: detailed
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: additional_api_key
             dd-evp-origin: host-profiler
@@ -7,6 +8,7 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/datadoghq.com_1:
+        compression: zstd
         headers:
             dd-api-key: main_api_key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler
@@ -7,6 +8,7 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/us3.datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: us3_api_key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/us3.datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: main_key
             dd-evp-origin: host-profiler
@@ -7,6 +8,7 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/datadoghq.eu_0:
+        compression: zstd
         headers:
             dd-api-key: eu_key_1
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: main_key
             dd-evp-origin: host-profiler
@@ -7,6 +8,7 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/datadoghq.eu_0:
+        compression: zstd
         headers:
             dd-api-key: eu_key_1
             dd-evp-origin: host-profiler
@@ -14,6 +16,7 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
     otlphttp/datadoghq.eu_1:
+        compression: zstd
         headers:
             dd-api-key: eu_key_2
             dd-evp-origin: host-profiler
@@ -21,6 +24,7 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
     otlphttp/datadoghq.eu_2:
+        compression: zstd
         headers:
             dd-api-key: eu_key_3
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: test_api_key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.eu_0:
+        compression: zstd
         headers:
             dd-api-key: test_key_123
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.eu_0:
+        compression: zstd
         headers:
             dd-api-key: test_api_key_456
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -343,6 +343,10 @@ func (c *converterWithoutAgent) ensureOtlpHTTPExporterConfig(conf confMap, expor
 		if name, ok := nameAny.(string); ok && isComponentType(name, componentTypeOtlpHTTP) {
 			hasOtlpHTTP = true
 
+			if _, err := SetDefault(conf, pathPrefixExporters+name+"::compression", "zstd"); err != nil {
+				return err
+			}
+
 			headers, err := Ensure[confMap](conf, pathPrefixExporters+name+"::headers")
 			if err != nil {
 				return err

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -63,12 +63,11 @@ const (
 
 // Configuration field names used multiple times
 const (
-	fieldAllowHostnameOverride = "allow_hostname_override"
-	fieldDDAPIKey              = "dd-api-key"
-	fieldDDEVPOrigin           = "dd-evp-origin"
-	fieldDDEVPOriginVersion    = "dd-evp-origin-version"
-	fieldAPIKey                = "api_key"
-	fieldAppKey                = "app_key"
+	fieldDDAPIKey           = "dd-api-key"
+	fieldDDEVPOrigin        = "dd-evp-origin"
+	fieldDDEVPOriginVersion = "dd-evp-origin-version"
+	fieldAPIKey             = "api_key"
+	fieldAppKey             = "app_key"
 )
 
 // OTEL config path prefixes

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: "12345"
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -2,6 +2,7 @@ exporters:
     debug: {}
     logging: {}
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-existing-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-existing-ep/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-infer-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-infer-ep/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-level-none/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-level-none/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-mixed/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-mixed/out.yaml
@@ -1,10 +1,12 @@
 exporters:
     otlphttp/no-ep:
+        compression: zstd
         headers:
             dd-api-key: test-api-key-2
             dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
     otlphttp/with-ep:
+        compression: zstd
         headers:
             dd-api-key: test-api-key-1
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -1,11 +1,13 @@
 exporters:
     logging: {}
     otlphttp/prod:
+        compression: zstd
         headers:
             dd-api-key: "11111"
             dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
     otlphttp/staging:
+        compression: zstd
         headers:
             dd-api-key: staging-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-profiling-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-profiling-recv/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-evp-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-evp-headers/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: custom-origin

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         endpoint: http://localhost:4318
         headers:
             dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp:
+        compression: zstd
         headers:
             dd-api-key: test-api-key
             dd-evp-origin: host-profiler


### PR DESCRIPTION
### What does this PR do?

Switches the `otlphttpexporter` compression from the default gzip to zstd for OTLP profile and metrics exports.

- Agent-managed mode: sets `compression: zstd` in the generated exporter config
- Standalone mode: defaults to zstd via `SetDefault`, preserving user overrides

### Motivation

Zstd provides better compression ratios at lower CPU cost than gzip, and the backend already supports it.

### Describe how you validated your changes

- Provider golden file tests pass (`TestProvider -update`)
- Converter golden file tests pass (`TestConverterWithoutAgent -update`)
- Tested that profiles work in a Datadog workspace, and started seeing zstd compressed payloads: 
<img width="781" height="360" alt="image" src="https://github.com/user-attachments/assets/af2c33fe-80fe-4aec-8328-6e009788f852" />

### Additional Notes

Also removes the unused `fieldAllowHostnameOverride` const in a separate commit. And removed the `datadog.yaml` unneeded bind mount, we can replace it with env vars that override the default config instead of replacing it entirely.