### PR TITLE
[ACTP] remove hostname for cluster agent enrollments

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -276,7 +276,9 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 	}
 
 	runnerNamePrefix := runnerHostname
+	enrollmentHostname := runnerHostname
 	// For cluster agent, use cluster name instead of hostname for better identification
+	// and do not send the hostname in the enrollment request or connection tags as the cluster agent is a deployment so not tied to a specific host
 	if flavor.GetFlavor() == flavor.ClusterAgent {
 		clusterName := clustername.GetClusterName(ctx, runnerHostname)
 		if clusterName != "" {
@@ -284,9 +286,10 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 		} else {
 			p.logger.Warnf("Cluster name not found, falling back to hostname '%s' for cluster agent enrollment", runnerHostname)
 		}
+		enrollmentHostname = ""
 	}
 
-	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerNamePrefix, runnerHostname, apiKey, appKey)
+	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerNamePrefix, enrollmentHostname, apiKey, appKey)
 	if err != nil {
 		return nil, fmt.Errorf("enrollment API call failed: %w", err)
 	}

--- a/pkg/privateactionrunner/autoconnections/client_test.go
+++ b/pkg/privateactionrunner/autoconnections/client_test.go
@@ -29,10 +29,13 @@ func (m *mockTagsProvider) GetTags(ctx context.Context, runnerID, hostname strin
 		return m.tags
 	}
 	// Default: return basic tags
-	return []string{
+	tags := []string{
 		"runner-id:" + runnerID,
-		"hostname:" + hostname,
 	}
+	if hostname != "" {
+		tags = append(tags, "hostname:"+hostname)
+	}
+	return tags
 }
 
 func TestNewConnectionAPIClient_ValidCredentials(t *testing.T) {
@@ -63,7 +66,7 @@ func TestBuildConnectionRequest_NoAdditionalFields(t *testing.T) {
 	runnerID := "2112072a-b24c-4f23-b80e-d4e93484cf3a"
 	runnerName := "runner-123"
 	connectionName := "HTTP (runner-123)"
-	tags := []string{"runner-id:test", "hostname:test-host"}
+	tags := []string{"runner-id:test"}
 
 	request := buildConnectionRequest(httpDef, runnerID, runnerName, tags)
 
@@ -206,7 +209,7 @@ func TestCreateConnection_ErrorResponses(t *testing.T) {
 				},
 			}
 
-			tags := []string{"runner-id:runner-id-123", "hostname:test-hostname"}
+			tags := []string{"runner-id:runner-id-123"}
 
 			err := client.CreateConnection(context.Background(), httpDef, "runner-id-123", "runner-name-abc", tags)
 
@@ -298,7 +301,7 @@ func TestBuildConnectionRequest_JSONStructureMatchesAPISpec(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tags := []string{"runner-id:runner-123", "hostname:test-host"}
+			tags := []string{"runner-id:runner-123"}
 			request := buildConnectionRequest(tt.definition, tt.runnerID, tt.runnerName, tags)
 
 			jsonBytes, err := jsonapi.Marshal(request, jsonapi.MarshalClientMode())

--- a/pkg/privateactionrunner/autoconnections/connections_creator_test.go
+++ b/pkg/privateactionrunner/autoconnections/connections_creator_test.go
@@ -49,7 +49,7 @@ func TestCreateConnection_CorrectHTTPRequest(t *testing.T) {
 
 	definition := supportedConnections["kubernetes"]
 
-	tags := []string{"runner-id:runner-id-abc123", "hostname:test-hostname"}
+	tags := []string{"runner-id:runner-id-abc123"}
 
 	err := client.CreateConnection(context.Background(), definition, "runner-id-abc123", "runner-name-abc123", tags)
 
@@ -121,7 +121,7 @@ func TestCreateConnection_StatusCodeHandling(t *testing.T) {
 
 			definition := supportedConnections["kubernetes"]
 
-			tags := []string{"runner-id:runner-id-abc123", "hostname:test-hostname"}
+			tags := []string{"runner-id:runner-id-abc123"}
 
 			err := client.CreateConnection(context.Background(), definition, "runner-id-abc123", "runner-name-abc123", tags)
 

--- a/pkg/privateactionrunner/autoconnections/tags_provider.go
+++ b/pkg/privateactionrunner/autoconnections/tags_provider.go
@@ -44,8 +44,11 @@ func NewTagsProvider(tagger tagger.Component) TagsProvider {
 func (p *taggerBasedTagsProvider) GetTags(ctx context.Context, runnerID, hostname string) []string {
 	tags := []string{
 		"runner-id:" + runnerID,
-		"hostname:" + hostname,
 		"agent_flavor:" + flavor.GetFlavor(),
+	}
+
+	if hostname != "" {
+		tags = append(tags, "hostname:"+hostname)
 	}
 
 	// Only attempt to get cluster tags if cluster_agent is enabled

--- a/pkg/privateactionrunner/autoconnections/tags_provider_test.go
+++ b/pkg/privateactionrunner/autoconnections/tags_provider_test.go
@@ -63,6 +63,18 @@ func TestTagsProvider_NoClusterTagsAvailable(t *testing.T) {
 	assert.Contains(t, tags, "agent_flavor:agent")
 }
 
+func TestTagsProvider_EmptyHostnameOmitted(t *testing.T) {
+	mockTagger := taggerfxmock.SetupFakeTagger(t)
+	provider := NewTagsProvider(mockTagger)
+
+	tags := provider.GetTags(context.Background(), "runner-abc", "")
+
+	require.Len(t, tags, 2)
+	assert.Contains(t, tags, "runner-id:runner-abc")
+	assert.Contains(t, tags, "agent_flavor:agent")
+	assert.NotContains(t, tags, "hostname:")
+}
+
 func TestTagsProvider_AllWhitelistedTags(t *testing.T) {
 	mockTagger := taggerfxmock.SetupFakeTagger(t)
 	mockTagger.SetGlobalTags([]string{

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -33,7 +33,7 @@ type Result struct {
 type PersistedIdentity struct {
 	PrivateKey string `json:"private_key"`
 	URN        string `json:"urn"`
-	Hostname   string `json:"hostname"`
+	Hostname   string `json:"hostname,omitempty"`
 }
 
 // SelfEnroll performs self-registration of a private action runner using API credentials


### PR DESCRIPTION
### What does this PR do?

Remove hostname tag for cluster agent enrollment (on PAR object and on connection tags)

### Motivation

Cluster Agents are deployed as kubernetes deployment so they are not tied to a specific host. We get the hostname from the leader at the time of the enrollment which is not really useful and could cause confusion

### Describe how you validated your changes

Deployed in a local cluster

For the cluster agent
<img width="292" height="112" alt="image" src="https://github.com/user-attachments/assets/cc6a94eb-b089-44a5-9ddd-4c666e01a019" />

For the node agent
<img width="293" height="69" alt="image" src="https://github.com/user-attachments/assets/843f6310-dd34-42bc-9f8e-e0b3a20a72e4" />


### Additional Notes
