### PR TITLE
[PROF-14197] feat: add ddprofiling option to agent config

### DIFF
--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -168,8 +168,17 @@ func buildConfig(agent configManager, p params.CollectorParams) confMap {
 
 	buildMetricsPipeline(config, p.GetGoRuntimeMetrics(), profilesProcessors, profilesExporters)
 
-	_ = converters.Set(config, "extensions::ddprofiling/default", confMap{})
 	_ = converters.Set(config, "extensions::hpflare/default", confMap{})
+	serviceExtensions := []any{"hpflare/default"}
+	if agent.hostProfilerConfig.DDProfilingEnabled {
+		ddprofilingConfig := make(confMap)
+		if agent.hostProfilerConfig.DDProfilingPeriod > 0 {
+			_ = converters.Set(ddprofilingConfig, "profiler_options::period", agent.hostProfilerConfig.DDProfilingPeriod)
+		}
+		_ = converters.Set(config, "extensions::ddprofiling/default", ddprofilingConfig)
+		serviceExtensions = append(serviceExtensions, "ddprofiling/default")
+	}
+	_ = converters.Set(config, "service::extensions", serviceExtensions)
 
 	log.Debugf("Generated configuration: %+v", config)
 

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build test
+//go:build linux && test
 
 package agentprovider
 

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
@@ -65,6 +65,85 @@ func TestBuildExportersNoAdditionalHTTPHeaders(t *testing.T) {
 	assert.Len(t, headers, 3) // dd-api-key, dd-evp-origin, dd-evp-origin-version
 }
 
+func TestBuildConfigDDProfilingEnabled(t *testing.T) {
+	agent := configManager{
+		endpoints: []endpoint{{
+			site:    "datadoghq.com",
+			apiKeys: []string{"test_key"},
+		}},
+		endpointsTotalLength: 1,
+		hostProfilerConfig: hostProfilerConfig{
+			DDProfilingEnabled: true,
+		},
+	}
+	conf := buildConfig(agent, testCollectorParams{})
+
+	extensions, ok := conf["extensions"].(confMap)
+	require.True(t, ok)
+	ddprofiling, ok := extensions["ddprofiling/default"].(confMap)
+	require.True(t, ok)
+	assert.Empty(t, ddprofiling, "ddprofiling config should be empty when period is not set")
+
+	service, ok := conf["service"].(confMap)
+	require.True(t, ok)
+	svcExtensions, ok := service["extensions"].([]any)
+	require.True(t, ok)
+	assert.Contains(t, svcExtensions, "ddprofiling/default")
+	assert.Contains(t, svcExtensions, "hpflare/default")
+}
+
+func TestBuildConfigDDProfilingEnabledWithPeriod(t *testing.T) {
+	agent := configManager{
+		endpoints: []endpoint{{
+			site:    "datadoghq.com",
+			apiKeys: []string{"test_key"},
+		}},
+		endpointsTotalLength: 1,
+		hostProfilerConfig: hostProfilerConfig{
+			DDProfilingEnabled: true,
+			DDProfilingPeriod:  30,
+		},
+	}
+	conf := buildConfig(agent, testCollectorParams{})
+
+	extensions, ok := conf["extensions"].(confMap)
+	require.True(t, ok)
+	ddprofiling, ok := extensions["ddprofiling/default"].(confMap)
+	require.True(t, ok)
+	profilerOptions, ok := ddprofiling["profiler_options"].(confMap)
+	require.True(t, ok)
+	assert.Equal(t, 30, profilerOptions["period"])
+
+	service, ok := conf["service"].(confMap)
+	require.True(t, ok)
+	svcExtensions, ok := service["extensions"].([]any)
+	require.True(t, ok)
+	assert.Contains(t, svcExtensions, "ddprofiling/default")
+}
+
+func TestBuildConfigDDProfilingDisabled(t *testing.T) {
+	agent := configManager{
+		endpoints: []endpoint{{
+			site:    "datadoghq.com",
+			apiKeys: []string{"test_key"},
+		}},
+		endpointsTotalLength: 1,
+	}
+	conf := buildConfig(agent, testCollectorParams{})
+
+	extensions, ok := conf["extensions"].(confMap)
+	require.True(t, ok)
+	_, ok = extensions["ddprofiling/default"]
+	assert.False(t, ok, "ddprofiling extension should not be present when disabled")
+
+	service, ok := conf["service"].(confMap)
+	require.True(t, ok)
+	svcExtensions, ok := service["extensions"].([]any)
+	require.True(t, ok)
+	assert.NotContains(t, svcExtensions, "ddprofiling/default")
+	assert.Contains(t, svcExtensions, "hpflare/default")
+}
+
 func TestBuildExportersAdditionalHTTPHeadersDoNotOverrideRequired(t *testing.T) {
 	agent := configManager{
 		endpoints: []endpoint{{

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager.go
@@ -15,8 +15,9 @@ import (
 type hostProfilerConfig struct {
 	DebugVerbosity        string
 	AdditionalHTTPHeaders map[string]string
-	DDProfilingEnabled    bool
-	DDProfilingPeriod     int
+	DDProfilingEnabled bool
+	// DDProfilingPeriod is the profiling period in seconds. Values <= 0 fall back to the extension's default.
+	DDProfilingPeriod int
 }
 
 type endpoint struct {

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager.go
@@ -15,9 +15,8 @@ import (
 type hostProfilerConfig struct {
 	DebugVerbosity        string
 	AdditionalHTTPHeaders map[string]string
-	DDProfilingEnabled bool
-	// DDProfilingPeriod is the profiling period in seconds. Values <= 0 fall back to the extension's default.
-	DDProfilingPeriod int
+	DDProfilingEnabled    bool
+	DDProfilingPeriod     int
 }
 
 type endpoint struct {

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager.go
@@ -15,6 +15,8 @@ import (
 type hostProfilerConfig struct {
 	DebugVerbosity        string
 	AdditionalHTTPHeaders map[string]string
+	DDProfilingEnabled    bool
+	DDProfilingPeriod     int
 }
 
 type endpoint struct {
@@ -88,6 +90,8 @@ func newConfigManager(config config.Component) configManager {
 	hostProfilerConfig := hostProfilerConfig{
 		DebugVerbosity:        config.GetString("hostprofiler.debug.verbosity"),
 		AdditionalHTTPHeaders: config.GetStringMapString("hostprofiler.additional_http_headers"),
+		DDProfilingEnabled:    config.GetBool("hostprofiler.ddprofiling.enabled"),
+		DDProfilingPeriod:     config.GetInt("hostprofiler.ddprofiling.period"),
 	}
 
 	return configManager{

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager_test.go
@@ -79,3 +79,73 @@ site: datadoghq.com
 
 	assert.Empty(t, mgr.hostProfilerConfig.AdditionalHTTPHeaders)
 }
+
+func TestNewConfigManagerDDProfilingEnabledFromYAML(t *testing.T) {
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+hostprofiler:
+  ddprofiling:
+    enabled: true
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.True(t, mgr.hostProfilerConfig.DDProfilingEnabled)
+}
+
+func TestNewConfigManagerDDProfilingEnabledFromEnvVar(t *testing.T) {
+	t.Setenv("DD_HOSTPROFILER_DDPROFILING_ENABLED", "true")
+
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.True(t, mgr.hostProfilerConfig.DDProfilingEnabled)
+}
+
+func TestNewConfigManagerDDProfilingEnabledDefault(t *testing.T) {
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.False(t, mgr.hostProfilerConfig.DDProfilingEnabled)
+}
+
+func TestNewConfigManagerDDProfilingPeriodFromYAML(t *testing.T) {
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+hostprofiler:
+  ddprofiling:
+    period: 30
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.Equal(t, 30, mgr.hostProfilerConfig.DDProfilingPeriod)
+}
+
+func TestNewConfigManagerDDProfilingPeriodFromEnvVar(t *testing.T) {
+	t.Setenv("DD_HOSTPROFILER_DDPROFILING_PERIOD", "45")
+
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.Equal(t, 45, mgr.hostProfilerConfig.DDProfilingPeriod)
+}
+
+func TestNewConfigManagerDDProfilingPeriodDefault(t *testing.T) {
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.Equal(t, 0, mgr.hostProfilerConfig.DDProfilingPeriod)
+}

--- a/comp/host-profiler/collector/impl/agentprovider/provider_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/provider_test.go
@@ -230,6 +230,16 @@ func TestProvider(t *testing.T) {
 			agentConfig:  "provider/add-headers-debug/agent.yaml",
 			expectedOTel: "provider/add-headers-debug/otel.yaml",
 		},
+		{
+			name:         "ddprofiling-enabled",
+			agentConfig:  "provider/ddprofiling-enabled/agent.yaml",
+			expectedOTel: "provider/ddprofiling-enabled/otel.yaml",
+		},
+		{
+			name:         "ddprofiling-period",
+			agentConfig:  "provider/ddprofiling-period/agent.yaml",
+			expectedOTel: "provider/ddprofiling-period/otel.yaml",
+		},
 	}
 
 	for _, tt := range tests {

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
@@ -11,7 +11,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -55,6 +54,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
@@ -10,7 +10,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -54,6 +53,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
@@ -8,7 +8,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -52,6 +51,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/agent.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/agent.yaml
@@ -1,0 +1,5 @@
+site: datadoghq.com
+api_key: test_api_key_123
+hostprofiler:
+    ddprofiling:
+        enabled: true

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/otel.yaml
@@ -1,13 +1,13 @@
 exporters:
-    otlphttp/datadoghq.eu_0:
-        compression: zstd
+    otlphttp/datadoghq.com_0:
         headers:
-            dd-api-key: eu_key_1
+            dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
-        metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
-        profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:
+    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -35,8 +35,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-                - api_key: eu_key_1
-                  site: datadoghq.eu
+                - api_key: test_api_key_123
+                  site: datadoghq.com
     prometheus:
         config:
             scrape_configs:
@@ -53,10 +53,11 @@ receivers:
 service:
     extensions:
         - hpflare/default
+        - ddprofiling/default
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.eu_0
+                - otlphttp/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -66,7 +67,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.eu_0
+                - otlphttp/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/agent.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/agent.yaml
@@ -1,0 +1,6 @@
+site: datadoghq.com
+api_key: test_api_key_123
+hostprofiler:
+    ddprofiling:
+        enabled: true
+        period: 30

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/otel.yaml
@@ -1,5 +1,6 @@
 exporters:
     otlphttp/datadoghq.com_0:
+        compression: zstd
         headers:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/otel.yaml
@@ -1,13 +1,15 @@
 exporters:
-    otlphttp/datadoghq.eu_0:
-        compression: zstd
+    otlphttp/datadoghq.com_0:
         headers:
-            dd-api-key: eu_key_1
+            dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
-        metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
-        profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:
+    ddprofiling/default:
+        profiler_options:
+            period: 30
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -35,8 +37,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-                - api_key: eu_key_1
-                  site: datadoghq.eu
+                - api_key: test_api_key_123
+                  site: datadoghq.com
     prometheus:
         config:
             scrape_configs:
@@ -53,10 +55,11 @@ receivers:
 service:
     extensions:
         - hpflare/default
+        - ddprofiling/default
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.eu_0
+                - otlphttp/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -66,7 +69,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.eu_0
+                - otlphttp/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-disabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-disabled/otel.yaml
@@ -8,7 +8,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -52,6 +51,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-enabled/otel.yaml
@@ -10,7 +10,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -54,6 +53,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
@@ -16,7 +16,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -62,6 +61,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
@@ -16,7 +16,6 @@ exporters:
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -62,6 +61,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
@@ -8,7 +8,6 @@ exporters:
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -52,6 +51,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
@@ -16,7 +16,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -62,6 +61,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
@@ -32,7 +32,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -82,6 +81,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/multiple-endpoints/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/multiple-endpoints/otel.yaml
@@ -15,7 +15,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     infraattributes/default:
@@ -34,6 +33,8 @@ receivers:
                 - api_key: main_api_key
                   site: datadoghq.com
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         profiles:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
@@ -8,7 +8,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -52,6 +51,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
@@ -8,7 +8,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -52,6 +51,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
@@ -8,7 +8,6 @@ exporters:
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
 extensions:
-    ddprofiling/default: {}
     hpflare/default: {}
 processors:
     cumulativetodelta: {}
@@ -52,6 +51,8 @@ receivers:
                     - targets:
                         - 127.0.0.1:8888
 service:
+    extensions:
+        - hpflare/default
     pipelines:
         metrics:
             exporters:

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1055,6 +1055,8 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	// Host Profiler config
 	config.BindEnvAndSetDefault("hostprofiler.debug.verbosity", "")
 	config.BindEnvAndSetDefault("hostprofiler.additional_http_headers", map[string]string{})
+	config.BindEnvAndSetDefault("hostprofiler.ddprofiling.enabled", false)
+	config.BindEnvAndSetDefault("hostprofiler.ddprofiling.period", 0)
 }
 
 func agent(config pkgconfigmodel.Setup) {


### PR DESCRIPTION
### What does this PR do?

Add a `ddprofiling` config option in the agent config, with support for `period`.

### Motivation

Recently, we added support for enabling `ddprofiling` in bundled deployments in `k8s-datadog-agent-ops`. However, we no longer rely on the OTel config for bundled mode, so we need to figure out how to support this through the agent config.

### Describe how you validated your changes

### Additional Notes
