### PR TITLE
bazel: remove erroneous exclusion of comp/core/tagger/telemetry

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -93,7 +93,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/core/tagger/subscriber
 # gazelle:exclude comp/core/tagger/taglist
 # gazelle:exclude comp/core/tagger/tagstore
-# gazelle:exclude comp/core/tagger/telemetry
 # gazelle:exclude comp/core/workloadfilter
 # gazelle:exclude comp/core/workloadmeta
 # gazelle:exclude comp/core/workloadmeta


### PR DESCRIPTION
### What does this PR do?

Remove a leftover exclude clause, most likely due to a faulty commit resolution

### Motivation

Its build file is already present and can be regenerated by gazelle

### Describe how you validated your changes

Re-run gazelle after applying this change and verified that nothing is updated

### Additional Notes
