### PR TITLE
Correct post-install ddot installation without datadog.yaml

### DIFF
--- a/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
@@ -219,7 +219,7 @@ func preRemoveDatadogAgentDDOT(ctx HookContext) error {
 	return nil
 }
 
-// writeOTelConfig creates otel-config.yaml by substituting API key and site values from datadog.yaml
+// writeOTelConfig creates otel-config.yaml by substituting API key and site values from datadog.yaml, fallback with env variables.
 func writeOTelConfig(ctx HookContext) error {
 	return writeOTelConfigCommon(ctx, datadogYamlPath, otelConfigExamplePath, otelConfigPath, false, 0640)
 }

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_windows.go
@@ -139,7 +139,7 @@ func preRemoveDatadogAgentDdot(ctx HookContext) error {
 	return nil
 }
 
-// writeOTelConfigWindows creates otel-config.yaml by substituting API key and site values from datadog.yaml
+// writeOTelConfigWindows creates otel-config.yaml by substituting API key and site values from datadog.yaml, fallback with env variables.
 func writeOTelConfigWindows(ctx HookContext) error {
 	ddYaml := filepath.Join(paths.DatadogDataDir, "datadog.yaml")
 	// Prefer packaged example/template from the installed package repository

--- a/pkg/fleet/installer/packages/otel_config_common.go
+++ b/pkg/fleet/installer/packages/otel_config_common.go
@@ -6,11 +6,14 @@
 package packages
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"go.yaml.in/yaml/v2"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 )
 
 // enableOTelCollectorConfigInDatadogYAML adds otelcollector.enabled and agent_ipc defaults to the given datadog.yaml path
@@ -21,6 +24,13 @@ func enableOTelCollectorConfigInDatadogYAML(ctx HookContext, datadogYamlPath str
 
 	data, err := os.ReadFile(datadogYamlPath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// datadog.yaml not yet written (fresh install); the install script or a
+			// subsequent configure step is responsible for enabling otelcollector.
+			span.SetTag("datadog.yaml_found", false)
+			return nil
+		}
+		span.SetTag("datadog.yaml_found", true)
 		return fmt.Errorf("failed to read datadog.yaml: %w", err)
 	}
 	var existing map[string]any
@@ -75,16 +85,26 @@ func writeOTelConfigCommon(ctx HookContext, datadogYamlPath, templatePath, outPa
 		}
 	}
 
+	var apiKey, site string
 	data, err := os.ReadFile(datadogYamlPath)
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to read datadog.yaml: %w", err)
 	}
-	var cfg map[string]any
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return fmt.Errorf("failed to parse datadog.yaml: %w", err)
+	if err == nil {
+		span.SetTag("datadog.yaml_found", true)
+		var cfg map[string]any
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			return fmt.Errorf("failed to parse datadog.yaml: %w", err)
+		}
+		apiKey, _ = cfg["api_key"].(string)
+		site, _ = cfg["site"].(string)
+	} else {
+		// datadog.yaml not yet written (fresh install); fall back to environment variables
+		span.SetTag("datadog.yaml_found", false)
+		e := env.FromEnv()
+		apiKey = e.APIKey
+		site = e.Site
 	}
-	apiKey, _ := cfg["api_key"].(string)
-	site, _ := cfg["site"].(string)
 
 	templateData, err := os.ReadFile(templatePath)
 	if err != nil {

--- a/pkg/fleet/installer/packages/otel_config_common_test.go
+++ b/pkg/fleet/installer/packages/otel_config_common_test.go
@@ -15,23 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWriteOTelConfigCommonSiteSubstitution(t *testing.T) {
-	const template = "endpoint: ${env:DD_SITE}\napi_key: ${env:DD_API_KEY}\n"
-
+func TestEnableOTelCollectorConfigInDatadogYAML(t *testing.T) {
 	tests := []struct {
-		name         string
-		datadogYAML  string
-		expectedSite string
+		name          string
+		datadogYAML   string
+		expectContent []string
+		isDatadogYAML bool
 	}{
 		{
-			name:         "defaults to datadoghq.com when site is not set",
-			datadogYAML:  "api_key: testapikey\n",
-			expectedSite: "datadoghq.com",
+			name:          "adds otelcollector.enabled and agent_ipc defaults when datadog.yaml is present",
+			datadogYAML:   "initial_configuration: present\n",
+			expectContent: []string{"otelcollector:\n  enabled: true", "agent_ipc:\n", "  port: 5009\n", "  config_refresh_interval: 60\n"},
+			isDatadogYAML: true,
 		},
 		{
-			name:         "uses explicit site when set",
-			datadogYAML:  "api_key: testapikey\nsite: datadoghq.eu\n",
-			expectedSite: "datadoghq.eu",
+			name:          "Skip when datadog.yaml is not present",
+			isDatadogYAML: false,
 		},
 	}
 
@@ -40,7 +39,65 @@ func TestWriteOTelConfigCommonSiteSubstitution(t *testing.T) {
 			dir := t.TempDir()
 
 			datadogYamlPath := filepath.Join(dir, "datadog.yaml")
-			require.NoError(t, os.WriteFile(datadogYamlPath, []byte(tc.datadogYAML), 0o644))
+			if tc.isDatadogYAML {
+				require.NoError(t, os.WriteFile(datadogYamlPath, []byte(tc.datadogYAML), 0o644))
+			}
+
+			ctx := HookContext{Context: context.Background()}
+			require.NoError(t, enableOTelCollectorConfigInDatadogYAML(ctx, datadogYamlPath))
+
+			if tc.isDatadogYAML {
+				content, err := os.ReadFile(datadogYamlPath)
+				require.NoError(t, err)
+
+				for _, expected := range tc.expectContent {
+					assert.Contains(t, string(content), expected)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteOTelConfigCommonSiteSubstitution(t *testing.T) {
+	const template = "endpoint: ${env:DD_SITE}\napi_key: ${env:DD_API_KEY}\n"
+
+	tests := []struct {
+		name           string
+		datadogYAML    string
+		expectedAPIKey string
+		expectedSite   string
+		isDatadogYAML  bool
+	}{
+		{
+			name:           "defaults to datadoghq.com when site is not set",
+			datadogYAML:    "api_key: testapikey\n",
+			expectedAPIKey: "testapikey",
+			expectedSite:   "datadoghq.com",
+			isDatadogYAML:  true,
+		},
+		{
+			name:           "uses explicit site when set",
+			datadogYAML:    "api_key: testapikey\nsite: datadoghq.eu\n",
+			expectedAPIKey: "testapikey",
+			expectedSite:   "datadoghq.eu",
+			isDatadogYAML:  true,
+		},
+		{
+			name:           "Fallback when datadog.yaml is not present",
+			expectedAPIKey: "${env:DD_API_KEY}",
+			expectedSite:   "datadoghq.com",
+			isDatadogYAML:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			datadogYamlPath := filepath.Join(dir, "datadog.yaml")
+			if tc.isDatadogYAML {
+				require.NoError(t, os.WriteFile(datadogYamlPath, []byte(tc.datadogYAML), 0o644))
+			}
 
 			templatePath := filepath.Join(dir, "otel-config.yaml.tmpl")
 			require.NoError(t, os.WriteFile(templatePath, []byte(template), 0o644))

--- a/test/new-e2e/tests/installer/unix/package_ddot_test.go
+++ b/test/new-e2e/tests/installer/unix/package_ddot_test.go
@@ -125,6 +125,75 @@ func (s *packageDDOTSuite) TestInstallDDOTInstaller() {
 	s.host.Run("sudo grep -q 'otelcollector:' /etc/datadog-agent/datadog.yaml")
 }
 
+func (s *packageDDOTSuite) TestInstallDDOTWithoutDatadogYAML() {
+	testAPIKey := GetAPIKey()
+	testSite := "datadoghq.com"
+	defer s.Purge()
+
+	// Step 1: install the agent via the standard install script
+	// and creates /etc/datadog-agent/datadog.yaml.
+	s.RunInstallScript()
+	s.host.AssertPackageInstalledByInstaller("datadog-agent")
+
+	// Step 2: remove the agent package while keeping config files.
+	// apt-get remove (not purge) preserves /etc/datadog-agent/.
+	switch s.host.GetPkgManager() {
+	case "apt":
+		s.Env().RemoteHost.MustExecute("sudo apt-get remove -y datadog-agent")
+	case "yum":
+		s.Env().RemoteHost.MustExecute("sudo yum remove -y datadog-agent")
+	case "zypper":
+		s.Env().RemoteHost.MustExecute("sudo zypper remove -y datadog-agent")
+	default:
+		s.T().Fatalf("unsupported package manager: %s", s.host.GetPkgManager())
+	}
+
+	// Step 3: move datadog.yaml out of the way so the reinstall has no yaml.
+	s.Env().RemoteHost.MustExecute("sudo mv /etc/datadog-agent/datadog.yaml /etc/datadog-agent/datadog.yaml.bak")
+
+	// Step 4: reinstall via the package manager with DD_OTELCOLLECTOR_ENABLED=true.
+	// The repos are already configured by the install script in step 1.
+	// The full env from InstallScriptEnvWithPackages is required because the postinst
+	// hook downloads the DDOT extension via OCI and needs the registry/version overrides.
+	env := InstallScriptEnvWithPackages(s.arch, PackagesConfig)
+	env["DD_OTELCOLLECTOR_ENABLED"] = "true"
+	env["DD_API_KEY"] = testAPIKey
+	env["DD_SITE"] = testSite
+	switch s.host.GetPkgManager() {
+	case "apt":
+		s.Env().RemoteHost.MustExecute("sudo -E apt-get install -y datadog-agent", client.WithEnvVariables(env))
+	case "yum":
+		s.Env().RemoteHost.MustExecute("sudo -E yum install -y datadog-agent", client.WithEnvVariables(env))
+	case "zypper":
+		s.Env().RemoteHost.MustExecute("sudo -E zypper --non-interactive install datadog-agent", client.WithEnvVariables(env))
+	default:
+		s.T().Fatalf("unsupported package manager: %s", s.host.GetPkgManager())
+	}
+
+	// Step 5: ddot must NOT have started — there is no datadog.yaml to enable it.
+	state := s.host.State()
+	state.AssertUnitsDead(ddotUnit)
+
+	// Step 6: otel-config.yaml must exist and contain the api_key and site from env vars.
+	state.AssertFileExists("/etc/datadog-agent/otel-config.yaml", 0640, "dd-agent", "dd-agent")
+	s.host.Run(fmt.Sprintf("sudo grep -q '%s' /etc/datadog-agent/otel-config.yaml", testAPIKey))
+	s.host.Run(fmt.Sprintf("sudo grep -q '%s' /etc/datadog-agent/otel-config.yaml", testSite))
+	state.AssertPathDoesNotExist("/etc/datadog-agent/datadog.yaml")
+
+	// Step 7: restore datadog.yaml and append the otelcollector activation stanza.
+	s.Env().RemoteHost.MustExecute("sudo mv /etc/datadog-agent/datadog.yaml.bak /etc/datadog-agent/datadog.yaml")
+	s.Env().RemoteHost.MustExecute(`sudo sh -c "printf 'otelcollector:\n  enabled: true\n  agent_ipc:\n    port: 5009\n    config_refresh_interval: 60\n' >> /etc/datadog-agent/datadog.yaml"`)
+
+	// Step 8: restart the agent so it picks up the updated configuration.
+	s.Env().RemoteHost.MustExecute("sudo systemctl restart datadog-agent.service")
+
+	// Step 9: verify the agent and ddot are both running.
+	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit, ddotUnit)
+	state = s.host.State()
+	s.assertCoreUnits(state, true)  // oldUnits=true: core agent installed via package manager
+	s.assertDDOTUnits(state, false) // oldUnits=false: ddot installed via installer postinst hook
+}
+
 func (s *packageDDOTSuite) assertCoreUnits(state host.State, oldUnits bool) {
 	state.AssertUnitsLoaded(agentUnit, traceUnit, processUnit, probeUnit, securityUnit)
 	state.AssertUnitsEnabled(agentUnit)


### PR DESCRIPTION

### What does this PR do?

This PR removes the 'datadog.yaml' not find error during the DDOT extension. I add a fallback to get the api_key and site from the environment variable. Else, fallback to ${env:DD_API_KEY} The installer create the otel-config.yaml even if there is no datadog.yaml, leaving the responsibility to correctly fill the datadog.yaml to enable DDOT when the file will be created.

### Motivation

The installation of DDOT through the installer using DD_OTELCOLLECTOR_ENABLE flag was failing due to datadog.yaml not existing. In particular, the installer was using the datadog.yaml config to extract api_key and site values and create + fill the otel-config.yaml config. In practice in a fresh installation, the datadog.yaml is created after the installer run. We need the installer to install DDOT without failing.

### Describe how you validated your changes

- Add unit test for otel_config_common to check the path without datadog.yaml
- Add e2e test to check that installation of datadog-agent package with ddot without datadog.yaml is successful and with a valid otel-config.yaml
- Execute the current install script + modified install script (with flags to install ddot) with this datadog-agent version

### Additional Notes


(cherry picked from commit ba75d061496b6b2796959471edcacbe5219c47ca)

