### PR TITLE
Decouple CWS and SBOM event monitor

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -72,7 +72,7 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 	if cwsEnabled || runtimeUsageEnabled {
 		stopChan := make(chan struct{})
 
-		cmdServer, err := secmodule.NewCommandServer(secconfig.RuntimeSecurity, stopChan)
+		cmdServer, err := secmodule.NewCommandServer(secconfig.RuntimeSecurity)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -66,14 +66,35 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 		return nil, module.ErrNotEnabled
 	}
 
-	if secconfig.RuntimeSecurity.IsRuntimeEnabled() {
-		cws, err := secmodule.NewCWSConsumer(evm, secconfig.RuntimeSecurity, deps.WMeta, deps.FilterStore, secmoduleOpts, deps.Compression, deps.Ipc, hostname, deps.Secrets)
+	cwsEnabled := secconfig.RuntimeSecurity.IsRuntimeEnabled()
+	runtimeUsageEnabled := secconfig.RuntimeSecurity.SBOMResolverEnabled
+
+	if cwsEnabled || runtimeUsageEnabled {
+		stopChan := make(chan struct{})
+
+		cmdServer, err := secmodule.NewCommandServer(secconfig.RuntimeSecurity, stopChan)
 		if err != nil {
 			return nil, err
 		}
-		evm.RegisterEventConsumer(cws)
-		evm.SetCWSStatusProvider(cws)
-		log.Info("event monitoring cws consumer initialized")
+
+		if cwsEnabled {
+			cws, err := secmodule.NewCWSConsumer(cmdServer, evm, secconfig.RuntimeSecurity, deps.WMeta, deps.FilterStore, secmoduleOpts, deps.Compression, deps.Ipc, hostname, deps.Secrets)
+			if err != nil {
+				return nil, err
+			}
+			evm.RegisterEventConsumer(cws)
+			evm.SetCWSStatusProvider(cws)
+			log.Info("event monitoring cws consumer initialized")
+		}
+
+		if runtimeUsageEnabled {
+			usage, err := secmodule.NewUsageConsumer(cmdServer, evm, secconfig.RuntimeSecurity, stopChan)
+			if err != nil {
+				return nil, err
+			}
+			evm.RegisterEventConsumer(usage)
+			log.Info("event monitoring usage consumer initialized")
+		}
 	}
 
 	netconfig := netconfig.New()

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -22,7 +22,6 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
-	sbomapi "github.com/DataDog/datadog-agent/pkg/proto/pbgo/sbom"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/events"
@@ -49,9 +48,50 @@ const (
 	selftestPassedDelay = 60 * time.Minute
 )
 
+// CommandServer is the gRPC server for the module command API
+type CommandServer struct {
+	started       bool
+	grpcCmdServer *grpcutils.Server
+}
+
+// Start starts the command server
+func (c *CommandServer) Start() error {
+	if c.started {
+		return nil
+	}
+
+	if err := c.grpcCmdServer.Start(); err != nil {
+		return err
+	}
+
+	c.started = true
+	return nil
+}
+
+// Stop stops the command server
+func (c *CommandServer) Stop() {
+	c.grpcCmdServer.Stop()
+	c.started = false
+}
+
+// NewCommandServer initializes the gRPC server for the module command API
+func NewCommandServer(cfg *config.RuntimeSecurityConfig, stopChan chan struct{}) (*CommandServer, error) {
+	cmdSocketPath, err := common.GetCmdSocketPath(cfg.SocketPath, cfg.CmdSocketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	family, socketPath := socket.GetSocketAddress(cmdSocketPath)
+
+	return &CommandServer{
+		grpcCmdServer: grpcutils.NewServer(family, socketPath),
+	}, nil
+}
+
 // CWSConsumer represents the system-probe module for the runtime security agent
 type CWSConsumer struct {
 	sync.RWMutex
+
 	config       *config.RuntimeSecurityConfig
 	probe        *probe.Probe
 	statsdClient statsd.ClientInterface
@@ -61,11 +101,11 @@ type CWSConsumer struct {
 	ctx             context.Context
 	cancelFnc       context.CancelFunc
 	apiServer       *APIServer
+	cmdServer       *CommandServer
+	grpcEventServer *grpcutils.Server
 	rateLimiter     *events.RateLimiter
 	sendStatsChan   chan chan bool
 	eventSender     events.EventSender
-	grpcCmdServer   *grpcutils.Server
-	grpcEventServer *grpcutils.Server
 	ruleEngine      *rulesmodule.RuleEngine
 	selfTester      *selftests.SelfTester
 	selfTestCount   int
@@ -75,7 +115,7 @@ type CWSConsumer struct {
 }
 
 // NewCWSConsumer initializes the module with options
-func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityConfig, wmeta workloadmeta.Component, filterStore workloadfilter.Component, opts Opts, compression compression.Component, ipc ipc.Component, hostname string, secretsComp secrets.Component) (*CWSConsumer, error) {
+func NewCWSConsumer(cmdServer *CommandServer, evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityConfig, wmeta workloadmeta.Component, filterStore workloadfilter.Component, opts Opts, compression compression.Component, ipc ipc.Component, hostname string, secretsComp secrets.Component) (*CWSConsumer, error) {
 	crtelemcfg := telemetry.ContainersRunningTelemetryConfig{
 		RuntimeEnabled: cfg.RuntimeEnabled,
 		FIMEnabled:     cfg.FIMEnabled,
@@ -102,13 +142,8 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 		}
 	}
 
-	cmdSocketPath, err := common.GetCmdSocketPath(cfg.SocketPath, cfg.CmdSocketPath)
-	if err != nil {
-		return nil, err
-	}
-
-	family, socketPath := socket.GetSocketAddress(cmdSocketPath)
-	apiServer, err := NewAPIServer(cfg, evm.Probe, opts.MsgSender, evm.StatsdClient, selfTester, compression, hostname, secretsComp, filterStore)
+	stopChan := make(chan struct{})
+	apiServer, err := NewAPIServer(cfg, evm.Probe, opts.MsgSender, evm.StatsdClient, selfTester, compression, hostname, stopChan, secretsComp, filterStore)
 	if err != nil {
 		return nil, err
 	}
@@ -123,9 +158,9 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 		ctx:           ctx,
 		cancelFnc:     cancelFnc,
 		apiServer:     apiServer,
+		cmdServer:     cmdServer,
 		rateLimiter:   events.NewRateLimiter(cfg, evm.StatsdClient),
 		sendStatsChan: make(chan chan bool, 1),
-		grpcCmdServer: grpcutils.NewServer(family, socketPath),
 		selfTester:    selfTester,
 		reloader:      NewReloader(),
 		crtelemetry:   crtelemetry,
@@ -165,7 +200,8 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 
 	// setup gRPC servers
 	seclog.Debugf("Registering API server")
-	api.RegisterSecurityModuleCmdServer(c.grpcCmdServer.ServiceRegistrar(), c.apiServer)
+	api.RegisterSecurityModuleCmdServer(c.cmdServer.grpcCmdServer.ServiceRegistrar(), c.apiServer)
+
 	if cfg.EventGRPCServer != "security-agent" {
 		seclog.Infof("start security module event grpc server with %s", cfg.SocketPath)
 
@@ -174,9 +210,6 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 
 		api.RegisterSecurityModuleEventServer(c.grpcEventServer.ServiceRegistrar(), c.apiServer)
 	}
-
-	seclog.Debugf("Registering SBOM collector server")
-	sbomapi.RegisterSBOMCollectorServer(c.grpcCmdServer.ServiceRegistrar(), c.apiServer)
 
 	// platform specific initialization
 	if err := c.init(evm, cfg, opts); err != nil {
@@ -207,7 +240,7 @@ func (c *CWSConsumer) ID() string {
 
 // Start the module
 func (c *CWSConsumer) Start() error {
-	if err := c.grpcCmdServer.Start(); err != nil {
+	if err := c.cmdServer.Start(); err != nil {
 		return err
 	}
 
@@ -347,7 +380,7 @@ func (c *CWSConsumer) Stop() {
 		c.apiServer.Stop()
 	}
 
-	c.grpcCmdServer.Stop()
+	c.cmdServer.Stop()
 	if c.grpcEventServer != nil {
 		c.grpcEventServer.Stop()
 	}

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -75,7 +75,7 @@ func (c *CommandServer) Stop() {
 }
 
 // NewCommandServer initializes the gRPC server for the module command API
-func NewCommandServer(cfg *config.RuntimeSecurityConfig, stopChan chan struct{}) (*CommandServer, error) {
+func NewCommandServer(cfg *config.RuntimeSecurityConfig) (*CommandServer, error) {
 	cmdSocketPath, err := common.GetCmdSocketPath(cfg.SocketPath, cfg.CmdSocketPath)
 	if err != nil {
 		return nil, err

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -148,15 +148,23 @@ func mergeJSON(j1, j2 []byte) ([]byte, error) {
 	return append(data, j2[1:]...), nil
 }
 
+// SBOMAPISServer represents a gRPC server in charge of receiving SBOM requests sent by
+type SBOMAPIServer struct {
+	sbomapi.UnimplementedSBOMCollectorServer
+
+	sboms    chan *sbom.ScanResult
+	probe    *sprobe.Probe
+	stopChan chan struct{}
+}
+
 // APIServer represents a gRPC server in charge of receiving events sent by
 // the runtime security system-probe module and forwards them to Datadog
 type APIServer struct {
 	api.UnimplementedSecurityModuleEventServer
 	api.UnimplementedSecurityModuleCmdServer
-	sbomapi.UnimplementedSBOMCollectorServer
+
 	events             chan *api.SecurityEventMessage
 	activityDumps      chan *api.ActivityDumpStreamMessage
-	sboms              chan *sbom.ScanResult
 	expiredEventsLock  sync.RWMutex
 	expiredEvents      map[rules.RuleID]*atomic.Int64
 	expiredDumps       *atomic.Int64
@@ -830,7 +838,7 @@ func getEnvAsTags(cfg *config.RuntimeSecurityConfig) []string {
 }
 
 // NewAPIServer returns a new gRPC event server
-func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSender MsgSender[api.SecurityEventMessage], client statsd.ClientInterface, selfTester *selftests.SelfTester, compression compression.Component, hostname string, secretsComp secrets.Component, filterStore workloadfilter.Component) (*APIServer, error) {
+func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSender MsgSender[api.SecurityEventMessage], client statsd.ClientInterface, selfTester *selftests.SelfTester, compression compression.Component, hostname string, stopChan chan struct{}, secretsComp secrets.Component, filterStore workloadfilter.Component) (*APIServer, error) {
 	stopper := startstop.NewSerialStopper()
 
 	var containerFilter workloadfilter.FilterBundle
@@ -844,7 +852,6 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 	as := &APIServer{
 		events:          make(chan *api.SecurityEventMessage, cfg.EventServerBurst*3),
 		activityDumps:   make(chan *api.ActivityDumpStreamMessage, model.MaxTracedCgroupsCount*2),
-		sboms:           make(chan *sbom.ScanResult, 100),
 		expiredEvents:   make(map[rules.RuleID]*atomic.Int64),
 		expiredDumps:    atomic.NewInt64(0),
 		statsdClient:    client,
@@ -853,7 +860,7 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 		cfg:             cfg,
 		stopper:         stopper,
 		selfTester:      selfTester,
-		stopChan:        make(chan struct{}),
+		stopChan:        stopChan,
 		msgSender:       msgSender,
 		connEstablished: atomic.NewBool(false),
 		envAsTags:       getEnvAsTags(cfg),
@@ -871,7 +878,6 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 	}
 
 	as.collectOSReleaseData()
-	as.collectSBOMS()
 
 	if as.msgSender == nil {
 		if cfg.SendPayloadsFromSystemProbe {
@@ -904,4 +910,16 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 	}
 
 	return as, nil
+}
+
+// NewSBOMAPIServer returns a new gRPC SBOM server
+func NewSBOMAPIServer(probe *sprobe.Probe, stopChan chan struct{}) *SBOMAPIServer {
+	as := &SBOMAPIServer{
+		probe:    probe,
+		sboms:    make(chan *sbom.ScanResult, 100),
+		stopChan: stopChan,
+	}
+
+	as.collectSBOMS()
+	return as
 }

--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -308,7 +308,7 @@ func createSSHSessionPatcher(ev *model.Event, p *probe.Probe) sshSessionPatcher 
 	return nil
 }
 
-func (a *APIServer) collectSBOMS() {
+func (a *SBOMAPIServer) collectSBOMS() {
 	ebpfProbe, ok := a.probe.PlatformProbe.(*probe.EBPFProbe)
 	if !ok {
 		return
@@ -330,7 +330,7 @@ func (a *APIServer) collectSBOMS() {
 }
 
 // GetSBOMStream handles SBOM stream requests
-func (a *APIServer) GetSBOMStream(_ *sbompb.SBOMStreamParams, stream sbompb.SBOMCollector_GetSBOMStreamServer) error {
+func (a *SBOMAPIServer) GetSBOMStream(_ *sbompb.SBOMStreamParams, stream sbompb.SBOMCollector_GetSBOMStreamServer) error {
 	for {
 		select {
 		case <-stream.Context().Done():

--- a/pkg/security/module/server_other.go
+++ b/pkg/security/module/server_other.go
@@ -31,4 +31,4 @@ func (a *APIServer) fillStatusPlatform(_ *api.Status) error {
 	return nil
 }
 
-func (a *APIServer) collectSBOMS() {}
+func (a *SBOMAPIServer) collectSBOMS() {}

--- a/pkg/security/module/server_windows.go
+++ b/pkg/security/module/server_windows.go
@@ -98,4 +98,4 @@ func (a *APIServer) RunSelfTest(_ context.Context, _ *api.RunSelfTestParams) (*a
 
 func (a *APIServer) collectOSReleaseData() {}
 
-func (a *APIServer) collectSBOMS() {}
+func (a *SBOMAPIServer) collectSBOMS() {}

--- a/pkg/security/module/usage_consumer.go
+++ b/pkg/security/module/usage_consumer.go
@@ -21,9 +21,8 @@ import (
 // enrichment are not billed for CWS.
 type UsageConsumer struct {
 	*CommandServer
-	config     *config.RuntimeSecurityConfig
-	probe      *probe.Probe
-	sbomServer *SBOMAPIServer
+	config *config.RuntimeSecurityConfig
+	probe  *probe.Probe
 }
 
 // NewUsageConsumer initializes the UsageConsumer

--- a/pkg/security/module/usage_consumer.go
+++ b/pkg/security/module/usage_consumer.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package module holds module related files
+package module
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
+	sbomapi "github.com/DataDog/datadog-agent/pkg/proto/pbgo/sbom"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+)
+
+// UsageConsumer is a minimal event consumer that brings up the security probe
+// (including the SBOM resolver) without the CWS rule engine or billing metrics.
+// It is active when runtime_security_config.sbom.enabled is true but
+// runtime_security_config.enabled is false, so that customers using only SBOM
+// enrichment are not billed for CWS.
+type UsageConsumer struct {
+	*CommandServer
+	config     *config.RuntimeSecurityConfig
+	probe      *probe.Probe
+	sbomServer *SBOMAPIServer
+}
+
+// NewUsageConsumer initializes the UsageConsumer
+func NewUsageConsumer(cmdServer *CommandServer, evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityConfig, stopChan chan struct{}) (*UsageConsumer, error) {
+	c := &UsageConsumer{
+		CommandServer: cmdServer,
+		config:        cfg,
+		probe:         evm.Probe,
+	}
+
+	sbomServer := NewSBOMAPIServer(evm.Probe, stopChan)
+
+	seclog.Debugf("Registering SBOM collector server")
+	sbomapi.RegisterSBOMCollectorServer(c.grpcCmdServer.ServiceRegistrar(), sbomServer)
+
+	return c, nil
+}
+
+// ID returns the identifier for the usage consumer
+func (u *UsageConsumer) ID() string {
+	return "USAGE"
+}
+
+// Start starts the usage consumer
+func (u *UsageConsumer) Start() error {
+	seclog.Infof("usage consumer started")
+	return nil
+}
+
+// Stop stops the usage consumer
+func (u *UsageConsumer) Stop() {
+	seclog.Infof("usage consumer stopped")
+}

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -133,11 +133,11 @@ func (cr *Resolver) removeCacheEntry(cacheEntry *cgroupModel.CacheEntry) {
 	cr.deletedCgroups.Inc()
 }
 
-// syncOrDeleteCaheEntry uses the cgroupFS to check if the cgroup still contains pids.
+// syncOrDeleteCacheEntry uses the cgroupFS to check if the cgroup still contains pids.
 // If there is no pid left, or the only one being the one we want to delete,
 // remove the cgroup from the caches.
 // Otherwise, sync it with new values.
-func (cr *Resolver) syncOrDeleteCaheEntry(cacheEntry *cgroupModel.CacheEntry, deletedPid uint32) {
+func (cr *Resolver) syncOrDeleteCacheEntry(cacheEntry *cgroupModel.CacheEntry, deletedPid uint32) {
 	// check if the cgroup still contains pids
 	pids, err := cr.cgroupFS.GetCGroupPids(string(cacheEntry.GetCGroupID()))
 	if err != nil {
@@ -361,7 +361,7 @@ func (cr *Resolver) AddPID(pid uint32, ppid uint32, cgroupContext model.CGroupCo
 			// it means that the process has been migrated to a different cgroup.
 			if cacheEntry.RemovePID(pid) == 0 {
 				// try to sync the cgroup with the pid in order to detect the migration.
-				cr.syncOrDeleteCaheEntry(cacheEntry, pid)
+				cr.syncOrDeleteCacheEntry(cacheEntry, pid)
 			}
 		}
 
@@ -469,7 +469,7 @@ func (cr *Resolver) deleteCacheEntryPID(pid uint32, cacheEntry *cgroupModel.Cach
 
 	// check if the cacheEntry should be deleted
 	if cacheEntry.RemovePID(pid) == 0 {
-		cr.syncOrDeleteCaheEntry(cacheEntry, pid)
+		cr.syncOrDeleteCacheEntry(cacheEntry, pid)
 	}
 }
 

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -184,6 +184,14 @@ func (cr *Resolver) pushNewCacheEntry(pid uint32, containerContext model.Contain
 
 	cr.addedCgroups.Inc()
 
+	// When the entry is created with a real pid (pid != 0), it means a process already exists
+	// in this cgroup — this covers both snapshot discovery and runtime cases where no prior
+	// Add() call was made. Entries pre-created with pid=0 (via Add()) will fire CGroupCreated
+	// later when AddPID transitions their count from 0 to 1.
+	if pid != 0 {
+		cr.NotifyListeners(CGroupCreated, cacheEntry)
+	}
+
 	return cacheEntry
 }
 

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -123,6 +123,9 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 	}
 
 	if config.RuntimeSecurity.SBOMResolverEnabled {
+		if err := cgroupsResolver.RegisterListener(cgroup.CGroupCreated, sbomResolver.OnCGroupCreatedEvent); err != nil {
+			return nil, err
+		}
 		if err := cgroupsResolver.RegisterListener(cgroup.CGroupDeleted, sbomResolver.OnCGroupDeletedEvent); err != nil {
 			return nil, err
 		}

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -685,6 +685,15 @@ func (r *Resolver) ResolvePackage(pc *model.ProcessContext, file *model.FileEven
 	}
 
 	sbom.Lock()
+
+	// If the SBOM scan hasn't completed yet, queue this access so it is replayed once
+	// the scan finishes (processPendingFileEvents is called at the end of analyzeWorkload).
+	if !sbom.IsComputed() {
+		sbom.Unlock()
+		r.queuePendingFileEvent(pc.ContainerContext.ContainerID, file.PathnameStr, file.Mode, pc.UID)
+		return nil
+	}
+
 	defer sbom.Unlock()
 
 	// replay any file accesses that arrived before the SBOM was ready

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -858,6 +858,25 @@ func (r *Resolver) GetWorkload(id containerutils.ContainerID) *SBOM {
 	return sbom
 }
 
+// OnCGroupCreatedEvent is used to handle a CGroupCreated event. It queues an SBOM scan for
+// the container as soon as the cgroup is known, without waiting for tag resolution.
+func (r *Resolver) OnCGroupCreatedEvent(cgroup *cgroupModel.CacheEntry) {
+	id := cgroup.GetContainerID()
+	if len(id) == 0 {
+		return
+	}
+
+	r.sbomsLock.Lock()
+	defer r.sbomsLock.Unlock()
+
+	if _, ok := r.sboms.Get(id); ok {
+		return
+	}
+
+	sbom := r.newSBOM(id, cgroup, workloadKey(id))
+	r.triggerScan(sbom)
+}
+
 // OnCGroupDeletedEvent is used to handle a CGroupDeleted event
 func (r *Resolver) OnCGroupDeletedEvent(cgroup *cgroupModel.CacheEntry) {
 	if !cgroup.IsContainerContextNull() {

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -802,8 +802,13 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	if !opts.staticOpts.disableRuntimeSecurity {
 		msgSender := newFakeMsgSender(testMod)
 
+		cmdServer, err := module.NewCommandServer(secconfig.RuntimeSecurity)
+		if err != nil {
+			return nil, err
+		}
+
 		compression := logscompression.NewComponent()
-		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod, MsgSender: msgSender}, compression, ipcComp, functionalTestsHostname, secretsnoopimpl.NewComponent().Comp)
+		cws, err := module.NewCWSConsumer(cmdServer, testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod, MsgSender: msgSender}, compression, ipcComp, functionalTestsHostname, secretsnoopimpl.NewComponent().Comp)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create module: %w", err)
 		}

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -178,7 +178,12 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	var ruleSetloadedErr *multierror.Error
 	if !opts.staticOpts.disableRuntimeSecurity {
 		compression := logscompression.NewComponent()
-		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod}, compression, ipcComp, functionalTestsHostname, secretsnoopimpl.NewComponent().Comp)
+		cmdServer, err := module.NewCommandServer(secconfig.RuntimeSecurity)
+		if err != nil {
+			return nil, err
+		}
+
+		cws, err := module.NewCWSConsumer(cmdServer, testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod}, compression, ipcComp, functionalTestsHostname, secretsnoopimpl.NewComponent().Comp)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create module: %w", err)
 		}

--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -140,6 +140,7 @@ func load() (*types.Config, error) {
 	}
 	if csmEnabled ||
 		cfg.GetBool(secNS("fim_enabled")) ||
+		cfg.GetBool(secNS("sbom.enabled")) ||
 		(usmEnabled && cfg.GetBool(smNS("enable_event_stream"))) ||
 		(c.ModuleIsEnabled(NetworkTracerModule) && cfg.GetBool(evNS("network_process.enabled"))) ||
 		gpuEnabled ||


### PR DESCRIPTION
### What does this PR do?

Decouples the CWS (Cloud Workload Security) consumer and the SBOM event monitor by introducing two new types:                                             
                                                                                                                                                            
  - CommandServer: extracts the shared gRPC command server from CWSConsumer, so it can be reused by both CWS and SBOM without coupling.                     
  - UsageConsumer: a new, minimal event consumer that starts the security probe (including the SBOM resolver) without the CWS rule engine. It is registered 
  when runtime_security_config.sbom.enabled = true but runtime_security_config.enabled = false.                                                             
  - SBOMAPIServer: moves the SBOM gRPC server implementation (GetSBOMStream, collectSBOMS) out of APIServer into its own type, registered only by           
  UsageConsumer.                                                                                                                                            
                                                                                                                                                            
Additionally, system-probe is now enabled when sbom.enabled is set, independent of CWS.

### Motivation

Customers using SBOM enrichment (e.g., container image scanning) had to also enable CWS, because the SBOM resolver was embedded inside CWS. This PR makes SBOM a standalone capability that can run independently.                 

### Describe how you validated your changes

- Verified the event monitor initializes UsageConsumer when only sbom.enabled = true and CWSConsumer when runtime_security_config.enabled = true
- Verify we do not have ruleset_loaded events and metrics sent when only enabling SBOM resolver.

### Additional Notes
