### PR TITLE
[SNMP] Add timeout messages to SNMP walk command

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -329,7 +329,7 @@ func snmpWalk(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snmps
 		return configErr{err}
 	}
 
-	// Print connection info so the user knows what's happening during long timeouts
+	// Print progress to stderr so it doesn't pollute walk output when piped
 	_, _ = fmt.Fprintf(os.Stderr, "Connecting to %s:%d (timeout: %ds, retries: %d)\n", snmp.Target, snmp.Port, connParams.Timeout, snmp.Retries)
 	// Notify the user on each retry so they know the tool is still running.
 	// gosnmp calls OnRetry once more on the iteration that exits the retry

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/gosnmp/gosnmp"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
@@ -327,6 +328,20 @@ func snmpWalk(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snmps
 		// newSNMP only returns config errors, so any problem is a usage error
 		return configErr{err}
 	}
+
+	// Print connection info so the user knows what's happening during long timeouts
+	_, _ = fmt.Fprintf(os.Stderr, "Querying %s:%d, timeout: %ds, retries: %d\n", snmp.Target, snmp.Port, connParams.Timeout, snmp.Retries)
+	// Notify the user on each retry so they know the tool is still running.
+	// gosnmp calls OnRetry once more on the iteration that exits the retry
+	// loop, so cap output at snmp.Retries to avoid a spurious message.
+	retryNum := 0
+	snmp.OnRetry = func(_ *gosnmp.GoSNMP) {
+		retryNum++
+		if retryNum <= snmp.Retries {
+			_, _ = fmt.Fprintf(os.Stderr, "  Request failed, retrying (%d/%d)...\n", retryNum, snmp.Retries)
+		}
+	}
+
 	if err := snmp.Connect(); err != nil {
 		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
 	}

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -330,7 +330,7 @@ func snmpWalk(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snmps
 	}
 
 	// Print connection info so the user knows what's happening during long timeouts
-	_, _ = fmt.Fprintf(os.Stderr, "Querying %s:%d, timeout: %ds, retries: %d\n", snmp.Target, snmp.Port, connParams.Timeout, snmp.Retries)
+	_, _ = fmt.Fprintf(os.Stderr, "Connecting to %s:%d (timeout: %ds, retries: %d)\n", snmp.Target, snmp.Port, connParams.Timeout, snmp.Retries)
 	// Notify the user on each retry so they know the tool is still running.
 	// gosnmp calls OnRetry once more on the iteration that exits the retry
 	// loop, so cap output at snmp.Retries to avoid a spurious message.
@@ -338,7 +338,7 @@ func snmpWalk(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snmps
 	snmp.OnRetry = func(_ *gosnmp.GoSNMP) {
 		retryNum++
 		if retryNum <= snmp.Retries {
-			_, _ = fmt.Fprintf(os.Stderr, "  Request failed, retrying (%d/%d)...\n", retryNum, snmp.Retries)
+			_, _ = fmt.Fprintf(os.Stderr, "  Connection failed, retrying (%d/%d)...\n", retryNum, snmp.Retries)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Adds showing messages to users when they run the SNMP walk command such that they are aware the command is doing something.

<img width="1512" height="464" alt="image" src="https://github.com/user-attachments/assets/07a1a0ad-6634-43b7-b7a3-230b13d4d336" />

https://datadoghq.atlassian.net/browse/NDMC-232

### Motivation

### Describe how you validated your changes

### Additional Notes
