### PR TITLE
Fix `gitlab.print-ci` on Windows

### DIFF
--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -1072,7 +1072,7 @@ def read_content(ctx, file_path, git_ref: str | None = None):
             response.raise_for_status()
             content = response.text
         elif not git_ref:
-            with open(file_path) as f:
+            with open(file_path, encoding="utf-8") as f:
                 content = f.read()
         elif ctx.run(f"git cat-file -e '{git_ref}:{file_path}'", hide=True, warn=True).ok:
             content = ctx.run(f"git show '{git_ref}:{file_path}'", hide=True).stdout


### PR DESCRIPTION
### Motivation

```
❯ dda inv -- gitlab.print-ci
colorama is not up to date, terminal colors may not work properly. Please run 'dda self dep sync' to fix this.
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\ofek\AppData\Local\dda\venvs\legacy\Lib\site-packages\invoke\__main__.py", line 3, in <module>
    program.run()
  File "C:\Users\ofek\AppData\Local\dda\venvs\legacy\Lib\site-packages\invoke\program.py", line 398, in run
    self.execute()
  File "C:\Users\ofek\AppData\Local\dda\venvs\legacy\Lib\site-packages\invoke\program.py", line 583, in execute
    executor.execute(*self.tasks)
  File "C:\Users\ofek\AppData\Local\dda\venvs\legacy\Lib\site-packages\invoke\executor.py", line 140, in execute
    result = call.task(*args, **call.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ofek\Desktop\code\datadog-agent\tasks\custom_task\custom_task.py", line 149, in custom__call__
    result = self.body(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ofek\Desktop\code\datadog-agent\tasks\gitlab_helpers.py", line 273, in print_ci
    yml = resolve_gitlab_ci_configuration(ctx, input_file, resolve_only_includes=resolve_only_includes, git_ref=git_ref)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ofek\Desktop\code\datadog-agent\tasks\libs\ciproviders\gitlab_api.py", line 983, in resolve_gitlab_ci_configuration
    input_config = read_includes(ctx, input_config_or_file, return_config=True, git_ref=git_ref)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ofek\Desktop\code\datadog-agent\tasks\libs\ciproviders\gitlab_api.py", line 1026, in read_includes
    read_includes(
  File "C:\Users\ofek\Desktop\code\datadog-agent\tasks\libs\ciproviders\gitlab_api.py", line 1016, in read_includes
    current_file = read_content(ctx, yaml_file, git_ref=git_ref)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ofek\Desktop\code\datadog-agent\tasks\libs\ciproviders\gitlab_api.py", line 1085, in read_content
    return read_content_cached(file_path, git_ref)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ofek\Desktop\code\datadog-agent\tasks\libs\ciproviders\gitlab_api.py", line 1076, in read_content_cached
    content = f.read()
              ^^^^^^^^
  File "C:\Users\ofek\AppData\Local\Programs\Python\Python312\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 1602: character maps to <undefined>
```