### PR TITLE
feat(helm-check): add helm.release_age gauge metric

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -39,6 +39,7 @@ const (
 	// CheckName is the name of the check
 	CheckName               = "helm"
 	serviceCheckName        = "helm.release_state"
+	releaseAgeMetricName    = "helm.release_age"
 	maximumWaitForAPIServer = 10 * time.Second
 	defaultExtraSyncTimeout = 120 * time.Second
 	defaultResyncInterval   = 10 * time.Minute
@@ -160,6 +161,17 @@ func (hc *HelmCheck) Run() error {
 		for _, rel := range hc.store.getAll(storageDriver) {
 			tags := append(rel.commonTags, rel.tagsForMetricsAndEvents...)
 			sender.Gauge("helm.release", 1, "", tags)
+		}
+	}
+
+	for _, storageDriver := range []helmStorage{k8sConfigmaps, k8sSecrets} {
+		for _, taggedRel := range hc.store.getLatestRevisions(storageDriver) {
+			if taggedRel.release.Info == nil || taggedRel.release.Info.LastDeployed.IsZero() {
+				continue
+			}
+			age := time.Since(taggedRel.release.Info.LastDeployed).Seconds()
+			tags := append(taggedRel.commonTags, taggedRel.tagsForMetricsAndEvents...)
+			sender.Gauge(releaseAgeMetricName, age, "", tags)
 		}
 	}
 

--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -632,6 +632,72 @@ func TestRun_ServiceCheck(t *testing.T) {
 
 }
 
+func TestRun_releaseAge(t *testing.T) {
+	lastDeployed := time.Now().Add(-2 * time.Hour)
+
+	rel := &release{
+		Name: "my_datadog",
+		Info: &info{
+			Status:       "deployed",
+			LastDeployed: lastDeployed,
+		},
+		Chart: &chart{
+			Metadata: &metadata{
+				Name:       "datadog",
+				Version:    "2.30.5",
+				AppVersion: "7",
+			},
+		},
+		Version:   1,
+		Namespace: "default",
+	}
+
+	relWithoutInfo := &release{
+		Name:      "no_info",
+		Info:      nil,
+		Version:   1,
+		Namespace: "default",
+	}
+
+	relWithZeroLastDeployed := &release{
+		Name: "zero_last_deployed",
+		Info: &info{
+			Status: "deployed",
+		},
+		Version:   1,
+		Namespace: "default",
+	}
+
+	for _, storage := range []helmStorage{k8sSecrets, k8sConfigmaps} {
+		t.Run(string(storage), func(t *testing.T) {
+			check := newCheck().(*HelmCheck)
+			check.runLeaderElection = false
+			check.store.add(rel, storage, commonTags(rel, storage), check.tagsForMetricsAndEvents(rel, true))
+			check.store.add(relWithoutInfo, storage, commonTags(relWithoutInfo, storage), check.tagsForMetricsAndEvents(relWithoutInfo, true))
+			check.store.add(relWithZeroLastDeployed, storage, commonTags(relWithZeroLastDeployed, storage), check.tagsForMetricsAndEvents(relWithZeroLastDeployed, true))
+
+			mockedSender := mocksender.NewMockSender(CheckName)
+			mockedSender.SetupAcceptAll()
+
+			k8sClient := fake.NewSimpleClientset()
+			check.informerFactory = informers.NewSharedInformerFactory(k8sClient, time.Minute)
+			err := check.CommonConfigure(mockedSender.GetSenderManager(), nil, nil, "", "")
+			require.NoError(t, err)
+
+			err = check.Run()
+			require.NoError(t, err)
+
+			expectedMinAge := time.Since(lastDeployed).Seconds() - 5
+			expectedMaxAge := time.Since(lastDeployed).Seconds() + 5
+			expectedTags := append(commonTags(rel, storage), check.tagsForMetricsAndEvents(rel, true)...)
+			mockedSender.AssertMetricInRange(t, "Gauge", releaseAgeMetricName, expectedMinAge, expectedMaxAge, "", expectedTags)
+
+			mockedSender.AssertMetricNotTaggedWith(t, "Gauge", releaseAgeMetricName, commonTags(relWithoutInfo, storage))
+			mockedSender.AssertMetricNotTaggedWith(t, "Gauge", releaseAgeMetricName, commonTags(relWithZeroLastDeployed, storage))
+		})
+	}
+}
+
 // secretForRelease returns a Kubernetes secret that contains the info of the
 // given Helm release.
 func secretForRelease(rls *release, creationTS time.Time) (*v1.Secret, error) {

--- a/pkg/collector/corechecks/cluster/helm/release.go
+++ b/pkg/collector/corechecks/cluster/helm/release.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"time"
 )
 
 // The "release" struct and the related ones, are a simplified version of the
@@ -50,7 +51,9 @@ func (rel *release) revision() revision {
 }
 
 type info struct {
-	Status string `json:"status,omitempty"`
+	FirstDeployed time.Time `json:"first_deployed,omitempty"`
+	LastDeployed  time.Time `json:"last_deployed,omitempty"`
+	Status        string    `json:"status,omitempty"`
 }
 
 type chart struct {


### PR DESCRIPTION
## What does this PR do?

Adds a `helm.release_age` gauge metric to the Helm cluster check. The value is the age in seconds of the release's latest revision, measured from Helm's `last_deployed` timestamp.

- Extends the `info` struct to deserialize `first_deployed` and `last_deployed` from the Helm release JSON (these fields already exist in the encoded payload — we just weren't capturing them)
- Emits `helm.release_age` per release (latest revision only, consistent with `helm.release_state` service check)
- Skips releases where `LastDeployed` is zero (missing info or pre-v3 releases)
- Tags match `helm.release`: `helm_release`, `kube_namespace`, `helm_namespace`, `helm_storage`, `helm_chart_name`, `helm_chart`, `helm_chart_version`, `helm_app_version`, `helm_status`, `helm_revision`, plus any `helm_values_as_tags`

## Motivation

The existing `helm.release` gauge only indicates presence (value=1). There's no way to alert on stale releases or track how long a release has been in a given state without this metric.

## Test plan

- [ ] `TestRun_releaseAge` — verifies value is within ±5s of expected age (~7200s for a 2h-old release), and that releases with `nil` info or zero `LastDeployed` do not emit the metric
- [ ] Existing `TestRun`, `TestRun_ServiceCheck`, `TestRun_withCollectEvents` all pass unchanged