### PR TITLE
fix(ksm check): cancel CRDiscoverer client on KSM unschedule

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/cr.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/cr.go
@@ -113,7 +113,7 @@ func (d customResourceDecoder) Decode(v interface{}) error {
 }
 
 // StartDiscovery starts the custom resource discovery and returns a discoverer instance
-func StartDiscovery() *discovery.CRDiscoverer {
+func StartDiscovery() (*discovery.CRDiscoverer, context.CancelFunc) {
 	discovererInstance := &discovery.CRDiscoverer{
 		CRDsAddEventsCounter:    crdsAddEventsCounter,
 		CRDsDeleteEventsCounter: crdsDeleteEventsCounter,
@@ -125,11 +125,12 @@ func StartDiscovery() *discovery.CRDiscoverer {
 		panic(err)
 	}
 
-	if err := discovererInstance.StartDiscovery(context.Background(), clientConfig); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := discovererInstance.StartDiscovery(ctx, clientConfig); err != nil {
 		log.Errorf("failed to start custom resource discovery: %v", err)
 	}
 
-	return discovererInstance
+	return discovererInstance, cancel
 }
 
 // GetCustomResourceFactories returns a list of custom resource factories

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -256,6 +256,7 @@ type KSMCheck struct {
 	workloadmetaStore          workloadmeta.Component
 	rolloutTracker             *customresources.RolloutTracker
 	customResourceDiscoverer   *ksmDiscovery.CRDiscoverer
+	cancelCRDiscoverer         context.CancelFunc
 	namespaceTagsErrorLogLimit *log.Limit
 }
 
@@ -327,7 +328,7 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 
 	// Start custom resource discovery if not
 	if k.instance.PodCollectionMode != nodeKubeletPodCollection {
-		k.customResourceDiscoverer = customresources.StartDiscovery()
+		k.customResourceDiscoverer, k.cancelCRDiscoverer = customresources.StartDiscovery()
 	}
 
 	// Retry configuration steps related to API Server in check executions if necessary
@@ -762,6 +763,9 @@ func (k *KSMCheck) Cancel() {
 	log.Infof("Shutting down informers used by the check '%s'", k.ID())
 	if k.cancel != nil {
 		k.cancel()
+	}
+	if k.cancelCRDiscoverer != nil {
+		k.cancelCRDiscoverer()
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes a resource leak in the `kubernetes_state_core` check where the `CRDiscoverer` informer was never stopped when the check was unscheduled.

`StartDiscovery()` in `customresources/cr.go` previously started a CRD informer using `context.Background()`, meaning the informer's goroutines and Kubernetes API watch connection had no way to be cancelled. This PR:

- Changes `StartDiscovery()` to create a cancellable context and return its `CancelFunc` alongside the `*CRDiscoverer`
- Stores the `CancelFunc` on `KSMCheck` as `cancelCRDiscoverer`
- Calls `cancelCRDiscoverer()` in `KSMCheck.Cancel()` to properly stop the CRD informer when the check is unscheduled

### Motivation

When the KSM check is unscheduled (e.g., during CLC runner rebalancing), `Cancel()` only cancelled the main KSM store informers via `k.cancel()`. The `CRDiscoverer` informer — started eagerly during `Configure()` — was left running because it used a non-cancellable `context.Background()`.

The `CRDiscoverer.StartDiscovery()` method (in `kube-state-metrics/pkg/discovery/discovery.go`) registers event handler closures that capture the `*CRDiscoverer` pointer, and starts a goroutine (`go informer.Run(stopper)`) that only exits when the `stopper` channel is closed. Since `stopper` is gated on `ctx.Done()` and the context was `context.Background()`, these goroutines could never terminate. Running goroutines are GC roots in Go, so the entire `CRDiscoverer` — including its CRD object cache, event handlers, and Kubernetes API watch connection — was permanently pinned in memory.

In CLC runner environments with advanced dispatching enabled, the rebalancer periodically moves checks between runners. Each rebalance cycle that touched a KSM check would leak one `CRDiscoverer` instance (with its goroutines, CRD cache, and watch connection) on the source runner. Over time, this accumulates leaked goroutines, file descriptors, and memory proportional to the number of rebalance events.

### Describe how you validated your changes

- Verified that the `CRDiscoverer.StartDiscovery()` method in the upstream `kube-state-metrics` library respects context cancellation: the goroutine at line 107-113 of `discovery.go` closes the `stopper` channel on `ctx.Done()`, which causes `informer.Run(stopper)` to exit
- Confirmed that after this change, calling `KSMCheck.Cancel()` will trigger context cancellation → `stopper` closed → informer goroutines exit → `CRDiscoverer` becomes unreferenced and eligible for GC
- **TODO: add a unit test that verifies `Cancel()` stops the CRDiscoverer (e.g., assert goroutine count does not grow across configure/cancel cycles)**

### Additional Notes

- The `CRDiscoverer` was moved from lazy initialization (inside the retrier's `AttemptMethod` during `Run()`) to eager initialization in `Configure()` in PR #43315. The leak was introduced at that point because the original code created a new discoverer on each `Run()` cycle inside the retrier, whereas the new code creates it once in `Configure()` but never cleans it up.
- The `CRDiscoverer` is only started when `PodCollectionMode != nodeKubeletPodCollection`, so the leak only affects KSM checks running in cluster-level mode (the default for CLC runners).