### PR TITLE
[CONS-8214] Add RetryOnConflict for updateDatadogMetric

### DIFF
--- a/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller.go
@@ -316,7 +316,7 @@ func (c *DatadogMetricController) createDatadogMetric(ns, name string, datadogMe
 	return nil
 }
 
-func (c *DatadogMetricController) updateDatadogMetric(ns, name string, datadogMetricInternal *model.DatadogMetricInternal, _ *datadoghq.DatadogMetric) error {
+func (c *DatadogMetricController) updateDatadogMetric(ns, name string, datadogMetricInternal *model.DatadogMetricInternal, datadogMetric *datadoghq.DatadogMetric) error {
 	err := k8sretry.RetryOnConflict(k8sretry.DefaultBackoff, func() error {
 		// Always fetch the latest version directly from the API server to
 		// avoid stale resourceVersion from the informer cache.

--- a/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
+	k8sretry "k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 )
 

--- a/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller.go
@@ -317,8 +317,9 @@ func (c *DatadogMetricController) createDatadogMetric(ns, name string, datadogMe
 }
 
 func (c *DatadogMetricController) updateDatadogMetric(ns, name string, datadogMetricInternal *model.DatadogMetricInternal, _ *datadoghq.DatadogMetric) error {
-	return k8sretry.RetryOnConflict(k8sretry.DefaultBackoff, func() error {
-		// Always fetch the latest version directly from the API server to avoid stale resourceVersion from the informer cache.
+	err := k8sretry.RetryOnConflict(k8sretry.DefaultBackoff, func() error {
+		// Always fetch the latest version directly from the API server to
+		// avoid stale resourceVersion from the informer cache.
 		currentObj, err := c.clientSet.Resource(gvrDDM).Namespace(ns).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("Unable to get DatadogMetric: %s/%s, err: %v", ns, name, err)
@@ -356,6 +357,8 @@ func (c *DatadogMetricController) updateDatadogMetric(ns, name string, datadogMe
 
 		return nil
 	})
+
+	return err
 }
 
 func (c *DatadogMetricController) deleteDatadogMetric(ns, name string) error {

--- a/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller.go
@@ -315,33 +315,46 @@ func (c *DatadogMetricController) createDatadogMetric(ns, name string, datadogMe
 	return nil
 }
 
-func (c *DatadogMetricController) updateDatadogMetric(ns, name string, datadogMetricInternal *model.DatadogMetricInternal, datadogMetric *datadoghq.DatadogMetric) error {
-	newStatus := datadogMetricInternal.BuildStatus(&datadogMetric.Status)
-	if newStatus != nil {
-		log.Debugf("Updating status of DatadogMetric: %s/%s", ns, name)
-		datadogMetric := &datadoghq.DatadogMetric{
-			TypeMeta: metaDDM,
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace:       ns,
-				Name:            name,
-				ResourceVersion: datadogMetric.ResourceVersion,
-			},
-			Status: *newStatus,
+func (c *DatadogMetricController) updateDatadogMetric(ns, name string, datadogMetricInternal *model.DatadogMetricInternal, _ *datadoghq.DatadogMetric) error {
+	return k8sretry.RetryOnConflict(k8sretry.DefaultBackoff, func() error {
+		// Always fetch the latest version directly from the API server to avoid stale resourceVersion from the informer cache.
+		currentObj, err := c.clientSet.Resource(gvrDDM).Namespace(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("Unable to get DatadogMetric: %s/%s, err: %v", ns, name, err)
 		}
-		datadogMetricObj := &unstructured.Unstructured{}
-		if err := UnstructuredFromDDM(datadogMetric, datadogMetricObj); err != nil {
+
+		current := &datadoghq.DatadogMetric{}
+		if err := UnstructuredIntoDDM(currentObj, current); err != nil {
 			return err
 		}
-		_, err := c.clientSet.Resource(gvrDDM).Namespace(ns).UpdateStatus(context.TODO(), datadogMetricObj, metav1.UpdateOptions{})
-		if err != nil {
-			return fmt.Errorf("Unable to update DatadogMetric: %s/%s, err: %v", ns, name, err)
-		}
-		setDatadogMetricTelemetry(datadogMetric)
-	} else {
-		return fmt.Errorf("Impossible to build new status for DatadogMetric: %s", datadogMetricInternal.ID)
-	}
 
-	return nil
+		newStatus := datadogMetricInternal.BuildStatus(&current.Status)
+		if newStatus != nil {
+			log.Debugf("Updating status of DatadogMetric: %s/%s", ns, name)
+			datadogMetric := &datadoghq.DatadogMetric{
+				TypeMeta: metaDDM,
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       ns,
+					Name:            name,
+					ResourceVersion: current.ResourceVersion,
+				},
+				Status: *newStatus,
+			}
+			datadogMetricObj := &unstructured.Unstructured{}
+			if err := UnstructuredFromDDM(datadogMetric, datadogMetricObj); err != nil {
+				return err
+			}
+			_, err = c.clientSet.Resource(gvrDDM).Namespace(ns).UpdateStatus(context.TODO(), datadogMetricObj, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+			setDatadogMetricTelemetry(datadogMetric)
+		} else {
+			return fmt.Errorf("Impossible to build new status for DatadogMetric: %s", datadogMetricInternal.ID)
+		}
+
+		return nil
+	})
 }
 
 func (c *DatadogMetricController) deleteDatadogMetric(ns, name string) error {

--- a/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller_test.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller_test.go
@@ -9,13 +9,16 @@ package externalmetrics
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/fake"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
@@ -760,4 +763,72 @@ func TestFollower(t *testing.T) {
 	}
 	ddm.SetQueries("metric query1")
 	assert.Equal(t, &ddm, f.store.Get("default/autogen-1"))
+}
+
+// Scenario: UpdateStatus returns a conflict error (409) on the first attempt.
+// RetryOnConflict should re-GET the latest version and succeed on the second attempt.
+func TestLeaderUpdateRetryOnConflict(t *testing.T) {
+	f := newFixture(t)
+
+	updateTime := time.Now()
+	metric, metricTyped := newFakeDatadogMetric("default", "dd-metric-0", "metric query0", datadoghq.DatadogMetricStatus{})
+	f.datadogMetricLister = append(f.datadogMetricLister, metric)
+	f.objects = append(f.objects, metricTyped)
+
+	ddm := model.DatadogMetricInternal{
+		ID:         "default/dd-metric-0",
+		Valid:      true,
+		Value:      42.0,
+		UpdateTime: updateTime,
+		DataTime:   updateTime,
+		Error:      nil,
+	}
+	ddm.SetQueries("metric query0")
+	f.store.Set("default/dd-metric-0", ddm, "utest")
+
+	controller, informer := f.newController(true)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	informer.Start(stopCh)
+
+	// Inject a reactor that returns a conflict error on the first UpdateStatus call,
+	// then allows subsequent calls to proceed normally.
+	var updateAttempts int32
+	f.client.PrependReactor("update", "datadogmetrics", func(action core.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "status" {
+			return false, nil, nil
+		}
+		attempt := atomic.AddInt32(&updateAttempts, 1)
+		if attempt == 1 {
+			return true, nil, k8serrors.NewConflict(
+				schema.GroupResource{Group: "datadoghq.com", Resource: "datadogmetrics"},
+				"dd-metric-0",
+				errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+			)
+		}
+		// Let subsequent attempts fall through to the default handler
+		return false, nil, nil
+	})
+
+	_, err := controller.processDatadogMetric(0, "default/dd-metric-0")
+	assert.NoError(t, err)
+
+	// Verify that the update was retried: at least 2 UpdateStatus attempts
+	assert.GreaterOrEqual(t, int(atomic.LoadInt32(&updateAttempts)), 2,
+		"expected at least 2 update attempts (1 conflict + 1 success)")
+
+	// Verify the actions include GET (from RetryOnConflict re-read) and UpdateStatus calls
+	actions := autoscaling.FilterInformerActions(f.client.Actions(), "datadogmetrics")
+	getCount := 0
+	updateCount := 0
+	for _, action := range actions {
+		if action.GetVerb() == "get" {
+			getCount++
+		}
+		if action.GetVerb() == "update" && action.GetSubresource() == "status" {
+			updateCount++
+		}
+	}
+	assert.GreaterOrEqual(t, getCount, 2, "expected at least 2 GET calls (one per RetryOnConflict attempt)")
+	assert.GreaterOrEqual(t, updateCount, 2, "expected at least 2 UpdateStatus calls (1 conflict + 1 success)")
 }


### PR DESCRIPTION
### What does this PR do?
Implements the client-go's RetryOnConflict for updateDatadogMetric.

This is to resolve intermittent conflict errors like:
```
2026-03-17 01:55:47 UTC | CLUSTER | ERROR | (pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller.go:182 in process) | Impossible to synchronize DatadogMetric (attempt #2): default/stream-request-hits-with-buffer, err: Unable to update DatadogMetric: default/stream-request-hits-with-buffer, err: Operation cannot be fulfilled on datadogmetrics.datadoghq.com "stream-request-hits-with-buffer": the object has been modified; please apply your changes to the latest version and try again
```
Generally when the DCA's informer cache hasn't caught up yet resulting in fetching stale resourceVersion from the DatadogMetric hence producing this error.

### Motivation
CONS-8214

### Describe how you validated your changes

Validated the change with Included tests.

