### PR TITLE
fix(ksm_check): Cancel CRDiscoverer client on KSM unschedule

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/cr.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/cr.go
@@ -113,7 +113,7 @@ func (d customResourceDecoder) Decode(v interface{}) error {
 }
 
 // StartDiscovery starts the custom resource discovery and returns a discoverer instance
-func StartDiscovery() *discovery.CRDiscoverer {
+func StartDiscovery() (*discovery.CRDiscoverer, context.CancelFunc) {
 	discovererInstance := &discovery.CRDiscoverer{
 		CRDsAddEventsCounter:    crdsAddEventsCounter,
 		CRDsDeleteEventsCounter: crdsDeleteEventsCounter,
@@ -125,11 +125,12 @@ func StartDiscovery() *discovery.CRDiscoverer {
 		panic(err)
 	}
 
-	if err := discovererInstance.StartDiscovery(context.Background(), clientConfig); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := discovererInstance.StartDiscovery(ctx, clientConfig); err != nil {
 		log.Errorf("failed to start custom resource discovery: %v", err)
 	}
 
-	return discovererInstance
+	return discovererInstance, cancel
 }
 
 // GetCustomResourceFactories returns a list of custom resource factories

--- a/pkg/collector/corechecks/cluster/ksm/customresources/job.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/job.go
@@ -108,13 +108,12 @@ func (f *extendedJobFactory) ExpectedType() interface{} {
 // ListWatch returns a ListerWatcher for batchv1.Job
 func (f *extendedJobFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
 	client := customResourceClient.(kubernetes.Interface)
-	ctx := context.Background()
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
 			return client.BatchV1().Jobs(ns).List(ctx, opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
 			return client.BatchV1().Jobs(ns).Watch(ctx, opts)
 		},

--- a/pkg/collector/corechecks/cluster/ksm/customresources/replicaset.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/replicaset.go
@@ -82,13 +82,13 @@ func (f *replicaSetRolloutFactory) ExpectedType() interface{} {
 func (f *replicaSetRolloutFactory) ListWatch(customResourceClient interface{}, ns string, fieldSelector string) cache.ListerWatcher {
 	client := customResourceClient.(kubernetes.Interface)
 	return &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return client.AppsV1().ReplicaSets(ns).List(context.TODO(), opts)
+			return client.AppsV1().ReplicaSets(ns).List(ctx, opts)
 		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return client.AppsV1().ReplicaSets(ns).Watch(context.TODO(), opts)
+			return client.AppsV1().ReplicaSets(ns).Watch(ctx, opts)
 		},
 	}
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -256,6 +256,7 @@ type KSMCheck struct {
 	workloadmetaStore          workloadmeta.Component
 	rolloutTracker             *customresources.RolloutTracker
 	customResourceDiscoverer   *ksmDiscovery.CRDiscoverer
+	cancelCRDiscoverer         context.CancelFunc
 	namespaceTagsErrorLogLimit *log.Limit
 }
 
@@ -327,7 +328,7 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 
 	// Start custom resource discovery if not
 	if k.instance.PodCollectionMode != nodeKubeletPodCollection {
-		k.customResourceDiscoverer = customresources.StartDiscovery()
+		k.customResourceDiscoverer, k.cancelCRDiscoverer = customresources.StartDiscovery()
 	}
 
 	// Retry configuration steps related to API Server in check executions if necessary
@@ -762,6 +763,9 @@ func (k *KSMCheck) Cancel() {
 	log.Infof("Shutting down informers used by the check '%s'", k.ID())
 	if k.cancel != nil {
 		k.cancel()
+	}
+	if k.cancelCRDiscoverer != nil {
+		k.cancelCRDiscoverer()
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -490,15 +490,15 @@ func (k *KSMCheck) buildStores() error {
 	// Configure builder to enable callbacks for specific resource types
 	builder.WithCallbacksForResources(callbackResourceTypes)
 
-	// Start the collection process
-	k.allStores = builder.BuildStores()
-
 	// Cancel the old reflectors after the new store is created. Cancelling the
 	// old context ensures previous reflectors release their resources.
 	if k.cancel != nil {
 		k.cancel()
 	}
 	k.cancel = cancel
+
+	// Start the collection process
+	k.allStores = builder.BuildStores()
 
 	return nil
 }

--- a/pkg/kubestatemetrics/builder/builder.go
+++ b/pkg/kubestatemetrics/builder/builder.go
@@ -458,8 +458,8 @@ func generateConfigMapStores(
 
 func createConfigMapListWatch(metadataClient metadata.Interface, gvr schema.GroupVersionResource, namespace string) *cache.ListWatch {
 	return &cache.ListWatch{
-		ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-			result, err := metadataClient.Resource(gvr).Namespace(namespace).List(context.TODO(), options)
+		ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
+			result, err := metadataClient.Resource(gvr).Namespace(namespace).List(ctx, options)
 			if err != nil {
 				return nil, err
 			}
@@ -478,8 +478,8 @@ func createConfigMapListWatch(metadataClient metadata.Interface, gvr schema.Grou
 
 			return configMapList, nil
 		},
-		WatchFunc: func(options v1.ListOptions) (apiwatch.Interface, error) {
-			watcher, err := metadataClient.Resource(gvr).Namespace(namespace).Watch(context.TODO(), options)
+		WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (apiwatch.Interface, error) {
+			watcher, err := metadataClient.Resource(gvr).Namespace(namespace).Watch(ctx, options)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
### What does this PR do?

Fixes a resource leak in the `kubernetes_state_core` check where the `CRDiscoverer` informer was never stopped when the check was unscheduled.

`StartDiscovery()` in `customresources/cr.go` previously started a CRD informer using `context.Background()`, meaning the informer's goroutines and Kubernetes API watch connection had no way to be cancelled. This PR:

- Changes `StartDiscovery()` to create a cancellable context and return its `CancelFunc` alongside the `*CRDiscoverer`
- Stores the `CancelFunc` on `KSMCheck` as `cancelCRDiscoverer`
- Calls `cancelCRDiscoverer()` in `KSMCheck.Cancel()` to properly stop the CRD informer when the check is unscheduled

### Motivation

When the KSM check is unscheduled (e.g., during CLC runner rebalancing), `Cancel()` only cancelled the main KSM store informers via `k.cancel()`. The `CRDiscoverer` informer — started eagerly during `Configure()` — was left running because it used a non-cancellable `context.Background()`.

The `CRDiscoverer.StartDiscovery()` method (in `kube-state-metrics/pkg/discovery/discovery.go`) registers event handler closures that capture the `*CRDiscoverer` pointer, and starts a goroutine (`go informer.Run(stopper)`) that only exits when the `stopper` channel is closed. Since `stopper` is gated on `ctx.Done()` and the context was `context.Background()`, these goroutines could never terminate. Running goroutines are GC roots in Go, so the entire `CRDiscoverer` — including its CRD object cache, event handlers, and Kubernetes API watch connection — was permanently pinned in memory.

In CLC runner environments with advanced dispatching enabled, the rebalancer periodically moves checks between runners. Each rebalance cycle that touched a KSM check would leak one `CRDiscoverer` instance (with its goroutines, CRD cache, and watch connection) on the source runner. Over time, this accumulates leaked goroutines, file descriptors, and memory proportional to the number of rebalance events.

### Describe how you validated your changes

- Verified that the `CRDiscoverer.StartDiscovery()` method in the upstream `kube-state-metrics` library respects context cancellation: the goroutine at line 107-113 of `discovery.go` closes the `stopper` channel on `ctx.Done()`, which causes `informer.Run(stopper)` to exit
- Confirmed that after this change, calling `KSMCheck.Cancel()` will trigger context cancellation → `stopper` closed → informer goroutines exit → `CRDiscoverer` becomes unreferenced and eligible for GC

### Additional Information

Original refactor PR: https://github.com/DataDog/datadog-agent/pull/43315