### PR TITLE
[auto-jira][AGENTCFG-210] otel-agent: remove Datadog() global dependency from TestBadLogLevel

### DIFF
--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -7,7 +7,6 @@ package config
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"os"
 	"testing"
@@ -16,7 +15,6 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -304,10 +302,7 @@ func (suite *ConfigTestSuite) TestBadLogLevel() {
 	ddFileName := "testdata/datadog_bad_log_level.yaml"
 	_, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
 
-	expectedError := fmt.Sprintf(
-		"invalid log level (%v) set in the Datadog Agent configuration",
-		pkgconfigsetup.Datadog().GetString("log_level"))
-	assert.ErrorContains(t, err, expectedError)
+	assert.EqualError(t, err, "invalid log level (yabadabadoo) set in the Datadog Agent configuration")
 }
 
 func (suite *ConfigTestSuite) TestNoDDExporter() {


### PR DESCRIPTION
## What does this PR do?

`TestBadLogLevel` in `cmd/otel-agent/config/agent_config_test.go` was building its expected error string by reading `log_level` back from the `pkgconfigsetup.Datadog()` global accessor after `NewConfigComponent` loaded the config. This couples the test assertion to the global config — when the global is not used (e.g. in an isolated test environment), the test would read the wrong value and fail.

The bad log level is statically known from `testdata/datadog_bad_log_level.yaml` (`yabadabadoo`), so the fix hardcodes it directly — matching the pattern already used in `TestLowLogLevel`.

Also removes the now-unused `"fmt"` and `pkgconfigsetup` imports.

## Motivation

Jira: https://datadoghq.atlassian.net/browse/AGENTCFG-210

_Created by [Auto-JIRA](https://github.com/DataDog/datadog-agent/blob/main/.claude/skills/auto-jira/SKILL.md)._