### PR TITLE
[observer] Add observer-dev, observer-eval, and local-gensim skills

### DIFF
--- a/.claude/skills/local-gensim/SKILL.md
+++ b/.claude/skills/local-gensim/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: local-gensim
+description: >
+  Running gensim episodes locally on Kind clusters for observer evaluation.
+  Use this skill when the user wants to run episodes locally instead of on EKS,
+  set up a Kind cluster for testing, collect parquet recordings, or monitor
+  local runs. Trigger on mentions of "local episode", "kind cluster",
+  "run-local-episode", "local gensim", "food-delivery-redis locally",
+  "test observer changes locally", or wanting to evaluate observer without EKS.
+  Complements the gensim-episode-management skill (which covers EKS runs).
+---
+
+# Local Gensim Episode Runner
+
+Run gensim episodes on a local Kind cluster instead of EKS. Same episode
+format, same parquet output, compatible with `q.eval-scenarios`.
+
+## Quick start
+
+```bash
+dda inv q.run-local-episode \
+  --episode=food-delivery-redis \
+  --image=datadog/agent-dev:my-branch-tag \
+  --mode=live-and-record
+```
+
+## Prerequisites
+
+- `kind`, `kubectl`, `helm`, `docker` installed and in PATH
+- DD API + app keys in environment. The task checks `DDDEV_API_KEY` /
+  `DDDEV_APP_KEY` first (org-specific convention), then falls back to
+  `DD_API_KEY` / `DD_APP_KEY` (standard). The app key must be in `ddapp_*`
+  format — UUID-format keys will fail monitor creation with "Unauthorized".
+- gensim-episodes repo at `~/dd/gensim-episodes` (or set `--gensim-path`)
+- Agent image — either CI-built (`datadog/agent-dev:branch-tag`) or local
+  (`dda inv agent.hacky-dev-image-build --trace-agent --target-image observer-agent`)
+
+## Flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--episode` | `food-delivery-redis` | Episode name |
+| `--scenario` | auto from episode | Scenario file name (without .yaml) |
+| `--image` | required | Agent Docker image |
+| `--mode` | `live-and-record` | `live-and-record`, `record-parquet`, or `live-anomaly-detection` |
+| `--skip-build` | false | Skip docker compose build + kind load (images already in cluster) |
+| `--skip-teardown` | false | Leave episode + agent running after completion |
+| `--cluster-name` | `observer-local` | Kind cluster name |
+| `--output-dir` | `comp/observer/scenarios/<name>/parquet` | Where to save parquets |
+| `--gensim-path` | `~/dd/gensim-episodes` | Path to gensim-episodes repo |
+
+## What it does (7 phases)
+
+1. **Ensure Kind cluster** — auto-creates if missing, reuses if exists
+2. **Build/load images** — `docker compose build` for episode services, `kind load` each + agent image
+3. **Create K8s secrets** — `datadog-secret` from DD credentials
+4. **Install episode chart** — Helm install (services, Redis, Postgres, etc.)
+5. **Install Datadog Agent** — Helm install with observer config (HF checks, recording, analysis)
+6. **Run episode** — `play-episode.sh run-episode <scenario>` (~34 min: warmup → baseline → disruption → cooldown)
+7. **Collect parquet** — `kubectl cp` from agent pod to output dir
+
+## Monitoring a run
+
+```bash
+# TUI with mode picker (probes local Kind + remote EKS)
+uv run q_branch/gensim-status.py
+
+# Or skip picker, go straight to local
+uv run q_branch/gensim-status.py --local
+```
+
+The TUI shows episode status, phase, pod health, and tails the episode log.
+
+## After completion
+
+```bash
+# Copy episode.json (ground truth timestamps) if not already there
+cp ~/dd/gensim-episodes/synthetics/food-delivery-redis-cpu-saturation/results/redis-cpu-saturation-1.json \
+   comp/observer/scenarios/food_delivery_redis/episode.json
+
+# Optionally compact parquets (reduces disk usage ~98%)
+dda inv q.compact-parquets --scenario=food_delivery_redis
+
+# Score
+dda inv q.eval-scenarios --scenario=food_delivery_redis
+```
+
+## Fastest iteration (images already loaded)
+
+```bash
+dda inv q.run-local-episode \
+  --episode=food-delivery-redis \
+  --image=observer-agent:latest \
+  --mode=live-and-record \
+  --skip-build
+```
+
+## Available episodes
+
+The canonical episode corpus is in `q_branch/gensim-eval-scenarios.json`
+(added in #48607, merged to main). It lists episode/scenario pairs with
+pinned tree SHAs for reproducibility. For EKS runs, use
+`--episode-manifest=./q_branch/gensim-eval-scenarios.json`.
+
+For the local runner, the `_EPISODE_PATHS` dict in `tasks/q.py` maps short
+names to directory paths within the gensim-episodes repo. Add new episodes
+there. Episode directories live under `~/dd/gensim-episodes/synthetics/`
+and `~/dd/gensim-episodes/postmortems/`, each containing `play-episode.sh`,
+`chart/`, `episodes/*.yaml`, and optionally `docker-compose.yaml`.
+
+## Known issues
+
+### dd_url doesn't route event platform traffic
+
+Setting `dd_url` only routes metrics. Container lifecycle (`contlcycle`),
+container image, and log event platform pipelines use separate endpoints.
+Workaround: explicit per-pipeline `logs_dd_url` overrides in agent config.
+Root cause tracked in DataDog/datadog-agent#48814.
+
+### App key format
+
+The app key must be in `ddapp_*` format. If monitor creation fails with
+"Unauthorized", check which key format is in your environment. Stale tmux
+sessions may have an old UUID-format key cached — re-export with the
+correct value.
+
+### Python output buffering
+
+When piping through `tee`, Python's stdout buffering can make logs appear
+stuck at "Synchronizing dependencies". The task is actually running — verify
+via `kubectl get pods` or `ps aux | grep play-episode`.
+
+### Cleanup on failure
+
+Phases 3-7 are wrapped in try/finally. If a phase fails, previously-installed
+Helm releases are cleaned up automatically (unless `--skip-teardown`).
+
+### Cleanup
+
+```bash
+kind delete cluster --name observer-local
+```
+
+## Related skills
+
+- **gensim-episode-management** — for EKS-based runs
+- **observer-eval** — for scoring results after collection
+- **inspect-agent-egress-traffic** — for proxy-dumper egress inspection

--- a/.claude/skills/observer-dev/SKILL.md
+++ b/.claude/skills/observer-dev/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: observer-dev
+description: >
+  Development guide for comp/observer — the anomaly detection component. Use
+  this skill when working on observer internals: adding new signal types,
+  writing detectors or correlators, modifying the engine pipeline, adding Handle
+  methods, creating HF runners, or understanding how metrics flow from checks
+  through the observer. Also trigger on mentions of "observer component",
+  "anomaly detection pipeline", "detector", "correlator", "Handle interface",
+  or any work touching files in comp/observer/.
+---
+
+# Observer Development Guide
+
+## Architecture
+
+The observer is a self-contained anomaly detection engine that sits alongside
+the normal agent pipeline. It receives copies of metrics, logs, traces, and
+lifecycle events via lightweight handles, stores them in an internal time
+series database, and runs detectors and correlators to find anomalies.
+
+### Data flow
+
+```
+Check/DogStatsD/TraceAgent
+  → handle.ObserveMetric(sample)        # non-blocking channel send
+    → observation channel (cap 1000)
+      → run() loop (single goroutine)
+        → engine.IngestMetric(source, metricObs)
+          → storage.Add(source, name, value, ts, tags)
+          → scheduler.onObservation(ts, state)
+            → advanceRequest{upToSec, reason}
+              → engine.Advance(upToSec)
+                → detector.Detect(storage, dataTime) for each detector
+                → correlator.ProcessAnomaly() + Advance()
+                → emit events to reporters
+```
+
+### Key types
+
+| Type | File | Purpose |
+|------|------|---------|
+| `observation` | observer.go | Union struct: metric/log/trace/profile/lifecycle |
+| `engine` | engine.go | Orchestrates storage, detection, correlation |
+| `timeSeriesStorage` | storage.go | In-memory time series with summary stats |
+| `Detector` | component.go | Pulls data from storage, returns anomalies |
+| `SeriesDetector` | component.go | Simpler: receives a single Series, returns anomalies |
+| `Correlator` | component.go | Clusters anomalies into patterns |
+| `Handle` | component.go | Lightweight observation interface for data sources |
+
+### Handle interface
+
+Every data source gets a Handle via `observer.GetHandle("source-name")`. The
+Handle has methods for each signal type:
+
+- `ObserveMetric(MetricView)` — check metrics, DogStatsD, HF runner
+- `ObserveLog(LogView)` — log messages
+- `ObserveTrace(TraceView)` — APM traces
+- `ObserveTraceStats(TraceStatsView)` — pre-aggregated APM stats
+- `ObserveProfile(ProfileView)` — profiling samples
+- `ObserveLifecycle(LifecycleView)` — container create/start/delete events
+
+All sends are non-blocking. When the channel is full, both `dropCount`
+(atomic, for parity debugging) and `dropCounter` (telemetry, tagged by source)
+are incremented.
+
+## Adding a new observation type
+
+Follow this pattern (used for LifecycleView):
+
+1. **Interface** — add to `comp/observer/def/component.go`:
+   - New `FooView` interface with getter methods
+   - New `ObserveFoo(FooView)` method on `Handle`
+
+2. **Obs struct** — in `observer.go`:
+   - `fooObs` struct copying FooView fields
+   - Implement FooView getters on it
+   - Add `foo *fooObs` field to `observation` struct
+
+3. **Handle implementations** — update ALL of these:
+   - `handle` — copy data, send to channel (with drop counters)
+   - `noopObserveHandle` — empty body
+   - `hfFilteredHandle` — pass through to inner
+   - `storageHandle` (testbench.go) — empty body or store
+   - `recordingHandle` (recorder.go) — forward + write to storage
+
+4. **run() loop** — add `if obs.foo != nil { ... }` handling
+
+5. **Recorder** — add a writer if the data should be persisted (JSONL for
+   low-volume events, parquet for high-volume structured data)
+
+## HF runner pattern
+
+The high-frequency runner (`comp/observer/impl/hfrunner/`) runs existing agent
+checks at 1-second intervals, routing output directly into the observer via a
+custom `sender.Sender` implementation.
+
+### Key components
+
+- `observerSenderManager` — implements `sender.SenderManager`, returns
+  `observerSender` instances
+- `observerSender` — implements `sender.Sender`, routes Gauge/Rate/Count/etc.
+  to `handle.ObserveMetric()`
+- `Runner` — instantiates check factories, runs them on a 1s tick with
+  retry/backoff
+
+### Delta normalization
+
+Rate and MonotonicCount checks emit cumulative values. The normal aggregator
+converts these to per-second rates and deltas. The `observerSender` must do
+the same via `prevSample` tracking:
+
+- `Rate()` → `(current - previous) / elapsed_seconds`
+- `MonotonicCount()` → `current - previous` (handles counter wraps)
+- First sample silently dropped (no previous to diff against)
+
+### Source-based filtering
+
+When HF checks run at 1s, the 15s versions from the normal pipeline must be
+suppressed so the scorer doesn't double-count. This uses:
+
+- `MetricSource` enum (from `pkg/metrics/metricsource.go`)
+- `sourceProvider` interface (type assertion on `*metrics.MetricSample`)
+- `hfFilteredHandle` wrapping the `"all-metrics"` handle with a dynamic
+  source set
+
+The filter activates ONLY after the runner starts successfully — not on config
+flag alone. This prevents suppressing 15s data when the HF replacement fails.
+
+### Adding deps for container checks
+
+System checks need no deps. Container checks need WMeta, FilterStore, Tagger:
+
+```go
+type ContainerDeps struct {
+    WMeta       workloadmetadef.Component
+    FilterStore workloadfilterdef.Component
+    Tagger      taggerdef.Component
+}
+func NewContainer(handle, deps ContainerDeps) *Runner
+```
+
+These come from `option.Option[T]` fields in observer's `Requires`. The
+options are provided by each dep's own fx module — don't add `ProvideOptional`
+to the observer's `fx.go`.
+
+## Key files
+
+| File | What's there |
+|------|-------------|
+| `comp/observer/def/component.go` | All public interfaces |
+| `comp/observer/impl/observer.go` | Handles, plumbing, run loop, NewComponent |
+| `comp/observer/impl/engine.go` | Detection/correlation pipeline |
+| `comp/observer/impl/storage.go` | Time series storage |
+| `comp/observer/impl/telemetry.go` | Telemetry constants and handler |
+| `comp/observer/impl/hfrunner/` | HF check runner + sender |
+| `comp/observer/impl/component_catalog.go` | Detector/correlator registration |
+| `comp/observer/impl/lifecycle_watcher.go` | WLM container event subscription |
+| `comp/observer/fx/fx.go` | fx module |
+| `pkg/config/setup/config.go` | Config keys (search `observer.`) |
+
+## Config keys
+
+```yaml
+observer:
+  analysis:
+    enabled: true                              # enable detection pipeline
+  high_frequency_system_checks:
+    enabled: false                             # 1s system checks
+  high_frequency_container_checks:
+    enabled: false                             # 1s container checks
+  recording:
+    enabled: false                             # parquet recording
+    parquet_output_dir: /tmp/observer-parquet
+    parquet_flush_interval: 30s
+  debug_dump_path: ""                          # JSON dump of storage
+  debug_dump_interval: 0                       # dump interval
+  components:
+    bocpd:
+      enabled: true                            # per-detector toggles
+    rrcf:
+      enabled: true
+    scanwelch:
+      enabled: false
+    time_cluster:
+      enabled: true
+```
+
+## Build and test
+
+```bash
+go build ./comp/observer/impl/...
+go test -count=1 ./comp/observer/impl/...
+```

--- a/.claude/skills/observer-eval/SKILL.md
+++ b/.claude/skills/observer-eval/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: observer-eval
+description: >
+  Running and scoring observer anomaly detection evaluations. Use this skill
+  when the user wants to run eval scenarios, score detection results, interpret
+  F1/precision/recall metrics, compare detector configurations, manage parquet
+  files, or debug testbench replay divergences. Trigger on mentions of "eval",
+  "scoring", "F1 score", "testbench", "parquet", "ground truth", "scenario",
+  "q.eval-scenarios", "q.eval-tp", anomaly detection quality, or detector
+  comparison — even if the user doesn't use these exact terms.
+---
+
+# Observer Evaluation Guide
+
+## Running evals
+
+```bash
+# All scenarios with default detectors (bocpd, rrcf, time_cluster)
+dda inv q.eval-scenarios
+
+# Single scenario
+dda inv q.eval-scenarios --scenario=food_delivery_redis
+
+# Specific detectors
+dda inv q.eval-scenarios --scenario=food_delivery_redis --only bocpd,rrcf,scanwelch,time_cluster
+
+# True-positive scoring (needs passthrough correlator)
+dda inv q.eval-tp --scenario=food_delivery_redis --only bocpd,passthrough
+```
+
+The `--only` flag controls which detectors/correlators are enabled. The
+`time_cluster` correlator is always auto-added for `eval-scenarios`.
+
+## What the eval does
+
+1. Builds `observer-testbench` and `observer-scorer` Go binaries
+2. Loads parquets from `comp/observer/scenarios/<scenario>/parquet/`
+3. Testbench replays all data through the observer engine (same code path as live)
+4. Outputs `/tmp/observer-eval-<scenario>.json`
+5. Scorer matches anomaly periods against ground truth
+6. Prints summary table: F1, precision, recall, alpha, scored, baseline FPs
+
+## Interpreting results
+
+```
+Scenario                    F1  Precision  Recall  Alpha  Scored  Baseline FPs
+food_delivery_redis     0.0000     0.0000  0.0000 0.0116      20             7
+```
+
+| Metric | Meaning |
+|--------|---------|
+| **F1** | Harmonic mean of precision and recall. 0 = no true positives matched. |
+| **Precision** | What fraction of detected anomalies are real incidents |
+| **Recall** | What fraction of real incidents were detected |
+| **Alpha** | False positive rate = FPs / baseline duration (lower is better) |
+| **Scored** | Total anomaly periods evaluated |
+| **Baseline FPs** | Anomalies during the baseline (pre-disruption) period |
+| **Warmup (excl)** | Anomalies excluded because they're in the detector warmup window |
+| **Cascading (excl)** | Anomalies excluded as consequences of an earlier detection |
+
+### Common gotchas
+
+- **F1=0 doesn't mean detection failed.** The scorer checks specific ground
+  truth metric names. If the observer detects anomalies under a different
+  namespace (e.g. `system-checks-hf` vs `parquet`), they won't match.
+- **BOCPD warmup is ~120 data points.** For 15s metrics that's 30 minutes.
+  For 1s HF metrics it's 2 minutes. Anomalies during warmup are excluded.
+- **Live vs replay divergences** are expected when HF data exists only in
+  live. The divergence log shows "live-only" and "replay-only" anomalies
+  by source namespace.
+
+## Ground truth
+
+Two files are needed per scenario:
+
+1. **`comp/observer/scenarios/ground_truth.json`** — maps scenarios to expected
+   TP metrics (service + metric name pairs)
+
+2. **`comp/observer/scenarios/<scenario>/episode.json`** — disruption window
+   timestamps from the episode run. If missing after a local run, copy from
+   gensim-episodes:
+   ```bash
+   cp ~/dd/gensim-episodes/synthetics/food-delivery-redis-cpu-saturation/results/redis-cpu-saturation-1.json \
+      comp/observer/scenarios/food_delivery_redis/episode.json
+   ```
+
+## Parquet management
+
+### File types
+
+| File pattern | Contents |
+|-------------|----------|
+| `observer-metrics-*.parquet` | Check metrics + DogStatsD |
+| `observer-logs-*.parquet` | Log messages |
+| `observer-trace-stats-*.parquet` | Pre-aggregated APM stats |
+| `observer-traces-*.parquet` | Raw spans |
+| `observer-lifecycle.jsonl` | Container lifecycle events |
+| `advances.jsonl` | Scheduler advance log (parity debugging) |
+| `detect_digests.jsonl` | Detection digests (parity debugging) |
+
+### Compacting
+
+Per-flush parquet files are small and numerous. Compact them:
+
+```bash
+dda inv q.compact-parquets --scenario=food_delivery_redis
+# 468 files (959MB) → 4 files (23MB), 98% reduction
+```
+
+Uses pyarrow (in `deps/py_dev_requirements.txt`, synced by dda automatically).
+
+### Downloading from S3
+
+```bash
+dda inv q.download-scenarios                    # all scenarios
+dda inv q.download-scenarios --scenario=food_delivery_redis  # single
+```
+
+Fetches from `s3://qbranch-gensim-recordings` via `runs.jsonl` audit trail.
+Requires AWS SSO auth: `aws-vault exec sso-agent-sandbox-account-admin`.
+
+## Available detectors
+
+| Detector | Default | Notes |
+|----------|---------|-------|
+| `bocpd` | on | Bayesian online changepoint detection. Needs ~120 points warmup. |
+| `rrcf` | on | Robust random cut forest. Streaming anomaly scores. |
+| `scanwelch` | off | Spectral (Welch PSD) changepoint. Strict thresholds. |
+| `scanmw` | off | Mann-Whitney changepoint. Similar to ScanWelch. |
+| `cusum` | off | Cumulative sum changepoint. |
+| `time_cluster` | on (correlator) | Clusters anomalies by temporal proximity. |
+| `passthrough` | off (correlator) | No clustering, needed for eval-tp. |
+
+## Known detector issues
+
+- **ScanWelch/ScanMW**: `MinDeviationMAD` should be 3.0 (was 15.0 from a
+  temp noise reduction). `MinTStatistic=8.0` and `SignificanceThreshold=1e-8`
+  are very strict — may need tuning.
+- **Correlator ordering**: must accumulate correlations BEFORE advancing, or
+  clusters from historical-timestamp anomalies get evicted before capture.
+- **SamplingIntervalSec**: scan detectors populate this for dynamic proximity
+  scaling in the correlator. Proximity capped at `WindowSeconds/2`.


### PR DESCRIPTION
## Summary

Three skills capturing operational knowledge for working with comp/observer:

- **observer-dev** — architecture guide, adding new signal types (Handle interface pattern), HF runner pattern, source-based filtering, delta normalization, fx dependency patterns, key files and config keys
- **observer-eval** — running q.eval-scenarios, interpreting F1/precision/recall/alpha, parquet management, ground truth setup, detector configuration, known issues (ScanWelch thresholds, correlator ordering)
- **local-gensim** — running episodes on Kind via q.run-local-episode, monitoring with gensim-status.py, collecting parquets, episode manifest reference (q_branch/gensim-eval-scenarios.json from #48607)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)