### PR TITLE
[noisy_neighbor] Add latency-per-preemption derived metric

### DIFF
--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -131,6 +131,11 @@ func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat mod
 
 	psp := float64(stat.PreemptionCount) / float64(stat.UniquePidCount)
 	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.per_process", psp, "", tags)
+
+	if stat.PreemptionCount > 0 {
+		latPerPreempt := float64(stat.SumLatenciesNs) / float64(stat.PreemptionCount)
+		sender.Gauge("noisy_neighbor.latency_per_preemption", latPerPreempt, "", tags)
+	}
 }
 
 func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {


### PR DESCRIPTION
## Summary
- Adds a `noisy_neighbor.latency_per_preemption` gauge that divides total scheduling latency by preemption count
- This derived metric characterizes the *type* of contention: few long waits (deep run queue) vs many short preemptions (rapid thrashing)
- Pure agent-side change — no eBPF modifications, zero performance impact on the hot path

## Test plan
- [ ] Verify metric is emitted when `PreemptionCount > 0`
- [ ] Verify metric is NOT emitted when `PreemptionCount == 0` (no division by zero)
- [ ] Confirm existing PSL and PSP metrics are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)