### PR TITLE
[noisy_neighbor] Split preemptions into foreign vs self + add latency_per_preemption

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
@@ -6,7 +6,8 @@
 typedef struct {
     __u64 sum_latencies_ns;
     __u64 event_count;
-    __u64 preemption_count;
+    __u64 foreign_preemption_count;
+    __u64 self_preemption_count;
     __u64 pid_count;
 } cgroup_agg_stats_t;
 

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -95,11 +95,20 @@ int tp_sched_switch(u64 *ctx) {
         enqueue_timestamp(prev);
     }
 
+    // Hoist next cgroup lookup — used by both preemption classification and latency recording
+    u64 next_cgroup_id = 0;
+    if (next_pid) {
+        next_cgroup_id = get_task_cgroup_id(next);
+    }
+
     if (preempted && prev_pid) {
         u64 prev_cgroup_id = get_task_cgroup_id(prev);
         cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(prev_cgroup_id);
         if (stats) {
-            stats->preemption_count += 1;
+            if (prev_cgroup_id != next_cgroup_id)
+                stats->foreign_preemption_count += 1;
+            else
+                stats->self_preemption_count += 1;
         }
     }
 
@@ -115,8 +124,7 @@ int tp_sched_switch(u64 *ctx) {
     u64 runq_lat = bpf_ktime_get_ns() - *tsp;
     bpf_task_storage_delete(&runq_enqueued, next);
 
-    u64 cgroup_id = get_task_cgroup_id(next);
-    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(next_cgroup_id);
     if (stats) {
         stats->sum_latencies_ns += runq_lat;
         stats->event_count += 1;

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -131,6 +131,11 @@ func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat mod
 
 	psp := float64(stat.PreemptionCount) / float64(stat.UniquePidCount)
 	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.per_process", psp, "", tags)
+
+	if stat.PreemptionCount > 0 {
+		latPerPreempt := float64(stat.SumLatenciesNs) / float64(stat.PreemptionCount)
+		sender.Gauge("noisy_neighbor.latency_per_preemption", latPerPreempt, "", tags)
+	}
 }
 
 func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -129,11 +129,15 @@ func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat mod
 	psl := float64(stat.SumLatenciesNs) / float64(stat.UniquePidCount)
 	sender.Gauge("noisy_neighbor.process_scheduling_latency.per_process", psl, "", tags)
 
-	psp := float64(stat.PreemptionCount) / float64(stat.UniquePidCount)
-	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.per_process", psp, "", tags)
+	foreignPsp := float64(stat.ForeignPreemptionCount) / float64(stat.UniquePidCount)
+	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.foreign.per_process", foreignPsp, "", tags)
 
-	if stat.PreemptionCount > 0 {
-		latPerPreempt := float64(stat.SumLatenciesNs) / float64(stat.PreemptionCount)
+	selfPsp := float64(stat.SelfPreemptionCount) / float64(stat.UniquePidCount)
+	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.self.per_process", selfPsp, "", tags)
+
+	totalPreemptions := stat.ForeignPreemptionCount + stat.SelfPreemptionCount
+	if totalPreemptions > 0 {
+		latPerPreempt := float64(stat.SumLatenciesNs) / float64(totalPreemptions)
 		sender.Gauge("noisy_neighbor.latency_per_preemption", latPerPreempt, "", tags)
 	}
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
@@ -4,8 +4,9 @@
 package noisyneighbor
 
 type ebpfCgroupAggStats struct {
-	Sum_latencies_ns uint64
-	Event_count      uint64
-	Preemption_count uint64
-	Pid_count        uint64
+	Sum_latencies_ns         uint64
+	Event_count              uint64
+	Foreign_preemption_count uint64
+	Self_preemption_count    uint64
+	Pid_count                uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -11,6 +11,7 @@ type NoisyNeighborStats struct {
 	CgroupID        uint64
 	SumLatenciesNs  uint64
 	EventCount      uint64
-	PreemptionCount uint64
-	UniquePidCount  uint64 // kernel task_struct->pid (TID) count
+	ForeignPreemptionCount uint64
+	SelfPreemptionCount    uint64
+	UniquePidCount         uint64 // kernel task_struct->pid (TID) count
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -104,11 +104,12 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 	var cgroupsToDelete []uint64
 
 	for iter.Next(&cgroupID, &perCPUStats) {
-		var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
+		var cgroupLatencies, cgroupEvents, cgroupForeignPreemptions, cgroupSelfPreemptions, pidCount uint64
 		for _, cpuStat := range perCPUStats {
 			cgroupLatencies += cpuStat.Sum_latencies_ns
 			cgroupEvents += cpuStat.Event_count
-			cgroupPreemptions += cpuStat.Preemption_count
+			cgroupForeignPreemptions += cpuStat.Foreign_preemption_count
+			cgroupSelfPreemptions += cpuStat.Self_preemption_count
 			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
 			if cpuStat.Pid_count > pidCount {
 				pidCount = cpuStat.Pid_count
@@ -122,11 +123,12 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 		}
 
 		stat := model.NoisyNeighborStats{
-			CgroupID:        cgroupID,
-			SumLatenciesNs:  cgroupLatencies,
-			EventCount:      cgroupEvents,
-			PreemptionCount: cgroupPreemptions,
-			UniquePidCount:  pidCount,
+			CgroupID:               cgroupID,
+			SumLatenciesNs:         cgroupLatencies,
+			EventCount:             cgroupEvents,
+			ForeignPreemptionCount: cgroupForeignPreemptions,
+			SelfPreemptionCount:    cgroupSelfPreemptions,
+			UniquePidCount:         pidCount,
 		}
 
 		nnstats = append(nnstats, stat)


### PR DESCRIPTION
## Summary
- Replaces the single `preemption_count` with `foreign_preemption_count` and `self_preemption_count` in the eBPF program
- Foreign = preempted by a task in a **different** cgroup (the noisy neighbor signal)
- Self = preempted by a task in the **same** cgroup (internal workload contention)
- Hoists `get_task_cgroup_id(next)` above both the preemption and latency paths, eliminating a redundant pointer chase — the marginal cost of the cgroup comparison is effectively zero
- Emits `noisy_neighbor.process_scheduler_preemptions.foreign.per_process` and `.self.per_process`

## Test plan
- [ ] Verify both metrics are emitted with correct container tags
- [ ] Validate on a host with multiple containers that foreign/self counts are correctly classified
- [ ] Confirm no regression in `sched_switch` handler latency (hoisted lookup should be net-neutral)
- [ ] Check eBPF program loads successfully on kernel 6.2+

🤖 Generated with [Claude Code](https://claude.com/claude-code)