### PR TITLE
[noisy_neighbor] Rename unique_processes to cgroup_task_count

### DIFF
--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -122,18 +122,18 @@ func (n *NoisyNeighborCheck) getContainerTags(stat model.NoisyNeighborStats) []s
 // submitPrimaryMetrics sends the main PSL and PSP metrics
 // Note: "process" in metric names follows kernel convention, but these are thread-level measurements
 func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
-	if stat.UniquePidCount == 0 {
+	if stat.CgroupTaskCount == 0 {
 		return
 	}
 
-	psl := float64(stat.SumLatenciesNs) / float64(stat.UniquePidCount)
+	psl := float64(stat.SumLatenciesNs) / float64(stat.CgroupTaskCount)
 	sender.Gauge("noisy_neighbor.process_scheduling_latency.per_process", psl, "", tags)
 
-	psp := float64(stat.PreemptionCount) / float64(stat.UniquePidCount)
+	psp := float64(stat.PreemptionCount) / float64(stat.CgroupTaskCount)
 	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.per_process", psp, "", tags)
 }
 
 func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
 	sender.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
-	sender.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
+	sender.Gauge("noisy_neighbor.cgroup_task_count", float64(stat.CgroupTaskCount), "", tags)
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -12,5 +12,5 @@ type NoisyNeighborStats struct {
 	SumLatenciesNs  uint64
 	EventCount      uint64
 	PreemptionCount uint64
-	UniquePidCount  uint64 // kernel task_struct->pid (TID) count
+	CgroupTaskCount uint64 // total tasks in cgroup from pids_cgroup->counter, not unique active PIDs
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -126,7 +126,7 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 			SumLatenciesNs:  cgroupLatencies,
 			EventCount:      cgroupEvents,
 			PreemptionCount: cgroupPreemptions,
-			UniquePidCount:  pidCount,
+			CgroupTaskCount: pidCount,
 		}
 
 		nnstats = append(nnstats, stat)


### PR DESCRIPTION
## Summary
- Renames `UniquePidCount` field to `CgroupTaskCount` in the Go model
- Renames `noisy_neighbor.unique_processes` metric to `noisy_neighbor.cgroup_task_count`
- The value comes from `pids_cgroup->counter` which is total cgroup membership, NOT unique PIDs observed during the interval — the old name was misleading
- No eBPF changes; the underlying data is unchanged, only the naming is corrected

## Test plan
- [ ] Verify `noisy_neighbor.cgroup_task_count` is emitted (replaces `unique_processes`)
- [ ] Confirm PSL and PSP per-process normalization still works correctly
- [ ] **Note:** This is a breaking metric name change — downstream dashboards/monitors referencing `unique_processes` will need updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)