### PR TITLE
[noisy_neighbor] Rework into 3-layer architecture with conditional eBPF

### DIFF
--- a/cmd/system-probe/modules/noisy_neighbor.go
+++ b/cmd/system-probe/modules/noisy_neighbor.go
@@ -8,12 +8,14 @@
 package modules
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
@@ -59,11 +61,28 @@ func (n noisyNeighborModule) GetStats() map[string]interface{} {
 
 // Register implements module.Module.Register
 func (n noisyNeighborModule) Register(httpMux *module.Router) error {
-	// Limit concurrency to one as the probe check is not thread safe (mainly in the entry count buffers)
+	// Limit concurrency to one as the probe check is not thread safe
 	httpMux.HandleFunc("/check", utils.WithConcurrencyLimit(1, func(w http.ResponseWriter, req *http.Request) {
 		n.lastCheck.Store(time.Now().Unix())
 		stats := n.Probe.GetAndFlush()
 		utils.WriteAsJSON(req, w, stats, utils.GetPrettyPrintFromQueryParams(req))
+	}))
+
+	httpMux.HandleFunc("/watchlist", utils.WithConcurrencyLimit(1, func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var watchlistReq model.WatchlistRequest
+		if err := json.NewDecoder(req.Body).Decode(&watchlistReq); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := n.Probe.UpdateWatchlist(watchlistReq.CgroupIDs); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
 	}))
 
 	return nil

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
@@ -6,8 +6,23 @@
 typedef struct {
     __u64 sum_latencies_ns;
     __u64 event_count;
-    __u64 preemption_count;
-    __u64 pid_count;
+    __u64 foreign_preemption_count;
+    __u64 self_preemption_count;
+    __u64 task_count;
+    __u64 latency_bucket_lt_100us;
+    __u64 latency_bucket_100us_1ms;
+    __u64 latency_bucket_1ms_10ms;
+    __u64 latency_bucket_gt_10ms;
+    __u64 cpu_migrations;
 } cgroup_agg_stats_t;
+
+typedef struct {
+    __u64 victim_cgroup_id;
+    __u64 preemptor_cgroup_id;
+} preemptor_key_t;
+
+typedef struct {
+    __u64 count;
+} preemptor_stats_t;
 
 #endif

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -8,11 +8,21 @@
 #include "bpf_telemetry.h"
 
 #define MAX_TASK_ENTRIES 4096
+#define MAX_PREEMPTOR_ENTRIES 512
 #define TASK_RUNNING 0
 
 BPF_TASK_STORAGE_MAP(runq_enqueued, u64)
 
 BPF_PERCPU_HASH_MAP(cgroup_agg_stats, __u64, cgroup_agg_stats_t, MAX_TASK_ENTRIES)
+
+// watchlist_active: single-entry gate. If 0, sched_switch does minimal work.
+BPF_ARRAY_MAP(watchlist_active, __u8, 1)
+
+// watchlist: cgroup IDs that Layer 1 flagged for detailed monitoring
+BPF_HASH_MAP(watchlist, __u64, __u8, 128)
+
+// preemptor_stats: tracks which foreign cgroups preempt watched cgroups
+BPF_PERCPU_HASH_MAP(preemptor_stats, preemptor_key_t, preemptor_stats_t, MAX_PREEMPTOR_ENTRIES)
 
 void bpf_rcu_read_lock(void) __ksym;
 void bpf_rcu_read_unlock(void) __ksym;
@@ -85,6 +95,18 @@ int tp_sched_wakeup_new(u64 *ctx) {
 
 SEC("tp_btf/sched_switch")
 int tp_sched_switch(u64 *ctx) {
+    // Fast gate: skip all detailed work if no cgroups are being watched
+    u32 zero_key = 0;
+    u8 *active = bpf_map_lookup_elem(&watchlist_active, &zero_key);
+    if (!active || !*active) {
+        // Still re-enqueue runnable tasks so timestamps are ready when watchlist activates
+        struct task_struct *prev = (struct task_struct *)ctx[1];
+        if (prev->__state == TASK_RUNNING) {
+            enqueue_timestamp(prev);
+        }
+        return 0;
+    }
+
     bool preempted = ctx[0] & 1;
     struct task_struct *prev = (struct task_struct *)ctx[1];
     struct task_struct *next = (struct task_struct *)ctx[2];
@@ -95,15 +117,45 @@ int tp_sched_switch(u64 *ctx) {
         enqueue_timestamp(prev);
     }
 
-    if (preempted && prev_pid) {
-        u64 prev_cgroup_id = get_task_cgroup_id(prev);
+    // Resolve cgroup IDs for both tasks
+    u64 prev_cgroup_id = prev_pid ? get_task_cgroup_id(prev) : 0;
+    u64 next_cgroup_id = next_pid ? get_task_cgroup_id(next) : 0;
+
+    // Check if either cgroup is in the watchlist
+    bool prev_watched = prev_pid && bpf_map_lookup_elem(&watchlist, &prev_cgroup_id);
+    bool next_watched = next_pid && bpf_map_lookup_elem(&watchlist, &next_cgroup_id);
+
+    if (!prev_watched && !next_watched) {
+        return 0;
+    }
+
+    // Layer 2: Preemption classification for the victim (prev) cgroup
+    if (preempted && prev_watched) {
         cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(prev_cgroup_id);
         if (stats) {
-            stats->preemption_count += 1;
+            if (prev_cgroup_id != next_cgroup_id) {
+                stats->foreign_preemption_count += 1;
+
+                // Layer 3: Track which foreign cgroup is doing the preempting
+                preemptor_key_t pkey = {
+                    .victim_cgroup_id = prev_cgroup_id,
+                    .preemptor_cgroup_id = next_cgroup_id,
+                };
+                preemptor_stats_t *pstats = bpf_map_lookup_elem(&preemptor_stats, &pkey);
+                if (pstats) {
+                    pstats->count += 1;
+                } else {
+                    preemptor_stats_t new_pstats = { .count = 1 };
+                    bpf_map_update_with_telemetry(preemptor_stats, &pkey, &new_pstats, BPF_NOEXIST, -EEXIST);
+                }
+            } else {
+                stats->self_preemption_count += 1;
+            }
         }
     }
 
-    if (!next_pid) {
+    // Layer 2: Latency measurement for the scheduled-in (next) cgroup
+    if (!next_watched || !next_pid) {
         return 0;
     }
 
@@ -115,12 +167,49 @@ int tp_sched_switch(u64 *ctx) {
     u64 runq_lat = bpf_ktime_get_ns() - *tsp;
     bpf_task_storage_delete(&runq_enqueued, next);
 
-    u64 cgroup_id = get_task_cgroup_id(next);
-    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(next_cgroup_id);
     if (stats) {
         stats->sum_latencies_ns += runq_lat;
         stats->event_count += 1;
-        stats->pid_count = get_cgroup_pids_count(next);
+        stats->task_count = get_cgroup_pids_count(next);
+
+        // Latency histogram buckets
+        if (runq_lat < 100000)
+            stats->latency_bucket_lt_100us += 1;
+        else if (runq_lat < 1000000)
+            stats->latency_bucket_100us_1ms += 1;
+        else if (runq_lat < 10000000)
+            stats->latency_bucket_1ms_10ms += 1;
+        else
+            stats->latency_bucket_gt_10ms += 1;
+    }
+
+    return 0;
+}
+
+SEC("tp_btf/sched_migrate_task")
+int tp_sched_migrate_task(u64 *ctx) {
+    // Fast gate
+    u32 zero_key = 0;
+    u8 *active = bpf_map_lookup_elem(&watchlist_active, &zero_key);
+    if (!active || !*active) {
+        return 0;
+    }
+
+    struct task_struct *task = (struct task_struct *)ctx[0];
+    u32 pid = task->pid;
+    if (!pid) {
+        return 0;
+    }
+
+    u64 cgroup_id = get_task_cgroup_id(task);
+    if (!bpf_map_lookup_elem(&watchlist, &cgroup_id)) {
+        return 0;
+    }
+
+    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    if (stats) {
+        stats->cpu_migrations += 1;
     }
 
     return 0;

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -9,8 +9,11 @@ package noisyneighbor
 
 import (
 	"fmt"
+	"path/filepath"
+	"sort"
 	"time"
 
+	cpuutil "github.com/shirou/gopsutil/v4/cpu"
 	"go.yaml.in/yaml/v2"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
@@ -29,14 +32,37 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
-type NoisyNeighborConfig struct{}
+const (
+	defaultPSIThreshold     = 5.0  // PSI avg10 "some" percentage
+	defaultThrottleRatio    = 0.10 // 10% of wall clock spent throttled
+	defaultStealThreshold   = 5.0  // steal time percentage
+	maxWatchlistSize        = 100
+	maxTopNPreemptors       = 5
+	maxNonContainerCgroups  = 100
+	checkIntervalNs         = float64(10 * time.Second)
+)
 
+// NoisyNeighborConfig holds check configuration
+type NoisyNeighborConfig struct {
+	PSIThreshold   float64 `yaml:"psi_threshold"`
+	ThrottleRatio  float64 `yaml:"throttle_ratio"`
+	StealThreshold float64 `yaml:"steal_threshold"`
+}
+
+// NoisyNeighborCheck implements the 3-layer noisy neighbor detection check
 type NoisyNeighborCheck struct {
 	core.CheckBase
 	config         *NoisyNeighborConfig
 	tagger         tagger.Component
 	sysProbeClient *sysprobeclient.CheckClient
-	cgroupReader   *cgroups.Reader
+	cgroupReader   *cgroups.Reader     // container cgroups (for tagging)
+	allCgroupReader *cgroups.Reader    // all cgroups (for Layer 1 PSI reading)
+
+	// Layer 1 state
+	lastThrottledNs map[uint64]uint64 // cgroup inode -> last throttled_time in ns
+	lastStealTime   float64
+	lastTotalCPU    float64
+	firstRun        bool
 }
 
 func Factory(tagger tagger.Component) option.Option[func() check.Check] {
@@ -47,14 +73,28 @@ func Factory(tagger tagger.Component) option.Option[func() check.Check] {
 
 func newCheck(tagger tagger.Component) check.Check {
 	return &NoisyNeighborCheck{
-		CheckBase: core.NewCheckBaseWithInterval(CheckName, 10*time.Second),
-		config:    &NoisyNeighborConfig{},
-		tagger:    tagger,
+		CheckBase:       core.NewCheckBaseWithInterval(CheckName, 10*time.Second),
+		config:          &NoisyNeighborConfig{},
+		tagger:          tagger,
+		lastThrottledNs: make(map[uint64]uint64),
+		firstRun:        true,
 	}
 }
 
 func (c *NoisyNeighborConfig) Parse(data []byte) error {
-	return yaml.Unmarshal(data, c)
+	if err := yaml.Unmarshal(data, c); err != nil {
+		return err
+	}
+	if c.PSIThreshold == 0 {
+		c.PSIThreshold = defaultPSIThreshold
+	}
+	if c.ThrottleRatio == 0 {
+		c.ThrottleRatio = defaultThrottleRatio
+	}
+	if c.StealThreshold == 0 {
+		c.StealThreshold = defaultStealThreshold
+	}
+	return nil
 }
 
 func (n *NoisyNeighborCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string, provider string) error {
@@ -65,75 +105,259 @@ func (n *NoisyNeighborCheck) Configure(senderManager sender.SenderManager, _ uin
 		return fmt.Errorf("noisy_neighbor check config: %s", err)
 	}
 	n.sysProbeClient = sysprobeclient.GetCheckClient(sysprobeclient.WithSocketPath(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")))
+
+	// Container reader for tag resolution
 	reader, err := cgroups.NewReader(cgroups.WithReaderFilter(cgroups.ContainerFilter))
 	if err != nil {
-		return fmt.Errorf("noisy_neighbor: cgroup reader init failed: %s", err)
+		return fmt.Errorf("noisy_neighbor: container cgroup reader init failed: %s", err)
 	}
 	n.cgroupReader = reader
+
+	// All-cgroup reader for Layer 1 PSI/stat reading
+	allReader, err := cgroups.NewReader()
+	if err != nil {
+		return fmt.Errorf("noisy_neighbor: all cgroup reader init failed: %s", err)
+	}
+	n.allCgroupReader = allReader
+
 	return nil
 }
 
 func (n *NoisyNeighborCheck) Run() error {
-	stats, err := sysprobeclient.GetCheck[[]model.NoisyNeighborStats](n.sysProbeClient, sysconfig.NoisyNeighborModule)
-	if err != nil {
-		return fmt.Errorf("get noisy neighbor check: %s", err)
-	}
-
-	sender, err := n.GetSender()
+	s, err := n.GetSender()
 	if err != nil {
 		return fmt.Errorf("get metric sender: %s", err)
 	}
 
-	err = n.cgroupReader.RefreshCgroups(0)
-	if err != nil {
-		return fmt.Errorf("unable to refresh cgroups: %s", err)
+	// Refresh both cgroup readers
+	if err := n.allCgroupReader.RefreshCgroups(0); err != nil {
+		return fmt.Errorf("unable to refresh all cgroups: %s", err)
+	}
+	if err := n.cgroupReader.RefreshCgroups(0); err != nil {
+		return fmt.Errorf("unable to refresh container cgroups: %s", err)
 	}
 
-	var totalCgroups uint64
-	for _, stat := range stats {
-		totalCgroups++
-		tags := n.getContainerTags(stat)
-		n.submitPrimaryMetrics(sender, stat, tags)
-		n.submitRawCounters(sender, stat, tags)
+	// Layer 1: Read canary signals from filesystem
+	flaggedCgroupIDs, stealPct := n.runLayer1(s)
+
+	// Emit system-wide steal time
+	if !n.firstRun {
+		s.Gauge("noisy_neighbor.system.steal_time_pct", stealPct, "", nil)
 	}
-	sender.Gauge("noisy_neighbor.system.cgroups_tracked", float64(totalCgroups), "", nil)
-	sender.Commit()
+
+	// Update watchlist in system-probe
+	watchlistReq := model.WatchlistRequest{CgroupIDs: flaggedCgroupIDs}
+	if _, err := sysprobeclient.Post[struct{}](n.sysProbeClient, "/watchlist", watchlistReq, sysconfig.NoisyNeighborModule); err != nil {
+		log.Warnf("noisy_neighbor: failed to update watchlist: %v", err)
+	}
+
+	// Layer 2+3: Fetch eBPF stats from system-probe
+	resp, err := sysprobeclient.GetCheck[model.CheckResponse](n.sysProbeClient, sysconfig.NoisyNeighborModule)
+	if err != nil {
+		log.Warnf("noisy_neighbor: failed to get check data: %v", err)
+	} else {
+		n.emitLayer2Metrics(s, resp.CgroupStats)
+		n.emitLayer3Metrics(s, resp.PreemptorStats)
+	}
+
+	n.firstRun = false
+	s.Commit()
 	return nil
 }
 
-func (n *NoisyNeighborCheck) getContainerTags(stat model.NoisyNeighborStats) []string {
-	if cg := n.cgroupReader.GetCgroupByInode(stat.CgroupID); cg != nil {
+// runLayer1 reads PSI and throttle data from cgroup filesystem, emits Layer 1 metrics,
+// and returns the list of cgroup IDs that should be watched by Layer 2.
+func (n *NoisyNeighborCheck) runLayer1(s sender.Sender) (flaggedIDs []uint64, stealPct float64) {
+	stealPct = n.readStealTime()
+
+	nonContainerCount := 0
+	for _, cg := range n.allCgroupReader.ListCgroups() {
+		inode := cg.Inode()
+		tags, isContainer := n.resolveTagsForCgroup(inode)
+
+		if !isContainer {
+			nonContainerCount++
+			if nonContainerCount > maxNonContainerCgroups {
+				continue
+			}
+		}
+
+		var cpuStats cgroups.CPUStats
+		if err := cg.GetCPUStats(&cpuStats); err != nil {
+			continue
+		}
+
+		// PSI
+		var psiAvg10 float64
+		if cpuStats.PSISome.Avg10 != nil {
+			psiAvg10 = *cpuStats.PSISome.Avg10
+		}
+
+		// Throttle delta
+		var throttledDeltaNs uint64
+		if cpuStats.ThrottledTime != nil {
+			prev, hasPrev := n.lastThrottledNs[inode]
+			n.lastThrottledNs[inode] = *cpuStats.ThrottledTime
+			if hasPrev && *cpuStats.ThrottledTime >= prev {
+				throttledDeltaNs = *cpuStats.ThrottledTime - prev
+			}
+		}
+
+		// Emit Layer 1 metrics (always, for all cgroups)
+		if !n.firstRun {
+			s.Gauge("noisy_neighbor.cpu_pressure", psiAvg10, "", tags)
+			s.Count("noisy_neighbor.cpu_throttled_ns", float64(throttledDeltaNs), "", tags)
+		}
+
+		// Triage: should this cgroup be flagged for Layer 2?
+		if n.firstRun {
+			continue
+		}
+		throttleRatio := float64(throttledDeltaNs) / checkIntervalNs
+		if psiAvg10 >= n.config.PSIThreshold &&
+			throttleRatio < n.config.ThrottleRatio &&
+			stealPct < n.config.StealThreshold &&
+			len(flaggedIDs) < maxWatchlistSize {
+			flaggedIDs = append(flaggedIDs, inode)
+		}
+	}
+
+	// Clean up stale throttle entries for cgroups that no longer exist
+	activeCgroups := make(map[uint64]struct{})
+	for _, cg := range n.allCgroupReader.ListCgroups() {
+		activeCgroups[cg.Inode()] = struct{}{}
+	}
+	for inode := range n.lastThrottledNs {
+		if _, exists := activeCgroups[inode]; !exists {
+			delete(n.lastThrottledNs, inode)
+		}
+	}
+
+	return flaggedIDs, stealPct
+}
+
+// readStealTime reads /proc/stat and computes steal time percentage since last call
+func (n *NoisyNeighborCheck) readStealTime() float64 {
+	cpuTimes, err := cpuutil.Times(false)
+	if err != nil || len(cpuTimes) == 0 {
+		return 0
+	}
+	t := cpuTimes[0]
+	total := t.User + t.System + t.Idle + t.Nice + t.Iowait + t.Irq + t.Softirq + t.Steal + t.Guest + t.GuestNice
+
+	var stealPct float64
+	if !n.firstRun {
+		totalDelta := total - n.lastTotalCPU
+		stealDelta := t.Steal - n.lastStealTime
+		if totalDelta > 0 {
+			stealPct = (stealDelta / totalDelta) * 100
+		}
+	}
+
+	n.lastStealTime = t.Steal
+	n.lastTotalCPU = total
+	return stealPct
+}
+
+// resolveTagsForCgroup returns tags and whether the cgroup is a container
+func (n *NoisyNeighborCheck) resolveTagsForCgroup(cgroupInode uint64) ([]string, bool) {
+	// Try container tag resolution first
+	if cg := n.cgroupReader.GetCgroupByInode(cgroupInode); cg != nil {
 		containerID := cg.Identifier()
 		if containerID != "" {
 			entityID := types.NewEntityID(types.ContainerID, containerID)
 			if !entityID.Empty() {
 				taggerTags, err := n.tagger.Tag(entityID, types.HighCardinality)
-				if err != nil {
-					log.Warnf("noisy_neighbor: tagger error for container %s: %v", containerID, err)
-				} else {
-					return taggerTags
+				if err == nil && len(taggerTags) > 0 {
+					return taggerTags, true
 				}
 			}
 		}
 	}
-	return []string{}
+
+	// Fallback: use cgroup path basename as tag
+	if cg := n.allCgroupReader.GetCgroupByInode(cgroupInode); cg != nil {
+		identifier := cg.Identifier()
+		if identifier != "" {
+			name := filepath.Base(identifier)
+			return []string{"cgroup_name:" + name}, false
+		}
+	}
+
+	return nil, false
 }
 
-// submitPrimaryMetrics sends the main PSL and PSP metrics
-// Note: "process" in metric names follows kernel convention, but these are thread-level measurements
-func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
-	if stat.UniquePidCount == 0 {
+// emitLayer2Metrics emits detailed scheduling metrics for watched cgroups
+func (n *NoisyNeighborCheck) emitLayer2Metrics(s sender.Sender, stats []model.NoisyNeighborStats) {
+	for _, stat := range stats {
+		tags, _ := n.resolveTagsForCgroup(stat.CgroupID)
+
+		if stat.TaskCount > 0 {
+			psl := float64(stat.SumLatenciesNs) / float64(stat.TaskCount)
+			s.Gauge("noisy_neighbor.scheduling_latency.per_process", psl, "", tags)
+
+			foreignPsp := float64(stat.ForeignPreemptionCount) / float64(stat.TaskCount)
+			s.Gauge("noisy_neighbor.preemptions.foreign.per_process", foreignPsp, "", tags)
+
+			selfPsp := float64(stat.SelfPreemptionCount) / float64(stat.TaskCount)
+			s.Gauge("noisy_neighbor.preemptions.self.per_process", selfPsp, "", tags)
+		}
+
+		totalPreemptions := stat.ForeignPreemptionCount + stat.SelfPreemptionCount
+		if totalPreemptions > 0 {
+			latPerPreempt := float64(stat.SumLatenciesNs) / float64(totalPreemptions)
+			s.Gauge("noisy_neighbor.latency_per_preemption", latPerPreempt, "", tags)
+		}
+
+		// Latency histogram buckets
+		s.Count("noisy_neighbor.scheduling_latency.bucket.lt_100us", float64(stat.LatencyBucketLt100us), "", tags)
+		s.Count("noisy_neighbor.scheduling_latency.bucket.100us_1ms", float64(stat.LatencyBucket100us1ms), "", tags)
+		s.Count("noisy_neighbor.scheduling_latency.bucket.1ms_10ms", float64(stat.LatencyBucket1ms10ms), "", tags)
+		s.Count("noisy_neighbor.scheduling_latency.bucket.gt_10ms", float64(stat.LatencyBucketGt10ms), "", tags)
+
+		// Raw counters
+		s.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
+		s.Gauge("noisy_neighbor.cgroup_task_count", float64(stat.TaskCount), "", tags)
+		s.Count("noisy_neighbor.cpu_migrations", float64(stat.CpuMigrations), "", tags)
+	}
+}
+
+// emitLayer3Metrics emits top-N preemptor identification metrics
+func (n *NoisyNeighborCheck) emitLayer3Metrics(s sender.Sender, preemptorStats []model.PreemptorStats) {
+	if len(preemptorStats) == 0 {
 		return
 	}
 
-	psl := float64(stat.SumLatenciesNs) / float64(stat.UniquePidCount)
-	sender.Gauge("noisy_neighbor.process_scheduling_latency.per_process", psl, "", tags)
+	// Group by victim, sort by count descending, take top N
+	byVictim := make(map[uint64][]model.PreemptorStats)
+	for _, ps := range preemptorStats {
+		byVictim[ps.VictimCgroupID] = append(byVictim[ps.VictimCgroupID], ps)
+	}
 
-	psp := float64(stat.PreemptionCount) / float64(stat.UniquePidCount)
-	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.per_process", psp, "", tags)
-}
+	for victimCgroupID, entries := range byVictim {
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Count > entries[j].Count
+		})
 
-func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
-	sender.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
-	sender.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
+		victimTags, _ := n.resolveTagsForCgroup(victimCgroupID)
+
+		limit := maxTopNPreemptors
+		if len(entries) < limit {
+			limit = len(entries)
+		}
+		for _, ps := range entries[:limit] {
+			preemptorTags, _ := n.resolveTagsForCgroup(ps.PreemptorCgroupID)
+
+			// Combine victim tags with a preemptor identifier tag
+			metricTags := make([]string, len(victimTags))
+			copy(metricTags, victimTags)
+			if len(preemptorTags) > 0 {
+				metricTags = append(metricTags, "preemptor:"+preemptorTags[0])
+			} else {
+				metricTags = append(metricTags, fmt.Sprintf("preemptor_cgroup_id:%d", ps.PreemptorCgroupID))
+			}
+
+			s.Gauge("noisy_neighbor.top_preemptor.count", float64(ps.Count), "", metricTags)
+		}
+	}
 }

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/test_layered_check.sh
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/test_layered_check.sh
@@ -22,11 +22,11 @@ VICTIM_CG="${TEST_PREFIX}_victim"
 NOISY_CG="${TEST_PREFIX}_noisy"
 QUIET_CG="${TEST_PREFIX}_quiet"
 # CPU quota in microseconds per 100ms period
-VICTIM_QUOTA=50000   # 50% of one core
-NOISY_QUOTA=200000   # 200% (2 cores worth)
+VICTIM_QUOTA=800000  # 800% (8 cores worth) — enough headroom for threads to preempt each other
+NOISY_QUOTA=800000   # 800% (8 cores worth)
 QUIET_QUOTA=50000    # 50% of one core
 STRESS_DURATION=30   # seconds to run workloads
-SETTLE_TIME=5        # seconds to wait for metrics to accumulate
+SETTLE_TIME=8        # seconds to wait for metrics to accumulate
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -214,17 +214,16 @@ sysprobe_post "/watchlist" '{"cgroup_ids":[]}'
 sleep 1
 sysprobe_get "/check" > /dev/null  # flush
 
-# Start a workload in the victim cgroup
-stress-ng --cpu 2 --timeout "${STRESS_DURATION}s" --quiet &
+# Start a workload in the victim cgroup (exec inside cgroup so workers inherit)
+bash -c "echo \$\$ > ${CGROUP_ROOT}/${VICTIM_CG}/cgroup.procs && exec stress-ng --cpu 2 --timeout ${STRESS_DURATION}s --quiet" &
 STRESS_PID=$!
-echo "$STRESS_PID" > "${CGROUP_ROOT}/${VICTIM_CG}/cgroup.procs"
 PIDS_TO_KILL+=("$STRESS_PID")
 
 sleep "$SETTLE_TIME"
 
 # Fetch stats — should be empty since watchlist is empty
 STATS=$(sysprobe_get "/check")
-CGROUP_COUNT=$(echo "$STATS" | jq '.cgroup_stats | length')
+CGROUP_COUNT=$(echo "$STATS" | jq '(.cgroup_stats // []) | length')
 
 if [[ "$CGROUP_COUNT" -eq 0 ]] || [[ "$CGROUP_COUNT" == "null" ]]; then
     pass "No cgroup stats with empty watchlist (fast-exit gate working)"
@@ -243,7 +242,7 @@ info "Added victim cgroup (inode $VICTIM_INODE) to watchlist"
 sleep "$SETTLE_TIME"
 
 STATS=$(sysprobe_get "/check")
-VICTIM_STATS=$(echo "$STATS" | jq ".cgroup_stats[] | select(.CgroupID == $VICTIM_INODE)")
+VICTIM_STATS=$(echo "$STATS" | jq "(.cgroup_stats // [])[] | select(.CgroupID == $VICTIM_INODE)")
 
 if [[ -n "$VICTIM_STATS" ]]; then
     EVENT_COUNT=$(echo "$VICTIM_STATS" | jq '.EventCount')
@@ -256,13 +255,12 @@ fi
 
 header "Test 3: Self-Preemption (many threads, same cgroup)"
 
-# Run many threads in victim cgroup with limited CPU quota → self-preemption
+# Run many more threads than CPUs with high quota → threads preempt each other
 kill "$STRESS_PID" 2>/dev/null; wait "$STRESS_PID" 2>/dev/null || true
 PIDS_TO_KILL=()
 
-stress-ng --cpu 16 --timeout "${STRESS_DURATION}s" --quiet &
+bash -c "echo \$\$ > ${CGROUP_ROOT}/${VICTIM_CG}/cgroup.procs && exec stress-ng --cpu 64 --timeout ${STRESS_DURATION}s --quiet" &
 STRESS_PID=$!
-echo "$STRESS_PID" > "${CGROUP_ROOT}/${VICTIM_CG}/cgroup.procs"
 PIDS_TO_KILL+=("$STRESS_PID")
 
 # Ensure watchlist is set
@@ -274,7 +272,7 @@ sysprobe_get "/check" > /dev/null
 sleep "$SETTLE_TIME"
 
 STATS=$(sysprobe_get "/check")
-VICTIM_STATS=$(echo "$STATS" | jq ".cgroup_stats[] | select(.CgroupID == $VICTIM_INODE)")
+VICTIM_STATS=$(echo "$STATS" | jq "(.cgroup_stats // [])[] | select(.CgroupID == $VICTIM_INODE)")
 
 if [[ -n "$VICTIM_STATS" ]]; then
     SELF_PREEMPT=$(echo "$VICTIM_STATS" | jq '.SelfPreemptionCount')
@@ -295,9 +293,8 @@ fi
 header "Test 4: Foreign Preemption + Neighbor Identification"
 
 # Start aggressive workload in noisy cgroup
-stress-ng --cpu 16 --timeout "${STRESS_DURATION}s" --quiet &
+bash -c "echo \$\$ > ${CGROUP_ROOT}/${NOISY_CG}/cgroup.procs && exec stress-ng --cpu 64 --timeout ${STRESS_DURATION}s --quiet" &
 NOISY_PID=$!
-echo "$NOISY_PID" > "${CGROUP_ROOT}/${NOISY_CG}/cgroup.procs"
 PIDS_TO_KILL+=("$NOISY_PID")
 
 # Watch both cgroups
@@ -309,7 +306,7 @@ sysprobe_get "/check" > /dev/null
 sleep "$SETTLE_TIME"
 
 STATS=$(sysprobe_get "/check")
-VICTIM_STATS=$(echo "$STATS" | jq ".cgroup_stats[] | select(.CgroupID == $VICTIM_INODE)")
+VICTIM_STATS=$(echo "$STATS" | jq "(.cgroup_stats // [])[] | select(.CgroupID == $VICTIM_INODE)")
 PREEMPTOR_STATS=$(echo "$STATS" | jq '.preemptor_stats // []')
 
 if [[ -n "$VICTIM_STATS" ]]; then
@@ -420,7 +417,7 @@ sysprobe_get "/check" > /dev/null
 sleep "$SETTLE_TIME"
 
 STATS=$(sysprobe_get "/check")
-CGROUP_COUNT=$(echo "$STATS" | jq '.cgroup_stats | length')
+CGROUP_COUNT=$(echo "$STATS" | jq '(.cgroup_stats // []) | length')
 
 if [[ "$CGROUP_COUNT" -eq 0 ]] || [[ "$CGROUP_COUNT" == "null" ]]; then
     pass "No stats after clearing watchlist"
@@ -433,9 +430,8 @@ fi
 header "Test 9: Quiet Cgroup Baseline"
 
 # Run minimal workload in quiet cgroup
-stress-ng --cpu 1 --timeout "${STRESS_DURATION}s" --quiet &
+bash -c "echo \$\$ > ${CGROUP_ROOT}/${QUIET_CG}/cgroup.procs && exec stress-ng --cpu 1 --timeout ${STRESS_DURATION}s --quiet" &
 QUIET_PID=$!
-echo "$QUIET_PID" > "${CGROUP_ROOT}/${QUIET_CG}/cgroup.procs"
 PIDS_TO_KILL+=("$QUIET_PID")
 
 # Watch quiet cgroup
@@ -445,7 +441,7 @@ sysprobe_get "/check" > /dev/null
 sleep "$SETTLE_TIME"
 
 STATS=$(sysprobe_get "/check")
-QUIET_STATS=$(echo "$STATS" | jq ".cgroup_stats[] | select(.CgroupID == $QUIET_INODE)")
+QUIET_STATS=$(echo "$STATS" | jq "(.cgroup_stats // [])[] | select(.CgroupID == $QUIET_INODE)")
 
 if [[ -n "$QUIET_STATS" ]]; then
     Q_FOREIGN=$(echo "$QUIET_STATS" | jq '.ForeignPreemptionCount')
@@ -479,8 +475,8 @@ sysprobe_get "/check" > /dev/null
 sleep "$SETTLE_TIME"
 
 STATS=$(sysprobe_get "/check")
-VICTIM_IN_STATS=$(echo "$STATS" | jq "[.cgroup_stats[] | select(.CgroupID == $VICTIM_INODE)] | length")
-NOISY_IN_STATS=$(echo "$STATS" | jq "[.cgroup_stats[] | select(.CgroupID == $NOISY_INODE)] | length")
+VICTIM_IN_STATS=$(echo "$STATS" | jq "[(.cgroup_stats // [])[] | select(.CgroupID == $VICTIM_INODE)] | length")
+NOISY_IN_STATS=$(echo "$STATS" | jq "[(.cgroup_stats // [])[] | select(.CgroupID == $NOISY_INODE)] | length")
 
 if [[ "$VICTIM_IN_STATS" -eq 0 ]]; then
     pass "Victim cgroup NOT in stats after watchlist replacement"

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/test_layered_check.sh
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/test_layered_check.sh
@@ -1,0 +1,507 @@
+#!/bin/bash
+# test_layered_check.sh — Validates the 3-layer noisy neighbor check end-to-end.
+#
+# Prerequisites:
+#   - Linux kernel 6.2+ with cgroup v2 and PSI enabled
+#   - Root access (eBPF + cgroup manipulation)
+#   - system-probe running with noisy_neighbor module enabled
+#   - stress-ng installed (apt install stress-ng / dnf install stress-ng)
+#   - jq installed
+#
+# Usage:
+#   sudo ./test_layered_check.sh [--socket /path/to/sysprobe.sock]
+
+set -euo pipefail
+
+# ─── Configuration ────────────────────────────────────────────────────────────
+
+SYSPROBE_SOCKET="${DD_SYSPROBE_SOCKET:-/opt/datadog-agent/run/sysprobe.sock}"
+CGROUP_ROOT="/sys/fs/cgroup"
+TEST_PREFIX="nn_test"
+VICTIM_CG="${TEST_PREFIX}_victim"
+NOISY_CG="${TEST_PREFIX}_noisy"
+QUIET_CG="${TEST_PREFIX}_quiet"
+# CPU quota in microseconds per 100ms period
+VICTIM_QUOTA=50000   # 50% of one core
+NOISY_QUOTA=200000   # 200% (2 cores worth)
+QUIET_QUOTA=50000    # 50% of one core
+STRESS_DURATION=30   # seconds to run workloads
+SETTLE_TIME=5        # seconds to wait for metrics to accumulate
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ─── Argument parsing ────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --socket) SYSPROBE_SOCKET="$2"; shift 2 ;;
+        *) echo "Unknown arg: $1"; exit 1 ;;
+    esac
+done
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+pass() { echo -e "  ${GREEN}✓ PASS${NC}: $1"; }
+fail() { echo -e "  ${RED}✗ FAIL${NC}: $1"; FAILURES=$((FAILURES + 1)); }
+info() { echo -e "${BLUE}▸${NC} $1"; }
+warn() { echo -e "${YELLOW}⚠${NC} $1"; }
+header() { echo -e "\n${BLUE}━━━ $1 ━━━${NC}"; }
+
+FAILURES=0
+PIDS_TO_KILL=()
+
+sysprobe_get() {
+    curl -sf --unix-socket "$SYSPROBE_SOCKET" "http://unix/noisy_neighbor$1" 2>/dev/null
+}
+
+sysprobe_post() {
+    local endpoint="$1"
+    local body="$2"
+    curl -sf --unix-socket "$SYSPROBE_SOCKET" \
+        -X POST -H "Content-Type: application/json" \
+        -d "$body" \
+        "http://unix/noisy_neighbor$endpoint" 2>/dev/null
+}
+
+get_cgroup_inode() {
+    stat -c '%i' "${CGROUP_ROOT}/$1" 2>/dev/null
+}
+
+read_psi() {
+    local cg_path="${CGROUP_ROOT}/$1/cpu.pressure"
+    if [[ -f "$cg_path" ]]; then
+        grep '^some' "$cg_path" | grep -oP 'avg10=\K[0-9.]+'
+    else
+        echo "0"
+    fi
+}
+
+read_throttle() {
+    local stat_path="${CGROUP_ROOT}/$1/cpu.stat"
+    if [[ -f "$stat_path" ]]; then
+        grep 'throttled_usec' "$stat_path" | awk '{print $2}'
+    else
+        echo "0"
+    fi
+}
+
+# ─── Preflight checks ────────────────────────────────────────────────────────
+
+header "Preflight Checks"
+
+# Root check
+if [[ $EUID -ne 0 ]]; then
+    fail "Must run as root"
+    exit 1
+fi
+pass "Running as root"
+
+# Kernel version
+KVER=$(uname -r | cut -d. -f1-2)
+KMAJOR=$(echo "$KVER" | cut -d. -f1)
+KMINOR=$(echo "$KVER" | cut -d. -f2)
+if [[ "$KMAJOR" -lt 6 ]] || { [[ "$KMAJOR" -eq 6 ]] && [[ "$KMINOR" -lt 2 ]]; }; then
+    fail "Kernel $KVER < 6.2 (required for BPF task storage kfuncs)"
+    exit 1
+fi
+pass "Kernel version $KVER >= 6.2"
+
+# cgroup v2
+if ! mount | grep -q 'cgroup2'; then
+    fail "cgroup v2 not mounted"
+    exit 1
+fi
+pass "cgroup v2 available"
+
+# PSI enabled
+if [[ ! -f "${CGROUP_ROOT}/cpu.pressure" ]]; then
+    fail "PSI not enabled (no cpu.pressure at cgroup root)"
+    exit 1
+fi
+pass "PSI enabled"
+
+# stress-ng
+if ! command -v stress-ng &>/dev/null; then
+    fail "stress-ng not installed"
+    exit 1
+fi
+pass "stress-ng available"
+
+# jq
+if ! command -v jq &>/dev/null; then
+    fail "jq not installed"
+    exit 1
+fi
+pass "jq available"
+
+# system-probe socket
+if [[ ! -S "$SYSPROBE_SOCKET" ]]; then
+    fail "system-probe socket not found at $SYSPROBE_SOCKET"
+    exit 1
+fi
+pass "system-probe socket at $SYSPROBE_SOCKET"
+
+# noisy_neighbor module responsive
+if ! sysprobe_get "/check" >/dev/null; then
+    fail "noisy_neighbor module not responding (GET /check failed)"
+    exit 1
+fi
+pass "noisy_neighbor module responding"
+
+# ─── Cleanup function ────────────────────────────────────────────────────────
+
+cleanup() {
+    info "Cleaning up..."
+    for pid in "${PIDS_TO_KILL[@]}"; do
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+    # Clear watchlist
+    sysprobe_post "/watchlist" '{"cgroup_ids":[]}' >/dev/null 2>&1 || true
+    # Remove test cgroups (must kill all processes first)
+    for cg in "$VICTIM_CG" "$NOISY_CG" "$QUIET_CG"; do
+        if [[ -d "${CGROUP_ROOT}/${cg}" ]]; then
+            # Kill any remaining processes
+            if [[ -f "${CGROUP_ROOT}/${cg}/cgroup.procs" ]]; then
+                while read -r pid; do
+                    kill -9 "$pid" 2>/dev/null || true
+                done < "${CGROUP_ROOT}/${cg}/cgroup.procs"
+            fi
+            sleep 0.5
+            rmdir "${CGROUP_ROOT}/${cg}" 2>/dev/null || true
+        fi
+    done
+}
+trap cleanup EXIT
+
+# ─── Create test cgroups ──────────────────────────────────────────────────────
+
+header "Setting Up Test Cgroups"
+
+for cg in "$VICTIM_CG" "$NOISY_CG" "$QUIET_CG"; do
+    if [[ -d "${CGROUP_ROOT}/${cg}" ]]; then
+        rmdir "${CGROUP_ROOT}/${cg}" 2>/dev/null || true
+    fi
+    mkdir -p "${CGROUP_ROOT}/${cg}"
+    # Enable cpu controller
+    echo "+cpu +cpuset" > "${CGROUP_ROOT}/${cg}/cgroup.subtree_control" 2>/dev/null || true
+done
+
+# Set CPU quotas (period=100ms)
+echo "100000 ${VICTIM_QUOTA}" > "${CGROUP_ROOT}/${VICTIM_CG}/cpu.max"
+echo "100000 ${NOISY_QUOTA}"  > "${CGROUP_ROOT}/${NOISY_CG}/cpu.max"
+echo "100000 ${QUIET_QUOTA}"  > "${CGROUP_ROOT}/${QUIET_CG}/cpu.max"
+
+VICTIM_INODE=$(get_cgroup_inode "$VICTIM_CG")
+NOISY_INODE=$(get_cgroup_inode "$NOISY_CG")
+QUIET_INODE=$(get_cgroup_inode "$QUIET_CG")
+
+info "Created cgroups:"
+info "  victim: ${VICTIM_CG} (inode: ${VICTIM_INODE}, quota: ${VICTIM_QUOTA}us/100ms)"
+info "  noisy:  ${NOISY_CG}  (inode: ${NOISY_INODE}, quota: ${NOISY_QUOTA}us/100ms)"
+info "  quiet:  ${QUIET_CG}  (inode: ${QUIET_INODE}, quota: ${QUIET_QUOTA}us/100ms)"
+
+# ─── Test 1: Empty watchlist produces no eBPF stats ──────────────────────────
+
+header "Test 1: Empty Watchlist (fast-exit gate)"
+
+# Clear watchlist and flush any stale data
+sysprobe_post "/watchlist" '{"cgroup_ids":[]}'
+sleep 1
+sysprobe_get "/check" > /dev/null  # flush
+
+# Start a workload in the victim cgroup
+stress-ng --cpu 2 --timeout "${STRESS_DURATION}s" --quiet &
+STRESS_PID=$!
+echo "$STRESS_PID" > "${CGROUP_ROOT}/${VICTIM_CG}/cgroup.procs"
+PIDS_TO_KILL+=("$STRESS_PID")
+
+sleep "$SETTLE_TIME"
+
+# Fetch stats — should be empty since watchlist is empty
+STATS=$(sysprobe_get "/check")
+CGROUP_COUNT=$(echo "$STATS" | jq '.cgroup_stats | length')
+
+if [[ "$CGROUP_COUNT" -eq 0 ]] || [[ "$CGROUP_COUNT" == "null" ]]; then
+    pass "No cgroup stats with empty watchlist (fast-exit gate working)"
+else
+    fail "Got $CGROUP_COUNT cgroup stats with empty watchlist (fast-exit gate not working)"
+fi
+
+# ─── Test 2: Watchlist activation produces stats ──────────────────────────────
+
+header "Test 2: Watchlist Activation"
+
+# Add victim cgroup to watchlist
+sysprobe_post "/watchlist" "{\"cgroup_ids\":[${VICTIM_INODE}]}"
+info "Added victim cgroup (inode $VICTIM_INODE) to watchlist"
+
+sleep "$SETTLE_TIME"
+
+STATS=$(sysprobe_get "/check")
+VICTIM_STATS=$(echo "$STATS" | jq ".cgroup_stats[] | select(.CgroupID == $VICTIM_INODE)")
+
+if [[ -n "$VICTIM_STATS" ]]; then
+    EVENT_COUNT=$(echo "$VICTIM_STATS" | jq '.EventCount')
+    pass "Got stats for watched cgroup (EventCount: $EVENT_COUNT)"
+else
+    fail "No stats for watched cgroup after watchlist activation"
+fi
+
+# ─── Test 3: Self-preemption detection ────────────────────────────────────────
+
+header "Test 3: Self-Preemption (many threads, same cgroup)"
+
+# Run many threads in victim cgroup with limited CPU quota → self-preemption
+kill "$STRESS_PID" 2>/dev/null; wait "$STRESS_PID" 2>/dev/null || true
+PIDS_TO_KILL=()
+
+stress-ng --cpu 16 --timeout "${STRESS_DURATION}s" --quiet &
+STRESS_PID=$!
+echo "$STRESS_PID" > "${CGROUP_ROOT}/${VICTIM_CG}/cgroup.procs"
+PIDS_TO_KILL+=("$STRESS_PID")
+
+# Ensure watchlist is set
+sysprobe_post "/watchlist" "{\"cgroup_ids\":[${VICTIM_INODE}]}"
+
+sleep "$SETTLE_TIME"
+# Flush stale data
+sysprobe_get "/check" > /dev/null
+sleep "$SETTLE_TIME"
+
+STATS=$(sysprobe_get "/check")
+VICTIM_STATS=$(echo "$STATS" | jq ".cgroup_stats[] | select(.CgroupID == $VICTIM_INODE)")
+
+if [[ -n "$VICTIM_STATS" ]]; then
+    SELF_PREEMPT=$(echo "$VICTIM_STATS" | jq '.SelfPreemptionCount')
+    FOREIGN_PREEMPT=$(echo "$VICTIM_STATS" | jq '.ForeignPreemptionCount')
+    info "Self preemptions: $SELF_PREEMPT, Foreign preemptions: $FOREIGN_PREEMPT"
+
+    if [[ "$SELF_PREEMPT" -gt 0 ]]; then
+        pass "Self-preemptions detected (16 threads competing on limited CPU quota)"
+    else
+        fail "No self-preemptions detected (expected with 16 threads on limited quota)"
+    fi
+else
+    fail "No stats for victim cgroup"
+fi
+
+# ─── Test 4: Foreign preemption + preemptor identification ────────────────────
+
+header "Test 4: Foreign Preemption + Neighbor Identification"
+
+# Start aggressive workload in noisy cgroup
+stress-ng --cpu 16 --timeout "${STRESS_DURATION}s" --quiet &
+NOISY_PID=$!
+echo "$NOISY_PID" > "${CGROUP_ROOT}/${NOISY_CG}/cgroup.procs"
+PIDS_TO_KILL+=("$NOISY_PID")
+
+# Watch both cgroups
+sysprobe_post "/watchlist" "{\"cgroup_ids\":[${VICTIM_INODE},${NOISY_INODE}]}"
+
+sleep "$SETTLE_TIME"
+# Flush stale
+sysprobe_get "/check" > /dev/null
+sleep "$SETTLE_TIME"
+
+STATS=$(sysprobe_get "/check")
+VICTIM_STATS=$(echo "$STATS" | jq ".cgroup_stats[] | select(.CgroupID == $VICTIM_INODE)")
+PREEMPTOR_STATS=$(echo "$STATS" | jq '.preemptor_stats // []')
+
+if [[ -n "$VICTIM_STATS" ]]; then
+    FOREIGN_PREEMPT=$(echo "$VICTIM_STATS" | jq '.ForeignPreemptionCount')
+    info "Victim foreign preemptions: $FOREIGN_PREEMPT"
+
+    if [[ "$FOREIGN_PREEMPT" -gt 0 ]]; then
+        pass "Foreign preemptions detected on victim (noisy neighbor signal)"
+    else
+        warn "No foreign preemptions on victim — CPUs may not overlap. This is topology-dependent."
+    fi
+else
+    fail "No stats for victim cgroup"
+fi
+
+# Check preemptor identification (Layer 3)
+PREEMPTOR_COUNT=$(echo "$PREEMPTOR_STATS" | jq 'length')
+if [[ "$PREEMPTOR_COUNT" -gt 0 ]]; then
+    # Check if noisy cgroup appears as a preemptor of victim
+    NOISY_AS_PREEMPTOR=$(echo "$PREEMPTOR_STATS" | jq "[.[] | select(.VictimCgroupID == $VICTIM_INODE and .PreemptorCgroupID == $NOISY_INODE)] | length")
+    if [[ "$NOISY_AS_PREEMPTOR" -gt 0 ]]; then
+        PREEMPT_COUNT=$(echo "$PREEMPTOR_STATS" | jq ".[] | select(.VictimCgroupID == $VICTIM_INODE and .PreemptorCgroupID == $NOISY_INODE) | .Count")
+        pass "Layer 3: Identified noisy cgroup as preemptor of victim (count: $PREEMPT_COUNT)"
+    else
+        warn "Noisy cgroup not identified as preemptor — may be on different CPUs"
+    fi
+else
+    info "No preemptor stats (foreign preemptions may not have occurred)"
+fi
+
+# ─── Test 5: Latency histogram buckets ────────────────────────────────────────
+
+header "Test 5: Latency Histogram Buckets"
+
+# Re-fetch or use existing stats
+if [[ -n "$VICTIM_STATS" ]]; then
+    B_LT100=$(echo "$VICTIM_STATS" | jq '.LatencyBucketLt100us')
+    B_100_1M=$(echo "$VICTIM_STATS" | jq '.LatencyBucket100us1ms')
+    B_1M_10M=$(echo "$VICTIM_STATS" | jq '.LatencyBucket1ms10ms')
+    B_GT10M=$(echo "$VICTIM_STATS" | jq '.LatencyBucketGt10ms')
+    EVENT_COUNT=$(echo "$VICTIM_STATS" | jq '.EventCount')
+    BUCKET_SUM=$((B_LT100 + B_100_1M + B_1M_10M + B_GT10M))
+
+    info "Buckets: <100us=$B_LT100, 100us-1ms=$B_100_1M, 1ms-10ms=$B_1M_10M, >10ms=$B_GT10M"
+    info "Bucket sum: $BUCKET_SUM, EventCount: $EVENT_COUNT"
+
+    if [[ "$BUCKET_SUM" -eq "$EVENT_COUNT" ]]; then
+        pass "Histogram bucket sum equals EventCount"
+    else
+        fail "Histogram bucket sum ($BUCKET_SUM) != EventCount ($EVENT_COUNT)"
+    fi
+
+    if [[ "$BUCKET_SUM" -gt 0 ]]; then
+        pass "Histogram buckets are populated"
+    else
+        fail "All histogram buckets are zero"
+    fi
+else
+    fail "No victim stats to check buckets"
+fi
+
+# ─── Test 6: CPU migration tracking ──────────────────────────────────────────
+
+header "Test 6: CPU Migration Tracking"
+
+if [[ -n "$VICTIM_STATS" ]]; then
+    MIGRATIONS=$(echo "$VICTIM_STATS" | jq '.CpuMigrations')
+    info "CPU migrations: $MIGRATIONS"
+    if [[ "$MIGRATIONS" -ge 0 ]]; then
+        pass "CPU migration counter present (value: $MIGRATIONS)"
+    fi
+else
+    fail "No victim stats to check migrations"
+fi
+
+# ─── Test 7: PSI canary signal (Layer 1 simulation) ──────────────────────────
+
+header "Test 7: Layer 1 Canary Signals (PSI + Throttle)"
+
+PSI_VAL=$(read_psi "$VICTIM_CG")
+THROTTLE_VAL=$(read_throttle "$VICTIM_CG")
+info "Victim cgroup PSI avg10: $PSI_VAL"
+info "Victim cgroup throttled_usec: $THROTTLE_VAL"
+
+# With 16 threads on 50% quota, PSI should be elevated
+if (( $(echo "$PSI_VAL > 0" | bc -l) )); then
+    pass "PSI is non-zero for contended cgroup ($PSI_VAL%)"
+else
+    warn "PSI is zero — workload may not be generating enough pressure"
+fi
+
+if [[ "$THROTTLE_VAL" -gt 0 ]]; then
+    pass "Throttle counter is non-zero ($THROTTLE_VAL usec)"
+else
+    warn "No throttling detected"
+fi
+
+# ─── Test 8: Watchlist clear stops stats collection ───────────────────────────
+
+header "Test 8: Watchlist Clear"
+
+# Clear watchlist
+sysprobe_post "/watchlist" '{"cgroup_ids":[]}'
+info "Cleared watchlist"
+
+# Flush existing data
+sysprobe_get "/check" > /dev/null
+sleep "$SETTLE_TIME"
+
+STATS=$(sysprobe_get "/check")
+CGROUP_COUNT=$(echo "$STATS" | jq '.cgroup_stats | length')
+
+if [[ "$CGROUP_COUNT" -eq 0 ]] || [[ "$CGROUP_COUNT" == "null" ]]; then
+    pass "No stats after clearing watchlist"
+else
+    fail "Still getting $CGROUP_COUNT cgroup stats after clearing watchlist"
+fi
+
+# ─── Test 9: Quiet cgroup (no contention baseline) ───────────────────────────
+
+header "Test 9: Quiet Cgroup Baseline"
+
+# Run minimal workload in quiet cgroup
+stress-ng --cpu 1 --timeout "${STRESS_DURATION}s" --quiet &
+QUIET_PID=$!
+echo "$QUIET_PID" > "${CGROUP_ROOT}/${QUIET_CG}/cgroup.procs"
+PIDS_TO_KILL+=("$QUIET_PID")
+
+# Watch quiet cgroup
+sysprobe_post "/watchlist" "{\"cgroup_ids\":[${QUIET_INODE}]}"
+sleep "$SETTLE_TIME"
+sysprobe_get "/check" > /dev/null
+sleep "$SETTLE_TIME"
+
+STATS=$(sysprobe_get "/check")
+QUIET_STATS=$(echo "$STATS" | jq ".cgroup_stats[] | select(.CgroupID == $QUIET_INODE)")
+
+if [[ -n "$QUIET_STATS" ]]; then
+    Q_FOREIGN=$(echo "$QUIET_STATS" | jq '.ForeignPreemptionCount')
+    Q_SELF=$(echo "$QUIET_STATS" | jq '.SelfPreemptionCount')
+    Q_LATENCY=$(echo "$QUIET_STATS" | jq '.SumLatenciesNs')
+    Q_EVENTS=$(echo "$QUIET_STATS" | jq '.EventCount')
+
+    info "Quiet cgroup: events=$Q_EVENTS, latency=${Q_LATENCY}ns, foreign=$Q_FOREIGN, self=$Q_SELF"
+
+    if [[ "$Q_FOREIGN" -eq 0 ]] || [[ "$Q_FOREIGN" -lt 10 ]]; then
+        pass "Quiet cgroup has minimal foreign preemptions ($Q_FOREIGN)"
+    else
+        warn "Quiet cgroup has unexpected foreign preemptions ($Q_FOREIGN) — host may be busy"
+    fi
+else
+    info "No stats for quiet cgroup (may not have been scheduled on watched CPUs)"
+fi
+
+# ─── Test 10: Watchlist update replaces (doesn't append) ─────────────────────
+
+header "Test 10: Watchlist Replacement"
+
+# Set watchlist to victim only
+sysprobe_post "/watchlist" "{\"cgroup_ids\":[${VICTIM_INODE}]}"
+sleep 1
+
+# Replace with noisy only
+sysprobe_post "/watchlist" "{\"cgroup_ids\":[${NOISY_INODE}]}"
+sleep "$SETTLE_TIME"
+sysprobe_get "/check" > /dev/null
+sleep "$SETTLE_TIME"
+
+STATS=$(sysprobe_get "/check")
+VICTIM_IN_STATS=$(echo "$STATS" | jq "[.cgroup_stats[] | select(.CgroupID == $VICTIM_INODE)] | length")
+NOISY_IN_STATS=$(echo "$STATS" | jq "[.cgroup_stats[] | select(.CgroupID == $NOISY_INODE)] | length")
+
+if [[ "$VICTIM_IN_STATS" -eq 0 ]]; then
+    pass "Victim cgroup NOT in stats after watchlist replacement"
+else
+    fail "Victim cgroup still in stats after being removed from watchlist"
+fi
+
+if [[ "$NOISY_IN_STATS" -gt 0 ]]; then
+    pass "Noisy cgroup IS in stats after watchlist replacement"
+else
+    warn "Noisy cgroup not in stats (may not have generated events yet)"
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+header "Summary"
+
+if [[ "$FAILURES" -eq 0 ]]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+else
+    echo -e "${RED}${FAILURES} test(s) failed.${NC}"
+fi
+
+exit "$FAILURES"

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types.go
@@ -13,3 +13,5 @@ package noisyneighbor
 import "C"
 
 type ebpfCgroupAggStats C.cgroup_agg_stats_t
+type ebpfPreemptorKey C.preemptor_key_t
+type ebpfPreemptorStats C.preemptor_stats_t

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
@@ -4,8 +4,23 @@
 package noisyneighbor
 
 type ebpfCgroupAggStats struct {
-	Sum_latencies_ns uint64
-	Event_count      uint64
-	Preemption_count uint64
-	Pid_count        uint64
+	Sum_latencies_ns          uint64
+	Event_count               uint64
+	Foreign_preemption_count  uint64
+	Self_preemption_count     uint64
+	Task_count                uint64
+	Latency_bucket_lt_100us   uint64
+	Latency_bucket_100us_1ms  uint64
+	Latency_bucket_1ms_10ms   uint64
+	Latency_bucket_gt_10ms    uint64
+	Cpu_migrations            uint64
+}
+
+type ebpfPreemptorKey struct {
+	Victim_cgroup_id    uint64
+	Preemptor_cgroup_id uint64
+}
+
+type ebpfPreemptorStats struct {
+	Count uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux_test.go
@@ -11,3 +11,11 @@ import (
 func TestCgoAlignment_ebpfCgroupAggStats(t *testing.T) {
 	ebpftest.TestCgoAlignment[ebpfCgroupAggStats](t)
 }
+
+func TestCgoAlignment_ebpfPreemptorKey(t *testing.T) {
+	ebpftest.TestCgoAlignment[ebpfPreemptorKey](t)
+}
+
+func TestCgoAlignment_ebpfPreemptorStats(t *testing.T) {
+	ebpftest.TestCgoAlignment[ebpfPreemptorStats](t)
+}

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -6,11 +6,35 @@
 // Package model contains the model for the noisy neighbor check
 package model
 
-// NoisyNeighborStats contains the statistics from the noisy neighbor check
+// NoisyNeighborStats contains per-cgroup scheduling statistics from Layer 2
 type NoisyNeighborStats struct {
-	CgroupID        uint64
-	SumLatenciesNs  uint64
-	EventCount      uint64
-	PreemptionCount uint64
-	UniquePidCount  uint64 // kernel task_struct->pid (TID) count
+	CgroupID                uint64
+	SumLatenciesNs          uint64
+	EventCount              uint64
+	ForeignPreemptionCount  uint64
+	SelfPreemptionCount     uint64
+	TaskCount               uint64 // total tasks in cgroup from pids_cgroup->counter
+	LatencyBucketLt100us    uint64
+	LatencyBucket100us1ms   uint64
+	LatencyBucket1ms10ms    uint64
+	LatencyBucketGt10ms     uint64
+	CpuMigrations           uint64
+}
+
+// PreemptorStats identifies which foreign cgroup is preempting a victim cgroup
+type PreemptorStats struct {
+	VictimCgroupID    uint64
+	PreemptorCgroupID uint64
+	Count             uint64
+}
+
+// CheckResponse is the combined response from the system-probe noisy neighbor module
+type CheckResponse struct {
+	CgroupStats    []NoisyNeighborStats `json:"cgroup_stats"`
+	PreemptorStats []PreemptorStats     `json:"preemptor_stats"`
+}
+
+// WatchlistRequest is sent by the agent to update the eBPF watchlist
+type WatchlistRequest struct {
+	CgroupIDs []uint64 `json:"cgroup_ids"`
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -11,6 +11,7 @@ package noisyneighbor
 import (
 	"fmt"
 
+	"github.com/cilium/ebpf"
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model"
@@ -26,7 +27,9 @@ var minimumKernelVersion = kernel.VersionCode(6, 2, 0)
 
 // Probe is the eBPF side of the noisy neighbor check
 type Probe struct {
-	mgr *ddebpf.Manager
+	mgr                *ddebpf.Manager
+	watchlistActiveMap *ebpf.Map
+	watchlistMap       *ebpf.Map
 }
 
 // NewProbe creates a [Probe]
@@ -52,10 +55,14 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_wakeup", UID: uid}},
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_wakeup_new", UID: uid}},
 			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_switch", UID: uid}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tp_sched_migrate_task", UID: uid}},
 		}
 		p.mgr.Maps = []*manager.Map{
 			{Name: "runq_enqueued"},
 			{Name: "cgroup_agg_stats"},
+			{Name: "watchlist_active"},
+			{Name: "watchlist"},
+			{Name: "preemptor_stats"},
 		}
 		if err := p.mgr.InitWithOptions(buf, &opts); err != nil {
 			return fmt.Errorf("failed to init ebpf manager: %w", err)
@@ -70,6 +77,21 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Cache map references for direct access
+	if m, found, err := p.mgr.GetMap("watchlist_active"); err == nil && found {
+		p.watchlistActiveMap = m
+	} else {
+		p.Close()
+		return nil, fmt.Errorf("failed to get watchlist_active map: found=%v err=%v", found, err)
+	}
+	if m, found, err := p.mgr.GetMap("watchlist"); err == nil && found {
+		p.watchlistMap = m
+	} else {
+		p.Close()
+		return nil, fmt.Errorf("failed to get watchlist map: found=%v err=%v", found, err)
+	}
+
 	ddebpf.AddNameMappings(p.mgr.Manager, "noisy_neighbor")
 	return p, nil
 }
@@ -84,18 +106,57 @@ func (p *Probe) Close() {
 	}
 }
 
-// GetAndFlush gets the stats
-func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
-	var nnstats []model.NoisyNeighborStats
+// UpdateWatchlist replaces the current watchlist with the given cgroup IDs.
+// It sets/clears the watchlist_active gate accordingly.
+func (p *Probe) UpdateWatchlist(cgroupIDs []uint64) error {
+	// Clear existing watchlist entries
+	var key uint64
+	var val uint8
+	iter := p.watchlistMap.Iterate()
+	var keysToDelete []uint64
+	for iter.Next(&key, &val) {
+		keysToDelete = append(keysToDelete, key)
+	}
+	for _, k := range keysToDelete {
+		if err := p.watchlistMap.Delete(&k); err != nil {
+			log.Warnf("noisy_neighbor: failed to delete watchlist entry %d: %v", k, err)
+		}
+	}
 
+	// Insert new entries
+	var dummy uint8 = 1
+	for _, cgID := range cgroupIDs {
+		if err := p.watchlistMap.Put(&cgID, &dummy); err != nil {
+			log.Warnf("noisy_neighbor: failed to add watchlist entry %d: %v", cgID, err)
+		}
+	}
+
+	// Set/clear the global gate
+	var zeroKey uint32
+	var activeVal uint8
+	if len(cgroupIDs) > 0 {
+		activeVal = 1
+	}
+	if err := p.watchlistActiveMap.Put(&zeroKey, &activeVal); err != nil {
+		return fmt.Errorf("failed to update watchlist_active: %w", err)
+	}
+
+	return nil
+}
+
+// GetAndFlush gets the stats and clears the maps
+func (p *Probe) GetAndFlush() model.CheckResponse {
+	var resp model.CheckResponse
+
+	// Flush cgroup_agg_stats
 	aggMap, found, err := p.mgr.GetMap("cgroup_agg_stats")
 	if err != nil {
 		log.Errorf("failed to get cgroup_agg_stats map: %v", err)
-		return nnstats
+		return resp
 	}
 	if !found {
 		log.Warn("cgroup_agg_stats map not found")
-		return nnstats
+		return resp
 	}
 
 	iter := aggMap.Iterate()
@@ -104,32 +165,47 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 	var cgroupsToDelete []uint64
 
 	for iter.Next(&cgroupID, &perCPUStats) {
-		var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
+		var (
+			latencies, events, foreignPreemptions, selfPreemptions uint64
+			taskCount                                              uint64
+			bucketLt100us, bucket100us1ms, bucket1ms10ms           uint64
+			bucketGt10ms, migrations                               uint64
+		)
 		for _, cpuStat := range perCPUStats {
-			cgroupLatencies += cpuStat.Sum_latencies_ns
-			cgroupEvents += cpuStat.Event_count
-			cgroupPreemptions += cpuStat.Preemption_count
-			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
-			if cpuStat.Pid_count > pidCount {
-				pidCount = cpuStat.Pid_count
+			latencies += cpuStat.Sum_latencies_ns
+			events += cpuStat.Event_count
+			foreignPreemptions += cpuStat.Foreign_preemption_count
+			selfPreemptions += cpuStat.Self_preemption_count
+			// task_count is a global cgroup value (not per-CPU), so take the max
+			if cpuStat.Task_count > taskCount {
+				taskCount = cpuStat.Task_count
 			}
+			bucketLt100us += cpuStat.Latency_bucket_lt_100us
+			bucket100us1ms += cpuStat.Latency_bucket_100us_1ms
+			bucket1ms10ms += cpuStat.Latency_bucket_1ms_10ms
+			bucketGt10ms += cpuStat.Latency_bucket_gt_10ms
+			migrations += cpuStat.Cpu_migrations
 		}
 
 		cgroupsToDelete = append(cgroupsToDelete, cgroupID)
 
-		if cgroupEvents == 0 {
+		if events == 0 && foreignPreemptions == 0 && selfPreemptions == 0 && migrations == 0 {
 			continue
 		}
 
-		stat := model.NoisyNeighborStats{
-			CgroupID:        cgroupID,
-			SumLatenciesNs:  cgroupLatencies,
-			EventCount:      cgroupEvents,
-			PreemptionCount: cgroupPreemptions,
-			UniquePidCount:  pidCount,
-		}
-
-		nnstats = append(nnstats, stat)
+		resp.CgroupStats = append(resp.CgroupStats, model.NoisyNeighborStats{
+			CgroupID:               cgroupID,
+			SumLatenciesNs:         latencies,
+			EventCount:             events,
+			ForeignPreemptionCount: foreignPreemptions,
+			SelfPreemptionCount:    selfPreemptions,
+			TaskCount:              taskCount,
+			LatencyBucketLt100us:   bucketLt100us,
+			LatencyBucket100us1ms:  bucket100us1ms,
+			LatencyBucket1ms10ms:   bucket1ms10ms,
+			LatencyBucketGt10ms:    bucketGt10ms,
+			CpuMigrations:          migrations,
+		})
 	}
 
 	if err := iter.Err(); err != nil {
@@ -142,5 +218,48 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 		}
 	}
 
-	return nnstats
+	// Flush preemptor_stats
+	preemptorMap, found, err := p.mgr.GetMap("preemptor_stats")
+	if err != nil {
+		log.Errorf("failed to get preemptor_stats map: %v", err)
+		return resp
+	}
+	if !found {
+		return resp
+	}
+
+	var pkey ebpfPreemptorKey
+	var perCPUPreemptorStats []ebpfPreemptorStats
+	var pkeysToDelete []ebpfPreemptorKey
+
+	piter := preemptorMap.Iterate()
+	for piter.Next(&pkey, &perCPUPreemptorStats) {
+		var totalCount uint64
+		for _, cpuStat := range perCPUPreemptorStats {
+			totalCount += cpuStat.Count
+		}
+		pkeysToDelete = append(pkeysToDelete, pkey)
+
+		if totalCount == 0 {
+			continue
+		}
+
+		resp.PreemptorStats = append(resp.PreemptorStats, model.PreemptorStats{
+			VictimCgroupID:    pkey.Victim_cgroup_id,
+			PreemptorCgroupID: pkey.Preemptor_cgroup_id,
+			Count:             totalCount,
+		})
+	}
+
+	if err := piter.Err(); err != nil {
+		log.Errorf("error iterating preemptor_stats map: %v", err)
+	}
+
+	for _, pk := range pkeysToDelete {
+		if err := preemptorMap.Delete(&pk); err != nil {
+			log.Errorf("failed to delete preemptor entry: %v", err)
+		}
+	}
+
+	return resp
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
@@ -11,9 +11,11 @@ package noisyneighbor
 import (
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -40,15 +42,91 @@ func TestNoisyNeighborProbe(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(probe.Close)
 
-		require.Eventually(t, func() bool {
-			for _, r := range probe.GetAndFlush() {
-				if r.EventCount > 0 || r.PreemptionCount > 0 {
-					return true
+		// With empty watchlist, eBPF fast-exits and no stats are collected
+		resp := probe.GetAndFlush()
+		assert.Empty(t, resp.CgroupStats, "should have no stats with empty watchlist")
+
+		// Read our own cgroup ID and add it to the watchlist
+		cgroupID := readSelfCgroupID(t)
+		if cgroupID != 0 {
+			err = probe.UpdateWatchlist([]uint64{cgroupID})
+			require.NoError(t, err)
+
+			// With our cgroup watched, we should see stats
+			require.Eventually(t, func() bool {
+				resp := probe.GetAndFlush()
+				for _, r := range resp.CgroupStats {
+					if r.EventCount > 0 || r.ForeignPreemptionCount > 0 || r.SelfPreemptionCount > 0 {
+						return true
+					}
 				}
-			}
-			return false
-		}, 10*time.Second, 500*time.Millisecond, "failed to get noisy neighbor stats")
+				return false
+			}, 10*time.Second, 500*time.Millisecond, "failed to get noisy neighbor stats with watchlist active")
+
+			// Clear watchlist
+			err = probe.UpdateWatchlist(nil)
+			require.NoError(t, err)
+		}
 	})
+}
+
+func TestUpdateWatchlist(t *testing.T) {
+	ebpftest.TestBuildMode(t, ebpftest.CORE, "", func(t *testing.T) {
+		if kv < minimumKernelVersion {
+			t.Skipf("Kernel version %v is not supported by the Noisy Neighbor probe", kv)
+		}
+
+		if strings.Contains(os.Getenv("CI_JOB_NAME"), "fedora_38") {
+			t.Skipf("Noisy Neighbor probe is not supported on this environment: %s", os.Getenv("CI_JOB_NAME"))
+		}
+
+		cfg := testConfig()
+		probe, err := NewProbe(cfg)
+		require.NoError(t, err)
+		t.Cleanup(probe.Close)
+
+		// Empty watchlist
+		err = probe.UpdateWatchlist(nil)
+		require.NoError(t, err)
+
+		// Set watchlist
+		err = probe.UpdateWatchlist([]uint64{1, 2, 3})
+		require.NoError(t, err)
+
+		// Replace watchlist
+		err = probe.UpdateWatchlist([]uint64{4, 5})
+		require.NoError(t, err)
+
+		// Clear again
+		err = probe.UpdateWatchlist(nil)
+		require.NoError(t, err)
+	})
+}
+
+func readSelfCgroupID(t *testing.T) uint64 {
+	t.Helper()
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		t.Logf("cannot read /proc/self/cgroup: %v", err)
+		return 0
+	}
+	// On cgroup v2, the line looks like "0::/some/path"
+	// We need the kernfs inode of the cgroup directory
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "0::") {
+			relPath := strings.TrimPrefix(line, "0::")
+			relPath = strings.TrimSpace(relPath)
+			cgPath := "/sys/fs/cgroup" + relPath
+			var stat syscall.Stat_t
+			if err := syscall.Stat(cgPath, &stat); err != nil {
+				t.Logf("cannot stat cgroup path %s: %v", cgPath, err)
+				return 0
+			}
+			t.Logf("cgroup path: %s, inode: %d", cgPath, stat.Ino)
+			return stat.Ino
+		}
+	}
+	return 0
 }
 
 func testConfig() *ebpf.Config {


### PR DESCRIPTION
## Summary

Reworks the noisy neighbor check from a single always-on eBPF program into a 3-layer architecture that starts cheap and only does expensive work when there's a confirmed problem to investigate.

### Motivation

The current check fires its eBPF handler on **every `sched_switch` on every CPU** (~50-100ns × 200k+ events/sec on a busy 64-core host = 10-20ms/sec of CPU), yet produces a single undifferentiated `preemption_count` that can't distinguish between:

1. A neighbor starving your container (foreign preemption)
2. Your container contending with itself (self preemption)
3. CPU quota throttling by the scheduler

The remediation for each is completely different, making the current output not actionable for noisy neighbor detection specifically.

### New Architecture

```
┌─────────────────────────────────────────────────────────┐
│ Layer 1: Canary Signals (always on, no eBPF)            │
│ Reads PSI, throttle, steal from filesystem per cgroup   │
│ Cost: ~0.1-0.5ms every 10s (kernfs reads)               │
│                                                         │
│ Triage matrix:                                          │
│  PSI high + throttle low + steal low → flag for Layer 2 │
│  PSI high + throttle high            → self-inflicted   │
│  PSI high + steal high               → hypervisor-level │
│  PSI low                             → no problem       │
└────────────────────────┬────────────────────────────────┘
                         │ flagged cgroup IDs
                         ▼
┌─────────────────────────────────────────────────────────┐
│ Layer 2: Attribution (eBPF, conditional)                 │
│ Always loaded, fast-exit gate when idle (~5-10ns/event)  │
│ Only does real work for watchlisted cgroups              │
│                                                         │
│ • Foreign vs self preemption classification              │
│ • Scheduling latency with histogram buckets              │
│ • CPU migration tracking (sched_migrate_task)            │
└────────────────────────┬────────────────────────────────┘
                         │ foreign preemptions detected
                         ▼
┌─────────────────────────────────────────────────────────┐
│ Layer 3: Identification (who is the neighbor)            │
│ Per-CPU map tracks victim→preemptor cgroup pairs         │
│ Agent emits top-5 preemptors per victim with tags        │
│                                                         │
│ "container redis-cache-7b is preempting your workload"   │
└─────────────────────────────────────────────────────────┘
```

### Performance Profile

```
                         Current check        Layered design
                         ─────────────        ──────────────
Idle (no contention):    10-20ms/sec CPU      1-2ms/sec CPU      ← 10x cheaper
Active (3/50 cgroups):   10-20ms/sec          10-11ms/sec        ← comparable,
                         (no attribution)      (full attribution)    better signal
```

The main win is idle state. On most hosts most of the time, there's no noisy neighbor problem. Paying 1-2ms/sec for a single map lookup to confirm "nothing is wrong" instead of 10-20ms/sec doing full stats aggregation is the core value.

### Layer 1: Canary Signals

Every 10s check interval, reads from the filesystem (no eBPF):

| Signal | Source | What it tells you |
|---|---|---|
| `cpu.pressure` (PSI avg10 "some") | `/sys/fs/cgroup/<cg>/cpu.pressure` | % of time at least one task was stalled for CPU |
| `cpu.stat` throttled_usec | `/sys/fs/cgroup/<cg>/cpu.stat` | Time spent throttled by cgroup CPU quota |
| Steal time | `/proc/stat` | Time hypervisor gave the vCPU to another VM |

**Metrics emitted (always, for all cgroups):**
- `noisy_neighbor.cpu_pressure` — gauge, PSI avg10
- `noisy_neighbor.cpu_throttled_ns` — count, delta since last check
- `noisy_neighbor.system.steal_time_pct` — gauge, system-wide

**Flagging logic:** A cgroup is flagged for Layer 2 when `PSI avg10 >= 5.0` AND `throttle_ratio < 10%` AND `steal_pct < 5.0%`. All thresholds are configurable via check YAML.

### Layer 2: Attribution (eBPF)

The eBPF program attaches to 4 tracepoints:
- `sched_wakeup` / `sched_wakeup_new` — store enqueue timestamps (unconditional, cheap)
- `sched_switch` — gated by watchlist; classifies preemptions, measures latency
- `sched_migrate_task` — gated by watchlist; counts CPU migrations

**Fast-exit gate:** `sched_switch` first reads `watchlist_active[0]` (BPF array map, ~5-10ns). If zero, it re-enqueues runnable tasks (so timestamps are ready when the watchlist activates) and returns. No cgroup resolution, no stats updates.

When active, the handler:
1. Resolves cgroup IDs for both `prev` and `next` tasks (hoisted, computed once)
2. Checks if either cgroup is in the watchlist hash map
3. For preempted victims: classifies foreign (different cgroup) vs self (same cgroup)
4. For foreign preemptions: updates `preemptor_stats` map with (victim, preemptor) pair
5. For scheduled-in tasks: measures run-queue latency, buckets into 4 tiers (<100μs, 100μs-1ms, 1ms-10ms, >10ms)

**Metrics emitted (only for flagged cgroups):**
- `noisy_neighbor.scheduling_latency.per_process` — gauge
- `noisy_neighbor.preemptions.foreign.per_process` — gauge
- `noisy_neighbor.preemptions.self.per_process` — gauge
- `noisy_neighbor.latency_per_preemption` — gauge, characterizes contention type
- `noisy_neighbor.scheduling_latency.bucket.{lt_100us,100us_1ms,1ms_10ms,gt_10ms}` — counts
- `noisy_neighbor.events.total` — count
- `noisy_neighbor.cgroup_task_count` — gauge (renamed from `unique_processes` for accuracy)
- `noisy_neighbor.cpu_migrations` — count

### Layer 3: Neighbor Identification

When Layer 2 detects foreign preemptions, the `preemptor_stats` per-CPU hash map accumulates counts keyed by `(victim_cgroup_id, preemptor_cgroup_id)`. The agent groups by victim, sorts by count, and emits the top 5:

- `noisy_neighbor.top_preemptor.count` — gauge, tagged with both victim container tags and `preemptor:<tag>`

This is the difference between "you have a noisy neighbor" and "container `redis-cache-7b` is the neighbor."

### Agent ↔ System-probe Communication

| Endpoint | Method | Purpose |
|---|---|---|
| `/noisy_neighbor/check` | GET | Fetch and flush Layer 2+3 stats (existing pattern) |
| `/noisy_neighbor/watchlist` | POST | Update watched cgroup IDs (new) |

The agent POSTs flagged cgroup IDs every check interval. System-probe clears the old watchlist, inserts new entries, and sets/clears the `watchlist_active` gate. The eBPF program sees changes immediately on the next `sched_switch`.

### Configuration

```yaml
init_config:

instances:
  - psi_threshold: 5.0       # PSI avg10 "some" to trigger Layer 2 (default: 5.0)
    throttle_ratio: 0.10      # Max throttle ratio before attributing to quota (default: 0.10)
    steal_threshold: 5.0      # Max steal % before attributing to hypervisor (default: 5.0)
```

### eBPF Maps

| Map | Type | Key | Value | Max Entries | Purpose |
|---|---|---|---|---|---|
| `runq_enqueued` | Task storage | task | u64 (timestamp) | per-task | Run-queue enqueue time |
| `cgroup_agg_stats` | Per-CPU hash | u64 (cgroup ID) | `cgroup_agg_stats_t` | 4096 | Aggregated scheduling stats |
| `watchlist_active` | Array | u32 (0) | u8 | 1 | Global fast-exit gate |
| `watchlist` | Hash | u64 (cgroup ID) | u8 | 128 | Cgroups to monitor |
| `preemptor_stats` | Per-CPU hash | `preemptor_key_t` | `preemptor_stats_t` | 512 | Victim→preemptor tracking |

### Files Changed

- **`noisy-neighbor-kern-user.h`** — New struct fields (foreign/self preemption, latency buckets, migrations), new `preemptor_key_t` and `preemptor_stats_t` types
- **`noisy-neighbor-kern.c`** — Watchlist gate, 4 tracepoint handlers, foreign/self classification, histogram bucketing, preemptor tracking
- **`model/types.go`** — `CheckResponse`, `PreemptorStats`, `WatchlistRequest` types; renamed `UniquePidCount` → `TaskCount`
- **`probe.go`** — `UpdateWatchlist()` method, new map registration, reworked `GetAndFlush()` for `CheckResponse`
- **`noisy_neighbor.go`** — 3-layer `Run()` flow, Layer 1 PSI/throttle/steal reading, watchlist management, Layer 2+3 metric emission, configurable thresholds, non-container cgroup fallback tags
- **`noisy_neighbor.go` (module)** — Added `POST /watchlist` endpoint
- **`ebpf_types*.go`** — Updated cgo struct definitions for new fields and types
- **Tests** — Updated probe test for watchlist activation, alignment tests for new types

## Test plan

- [ ] Verify eBPF program loads on kernel 6.2+ and the fast-exit gate works (no stats with empty watchlist)
- [ ] Verify Layer 1 metrics (`cpu_pressure`, `cpu_throttled_ns`, `steal_time_pct`) are emitted for all cgroups
- [ ] Verify flagging logic: create CPU pressure with `stress-ng` in a container, confirm the cgroup gets flagged
- [ ] Verify Layer 2 metrics appear only for flagged cgroups, not all cgroups
- [ ] Verify foreign vs self preemption classification: run two containers on overlapping CPUs, confirm foreign preemptions are attributed correctly
- [ ] Verify Layer 3 top-preemptor tags identify the correct neighbor container
- [ ] Verify latency histogram bucket counts sum to `events.total`
- [ ] Verify idle-state overhead reduction: compare CPU usage of system-probe with old vs new check on a quiet host
- [ ] Verify watchlist lifecycle: confirm maps are cleared when no cgroups are flagged
- [ ] Verify non-container cgroup fallback tags (e.g., systemd services get `cgroup_name:` tags)
- [ ] Verify cardinality cap: >100 non-container cgroups should not all emit metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)