### PR TITLE
[observer] Fix CI failures after main merge into q-branch-observer

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,7 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude cmd
 # gazelle:exclude comp/agent
 # gazelle:exclude comp/aggregator
+# gazelle:exclude comp/anomalydetection
 # gazelle:exclude comp/api/bundle.go
 # gazelle:exclude comp/api/bundle_test.go
 # gazelle:exclude comp/api/authtoken
@@ -130,6 +131,7 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/networkdeviceconfig
 # gazelle:exclude comp/networkpath
 # gazelle:exclude comp/notableevents
+# gazelle:exclude comp/observer
 # gazelle:exclude comp/otelcol/collector
 # gazelle:exclude comp/otelcol/collector-contrib/fx
 # gazelle:exclude comp/otelcol/collector-contrib/impl
@@ -167,6 +169,7 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/trace/compression/fx-zstd
 # gazelle:exclude comp/trace/config
 # gazelle:exclude comp/trace/etwtracer
+# gazelle:exclude comp/trace/observerbuffer
 # gazelle:exclude comp/trace/payload-modifier
 # gazelle:exclude comp/trace/status
 # gazelle:exclude comp/updater

--- a/cmd/observer-testbench/main_test.go
+++ b/cmd/observer-testbench/main_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +23,6 @@ func TestFxApp(t *testing.T) {
 		err := fxutil.OneShot(run,
 			recorderfx.Module(),
 			core.Bundle(),
-			secretsnoopfx.Module(),
 			fx.Supply(core.BundleParams{
 				ConfigParams: config.NewAgentParams(""),
 				LogParams:    log.ForOneShot("", "off", true),

--- a/comp/core/configstream/server/server_test.go
+++ b/comp/core/configstream/server/server_test.go
@@ -78,6 +78,14 @@ func (m *mockRemoteAgentRegistry) GetRegisteredAgentStatuses() []remoteagentregi
 	return nil
 }
 
+func (m *mockRemoteAgentRegistry) GetObserverTraces(_ uint32) []remoteagentregistry.ObserverTracesData {
+	return nil
+}
+
+func (m *mockRemoteAgentRegistry) GetObserverProfiles(_ uint32) []remoteagentregistry.ObserverProfilesData {
+	return nil
+}
+
 func setupTest(ctx context.Context, t *testing.T, sessionID string) (*Server, *mockComp, *mockStream, chan *pb.ConfigEvent) {
 	cfg := configmock.New(t)
 	cfg.Set("remote_agent.configstream.sleep_interval", 10*time.Millisecond, model.SourceAgentRuntime)

--- a/comp/observer/def/go.mod
+++ b/comp/observer/def/go.mod
@@ -93,6 +93,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig => ../../../pkg/config/teeconfig
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../pkg/config/utils
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig => ../../../pkg/config/viperconfig
+	github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata/model => ../../../pkg/discovery/tracermetadata/model
 	github.com/DataDog/datadog-agent/pkg/errors => ../../../pkg/errors
 	github.com/DataDog/datadog-agent/pkg/fips => ../../../pkg/fips
 	github.com/DataDog/datadog-agent/pkg/fleet/installer => ../../../pkg/fleet/installer

--- a/comp/observer/def/go.mod
+++ b/comp/observer/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/observer/def
 
-go 1.25.3
+go 1.25.0
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 

--- a/comp/observer/impl/detect_digest_log.go
+++ b/comp/observer/impl/detect_digest_log.go
@@ -57,7 +57,7 @@ func enableDetectDigestRecordingToFile(e *engine, path string) (func(), error) {
 	log.Printf("[observer] detect digest recording enabled: %s", path)
 	return func() {
 		e.enableDetectDigestRecording(nil)
-		rec.close()
+		_ = rec.close()
 	}, nil
 }
 
@@ -117,13 +117,13 @@ func (d DetectDivergence) String() string {
 
 // detectDigestComparator compares replay digests against a live recording.
 type detectDigestComparator struct {
-	mu              sync.Mutex
-	expected        map[string]detectDigest // keyed by "detector|dataTime"
-	visited         map[string]bool         // keys seen during replay
-	divergences     []DetectDivergence
-	inputOnlyDiffs  int
-	matched         int
-	replayOnly      int
+	mu             sync.Mutex
+	expected       map[string]detectDigest // keyed by "detector|dataTime"
+	visited        map[string]bool         // keys seen during replay
+	divergences    []DetectDivergence
+	inputOnlyDiffs int
+	matched        int
+	replayOnly     int
 }
 
 func newDetectDigestComparator(path string) (*detectDigestComparator, error) {

--- a/comp/observer/impl/hfrunner/sender.go
+++ b/comp/observer/impl/hfrunner/sender.go
@@ -31,15 +31,15 @@ func newObserverSenderManager(handle observerdef.Handle) *observerSenderManager 
 	return &observerSenderManager{handle: handle}
 }
 
-func (m *observerSenderManager) GetSender(id checkid.ID) (aggsender.Sender, error) {
+func (m *observerSenderManager) GetSender(_id checkid.ID) (aggsender.Sender, error) {
 	return &observerSender{handle: m.handle}, nil
 }
 
-func (m *observerSenderManager) SetSender(s aggsender.Sender, id checkid.ID) error {
+func (m *observerSenderManager) SetSender(_s aggsender.Sender, _id checkid.ID) error {
 	return nil
 }
 
-func (m *observerSenderManager) DestroySender(id checkid.ID) {}
+func (m *observerSenderManager) DestroySender(_id checkid.ID) {}
 
 func (m *observerSenderManager) GetDefaultSender() (aggsender.Sender, error) {
 	return &observerSender{handle: m.handle}, nil

--- a/comp/observer/impl/log_tagged_pattern_clusterer.go
+++ b/comp/observer/impl/log_tagged_pattern_clusterer.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/fnv"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/observer/impl/patterns"
@@ -139,7 +140,7 @@ func globalClusterHash(groupHash uint64, clusterID int64) string {
 	h := fnv.New64a()
 	_ = binary.Write(h, binary.LittleEndian, groupHash)
 	_ = binary.Write(h, binary.LittleEndian, clusterID)
-	return fmt.Sprintf("%x", h.Sum64())
+	return strconv.FormatUint(h.Sum64(), 16)
 }
 
 // TaggedPatternClusterer wraps one *patterns.PatternClusterer per tag-group

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -308,7 +308,7 @@ func NewComponent(deps Requires) Provides {
 				eng.onAdvance = advRec.record
 				obs.advanceLogCleanup = func() {
 					eng.onAdvance = nil
-					advRec.close()
+					_ = advRec.close()
 				}
 			}
 		}

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -16,7 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.uber.org/fx"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
 
 	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
 	config "github.com/DataDog/datadog-agent/comp/core/config"
@@ -41,7 +41,7 @@ type Requires struct {
 	// When fields are nil, values are read from configuration defaults.
 	AgentInternalLogTap AgentInternalLogTapConfig
 
-	Lifecycle fx.Lifecycle
+	Lifecycle compdef.Lifecycle
 	Config    config.Component
 	Log       log.Component
 	Telemetry telemetry.Component
@@ -341,7 +341,7 @@ func NewComponent(deps Requires) Provides {
 			obs.hfFilterSources[src] = struct{}{}
 		}
 		pkglog.Info("[observer] high-frequency system check runner started (1s interval)")
-		deps.Lifecycle.Append(fx.Hook{
+		deps.Lifecycle.Append(compdef.Hook{
 			OnStop: func(_ context.Context) error {
 				obs.hfRunner.Stop()
 				return nil
@@ -370,7 +370,7 @@ func NewComponent(deps Requires) Provides {
 				for src := range containerCheckSources {
 					obs.hfFilterSources[src] = struct{}{}
 				}
-				deps.Lifecycle.Append(fx.Hook{
+				deps.Lifecycle.Append(compdef.Hook{
 					OnStop: func(_ context.Context) error {
 						obs.hfContainerRunner.Stop()
 						return nil

--- a/comp/observer/impl/storage_instrumented.go
+++ b/comp/observer/impl/storage_instrumented.go
@@ -81,8 +81,7 @@ func newCallHasher() *callHasher {
 	return &callHasher{h: fnv.New64a()}
 }
 
-func (c *callHasher) mixBytes(data []byte) { c.h.Write(data) }
-func (c *callHasher) mixString(v string)   { c.h.Write([]byte(v)) }
+func (c *callHasher) mixString(v string) { c.h.Write([]byte(v)) }
 func (c *callHasher) mixUint64(v uint64) {
 	var b [8]byte
 	binary.LittleEndian.PutUint64(b[:], v)

--- a/comp/observer/impl/telemetry_test.go
+++ b/comp/observer/impl/telemetry_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTelemetryHandler_CounterAdd(t *testing.T) {
+func TestTelemetryHandler_CounterAdd(_t *testing.T) {
 	tel := noopsimpl.GetCompatComponent()
 	h := newTelemetryHandler(tel)
 
@@ -32,7 +32,7 @@ func TestTelemetryHandler_CounterAdd(t *testing.T) {
 	// No-op telemetry: asserts routing does not warn or panic.
 }
 
-func TestTelemetryHandler_GaugeSet(t *testing.T) {
+func TestTelemetryHandler_GaugeSet(_t *testing.T) {
 	tel := noopsimpl.GetCompatComponent()
 	h := newTelemetryHandler(tel)
 

--- a/comp/otelcol/ddprofilingextension/impl/go.mod
+++ b/comp/otelcol/ddprofilingextension/impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/ddprofilingextension/impl
 
-go 1.25.3
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.77.0-devel.0.20260213154712-e02b9359151a

--- a/comp/otelcol/logsagentpipeline/go.mod
+++ b/comp/otelcol/logsagentpipeline/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline
 
-go 1.25.3
+go 1.25.0
 
 require github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.64.0-rc.3
 

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl
 
-go 1.25.3
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.1

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/datadogexporter
 
-go 1.25.3
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.77.0-devel.0.20260213154712-e02b9359151a

--- a/comp/otelcol/otlp/components/metricsclient/go.mod
+++ b/comp/otelcol/otlp/components/metricsclient/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient
 
-go 1.25.3
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61

--- a/comp/trace/observerbuffer/def/go.mod
+++ b/comp/trace/observerbuffer/def/go.mod
@@ -102,6 +102,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig => ../../../../pkg/config/teeconfig
 	github.com/DataDog/datadog-agent/pkg/config/utils => ../../../../pkg/config/utils
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig => ../../../../pkg/config/viperconfig
+	github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata/model => ../../../../pkg/discovery/tracermetadata/model
 	github.com/DataDog/datadog-agent/pkg/errors => ../../../../pkg/errors
 	github.com/DataDog/datadog-agent/pkg/fips => ../../../../pkg/fips
 	github.com/DataDog/datadog-agent/pkg/fleet/installer => ../../../../pkg/fleet/installer

--- a/comp/trace/observerbuffer/def/go.mod
+++ b/comp/trace/observerbuffer/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/observerbuffer/def
 
-go 1.25.3
+go 1.25.0
 
 require github.com/DataDog/datadog-agent/pkg/proto v0.0.0-00010101000000-000000000000
 

--- a/go.mod
+++ b/go.mod
@@ -480,7 +480,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/orchestrator/util v0.0.0-20251120165911-0b75c97e8b50 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/buf v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/util/statstracker v0.64.0-rc.3 // indirect
-	github.com/DataDog/datadog-api-client-go/v2 v2.55.0 // indirect
+	github.com/DataDog/datadog-api-client-go/v2 v2.55.0
 	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/gostackparse v0.7.0 // indirect
@@ -955,6 +955,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/logs-library v0.77.0-devel.0.20260211235139-a5361978c2b6
+	github.com/DataDog/datadog-agent/comp/observer/def v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/impl v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/impl v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/datadog-agent/comp/otelcol/ddprofilingextension/impl v0.77.0-devel.0.20260211235139-a5361978c2b6
@@ -965,6 +966,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.65.0-devel.0.20250304124125-23a109221842
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/processor/infraattributesprocessor v0.59.0
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.77.0-devel.0.20260213154712-e02b9359151a
+	github.com/DataDog/datadog-agent/comp/trace/observerbuffer/def v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.64.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/logs/processor v0.64.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/process/util/api v0.77.0-devel.0.20260213154712-e02b9359151a
@@ -976,6 +978,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5
 	github.com/DataDog/rshell v0.0.9
+	github.com/apache/arrow-go/v18 v18.4.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.64.4
 	github.com/aymerick/raymond v2.0.2+incompatible
@@ -1052,6 +1055,7 @@ require (
 	github.com/ProtonMail/gopenpgp/v3 v3.2.1 // indirect
 	github.com/VictoriaMetrics/easyproto v0.1.4 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v1.63.107 // indirect
+	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
@@ -1085,6 +1089,7 @@ require (
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible // indirect
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/google/certificate-transparency-go v1.3.2 // indirect
+	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/go-metrics-stackdriver v0.2.0 // indirect
 	github.com/google/licensecheck v0.3.1 // indirect
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
@@ -1153,6 +1158,7 @@ require (
 	github.com/joyent/triton-go v1.7.1-0.20200416154420-6801d15b779f // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
@@ -1160,6 +1166,8 @@ require (
 	github.com/lestrrat-go/jwx v1.2.29 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/mattn/go-zglob v0.0.2-0.20191112051448-a8912a37f9e7 // indirect
+	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
+	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/mitchellh/pointerstructure v1.2.1 // indirect
 	github.com/moby/moby/api v1.52.0 // indirect
 	github.com/moby/moby/client v0.2.1 // indirect
@@ -1307,6 +1315,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs-library => ./comp/logs-library
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ./comp/logs/agent/config
 	github.com/DataDog/datadog-agent/comp/netflow/payload => ./comp/netflow/payload
+	github.com/DataDog/datadog-agent/comp/observer/def => ./comp/observer/def
 	github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/def => ./comp/otelcol/collector-contrib/def
 	github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/impl => ./comp/otelcol/collector-contrib/impl
 	github.com/DataDog/datadog-agent/comp/otelcol/converter/def => ./comp/otelcol/converter/def
@@ -1332,6 +1341,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/trace/compression/def => ./comp/trace/compression/def
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip => ./comp/trace/compression/impl-gzip
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd => ./comp/trace/compression/impl-zstd
+	github.com/DataDog/datadog-agent/comp/trace/observerbuffer/def => ./comp/trace/observerbuffer/def
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ./pkg/aggregator/ckey
 	github.com/DataDog/datadog-agent/pkg/api => ./pkg/api
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ./pkg/collector/check/defaults

--- a/go.sum
+++ b/go.sum
@@ -2608,6 +2608,8 @@ github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd
 github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7 h1:Vo3q7h44BfmnLQh5SdF+2xwIoVnHThmZLunx6odjrHI=
 github.com/xor-gate/ar v0.0.0-20170530204233-5c72ae81e2b7/go.mod h1:TCWCUPhQU1j7axqROa/VHnlgJGHthAOqJZahg7b/DUc=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBeEWqThExu54RFg=
 github.com/yashtewari/glob-intersection v0.2.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/pkg/discovery/tracermetadata/model/go.mod
+++ b/pkg/discovery/tracermetadata/model/go.mod
@@ -65,6 +65,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs-library => ../../../../comp/logs-library
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/comp/netflow/payload => ../../../../comp/netflow/payload
+	github.com/DataDog/datadog-agent/comp/observer/def => ../../../../comp/observer/def
 	github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/def => ../../../../comp/otelcol/collector-contrib/def
 	github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/impl => ../../../../comp/otelcol/collector-contrib/impl
 	github.com/DataDog/datadog-agent/comp/otelcol/converter/def => ../../../../comp/otelcol/converter/def
@@ -90,6 +91,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/trace/compression/def => ../../../../comp/trace/compression/def
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip => ../../../../comp/trace/compression/impl-gzip
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd => ../../../../comp/trace/compression/impl-zstd
+	github.com/DataDog/datadog-agent/comp/trace/observerbuffer/def => ../../../../comp/trace/observerbuffer/def
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../../../pkg/aggregator/ckey
 	github.com/DataDog/datadog-agent/pkg/api => ../../../../pkg/api
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../../pkg/collector/check/defaults

--- a/pkg/logs/pipeline/go.mod
+++ b/pkg/logs/pipeline/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/pipeline
 
-go 1.25.3
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.61.0

--- a/pkg/logs/pipeline/provider_failover_integration_test.go
+++ b/pkg/logs/pipeline/provider_failover_integration_test.go
@@ -55,6 +55,7 @@ func (suite *ProviderFailoverIntegrationSuite) SetupTest() {
 		compressionfx.NewMockCompressor(),
 		sender.NewServerlessMeta(false),
 		createMockSender(),
+		nil,
 	).(*provider)
 
 	suite.provider.Start()
@@ -186,6 +187,7 @@ func (suite *ProviderFailoverIntegrationSuite) TestRapidStartStopCycles() {
 			compressionfx.NewMockCompressor(),
 			sender.NewServerlessMeta(false),
 			createMockSender(),
+			nil,
 		).(*provider)
 
 		p.Start()

--- a/pkg/logs/pipeline/provider_failover_test.go
+++ b/pkg/logs/pipeline/provider_failover_test.go
@@ -81,6 +81,7 @@ func createTestProviderWithFailover(t *testing.T, numberOfPipelines int) *provid
 		compressionfx.NewMockCompressor(),
 		sender.NewServerlessMeta(false),
 		createMockSender(),
+		nil,
 	).(*provider)
 
 	p.Start()

--- a/pkg/logs/processor/go.mod
+++ b/pkg/logs/processor/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/processor
 
-go 1.25.3
+go 1.25.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.184

--- a/pkg/security/seclwin/go.mod
+++ b/pkg/security/seclwin/go.mod
@@ -68,6 +68,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs-library => ../../../comp/logs-library
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/comp/netflow/payload => ../../../comp/netflow/payload
+	github.com/DataDog/datadog-agent/comp/observer/def => ../../../comp/observer/def
 	github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/def => ../../../comp/otelcol/collector-contrib/def
 	github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/impl => ../../../comp/otelcol/collector-contrib/impl
 	github.com/DataDog/datadog-agent/comp/otelcol/converter/def => ../../../comp/otelcol/converter/def
@@ -93,6 +94,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/trace/compression/def => ../../../comp/trace/compression/def
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip => ../../../comp/trace/compression/impl-gzip
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd => ../../../comp/trace/compression/impl-zstd
+	github.com/DataDog/datadog-agent/comp/trace/observerbuffer/def => ../../../comp/trace/observerbuffer/def
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../../pkg/aggregator/ckey
 	github.com/DataDog/datadog-agent/pkg/api => ../../../pkg/api
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../../pkg/collector/check/defaults

--- a/pkg/trace/agent/obfuscate_test.go
+++ b/pkg/trace/agent/obfuscate_test.go
@@ -588,7 +588,7 @@ func TestObfuscateSpanParameterized(t *testing.T) {
 			cfg.Endpoints[0].APIKey = "test"
 			cfg.Features["sqllexer"] = struct{}{}
 			cfg.Obfuscation = &ocfg
-			agnt := NewAgent(ctx, cfg, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, gzip.NewComponent())
+			agnt := NewAgent(ctx, cfg, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, gzip.NewComponent(), nil)
 			agnt.ObfuscateSpan(&raw.Input)
 			assertSpanEqual(t, &raw.Expected, &raw.Input)
 		})

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace
 
-go 1.25.3
+go 1.25.0
 
 // NOTE: Prefer using simple `require` directives instead of using `replace` if possible.
 // See https://github.com/DataDog/datadog-agent/blob/main/docs/dev/gomodreplace.md

--- a/pkg/trace/otel/go.mod
+++ b/pkg/trace/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace/otel
 
-go 1.25.3
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.72.0-rc.5

--- a/pkg/trace/stats/go.mod
+++ b/pkg/trace/stats/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace/stats
 
-go 1.25.3
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.71.0

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "log_test_init.go",
         "logger.go",
         "logger_test_utils.go",
+        "observer_tap.go",
         "wrapper.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/util/log",

--- a/test/e2e-framework/go.mod
+++ b/test/e2e-framework/go.mod
@@ -330,6 +330,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs-library => ../../comp/logs-library
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/comp/netflow/payload => ../../comp/netflow/payload
+	github.com/DataDog/datadog-agent/comp/observer/def => ../../comp/observer/def
 	github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/def => ../../comp/otelcol/collector-contrib/def
 	github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/impl => ../../comp/otelcol/collector-contrib/impl
 	github.com/DataDog/datadog-agent/comp/otelcol/converter/def => ../../comp/otelcol/converter/def
@@ -355,6 +356,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/trace/compression/def => ../../comp/trace/compression/def
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip => ../../comp/trace/compression/impl-gzip
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd => ../../comp/trace/compression/impl-zstd
+	github.com/DataDog/datadog-agent/comp/trace/observerbuffer/def => ../../comp/trace/observerbuffer/def
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../pkg/aggregator/ckey
 	github.com/DataDog/datadog-agent/pkg/api => ../../pkg/api
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../pkg/collector/check/defaults

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -403,6 +403,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/logs-library => ../../comp/logs-library
 	github.com/DataDog/datadog-agent/comp/logs/agent/config => ../../comp/logs/agent/config
 	github.com/DataDog/datadog-agent/comp/netflow/payload => ../../comp/netflow/payload
+	github.com/DataDog/datadog-agent/comp/observer/def => ../../comp/observer/def
 	github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/def => ../../comp/otelcol/collector-contrib/def
 	github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/impl => ../../comp/otelcol/collector-contrib/impl
 	github.com/DataDog/datadog-agent/comp/otelcol/converter/def => ../../comp/otelcol/converter/def
@@ -428,6 +429,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/trace/compression/def => ../../comp/trace/compression/def
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip => ../../comp/trace/compression/impl-gzip
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd => ../../comp/trace/compression/impl-zstd
+	github.com/DataDog/datadog-agent/comp/trace/observerbuffer/def => ../../comp/trace/observerbuffer/def
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey => ../../pkg/aggregator/ckey
 	github.com/DataDog/datadog-agent/pkg/api => ../../pkg/api
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults => ../../pkg/collector/check/defaults

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/test/otel
 
-go 1.25.3
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.77.0-devel.0.20260213154712-e02b9359151a


### PR DESCRIPTION
## Summary

Fixes CI failures on q-branch-observer after merging main (#48883).

### 1. compdef lint fix
`comp/observer/impl/observer.go` imported `go.uber.org/fx` directly — component
implementations must use `comp/def`. Replaced `fx.Lifecycle`/`fx.Hook` with
`compdef.Lifecycle`/`compdef.Hook`. Introduced by #48707.

### 2. pkg/util/log BUILD.bazel update
Main's Bazel migration (#48676 by @aiuto) onboarded `pkg/util/log` to Bazel.
Q-branch added `observer_tap.go` to that package, which wasn't in the new
BUILD.bazel. Added it to the srcs list.

### 3. gazelle:exclude for q-branch-only packages
Added `gazelle:exclude` for `comp/observer`, `comp/anomalydetection`, and
`comp/trace/observerbuffer` in root BUILD.bazel. These packages don't exist
on main and were created without `dda inv create-module`. Gazelle generates
incorrect `@external` refs for them that Bazel can't resolve, so they need
to be excluded (same pattern as most other `comp/` packages).

### 4. go.mod replace directives
Ran `dda inv modules.add-all-replace` to propagate replace directives for
the q-branch-only modules across all go.mod files in the repo.

### 5. deps/go.MODULE.bazel
Added `com_github_apache_arrow_go_v18` and `com_github_datadog_datadog_agent_comp_observer_def`
to `use_repo` entries (required by `bzl mod tidy`).

### 6. Missing nil args in test call sites
Added missing `observerbuffer.Component` arg (`nil`) to `NewAgent()` call in
`pkg/trace/agent/obfuscate_test.go`, and missing `observer.Handle` arg (`nil`)
to `newProvider()` calls in `pkg/logs/pipeline/` test files. These params were
added by q-branch but missed in merge conflict resolution.

### 7. OTEL go version mismatch
Reverted `go` directive from `1.25.3` to `1.25.0` in 13 go.mod files used by
OTEL components. The main merge bumped these, but the OTEL version check
(`check-otel-module-versions`) requires `1.25.0` to match upstream.

### 8. configstream mock update
Added `GetObserverTraces` and `GetObserverProfiles` stub methods to
`mockRemoteAgentRegistry` in `comp/core/configstream/server/server_test.go`.

### 9. golangci-lint fixes in comp/observer/impl
Fixed 10 lint errors in observer implementation code:
- errcheck: unchecked `rec.close()` / `advRec.close()` returns
- gofmt: struct field alignment in `detect_digest_log.go`
- perfsprint: `fmt.Sprintf` → `strconv.FormatUint`
- revive: renamed unused params with `_` prefix
- unused: removed unused `mixBytes` method

## Root cause
The main merge brought in 20 Bazel migration commits (ABLD-425), including
#48676 which onboarded `pkg/util/log`. Q-branch's `observer_tap.go` in that
package wasn't reflected in the new BUILD.bazel. The q-branch-only observer
modules also lacked proper Bazel integration (replace directives, gazelle
exclusions) because they were created manually rather than via
`dda inv create-module`. Additionally, the merge resolution missed adding nil
args at several test call sites where q-branch added new parameters to function
signatures, and the OTEL go version check caught go directive bumps from the
merge.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)