### PR TITLE
Bump go-sdk to v1.4.1 for CVE-2026-33252

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1570,14 +1570,15 @@ core,github.com/moby/sys/sequential,Apache-2.0,Kir Kolyshkin <kolyshkin@gmail.co
 core,github.com/moby/sys/signal,Apache-2.0,Copyright (c) 2014-2018 The Docker & Go Authors. All rights reserved.
 core,github.com/moby/sys/user,Apache-2.0,Copyright (c) 2014-2018 The Docker & Go Authors. All rights reserved.
 core,github.com/moby/sys/userns,Apache-2.0,Copyright (c) 2014-2018 The Docker & Go Authors. All rights reserved.
-core,github.com/modelcontextprotocol/go-sdk/auth,MIT,Copyright (c) 2025 Go MCP SDK Authors
-core,github.com/modelcontextprotocol/go-sdk/internal/json,MIT,Copyright (c) 2025 Go MCP SDK Authors
-core,github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2,MIT,Copyright (c) 2025 Go MCP SDK Authors
-core,github.com/modelcontextprotocol/go-sdk/internal/util,MIT,Copyright (c) 2025 Go MCP SDK Authors
-core,github.com/modelcontextprotocol/go-sdk/internal/xcontext,MIT,Copyright (c) 2025 Go MCP SDK Authors
-core,github.com/modelcontextprotocol/go-sdk/jsonrpc,MIT,Copyright (c) 2025 Go MCP SDK Authors
-core,github.com/modelcontextprotocol/go-sdk/mcp,MIT,Copyright (c) 2025 Go MCP SDK Authors
-core,github.com/modelcontextprotocol/go-sdk/oauthex,MIT,Copyright (c) 2025 Go MCP SDK Authors
+core,github.com/modelcontextprotocol/go-sdk/auth,Apache-2.0,"Copyright (c) 2024-2025 Model Context Protocol a Series of LF Projects, LLC"
+core,github.com/modelcontextprotocol/go-sdk/internal/json,Apache-2.0,"Copyright (c) 2024-2025 Model Context Protocol a Series of LF Projects, LLC"
+core,github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2,Apache-2.0,"Copyright (c) 2024-2025 Model Context Protocol a Series of LF Projects, LLC"
+core,github.com/modelcontextprotocol/go-sdk/internal/mcpgodebug,Apache-2.0,"Copyright (c) 2024-2025 Model Context Protocol a Series of LF Projects, LLC"
+core,github.com/modelcontextprotocol/go-sdk/internal/util,Apache-2.0,"Copyright (c) 2024-2025 Model Context Protocol a Series of LF Projects, LLC"
+core,github.com/modelcontextprotocol/go-sdk/internal/xcontext,Apache-2.0,"Copyright (c) 2024-2025 Model Context Protocol a Series of LF Projects, LLC"
+core,github.com/modelcontextprotocol/go-sdk/jsonrpc,Apache-2.0,"Copyright (c) 2024-2025 Model Context Protocol a Series of LF Projects, LLC"
+core,github.com/modelcontextprotocol/go-sdk/mcp,Apache-2.0,"Copyright (c) 2024-2025 Model Context Protocol a Series of LF Projects, LLC"
+core,github.com/modelcontextprotocol/go-sdk/oauthex,Apache-2.0,"Copyright (c) 2024-2025 Model Context Protocol a Series of LF Projects, LLC"
 core,github.com/modern-go/concurrent,Apache-2.0,Copyright (c) 2018 Tao Wen
 core,github.com/modern-go/reflect2,Apache-2.0,Copyright (c) 2018 Tao Wen
 core,github.com/mohae/deepcopy,MIT,Copyright (c) 2014 Joel

--- a/go.mod
+++ b/go.mod
@@ -993,7 +993,7 @@ require (
 	github.com/hashicorp/vault/api/auth/userpass v0.11.0
 	github.com/jarcoal/httpmock v1.4.1
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
-	github.com/modelcontextprotocol/go-sdk v1.3.1
+	github.com/modelcontextprotocol/go-sdk v1.4.1
 	github.com/qri-io/jsonpointer v0.1.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	gitlab.com/gitlab-org/api/client-go v1.46.0
@@ -1187,7 +1187,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
-	github.com/segmentio/encoding v0.5.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/sethvargo/go-limiter v0.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1864,8 +1864,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.3.1 h1:TfqtNKOIWN4Z1oqmPAiWDC2Jq7K9OdJaooe0teoXASI=
-github.com/modelcontextprotocol/go-sdk v1.3.1/go.mod h1:DgVX498dMD8UJlseK1S5i1T4tFz2fkBk4xogC3D15nw=
+github.com/modelcontextprotocol/go-sdk v1.4.1 h1:M4x9GyIPj+HoIlHNGpK2hq5o3BFhC+78PkEaldQRphc=
+github.com/modelcontextprotocol/go-sdk v1.4.1/go.mod h1:Bo/mS87hPQqHSRkMv4dQq1XCu6zv4INdXnFZabkNU6s=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -2310,8 +2310,8 @@ github.com/secure-systems-lab/go-securesystemslib v0.9.0 h1:rf1HIbL64nUpEIZnjLZ3
 github.com/secure-systems-lab/go-securesystemslib v0.9.0/go.mod h1:DVHKMcZ+V4/woA/peqr+L0joiRXbPpQ042GgJckkFgw=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
-github.com/segmentio/encoding v0.5.3 h1:OjMgICtcSFuNvQCdwqMCv9Tg7lEOXGwm1J5RPQccx6w=
-github.com/segmentio/encoding v0.5.3/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=


### PR DESCRIPTION
<!-- dd-meta {"pullId":"bf5e1a75-99f4-4604-8112-c345e58231cd","source":"chat","resourceId":"47a2bf26-f9c4-40e2-822b-c362db9ddd5c","workflowId":"c3e12bd5-c2d7-4e6b-9a6e-14ff0e320da8","codeChangeId":"c3e12bd5-c2d7-4e6b-9a6e-14ff0e320da8","sourceType":"chat"} -->
### What does this PR do?

Bumps `github.com/modelcontextprotocol/go-sdk` from v1.3.1 to v1.4.1 to fix CVE-2026-33252.

### Motivation

CVE-2026-33252 is a high-severity CSRF vulnerability in the Go MCP SDK's Streamable HTTP transport. Prior to v1.4.1, the SDK accepted browser-generated cross-site `POST` requests without validating the `Origin` header or requiring `Content-Type: application/json`, potentially allowing arbitrary websites to trigger MCP tool execution on local servers.

The affected package is used by `pkg/clusteragent/mcp` (cluster-agent binary).

### Describe how you validated your changes

- Ran `go mod tidy` successfully
- Verified `go build -tags kubeapiserver ./pkg/clusteragent/mcp/...` compiles without errors

### Additional Notes

- Vuln source: AgentContainer Scan
- Fixed version: v1.4.1
- GitHub issue: https://github.com/DataDog/image-vuln-scans/issues/2888

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/47a2bf26-f9c4-40e2-822b-c362db9ddd5c)

Comment @datadog to request changes