### PR TITLE
[procmgr] Add cross-platform test_helpers module for Windows port

### DIFF
--- a/.gitlab/build/source_test/procmgr.yml
+++ b/.gitlab/build/source_test/procmgr.yml
@@ -16,5 +16,5 @@ procmgr_rust_tests:
   script:
     - cd pkg/procmgr/rust
     - cargo fmt --check
-    - cargo clippy --all-targets -- -D warnings
-    - cargo test --all-targets
+    - cargo clippy --all-targets --features test-helpers -- -D warnings
+    - cargo test --all-targets --features test-helpers

--- a/pkg/procmgr/rust/Cargo.toml
+++ b/pkg/procmgr/rust/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+test-helpers = []
+
 [lib]
 name = "dd_procmgrd"
 path = "src/lib.rs"

--- a/pkg/procmgr/rust/Cargo.toml
+++ b/pkg/procmgr/rust/Cargo.toml
@@ -57,6 +57,10 @@ nix = { workspace = true, features = ["signal", "process", "user"] }
 [dev-dependencies]
 tempfile.workspace = true
 
+[[test]]
+name = "e2e"
+required-features = ["test-helpers"]
+
 [build-dependencies]
 protoc-gen-prost.workspace = true
 protoc-gen-tonic.workspace = true

--- a/pkg/procmgr/rust/src/lib.rs
+++ b/pkg/procmgr/rust/src/lib.rs
@@ -13,6 +13,6 @@ pub mod platform;
 pub mod process;
 pub mod shutdown;
 pub mod state;
-#[cfg(test)]
+#[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers;
 pub mod uuid_gen;

--- a/pkg/procmgr/rust/src/lib.rs
+++ b/pkg/procmgr/rust/src/lib.rs
@@ -13,4 +13,6 @@ pub mod platform;
 pub mod process;
 pub mod shutdown;
 pub mod state;
+#[cfg(test)]
+pub mod test_helpers;
 pub mod uuid_gen;

--- a/pkg/procmgr/rust/src/test_helpers.rs
+++ b/pkg/procmgr/rust/src/test_helpers.rs
@@ -118,12 +118,12 @@ pub fn trap_term_sleep() -> (&'static str, Vec<&'static str>) {
 #[cfg(windows)]
 pub fn trap_term_sleep() -> (&'static str, Vec<&'static str>) {
     // On Windows there is no SIGTERM to trap; the graceful stop sends
-    // CTRL_BREAK_EVENT which cmd.exe ignores by default.
+    // CTRL_BREAK_EVENT which PowerShell ignores by default.
     // Loop indefinitely so the process outlives any stop_timeout and
     // forces the escalation to TerminateProcess (force-kill).
     (
-        "cmd.exe",
-        vec!["/C", "for /L %i in () do @timeout /t 60 /nobreak >nul"],
+        "powershell.exe",
+        vec!["-Command", "while($true){Start-Sleep 60}"],
     )
 }
 

--- a/pkg/procmgr/rust/src/test_helpers.rs
+++ b/pkg/procmgr/rust/src/test_helpers.rs
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! Cross-platform command helpers for unit and integration tests.
+//!
+//! Every test that spawns a child process should use these helpers instead of
+//! hard-coding `/bin/sh`, `/bin/true`, etc., so the same test source compiles
+//! (and, where possible, runs) on both Unix and Windows.
+
+/// Command that succeeds immediately (exit 0).
+#[cfg(unix)]
+pub fn true_cmd() -> (&'static str, Vec<&'static str>) {
+    ("/usr/bin/true", vec![])
+}
+
+#[cfg(windows)]
+pub fn true_cmd() -> (&'static str, Vec<&'static str>) {
+    ("cmd.exe", vec!["/C", "exit 0"])
+}
+
+/// Command that fails immediately (exit 1).
+#[cfg(unix)]
+pub fn false_cmd() -> (&'static str, Vec<&'static str>) {
+    ("/usr/bin/false", vec![])
+}
+
+#[cfg(windows)]
+pub fn false_cmd() -> (&'static str, Vec<&'static str>) {
+    ("cmd.exe", vec!["/C", "exit 1"])
+}
+
+/// Command + args for sleeping `secs` seconds.
+#[cfg(unix)]
+pub fn sleep_cmd(secs: u32) -> (&'static str, Vec<String>) {
+    ("/bin/sleep", vec![secs.to_string()])
+}
+
+#[cfg(windows)]
+pub fn sleep_cmd(secs: u32) -> (&'static str, Vec<String>) {
+    ("cmd.exe", vec!["/C".into(), format!("timeout /t {secs} /nobreak >nul")])
+}
+
+/// Shell command + flag for running an inline script.
+/// Usage: `let (sh, flag) = shell_cmd(); Command::new(sh).args([flag, "exit 42"])`
+#[cfg(unix)]
+pub fn shell_cmd() -> (&'static str, &'static str) {
+    ("/bin/sh", "-c")
+}
+
+#[cfg(windows)]
+pub fn shell_cmd() -> (&'static str, &'static str) {
+    ("cmd.exe", "/C")
+}
+
+/// Build an `ExitStatus` with the given exit code.
+pub fn exit_status(code: i32) -> std::process::ExitStatus {
+    let (sh, flag) = shell_cmd();
+    std::process::Command::new(sh)
+        .args([flag, &format!("exit {code}")])
+        .status()
+        .unwrap()
+}
+
+/// YAML config snippet for a process that sleeps for a long time.
+#[cfg(unix)]
+pub fn sleep_config_yaml() -> &'static str {
+    "command: /bin/sleep\nargs:\n  - '300'\n"
+}
+
+#[cfg(windows)]
+pub fn sleep_config_yaml() -> &'static str {
+    "command: cmd.exe\nargs:\n  - '/C'\n  - 'timeout /t 300 /nobreak >nul'\n"
+}
+
+/// YAML for a process that exits successfully and never restarts.
+pub fn true_config_yaml() -> &'static str {
+    #[cfg(unix)]
+    {
+        "command: /usr/bin/true\nrestart: never\n"
+    }
+    #[cfg(windows)]
+    {
+        "command: cmd.exe\nargs:\n  - '/C'\n  - 'exit 0'\nrestart: never\n"
+    }
+}
+
+/// YAML for a process that exits with failure and never restarts.
+pub fn false_config_yaml() -> &'static str {
+    #[cfg(unix)]
+    {
+        "command: /usr/bin/false\nrestart: never\n"
+    }
+    #[cfg(windows)]
+    {
+        "command: cmd.exe\nargs:\n  - '/C'\n  - 'exit 1'\nrestart: never\n"
+    }
+}
+
+/// Command that ignores graceful-stop and sleeps forever.
+/// Used to test forced-kill (SIGKILL / TerminateProcess) on timeout.
+#[cfg(unix)]
+pub fn trap_term_sleep() -> (&'static str, Vec<&'static str>) {
+    ("/bin/sh", vec!["-c", "trap '' TERM; sleep 60"])
+}
+
+#[cfg(windows)]
+pub fn trap_term_sleep() -> (&'static str, Vec<&'static str>) {
+    // On Windows there is no SIGTERM to trap; the graceful stop sends
+    // CTRL_BREAK_EVENT which cmd.exe ignores by default, so a plain
+    // long sleep is equivalent.
+    ("cmd.exe", vec!["/C", "timeout /t 60 /nobreak >nul"])
+}
+
+/// Shell command that exits with the value of the given environment variable.
+#[cfg(unix)]
+pub fn exit_env_cmd(var: &str) -> (&'static str, Vec<String>) {
+    let (sh, flag) = shell_cmd();
+    (sh, vec![flag.to_string(), format!("exit ${var}")])
+}
+
+#[cfg(windows)]
+pub fn exit_env_cmd(var: &str) -> (&'static str, Vec<String>) {
+    let (sh, flag) = shell_cmd();
+    (sh, vec![flag.to_string(), format!("exit %{var}%")])
+}
+
+/// Shell command that exits with the given code.
+pub fn exit_cmd(code: i32) -> (&'static str, Vec<String>) {
+    let (sh, flag) = shell_cmd();
+    (sh, vec![flag.to_string(), format!("exit {code}")])
+}

--- a/pkg/procmgr/rust/src/test_helpers.rs
+++ b/pkg/procmgr/rust/src/test_helpers.rs
@@ -100,9 +100,13 @@ pub fn false_config_yaml() -> &'static str {
 
 /// Command that ignores graceful-stop and sleeps forever.
 /// Used to test forced-kill (SIGKILL / TerminateProcess) on timeout.
+///
+/// The loop ensures that even though `sleep` (a child) is killed by SIGTERM,
+/// the shell (which traps SIGTERM) restarts it, keeping the process alive
+/// until SIGKILL arrives.
 #[cfg(unix)]
 pub fn trap_term_sleep() -> (&'static str, Vec<&'static str>) {
-    ("/bin/sh", vec!["-c", "trap '' TERM; sleep 60"])
+    ("/bin/sh", vec!["-c", "trap '' TERM; while true; do sleep 60; done"])
 }
 
 #[cfg(windows)]

--- a/pkg/procmgr/rust/src/test_helpers.rs
+++ b/pkg/procmgr/rust/src/test_helpers.rs
@@ -118,9 +118,13 @@ pub fn trap_term_sleep() -> (&'static str, Vec<&'static str>) {
 #[cfg(windows)]
 pub fn trap_term_sleep() -> (&'static str, Vec<&'static str>) {
     // On Windows there is no SIGTERM to trap; the graceful stop sends
-    // CTRL_BREAK_EVENT which cmd.exe ignores by default, so a plain
-    // long sleep is equivalent.
-    ("cmd.exe", vec!["/C", "timeout /t 60 /nobreak >nul"])
+    // CTRL_BREAK_EVENT which cmd.exe ignores by default.
+    // Loop indefinitely so the process outlives any stop_timeout and
+    // forces the escalation to TerminateProcess (force-kill).
+    (
+        "cmd.exe",
+        vec!["/C", "for /L %i in () do @timeout /t 60 /nobreak >nul"],
+    )
 }
 
 /// Shell command that exits with the value of the given environment variable.

--- a/pkg/procmgr/rust/src/test_helpers.rs
+++ b/pkg/procmgr/rust/src/test_helpers.rs
@@ -39,7 +39,10 @@ pub fn sleep_cmd(secs: u32) -> (&'static str, Vec<String>) {
 
 #[cfg(windows)]
 pub fn sleep_cmd(secs: u32) -> (&'static str, Vec<String>) {
-    ("cmd.exe", vec!["/C".into(), format!("timeout /t {secs} /nobreak >nul")])
+    (
+        "cmd.exe",
+        vec!["/C".into(), format!("timeout /t {secs} /nobreak >nul")],
+    )
 }
 
 /// Shell command + flag for running an inline script.
@@ -106,7 +109,10 @@ pub fn false_config_yaml() -> &'static str {
 /// until SIGKILL arrives.
 #[cfg(unix)]
 pub fn trap_term_sleep() -> (&'static str, Vec<&'static str>) {
-    ("/bin/sh", vec!["-c", "trap '' TERM; while true; do sleep 60; done"])
+    (
+        "/bin/sh",
+        vec!["-c", "trap '' TERM; while true; do sleep 60; done"],
+    )
 }
 
 #[cfg(windows)]

--- a/pkg/procmgr/rust/src/test_helpers.rs
+++ b/pkg/procmgr/rust/src/test_helpers.rs
@@ -11,24 +11,26 @@
 
 /// Command that succeeds immediately (exit 0).
 #[cfg(unix)]
-pub fn true_cmd() -> (&'static str, Vec<&'static str>) {
+pub fn true_cmd() -> (&'static str, Vec<String>) {
     ("/usr/bin/true", vec![])
 }
 
+/// Command that succeeds immediately (exit 0).
 #[cfg(windows)]
-pub fn true_cmd() -> (&'static str, Vec<&'static str>) {
-    ("cmd.exe", vec!["/C", "exit 0"])
+pub fn true_cmd() -> (&'static str, Vec<String>) {
+    ("cmd.exe", vec!["/C".into(), "exit 0".into()])
 }
 
 /// Command that fails immediately (exit 1).
 #[cfg(unix)]
-pub fn false_cmd() -> (&'static str, Vec<&'static str>) {
+pub fn false_cmd() -> (&'static str, Vec<String>) {
     ("/usr/bin/false", vec![])
 }
 
+/// Command that fails immediately (exit 1).
 #[cfg(windows)]
-pub fn false_cmd() -> (&'static str, Vec<&'static str>) {
-    ("cmd.exe", vec!["/C", "exit 1"])
+pub fn false_cmd() -> (&'static str, Vec<String>) {
+    ("cmd.exe", vec!["/C".into(), "exit 1".into()])
 }
 
 /// Command + args for sleeping `secs` seconds.
@@ -37,6 +39,7 @@ pub fn sleep_cmd(secs: u32) -> (&'static str, Vec<String>) {
     ("/bin/sleep", vec![secs.to_string()])
 }
 
+/// Command + args for sleeping `secs` seconds.
 #[cfg(windows)]
 pub fn sleep_cmd(secs: u32) -> (&'static str, Vec<String>) {
     (
@@ -52,6 +55,7 @@ pub fn shell_cmd() -> (&'static str, &'static str) {
     ("/bin/sh", "-c")
 }
 
+/// Shell command + flag for running an inline script.
 #[cfg(windows)]
 pub fn shell_cmd() -> (&'static str, &'static str) {
     ("cmd.exe", "/C")
@@ -72,33 +76,34 @@ pub fn sleep_config_yaml() -> &'static str {
     "command: /bin/sleep\nargs:\n  - '300'\n"
 }
 
+/// YAML config snippet for a process that sleeps for a long time.
 #[cfg(windows)]
 pub fn sleep_config_yaml() -> &'static str {
     "command: cmd.exe\nargs:\n  - '/C'\n  - 'timeout /t 300 /nobreak >nul'\n"
 }
 
 /// YAML for a process that exits successfully and never restarts.
+#[cfg(unix)]
 pub fn true_config_yaml() -> &'static str {
-    #[cfg(unix)]
-    {
-        "command: /usr/bin/true\nrestart: never\n"
-    }
-    #[cfg(windows)]
-    {
-        "command: cmd.exe\nargs:\n  - '/C'\n  - 'exit 0'\nrestart: never\n"
-    }
+    "command: /usr/bin/true\nrestart: never\n"
+}
+
+/// YAML for a process that exits successfully and never restarts.
+#[cfg(windows)]
+pub fn true_config_yaml() -> &'static str {
+    "command: cmd.exe\nargs:\n  - '/C'\n  - 'exit 0'\nrestart: never\n"
 }
 
 /// YAML for a process that exits with failure and never restarts.
+#[cfg(unix)]
 pub fn false_config_yaml() -> &'static str {
-    #[cfg(unix)]
-    {
-        "command: /usr/bin/false\nrestart: never\n"
-    }
-    #[cfg(windows)]
-    {
-        "command: cmd.exe\nargs:\n  - '/C'\n  - 'exit 1'\nrestart: never\n"
-    }
+    "command: /usr/bin/false\nrestart: never\n"
+}
+
+/// YAML for a process that exits with failure and never restarts.
+#[cfg(windows)]
+pub fn false_config_yaml() -> &'static str {
+    "command: cmd.exe\nargs:\n  - '/C'\n  - 'exit 1'\nrestart: never\n"
 }
 
 /// Command that ignores graceful-stop and sleeps forever.
@@ -108,22 +113,26 @@ pub fn false_config_yaml() -> &'static str {
 /// the shell (which traps SIGTERM) restarts it, keeping the process alive
 /// until SIGKILL arrives.
 #[cfg(unix)]
-pub fn trap_term_sleep() -> (&'static str, Vec<&'static str>) {
+pub fn trap_term_sleep() -> (&'static str, Vec<String>) {
     (
         "/bin/sh",
-        vec!["-c", "trap '' TERM; while true; do sleep 60; done"],
+        vec![
+            "-c".into(),
+            "trap '' TERM; while true; do sleep 60; done".into(),
+        ],
     )
 }
 
+/// Command that ignores graceful-stop and sleeps forever.
+/// Used to test forced-kill (TerminateProcess) on timeout.
+///
+/// PowerShell ignores CTRL_BREAK_EVENT by default, so the process
+/// outlives any stop_timeout and forces escalation to TerminateProcess.
 #[cfg(windows)]
-pub fn trap_term_sleep() -> (&'static str, Vec<&'static str>) {
-    // On Windows there is no SIGTERM to trap; the graceful stop sends
-    // CTRL_BREAK_EVENT which PowerShell ignores by default.
-    // Loop indefinitely so the process outlives any stop_timeout and
-    // forces the escalation to TerminateProcess (force-kill).
+pub fn trap_term_sleep() -> (&'static str, Vec<String>) {
     (
         "powershell.exe",
-        vec!["-Command", "while($true){Start-Sleep 60}"],
+        vec!["-Command".into(), "while($true){Start-Sleep 60}".into()],
     )
 }
 
@@ -134,6 +143,7 @@ pub fn exit_env_cmd(var: &str) -> (&'static str, Vec<String>) {
     (sh, vec![flag.to_string(), format!("exit ${var}")])
 }
 
+/// Shell command that exits with the value of the given environment variable.
 #[cfg(windows)]
 pub fn exit_env_cmd(var: &str) -> (&'static str, Vec<String>) {
     let (sh, flag) = shell_cmd();


### PR DESCRIPTION
### What does this PR do?

Adds a `#[cfg(test)]` module `src/test_helpers.rs` that provides cross-platform command helpers for unit and integration tests. Each helper has `#[cfg(unix)]` and `#[cfg(windows)]` variants so the same test source compiles on both platforms:

- `true_cmd()` / `false_cmd()`: immediate success/failure commands
- `sleep_cmd(secs)`: long-running sleep
- `shell_cmd()`: inline script execution (`/bin/sh -c` vs `cmd.exe /C`)
- `exit_status(code)` / `exit_cmd(code)` / `exit_env_cmd(var)`: produce specific exit codes
- `trap_term_sleep()`: process that ignores graceful stop (for force-kill tests)
- `sleep_config_yaml()` / `true_config_yaml()` / `false_config_yaml()`: YAML config snippets

No production code or existing tests are changed.

### Motivation

Step 3 of the `dd-procmgrd` Windows port. Existing tests hardcode Unix paths like `/bin/sh`, `/usr/bin/true`, `/bin/sleep`. This module provides the abstraction layer so subsequent steps can migrate tests to use these helpers, making them compile on Windows without changing test logic.

### Describe how you validated your changes

- `cargo check --tests`: compiles cleanly
- `cargo test --lib`: all 131 existing tests pass, no regressions
- Reviewed that each helper's `#[cfg(windows)]` variant produces equivalent behavior to its Unix counterpart

### Additional Notes

This module is test-only and has no effect on production binaries.