### PR TITLE
Do not collect VCS information in `gopls`

### DIFF
--- a/tasks/emacs.py
+++ b/tasks/emacs.py
@@ -34,4 +34,4 @@ def set_buildtags(
     )
 
     with open(".dir-locals.el", "w") as f:
-        f.write(f'((go-mode . ((lsp-go-build-flags . ["-tags" "{",".join(sorted(use_tags))}"]))))\n')
+        f.write(f'((go-mode . ((lsp-go-build-flags . ["-tags" "{",".join(sorted(use_tags))}" "-buildvcs=false"]))))\n')

--- a/tasks/vim.py
+++ b/tasks/vim.py
@@ -34,4 +34,6 @@ def set_buildtags(
     )
 
     with open(".vimrc", "w") as f:
-        f.write(f"let g:ale_go_gopls_init_options = {{'buildFlags': ['-tags', '{','.join(sorted(use_tags))}']}}\n")
+        f.write(
+            f"let g:ale_go_gopls_init_options = {{'buildFlags': ['-tags', '{','.join(sorted(use_tags))}', '-buildvcs=false']}}\n"
+        )


### PR DESCRIPTION
### What does this PR do?

Update Emacs and Vim configuration to avoid collecting VCS information in `gopls`.

### Motivation

As per golang/go#77419, `gopls` currently ends up collecting VCS info when collecting package information, and for the agent repository it takes minutes. It seems to be the cause for `gopls` hangs that we regularly observe.

### Describe how you validated your changes

Local testing.
* `dda inv emacs.set-buildtags`
* `dda inv vim.set-buildtags`
* Open a file in Emacs
* Open a file in Vim

In both cases, LSP features should become available in few seconds.

### Additional Notes

This is only a port of #46185 to Emacs and Vim.