### PR TITLE
[procmgr] Refactor process.rs: replace nix:: calls with platform:: abstraction

### DIFF
--- a/pkg/procmgr/rust/src/platform/unix.rs
+++ b/pkg/procmgr/rust/src/platform/unix.rs
@@ -14,18 +14,23 @@ pub fn setup_process_group(cmd: &mut tokio::process::Command) {
     cmd.process_group(0);
 }
 
+/// Negate a PID to produce the process group ID for `kill(2)`.
+/// Sending a signal to `-pgid` targets every process in the group.
+pub(crate) fn process_group_id(pid: u32) -> Result<Pid> {
+    let raw = i32::try_from(pid).context("PID overflows i32")?;
+    Ok(Pid::from_raw(-raw))
+}
+
 /// Send SIGTERM to the entire process group (graceful stop).
 pub fn send_graceful_stop(pid: u32) -> Result<()> {
-    let raw = i32::try_from(pid).context("PID overflows i32")?;
-    signal::kill(Pid::from_raw(-raw), Signal::SIGTERM)
+    signal::kill(process_group_id(pid)?, Signal::SIGTERM)
         .with_context(|| format!("failed to send SIGTERM to pgid {pid}"))?;
     Ok(())
 }
 
 /// Send SIGKILL to the entire process group (force kill).
 pub fn send_force_kill(pid: u32) -> Result<()> {
-    let raw = i32::try_from(pid).context("PID overflows i32")?;
-    signal::kill(Pid::from_raw(-raw), Signal::SIGKILL)
+    signal::kill(process_group_id(pid)?, Signal::SIGKILL)
         .with_context(|| format!("failed to send SIGKILL to pgid {pid}"))?;
     Ok(())
 }

--- a/pkg/procmgr/rust/src/platform/unix.rs
+++ b/pkg/procmgr/rust/src/platform/unix.rs
@@ -10,7 +10,7 @@ use std::os::unix::process::ExitStatusExt;
 
 /// Place the child in its own process group so signals don't propagate
 /// to the daemon itself and SIGTERM can target all descendants.
-pub fn configure_command(cmd: &mut tokio::process::Command) {
+pub fn setup_process_group(cmd: &mut tokio::process::Command) {
     cmd.process_group(0);
 }
 

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -7,9 +7,7 @@ use anyhow::Result;
 
 /// Configure the child process for Windows: create a new process group
 /// and assign to a Job Object so all descendants can be managed together.
-pub fn setup_process_group(_cmd: &mut tokio::process::Command) {
-    unimplemented!("Windows process group configuration not yet implemented")
-}
+pub fn setup_process_group(_cmd: &mut tokio::process::Command) {}
 
 /// Send a graceful stop signal (CTRL_BREAK_EVENT via GenerateConsoleCtrlEvent).
 pub fn send_graceful_stop(_pid: u32) -> Result<()> {

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -13,14 +13,12 @@ pub fn setup_process_group(_cmd: &mut tokio::process::Command) {
 
 /// Send a graceful stop signal (CTRL_BREAK_EVENT via GenerateConsoleCtrlEvent).
 pub fn send_graceful_stop(_pid: u32) -> Result<()> {
-    log::warn!("send_graceful_stop is not yet implemented on Windows");
-    Ok(())
+    anyhow::bail!("send_graceful_stop is not yet implemented on Windows")
 }
 
 /// Force-kill the process and all descendants (TerminateJobObject / TerminateProcess).
 pub fn send_force_kill(_pid: u32) -> Result<()> {
-    log::warn!("send_force_kill is not yet implemented on Windows");
-    Ok(())
+    anyhow::bail!("send_force_kill is not yet implemented on Windows")
 }
 
 /// On Windows, processes don't have Unix signals.

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 
 /// Configure the child process for Windows: create a new process group
 /// and assign to a Job Object so all descendants can be managed together.
-pub fn configure_command(_cmd: &mut tokio::process::Command) {
+pub fn setup_process_group(_cmd: &mut tokio::process::Command) {
     unimplemented!("Windows process group configuration not yet implemented")
 }
 

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -7,16 +7,20 @@ use anyhow::Result;
 
 /// Configure the child process for Windows: create a new process group
 /// and assign to a Job Object so all descendants can be managed together.
-pub fn setup_process_group(_cmd: &mut tokio::process::Command) {}
+pub fn setup_process_group(_cmd: &mut tokio::process::Command) {
+    log::warn!("setup_process_group is not yet implemented on Windows");
+}
 
 /// Send a graceful stop signal (CTRL_BREAK_EVENT via GenerateConsoleCtrlEvent).
 pub fn send_graceful_stop(_pid: u32) -> Result<()> {
-    unimplemented!("Windows graceful stop not yet implemented")
+    log::warn!("send_graceful_stop is not yet implemented on Windows");
+    Ok(())
 }
 
 /// Force-kill the process and all descendants (TerminateJobObject / TerminateProcess).
 pub fn send_force_kill(_pid: u32) -> Result<()> {
-    unimplemented!("Windows force kill not yet implemented")
+    log::warn!("send_force_kill is not yet implemented on Windows");
+    Ok(())
 }
 
 /// On Windows, processes don't have Unix signals.

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -162,7 +162,8 @@ impl ManagedProcess {
     }
 
     pub fn last_signal(&self) -> Option<i32> {
-        self.last_exit_status.and_then(|s| platform::last_signal(&s))
+        self.last_exit_status
+            .and_then(|s| platform::last_signal(&s))
     }
 
     pub fn set_config(&mut self, config: ProcessConfig) {
@@ -342,9 +343,7 @@ impl ManagedProcess {
         if let Some(raw_pid) = self.pid {
             match i32::try_from(raw_pid) {
                 Ok(pid) => {
-                    if let Err(e) =
-                        nix::sys::signal::kill(nix::unistd::Pid::from_raw(-pid), sig)
-                    {
+                    if let Err(e) = nix::sys::signal::kill(nix::unistd::Pid::from_raw(-pid), sig) {
                         warn!("[{}] failed to send {sig} to pgid {pid}: {e}", self.name);
                     }
                 }

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -336,22 +336,19 @@ impl ManagedProcess {
         }
     }
 
-    /// Send a Unix signal using the stored PID (works even after take_child).
+    /// Send a Unix signal to the entire process group (works even after take_child).
     /// Used by tests that need to send specific signals for cleanup.
     #[cfg(unix)]
     pub fn send_signal(&self, sig: nix::sys::signal::Signal) {
-        if let Some(raw_pid) = self.pid {
-            match i32::try_from(raw_pid) {
-                Ok(pid) => {
-                    if let Err(e) = nix::sys::signal::kill(nix::unistd::Pid::from_raw(-pid), sig) {
+        if let Some(pid) = self.pid {
+            match platform::process_group_id(pid) {
+                Ok(pgid) => {
+                    if let Err(e) = nix::sys::signal::kill(pgid, sig) {
                         warn!("[{}] failed to send {sig} to pgid {pid}: {e}", self.name);
                     }
                 }
-                Err(_) => {
-                    warn!(
-                        "[{}] PID {raw_pid} overflows i32, cannot send {sig}",
-                        self.name
-                    );
+                Err(e) => {
+                    warn!("[{}] {e}", self.name);
                 }
             }
         }
@@ -386,7 +383,10 @@ impl ManagedProcess {
                     stop.as_secs()
                 );
                 self.force_kill();
-                if time::timeout(Self::FORCE_KILL_TIMEOUT, handle).await.is_err() {
+                if time::timeout(Self::FORCE_KILL_TIMEOUT, handle)
+                    .await
+                    .is_err()
+                {
                     warn!("[{}] still running after force-kill, giving up", self.name);
                 }
             }

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -320,19 +320,19 @@ impl ManagedProcess {
 
     /// Send a graceful-stop signal (SIGTERM on Unix, CTRL_BREAK on Windows).
     fn graceful_stop(&self) {
-        if let Some(pid) = self.pid {
-            if let Err(e) = platform::send_graceful_stop(pid) {
-                warn!("[{}] graceful stop failed: {e}", self.name);
-            }
+        if let Some(pid) = self.pid
+            && let Err(e) = platform::send_graceful_stop(pid)
+        {
+            warn!("[{}] graceful stop failed: {e}", self.name);
         }
     }
 
     /// Force-kill the process and all descendants (SIGKILL / TerminateProcess).
     fn force_kill(&self) {
-        if let Some(pid) = self.pid {
-            if let Err(e) = platform::send_force_kill(pid) {
-                warn!("[{}] force kill failed: {e}", self.name);
-            }
+        if let Some(pid) = self.pid
+            && let Err(e) = platform::send_force_kill(pid)
+        {
+            warn!("[{}] force kill failed: {e}", self.name);
         }
     }
 

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -264,7 +264,7 @@ impl ManagedProcess {
         cmd.stdout(stdio_from_str(&self.config.stdout));
         cmd.stderr(stdio_from_str(&self.config.stderr));
 
-        platform::configure_command(&mut cmd);
+        platform::setup_process_group(&mut cmd);
 
         Ok(cmd)
     }

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -102,7 +102,7 @@ pub struct ManagedProcess {
 }
 
 impl ManagedProcess {
-    const SIGKILL_TIMEOUT: Duration = Duration::from_secs(10);
+    const FORCE_KILL_TIMEOUT: Duration = Duration::from_secs(10);
 
     pub fn new_config(name: String, uuid: String, config: ProcessConfig) -> Self {
         Self::new_inner(name, uuid, config, ProcessOrigin::Config)
@@ -386,7 +386,7 @@ impl ManagedProcess {
                     stop.as_secs()
                 );
                 self.force_kill();
-                if time::timeout(Self::SIGKILL_TIMEOUT, handle).await.is_err() {
+                if time::timeout(Self::FORCE_KILL_TIMEOUT, handle).await.is_err() {
                     warn!("[{}] still running after force-kill, giving up", self.name);
                 }
             }
@@ -397,7 +397,7 @@ impl ManagedProcess {
                 stop.as_secs()
             );
             self.force_kill();
-            if time::timeout(Self::SIGKILL_TIMEOUT, self.wait())
+            if time::timeout(Self::FORCE_KILL_TIMEOUT, self.wait())
                 .await
                 .is_err()
             {

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -5,11 +5,10 @@
 
 use crate::config::{ProcessConfig, RestartPolicy};
 use crate::env::parse_environment_file;
+use crate::platform;
 use crate::state::ProcessState;
 use anyhow::{Context, Result};
 use log::{info, warn};
-use nix::sys::signal::{self, Signal};
-use nix::unistd::Pid;
 use std::collections::VecDeque;
 use std::process::Stdio;
 use tokio::process::{Child, Command};
@@ -163,15 +162,7 @@ impl ManagedProcess {
     }
 
     pub fn last_signal(&self) -> Option<i32> {
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::ExitStatusExt;
-            self.last_exit_status.and_then(|s| s.signal())
-        }
-        #[cfg(not(unix))]
-        {
-            None
-        }
+        self.last_exit_status.and_then(|s| platform::last_signal(&s))
     }
 
     pub fn set_config(&mut self, config: ProcessConfig) {
@@ -273,9 +264,7 @@ impl ManagedProcess {
         cmd.stdout(stdio_from_str(&self.config.stdout));
         cmd.stderr(stdio_from_str(&self.config.stderr));
 
-        // Place child in its own process group so SIGTERM reaches all
-        // grandchildren and our own signals don't propagate to them.
-        cmd.process_group(0);
+        platform::configure_command(&mut cmd);
 
         Ok(cmd)
     }
@@ -318,28 +307,44 @@ impl ManagedProcess {
         }
     }
 
-    /// Mark the process for stop and send SIGTERM. The watcher will observe
-    /// the exit and `set_last_status` will transition to Stopped.
+    /// Mark the process for stop and send a graceful-stop signal. The watcher
+    /// will observe the exit and `set_last_status` will transition to Stopped.
     pub fn request_stop(&mut self) {
         if self.is_running() {
             self.stop_requested = true;
-            info!("[{}] sending SIGTERM (stop requested)", self.name);
-            self.send_signal(Signal::SIGTERM);
+            info!("[{}] sending graceful stop (stop requested)", self.name);
+            self.graceful_stop();
         }
     }
 
-    /// Send a signal using the stored PID (works even after take_child).
-    /// The caller must still call `wait()` afterward to reap the child and
-    /// avoid zombie processes. This is kept separate from `wait()` so
-    /// `shutdown_all()` can fan out SIGTERM to all processes before blocking
-    /// on each.
-    pub fn send_signal(&self, sig: Signal) {
+    /// Send a graceful-stop signal (SIGTERM on Unix, CTRL_BREAK on Windows).
+    fn graceful_stop(&self) {
+        if let Some(pid) = self.pid {
+            if let Err(e) = platform::send_graceful_stop(pid) {
+                warn!("[{}] graceful stop failed: {e}", self.name);
+            }
+        }
+    }
+
+    /// Force-kill the process and all descendants (SIGKILL / TerminateProcess).
+    fn force_kill(&self) {
+        if let Some(pid) = self.pid {
+            if let Err(e) = platform::send_force_kill(pid) {
+                warn!("[{}] force kill failed: {e}", self.name);
+            }
+        }
+    }
+
+    /// Send a Unix signal using the stored PID (works even after take_child).
+    /// Used by tests that need to send specific signals for cleanup.
+    #[cfg(unix)]
+    pub fn send_signal(&self, sig: nix::sys::signal::Signal) {
         if let Some(raw_pid) = self.pid {
             match i32::try_from(raw_pid) {
                 Ok(pid) => {
-                    // Negate PID to target the entire process group created
-                    // by process_group(0) in build_command.
-                    if let Err(e) = signal::kill(Pid::from_raw(-pid), sig) {
+                    if let Err(e) =
+                        nix::sys::signal::kill(nix::unistd::Pid::from_raw(-pid), sig)
+                    {
                         warn!("[{}] failed to send {sig} to pgid {pid}: {e}", self.name);
                     }
                 }
@@ -366,8 +371,8 @@ impl ManagedProcess {
         self.config.stop_timeout()
     }
 
-    /// Wait for the process to stop after SIGTERM has been sent.
-    /// Escalates to SIGKILL if the process doesn't exit within `stop_timeout`.
+    /// Wait for the process to stop after a graceful-stop signal has been sent.
+    /// Escalates to force-kill if the process doesn't exit within `stop_timeout`.
     pub async fn wait_for_stop(&mut self) {
         if !self.is_running() {
             return;
@@ -377,27 +382,27 @@ impl ManagedProcess {
             tokio::pin!(handle);
             if time::timeout(stop, &mut handle).await.is_err() {
                 warn!(
-                    "[{}] stop timeout ({}s) reached, sending SIGKILL",
+                    "[{}] stop timeout ({}s) reached, force-killing",
                     self.name,
                     stop.as_secs()
                 );
-                self.send_signal(Signal::SIGKILL);
+                self.force_kill();
                 if time::timeout(Self::SIGKILL_TIMEOUT, handle).await.is_err() {
-                    warn!("[{}] still running after SIGKILL, giving up", self.name);
+                    warn!("[{}] still running after force-kill, giving up", self.name);
                 }
             }
         } else if self.has_child_handle() && time::timeout(stop, self.wait()).await.is_err() {
             warn!(
-                "[{}] stop timeout ({}s) reached, sending SIGKILL",
+                "[{}] stop timeout ({}s) reached, force-killing",
                 self.name,
                 stop.as_secs()
             );
-            self.send_signal(Signal::SIGKILL);
+            self.force_kill();
             if time::timeout(Self::SIGKILL_TIMEOUT, self.wait())
                 .await
                 .is_err()
             {
-                warn!("[{}] still running after SIGKILL, giving up", self.name);
+                warn!("[{}] still running after force-kill, giving up", self.name);
             }
         }
         self.mark_stopped();
@@ -488,6 +493,7 @@ fn stdio_from_str(s: &str) -> Stdio {
 pub mod tests {
     use super::*;
     use crate::config::ProcessConfig;
+    use nix::sys::signal::Signal;
 
     pub fn test_uuid() -> String {
         "00000000-0000-0000-0000-000000000000".to_string()


### PR DESCRIPTION
### What does this PR do?

Refactors `process.rs` production code to use the `platform::` abstraction layer
instead of calling `nix` directly:

- `cmd.process_group(0)` → `platform::setup_process_group(&mut cmd)`
- `last_signal()` cfg-gated blocks → `platform::last_signal()`
- `send_signal(Signal::SIGTERM)` in `request_stop()` → new `graceful_stop()` method via `platform::send_graceful_stop()`
- `send_signal(Signal::SIGKILL)` in `wait_for_stop()` → new `force_kill()` method via `platform::send_force_kill()`

The old `send_signal(Signal)` method is kept as `#[cfg(unix)]` for existing test
code (will be ported in a follow-up step).

### Motivation

Part of the Windows port effort.
Production code in `process.rs` must go through the platform abstraction so the
same logic works on both Unix and Windows without `#[cfg]` gates scattered
throughout business logic.

### Describe how you validated your changes

- `cargo check`: production code compiles clean
- `cargo check --tests`: test code compiles clean
- `cargo test --lib`: all 131 tests pass unchanged

### Additional Notes

Tests still reference `nix::sys::signal::Signal` directly. That will be addressed in S05 (port
process.rs tests to use test_helpers and cfg-gate Unix-only tests).