### PR TITLE
[ AGNTLOG-584 ] Add automatic certificate rotation for the TLS TCP listener

### DIFF
--- a/comp/logs-library/utils/tls/certreloader/ca_reloader.go
+++ b/comp/logs-library/utils/tls/certreloader/ca_reloader.go
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package certreloader
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// CAReloader manages a CA certificate pool with automatic periodic reloading
+// from disk. It is safe for concurrent use.
+//
+// On reload failure, the last successfully loaded pool is preserved and
+// continues to be used for client certificate verification.
+type CAReloader struct {
+	mu         sync.RWMutex
+	clock      Clock
+	caFile     string
+	pool       *x509.CertPool
+	err        error
+	loadErr    error
+	lastUpdate time.Time
+	caFileMod  time.Time
+}
+
+// NewCAReloader creates a CAReloader that immediately loads the CA certificates
+// from disk and starts a background goroutine to periodically reload them. The
+// background goroutine exits when ctx is cancelled.
+func NewCAReloader(ctx context.Context, caFile string, clock Clock) *CAReloader {
+	r := &CAReloader{
+		caFile: caFile,
+		clock:  clock,
+	}
+	r.reloadCA()
+	go r.run(ctx)
+	return r
+}
+
+// GetPool returns the current CA certificate pool.
+func (r *CAReloader) GetPool() (*x509.CertPool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.pool, r.err
+}
+
+func (r *CAReloader) run(ctx context.Context) {
+	ticker := time.NewTicker(tickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if r.shouldReload() {
+				r.reloadCA()
+			}
+		}
+	}
+}
+
+func (r *CAReloader) shouldReload() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	now := r.clock.Now()
+	if r.loadErr != nil {
+		return now.After(r.lastUpdate.Add(errorCacheTimeout))
+	}
+	if !now.After(r.lastUpdate.Add(cacheTimeout)) {
+		return false
+	}
+	return fileModified(r.caFile, r.caFileMod)
+}
+
+func (r *CAReloader) reloadCA() {
+	pool, err := loadCACertPool(r.caFile)
+
+	r.mu.Lock()
+	r.loadErr = err
+	if err == nil {
+		r.pool = pool
+		r.err = nil
+		r.caFileMod = fileMtime(r.caFile)
+	} else if r.pool != nil {
+		log.Warnf("Failed to reload CA certificates from %s, continuing with previously loaded CA pool: %v", r.caFile, err)
+	} else {
+		r.err = err
+	}
+	r.lastUpdate = r.clock.Now()
+	r.mu.Unlock()
+}
+
+func loadCACertPool(caFile string) (*x509.CertPool, error) {
+	caPEM, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA file: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("CA file %q contains no valid certificates", caFile)
+	}
+	return pool, nil
+}

--- a/comp/logs-library/utils/tls/certreloader/cert_reloader.go
+++ b/comp/logs-library/utils/tls/certreloader/cert_reloader.go
@@ -1,0 +1,198 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package certreloader provides automatic TLS certificate reloading from disk.
+// It periodically checks and reloads cert/key pairs so that certificate
+// rotation does not require a process restart.
+package certreloader
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	cacheTimeout      = 10 * time.Minute
+	errorCacheTimeout = 1 * time.Minute
+	tickInterval      = 1 * time.Minute
+	loadRetryAttempts = 5
+	loadRetrySleep    = 50 * time.Millisecond
+)
+
+// Clock provides the current time. It is satisfied by k8s.io/utils/clock.Clock
+// and clocktesting.FakeClock without introducing that dependency.
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// RealClock returns a Clock backed by time.Now.
+func RealClock() Clock { return realClock{} }
+
+// CertReloader manages a single certificate/key pair with automatic periodic
+// reloading. It is safe for concurrent use.
+//
+// On reload failure, the last successfully loaded certificate is preserved
+// and continues to be served. This follows the same pattern used by gRPC-Go's
+// advancedtls pemfile watcher, nginx, and Envoy: a transient disk error should
+// not take down TLS serving when a valid certificate is already in memory.
+type CertReloader struct {
+	mu          sync.RWMutex
+	clock       Clock
+	certFile    string
+	keyFile     string
+	certificate *tls.Certificate
+	err         error
+	loadErr     error
+	lastUpdate  time.Time
+	certFileMod time.Time
+	keyFileMod  time.Time
+}
+
+// New creates a CertReloader that immediately loads the cert/key pair from
+// disk and starts a background goroutine to periodically reload it. The
+// background goroutine exits when ctx is cancelled.
+func New(ctx context.Context, certFile, keyFile string, clock Clock) *CertReloader {
+	r := &CertReloader{
+		certFile: certFile,
+		keyFile:  keyFile,
+		clock:    clock,
+	}
+	r.reloadCertificate()
+	go r.run(ctx)
+	return r
+}
+
+// GetCertificate returns the current certificate for use as a
+// tls.Config.GetCertificate callback (server-side).
+func (r *CertReloader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.certificate, r.err
+}
+
+// GetClientCertificate returns the current certificate for use as a
+// tls.Config.GetClientCertificate callback (client-side).
+func (r *CertReloader) GetClientCertificate(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.certificate, r.err
+}
+
+func (r *CertReloader) run(ctx context.Context) {
+	ticker := time.NewTicker(tickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if r.shouldReload() {
+				r.reloadCertificate()
+			}
+		}
+	}
+}
+
+func (r *CertReloader) shouldReload() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	now := r.clock.Now()
+
+	if r.loadErr != nil {
+		return now.After(r.lastUpdate.Add(errorCacheTimeout))
+	}
+
+	if r.certificate != nil && r.certificate.Leaf != nil && now.After(r.certificate.Leaf.NotAfter) {
+		return true
+	}
+
+	if !now.After(r.lastUpdate.Add(cacheTimeout)) {
+		return false
+	}
+
+	return fileModified(r.certFile, r.certFileMod) || fileModified(r.keyFile, r.keyFileMod)
+}
+
+func (r *CertReloader) reloadCertificate() {
+	certificate, err := retryLoadX509KeyPair(loadRetryAttempts, loadRetrySleep, r.certFile, r.keyFile)
+
+	r.mu.Lock()
+	r.loadErr = err
+	if err == nil {
+		r.certificate = certificate
+		r.err = nil
+		r.certFileMod = fileMtime(r.certFile)
+		r.keyFileMod = fileMtime(r.keyFile)
+	} else if r.certificate != nil {
+		log.Warnf("Failed to reload TLS certificate from %s / %s, continuing with previously loaded certificate: %v", r.certFile, r.keyFile, err)
+	} else {
+		r.err = err
+	}
+	r.lastUpdate = r.clock.Now()
+	r.mu.Unlock()
+}
+
+// retryLoadX509KeyPair attempts to load the cert/key pair, retrying on
+// key mismatch errors that can occur when cert and key files are written
+// non-atomically during rotation.
+func retryLoadX509KeyPair(attempts int, sleep time.Duration, certFile, keyFile string) (*tls.Certificate, error) {
+	var err error
+	for range attempts {
+		certificate, loadErr := tls.LoadX509KeyPair(certFile, keyFile)
+		if loadErr == nil {
+			if len(certificate.Certificate) > 0 {
+				if leaf, parseErr := x509.ParseCertificate(certificate.Certificate[0]); parseErr == nil {
+					certificate.Leaf = leaf
+				} else {
+					return nil, fmt.Errorf("failed to parse certificate leaf: %w", parseErr)
+				}
+			}
+			return &certificate, nil
+		}
+
+		err = loadErr
+
+		if !strings.Contains(loadErr.Error(), "private key does not match public key") {
+			return nil, loadErr
+		}
+
+		time.Sleep(sleep)
+	}
+	return nil, fmt.Errorf("unable to load a matching certificate and key after %d attempts, last error: %w", attempts, err)
+}
+
+// fileMtime returns the modification time of a file, or the zero time on error.
+func fileMtime(path string) time.Time {
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime()
+}
+
+// fileModified returns true if the file's current mtime differs from the
+// recorded mtime, or if the file cannot be stat'd (trigger a reload attempt
+// so the error path handles it).
+func fileModified(path string, recorded time.Time) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return true
+	}
+	return !info.ModTime().Equal(recorded)
+}

--- a/comp/logs-library/utils/tls/certreloader/cert_reloader_test.go
+++ b/comp/logs-library/utils/tls/certreloader/cert_reloader_test.go
@@ -1,0 +1,343 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package certreloader
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTestCert(t *testing.T, dir, cn string) (certFile, keyFile string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0644))
+
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	require.NoError(t, os.WriteFile(keyFile, keyPEM, 0600))
+
+	return certFile, keyFile
+}
+
+func TestNew_LoadsCertificate(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeTestCert(t, dir, "test-cert")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(ctx, certFile, keyFile, RealClock())
+
+	cert, err := r.GetCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	require.NotNil(t, cert.Leaf)
+	assert.Equal(t, "test-cert", cert.Leaf.Subject.CommonName)
+}
+
+func TestNew_ErrorOnMissingFile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(ctx, "/nonexistent/cert.pem", "/nonexistent/key.pem", RealClock())
+
+	cert, err := r.GetCertificate(nil)
+	assert.Nil(t, cert)
+	assert.Error(t, err)
+}
+
+func TestGetClientCertificate(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeTestCert(t, dir, "client-cert")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(ctx, certFile, keyFile, RealClock())
+
+	cert, err := r.GetClientCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	require.NotNil(t, cert.Leaf)
+	assert.Equal(t, "client-cert", cert.Leaf.Subject.CommonName)
+}
+
+func TestRetryLoadX509KeyPair_Success(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeTestCert(t, dir, "retry-test")
+
+	cert, err := retryLoadX509KeyPair(3, time.Millisecond, certFile, keyFile)
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+}
+
+func TestRetryLoadX509KeyPair_NonRetryableError(t *testing.T) {
+	cert, err := retryLoadX509KeyPair(3, time.Millisecond, "/nonexistent", "/nonexistent")
+	assert.Nil(t, cert)
+	assert.Error(t, err)
+}
+
+func TestShouldReload_AfterCacheTimeout(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeTestCert(t, dir, "reload-test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(ctx, certFile, keyFile, RealClock())
+
+	assert.False(t, r.shouldReload(), "should not reload immediately after creation")
+
+	r.mu.Lock()
+	r.lastUpdate = time.Now().Add(-cacheTimeout - time.Minute)
+	r.mu.Unlock()
+
+	assert.False(t, r.shouldReload(), "should not reload when cache expired but files unchanged")
+
+	// Simulate file rotation by advancing the cert file's mtime.
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(certFile, future, future))
+
+	assert.True(t, r.shouldReload(), "should reload after cache timeout when file has changed")
+}
+
+func TestShouldReload_AfterErrorCacheTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(ctx, "/nonexistent", "/nonexistent", RealClock())
+	assert.False(t, r.shouldReload(), "should not reload immediately after error")
+
+	r.mu.Lock()
+	r.lastUpdate = time.Now().Add(-errorCacheTimeout - time.Minute)
+	r.mu.Unlock()
+
+	assert.True(t, r.shouldReload(), "should reload after error cache timeout")
+}
+
+func TestCancelStopsBackground(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeTestCert(t, dir, "cancel-test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r := New(ctx, certFile, keyFile, RealClock())
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+	cert, err := r.GetCertificate(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, cert, "certificate should still be available after cancel")
+}
+
+func TestReloadPicksUpNewCert(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeTestCert(t, dir, "original-cert")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(ctx, certFile, keyFile, RealClock())
+
+	cert1, err := r.GetCertificate(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "original-cert", cert1.Leaf.Subject.CommonName)
+
+	writeTestCert(t, dir, "rotated-cert")
+	r.reloadCertificate()
+
+	cert2, err := r.GetCertificate(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "rotated-cert", cert2.Leaf.Subject.CommonName)
+}
+
+func TestShouldReload_ExpiredCert(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeTestCert(t, dir, "expiry-test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(ctx, certFile, keyFile, RealClock())
+
+	r.mu.Lock()
+	r.certificate.Leaf.NotAfter = time.Now().Add(-time.Hour)
+	r.mu.Unlock()
+
+	assert.True(t, r.shouldReload(), "should reload when certificate is expired")
+}
+
+func TestReloadFailurePreservesLastKnownGoodCert(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeTestCert(t, dir, "good-cert")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(ctx, certFile, keyFile, RealClock())
+
+	cert, err := r.GetCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	assert.Equal(t, "good-cert", cert.Leaf.Subject.CommonName)
+
+	require.NoError(t, os.Remove(certFile))
+	require.NoError(t, os.Remove(keyFile))
+	r.reloadCertificate()
+
+	cert, err = r.GetCertificate(nil)
+	require.NoError(t, err, "should not return error when last known good cert is available")
+	require.NotNil(t, cert, "should preserve last known good cert on reload failure")
+	assert.Equal(t, "good-cert", cert.Leaf.Subject.CommonName)
+}
+
+func TestReloadFailureStillRetriesQuickly(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeTestCert(t, dir, "retry-cadence")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(ctx, certFile, keyFile, RealClock())
+
+	require.NoError(t, os.Remove(certFile))
+	require.NoError(t, os.Remove(keyFile))
+	r.reloadCertificate()
+
+	r.mu.Lock()
+	r.lastUpdate = time.Now().Add(-errorCacheTimeout - time.Minute)
+	r.mu.Unlock()
+
+	assert.True(t, r.shouldReload(), "should use error retry cadence even when last known good cert is preserved")
+}
+
+func TestInitialLoadFailureReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(ctx, "/nonexistent/cert.pem", "/nonexistent/key.pem", RealClock())
+
+	cert, err := r.GetCertificate(nil)
+	assert.Nil(t, cert, "should return nil cert when initial load fails")
+	assert.Error(t, err, "should return error when no cert has ever been loaded")
+}
+
+func TestGetCertificate_ConcurrentAccess(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := writeTestCert(t, dir, "concurrent-test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := New(ctx, certFile, keyFile, RealClock())
+
+	done := make(chan struct{})
+	for range 10 {
+		go func() {
+			for i := range 100 {
+				if i%10 == 0 {
+					r.reloadCertificate()
+				} else {
+					_, _ = r.GetCertificate(nil)
+				}
+			}
+			done <- struct{}{}
+		}()
+	}
+	for range 10 {
+		<-done
+	}
+
+	cert, err := r.GetCertificate(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	assert.NotNil(t, cert)
+}
+
+func writeTestCA(t *testing.T, dir string) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-ca"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	caFile := filepath.Join(dir, "ca.pem")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	require.NoError(t, os.WriteFile(caFile, caPEM, 0644))
+	return caFile
+}
+
+func TestCAReloadFailurePreservesLastKnownGoodPool(t *testing.T) {
+	dir := t.TempDir()
+	caFile := writeTestCA(t, dir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := NewCAReloader(ctx, caFile, RealClock())
+
+	pool, err := r.GetPool()
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+
+	require.NoError(t, os.Remove(caFile))
+	r.reloadCA()
+
+	pool2, err := r.GetPool()
+	require.NoError(t, err, "should not return error when last known good pool is available")
+	require.NotNil(t, pool2, "should preserve last known good CA pool on reload failure")
+	assert.Equal(t, pool, pool2, "pool should be unchanged after failed reload")
+}
+
+func TestCAInitialLoadFailureReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := NewCAReloader(ctx, "/nonexistent/ca.pem", RealClock())
+
+	pool, err := r.GetPool()
+	assert.Nil(t, pool, "should return nil pool when initial load fails")
+	assert.Error(t, err, "should return error when no CA has ever been loaded")
+}

--- a/comp/logs-library/utils/tls/server_config.go
+++ b/comp/logs-library/utils/tls/server_config.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/DataDog/datadog-agent/comp/logs-library/utils/tls/certreloader"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -31,14 +32,22 @@ type ServerConfig struct {
 }
 
 // BuildTLSConfig loads certificates from disk and returns a *tls.Config ready
-// for use with tls.NewListener.
-func (c *ServerConfig) BuildTLSConfig(_ context.Context) (*tls.Config, error) {
+// for use with tls.NewListener. A CertReloader is created to support automatic
+// certificate rotation without process restarts.
+//
+// When a CA file is configured, a CAReloader is used so that CA certificate
+// rotation does not require a restart. Because tls.Config.ClientCAs cannot be
+// safely mutated after use, we set ClientAuth to its non-verifying equivalent
+// and perform CA verification in VerifyConnection against the
+// dynamically-reloaded pool. This follows the pattern recommended by the Go
+// crypto team: https://go.dev/issue/64796
+func (c *ServerConfig) BuildTLSConfig(ctx context.Context) (*tls.Config, error) {
 	if err := c.Validate(); err != nil {
 		return nil, err
 	}
 
-	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
-	if err != nil {
+	reloader := certreloader.New(ctx, c.CertFile, c.KeyFile, certreloader.RealClock())
+	if _, err := reloader.GetCertificate(nil); err != nil {
 		return nil, fmt.Errorf("failed to load TLS cert/key: %w", err)
 	}
 
@@ -48,17 +57,18 @@ func (c *ServerConfig) BuildTLSConfig(_ context.Context) (*tls.Config, error) {
 	}
 
 	tlsCfg := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   minVersion,
-		ClientAuth:   c.ClientAuth,
+		GetCertificate: reloader.GetCertificate,
+		MinVersion:     minVersion,
+		ClientAuth:     c.ClientAuth,
 	}
 
 	if c.CAFile != "" {
-		pool, err := loadCACertPool(c.CAFile)
-		if err != nil {
-			return nil, err
+		caReloader := certreloader.NewCAReloader(ctx, c.CAFile, certreloader.RealClock())
+		if _, err := caReloader.GetPool(); err != nil {
+			return nil, fmt.Errorf("failed to load TLS CA: %w", err)
 		}
-		tlsCfg.ClientCAs = pool
+		tlsCfg.ClientAuth = clientAuthNoVerify(c.ClientAuth)
+		tlsCfg.VerifyConnection = buildCAVerifier(caReloader)
 	}
 
 	return tlsCfg, nil
@@ -109,14 +119,42 @@ func WarnKeyFilePermissions(path string) {
 	}
 }
 
-func loadCACertPool(path string) (*x509.CertPool, error) {
-	caPEM, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read CA file: %w", err)
+// clientAuthNoVerify maps a verifying ClientAuthType to its non-verifying
+// equivalent so that CA verification can be performed via VerifyConnection
+// against a dynamically-reloaded pool.
+func clientAuthNoVerify(auth tls.ClientAuthType) tls.ClientAuthType {
+	switch auth {
+	case tls.VerifyClientCertIfGiven:
+		return tls.RequestClientCert
+	case tls.RequireAndVerifyClientCert:
+		return tls.RequireAnyClientCert
+	default:
+		return auth
 	}
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(caPEM) {
-		return nil, fmt.Errorf("CA file %q contains no valid certificates", path)
+}
+
+// buildCAVerifier returns a VerifyConnection callback that verifies client
+// certificates against the CAReloader's current pool.
+func buildCAVerifier(caReloader *certreloader.CAReloader) func(tls.ConnectionState) error {
+	return func(cs tls.ConnectionState) error {
+		if len(cs.PeerCertificates) == 0 {
+			return nil
+		}
+		pool, err := caReloader.GetPool()
+		if err != nil {
+			return fmt.Errorf("CA pool unavailable: %w", err)
+		}
+
+		intermediates := x509.NewCertPool()
+		for _, cert := range cs.PeerCertificates[1:] {
+			intermediates.AddCert(cert)
+		}
+
+		_, err = cs.PeerCertificates[0].Verify(x509.VerifyOptions{
+			Roots:         pool,
+			Intermediates: intermediates,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		})
+		return err
 	}
-	return pool, nil
 }

--- a/comp/logs-library/utils/tls/server_config_test.go
+++ b/comp/logs-library/utils/tls/server_config_test.go
@@ -20,6 +20,14 @@ func TestClientAuthRequiresVerification(t *testing.T) {
 	assert.True(t, ClientAuthRequiresVerification(tls.RequireAndVerifyClientCert))
 }
 
+func TestClientAuthNoVerify(t *testing.T) {
+	assert.Equal(t, tls.RequestClientCert, clientAuthNoVerify(tls.VerifyClientCertIfGiven))
+	assert.Equal(t, tls.RequireAnyClientCert, clientAuthNoVerify(tls.RequireAndVerifyClientCert))
+	assert.Equal(t, tls.NoClientCert, clientAuthNoVerify(tls.NoClientCert))
+	assert.Equal(t, tls.RequestClientCert, clientAuthNoVerify(tls.RequestClientCert))
+	assert.Equal(t, tls.RequireAnyClientCert, clientAuthNoVerify(tls.RequireAnyClientCert))
+}
+
 func TestValidate(t *testing.T) {
 	t.Run("valid with cert and key", func(t *testing.T) {
 		c := &ServerConfig{CertFile: "/cert", KeyFile: "/key"}

--- a/pkg/logs/launchers/listener/tcp.go
+++ b/pkg/logs/launchers/listener/tcp.go
@@ -105,6 +105,7 @@ func (l *TCPListener) Start() {
 	if err != nil {
 		log.Errorf("Can't start TCP%s forwarder on port %d: %v", tlsLabel, l.source.Config.Port, err)
 		l.source.Status.Error(err)
+		l.cancel()
 		return
 	}
 	l.source.Status.Success()

--- a/pkg/logs/launchers/listener/tcp_test.go
+++ b/pkg/logs/launchers/listener/tcp_test.go
@@ -213,7 +213,21 @@ func (p *testPKI) issueClientCert(t *testing.T) (certPath, keyPath string) {
 	return p.issueCert(t, "client", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
 }
 
+// issueExpiredClientCert creates an already-expired client certificate signed
+// by the CA. The cert's NotAfter is in the past.
+func (p *testPKI) issueExpiredClientCert(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	return p.issueCertWithValidity(t, "expired-client", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+}
+
 func (p *testPKI) issueCert(t *testing.T, prefix string, extKeyUsage []x509.ExtKeyUsage) (certPath, keyPath string) {
+	t.Helper()
+	return p.issueCertWithValidity(t, prefix, extKeyUsage,
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+}
+
+func (p *testPKI) issueCertWithValidity(t *testing.T, prefix string, extKeyUsage []x509.ExtKeyUsage, notBefore, notAfter time.Time) (certPath, keyPath string) {
 	t.Helper()
 	p.serialNo++
 
@@ -223,8 +237,8 @@ func (p *testPKI) issueCert(t *testing.T, prefix string, extKeyUsage []x509.ExtK
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(p.serialNo),
 		Subject:      pkix.Name{CommonName: prefix},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  extKeyUsage,
 		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
@@ -616,6 +630,56 @@ func TestTCPMTLSOptionalAcceptsNoClientCert(t *testing.T) {
 	fmt.Fprint(conn, "optional no cert\n")
 	msg := <-msgChan
 	assert.Equal(t, "optional no cert", string(msg.GetContent()))
+
+	listener.Stop()
+}
+
+func TestTCPMTLSRejectsExpiredClientCert(t *testing.T) {
+	pki := generateTestPKI(t)
+	serverCert, serverKey := pki.issueServerCert(t)
+	expiredCert, expiredKey := pki.issueExpiredClientCert(t)
+
+	pp := mock.NewMockProvider()
+
+	src := sources.NewLogSource("", &config.LogsConfig{
+		Port: tcpTestPort,
+		TLS: &config.TLSListenerConfig{
+			CertFile:   serverCert,
+			KeyFile:    serverKey,
+			CAFile:     pki.caPath,
+			ClientAuth: "required",
+		},
+	})
+
+	listener, err := NewTCPListener(pp, src, 9000)
+	require.NoError(t, err)
+	listener.Start()
+	require.NotNil(t, listener.listener)
+
+	clientTLSCert, err := tls.LoadX509KeyPair(expiredCert, expiredKey)
+	require.NoError(t, err)
+
+	conn, dialErr := tls.Dial("tcp", listener.listener.Addr().String(), &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		Certificates:       []tls.Certificate{clientTLSCert},
+	})
+
+	if dialErr != nil {
+		assert.Contains(t, dialErr.Error(), "expired")
+	} else {
+		// TLS 1.3: server rejects after handshake; error surfaces on I/O.
+		defer conn.Close()
+		conn.SetDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+		_, writeErr := fmt.Fprint(conn, "should fail\n")
+		if writeErr == nil {
+			buf := make([]byte, 1)
+			_, readErr := conn.Read(buf)
+			require.Error(t, readErr, "server should reject expired client certificate")
+		}
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 0, len(listener.tailers), "no tailer should exist for an expired client cert")
 
 	listener.Stop()
 }


### PR DESCRIPTION
## What does this PR do?

Introduces automatic certificate and CA rotation for the TLS TCP listener so that renewed certificates take effect without restarting the Agent. A `CertReloader` periodically reloads the server certificate/key pair, and a `CAReloader` reloads the CA trust pool from disk. Because `tls.Config.ClientCAs` cannot be safely mutated after use, client certificate verification is performed in `VerifyConnection` against the dynamically-reloaded pool, following the pattern recommended by the Go crypto team (go.dev/issue/64796).

This is part 3 of a 4-part stack, building on client authentication introduced in tls-v2.

## Motivation

In long-running deployments, TLS certificates are regularly rotated by external certificate management systems. Without a reload mechanism, the Agent must be restarted to pick up new certificates, which causes a gap in log collection. Automatic rotation eliminates this operational burden.

## Describe how you validated your changes

- Unit tests for `CertReloader`: initial load, reload on change, expiry detection, concurrent access safety, context cancellation.
- Unit tests for `CAReloader`: initial load, reload, error resilience, cancellation.
- Unit test for `clientAuthNoVerify` mapping (mTLS modes are translated to their non-verifying equivalents for `tls.Config.ClientAuth` when dynamic CA verification is used).
- All tls-v1 and tls-v2 tests continue to pass.

## Additional Notes

- Both reloaders use a `Clock` interface for deterministic testing without real timers.
- `ServerConfig.BuildTLSConfig` now uses `GetCertificate` instead of a static `Certificates` slice, enabling hot-swap of the server identity.
- Stacked PR: `ryan.hall/tls-v3` → `ryan.hall/tls-v2`