### PR TITLE
[procmgr] Port process.rs tests to cross-platform helpers

### DIFF
--- a/pkg/procmgr/rust/src/grpc/service.rs
+++ b/pkg/procmgr/rust/src/grpc/service.rs
@@ -340,7 +340,7 @@ fn process_detail(proc: &ManagedProcess) -> proto::ProcessDetail {
 mod tests {
     use super::*;
     use crate::config::ProcessConfig;
-    use crate::process::tests::test_uuid;
+    use crate::test_helpers::test_uuid;
 
     #[test]
     fn test_state_to_proto_mapping() {

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -492,7 +492,7 @@ fn stdio_from_str(s: &str) -> Stdio {
 pub mod tests {
     use super::*;
     use crate::config::ProcessConfig;
-    use crate::test_helpers::{self, make_config, test_uuid};
+    use crate::test_helpers;
     #[cfg(unix)]
     use nix::sys::signal::Signal;
 
@@ -501,7 +501,11 @@ pub mod tests {
     #[test]
     fn test_initial_state_is_created() {
         let (cmd, args) = test_helpers::true_cmd();
-        let proc = ManagedProcess::new_config("test".into(), test_uuid(), make_config(cmd, args));
+        let proc = ManagedProcess::new_config(
+            "test".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         assert_eq!(proc.state(), ProcessState::Created);
         assert!(!proc.is_running());
     }
@@ -509,7 +513,11 @@ pub mod tests {
     #[tokio::test]
     async fn test_state_transitions_spawn_exit_success() {
         let (cmd, args) = test_helpers::exit_cmd(0);
-        let mut proc = ManagedProcess::new_config("t".into(), test_uuid(), make_config(cmd, args));
+        let mut proc = ManagedProcess::new_config(
+            "t".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         assert_eq!(proc.state(), ProcessState::Created);
 
         proc.spawn().unwrap();
@@ -526,7 +534,11 @@ pub mod tests {
     #[tokio::test]
     async fn test_state_transitions_spawn_exit_failure() {
         let (cmd, args) = test_helpers::exit_cmd(1);
-        let mut proc = ManagedProcess::new_config("t".into(), test_uuid(), make_config(cmd, args));
+        let mut proc = ManagedProcess::new_config(
+            "t".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         proc.spawn().unwrap();
         assert_eq!(proc.state(), ProcessState::Running);
 
@@ -539,7 +551,11 @@ pub mod tests {
     #[tokio::test]
     async fn test_state_after_take_child_still_running() {
         let (cmd, args) = test_helpers::sleep_cmd(60);
-        let mut proc = ManagedProcess::new_config("t".into(), test_uuid(), make_config(cmd, args));
+        let mut proc = ManagedProcess::new_config(
+            "t".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         proc.spawn().unwrap();
         assert_eq!(proc.state(), ProcessState::Running);
 
@@ -563,7 +579,11 @@ pub mod tests {
     #[tokio::test]
     async fn test_send_signal_works_after_take_child() {
         let (cmd, args) = test_helpers::sleep_cmd(60);
-        let mut proc = ManagedProcess::new_config("t".into(), test_uuid(), make_config(cmd, args));
+        let mut proc = ManagedProcess::new_config(
+            "t".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         proc.spawn().unwrap();
         let mut child = proc.take_child().unwrap();
 
@@ -580,35 +600,39 @@ pub mod tests {
     #[test]
     fn test_should_start_auto_start_true_no_condition() {
         let (cmd, args) = test_helpers::true_cmd();
-        let proc = ManagedProcess::new_config("test".into(), test_uuid(), make_config(cmd, args));
+        let proc = ManagedProcess::new_config(
+            "test".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         assert!(proc.should_start());
     }
 
     #[test]
     fn test_should_start_auto_start_false() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.auto_start = false;
-        let proc = ManagedProcess::new_config("test".into(), test_uuid(), cfg);
+        let proc = ManagedProcess::new_config("test".into(), test_helpers::test_uuid(), cfg);
         assert!(!proc.should_start());
     }
 
     #[test]
     fn test_should_start_condition_path_exists_met() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         let exe = std::env::current_exe().unwrap();
         cfg.condition_path_exists = Some(exe.to_str().unwrap().to_string());
-        let proc = ManagedProcess::new_config("test".into(), test_uuid(), cfg);
+        let proc = ManagedProcess::new_config("test".into(), test_helpers::test_uuid(), cfg);
         assert!(proc.should_start());
     }
 
     #[test]
     fn test_should_start_condition_path_exists_not_met() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.condition_path_exists = Some("/nonexistent/path/binary".to_string());
-        let proc = ManagedProcess::new_config("test".into(), test_uuid(), cfg);
+        let proc = ManagedProcess::new_config("test".into(), test_helpers::test_uuid(), cfg);
         assert!(!proc.should_start());
     }
 
@@ -617,8 +641,11 @@ pub mod tests {
     #[tokio::test]
     async fn test_spawn_and_is_running() {
         let (cmd, args) = test_helpers::sleep_cmd(60);
-        let mut proc =
-            ManagedProcess::new_config("sleeper".into(), test_uuid(), make_config(cmd, args));
+        let mut proc = ManagedProcess::new_config(
+            "sleeper".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
 
         assert!(!proc.is_running());
         proc.spawn().unwrap();
@@ -631,8 +658,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_spawn_nonexistent_binary() {
-        let cfg = make_config::<&str>("/nonexistent/binary", vec![]);
-        let mut proc = ManagedProcess::new_config("bad".into(), test_uuid(), cfg);
+        let cfg = test_helpers::make_config::<&str>("/nonexistent/binary", vec![]);
+        let mut proc = ManagedProcess::new_config("bad".into(), test_helpers::test_uuid(), cfg);
         assert!(proc.spawn().is_err());
         assert!(!proc.is_running());
         assert_eq!(proc.state(), ProcessState::Failed);
@@ -641,10 +668,11 @@ pub mod tests {
     #[tokio::test]
     async fn test_spawn_with_env() {
         let (cmd, args) = test_helpers::exit_env_cmd("MY_EXIT_CODE");
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.env.insert("MY_EXIT_CODE".to_string(), "42".to_string());
 
-        let mut proc = ManagedProcess::new_config("env-test".into(), test_uuid(), cfg);
+        let mut proc =
+            ManagedProcess::new_config("env-test".into(), test_helpers::test_uuid(), cfg);
         proc.spawn().unwrap();
         let status = proc.wait().await.unwrap();
         assert_eq!(status.code(), Some(42));
@@ -653,8 +681,11 @@ pub mod tests {
     #[tokio::test]
     async fn test_spawn_with_args() {
         let (cmd, args) = test_helpers::exit_cmd(7);
-        let mut proc =
-            ManagedProcess::new_config("args-test".into(), test_uuid(), make_config(cmd, args));
+        let mut proc = ManagedProcess::new_config(
+            "args-test".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         proc.spawn().unwrap();
         let status = proc.wait().await.unwrap();
         assert_eq!(status.code(), Some(7));
@@ -666,8 +697,11 @@ pub mod tests {
     #[tokio::test]
     async fn test_send_signal_sigterm() {
         let (cmd, args) = test_helpers::sleep_cmd(60);
-        let mut proc =
-            ManagedProcess::new_config("sig-test".into(), test_uuid(), make_config(cmd, args));
+        let mut proc = ManagedProcess::new_config(
+            "sig-test".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         proc.spawn().unwrap();
 
         proc.send_signal(Signal::SIGTERM);
@@ -679,8 +713,11 @@ pub mod tests {
     #[test]
     fn test_send_signal_no_child_does_not_panic() {
         let (cmd, args) = test_helpers::true_cmd();
-        let proc =
-            ManagedProcess::new_config("no-child".into(), test_uuid(), make_config(cmd, args));
+        let proc = ManagedProcess::new_config(
+            "no-child".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         proc.send_signal(Signal::SIGTERM);
     }
 
@@ -695,8 +732,9 @@ pub mod tests {
         let script = "test -z \"$PROCMGRD_TEST_SECRET\" && exit 0 || exit 1";
         #[cfg(windows)]
         let script = "if defined PROCMGRD_TEST_SECRET (exit 1) else (exit 0)";
-        let cfg = make_config(sh, vec![flag, script]);
-        let mut proc = ManagedProcess::new_config("clean-env".into(), test_uuid(), cfg);
+        let cfg = test_helpers::make_config(sh, vec![flag, script]);
+        let mut proc =
+            ManagedProcess::new_config("clean-env".into(), test_helpers::test_uuid(), cfg);
         proc.spawn().unwrap();
         let status = proc.wait().await.unwrap();
         assert_eq!(
@@ -718,10 +756,10 @@ pub mod tests {
         let script = "test \"$FROM_FILE\" = 'hello' && echo $PATH";
         #[cfg(windows)]
         let script = "if \"%FROM_FILE%\"==\"hello\" (echo %PATH%) else (exit 1)";
-        let mut cfg = make_config(sh, vec![flag, script]);
+        let mut cfg = test_helpers::make_config(sh, vec![flag, script]);
         cfg.environment_file = Some(env_file.to_str().unwrap().to_string());
 
-        let mut proc = ManagedProcess::new_config("envfile".into(), test_uuid(), cfg);
+        let mut proc = ManagedProcess::new_config("envfile".into(), test_helpers::test_uuid(), cfg);
         proc.spawn().unwrap();
         let status = proc.wait().await.unwrap();
         assert_eq!(
@@ -742,12 +780,13 @@ pub mod tests {
         let script = "exit $(test \"$MY_VAR\" = 'overridden' && echo 0 || echo 1)";
         #[cfg(windows)]
         let script = "if \"%MY_VAR%\"==\"overridden\" (exit 0) else (exit 1)";
-        let mut cfg = make_config(sh, vec![flag, script]);
+        let mut cfg = test_helpers::make_config(sh, vec![flag, script]);
         cfg.environment_file = Some(env_file.to_str().unwrap().to_string());
         cfg.env
             .insert("MY_VAR".to_string(), "overridden".to_string());
 
-        let mut proc = ManagedProcess::new_config("override".into(), test_uuid(), cfg);
+        let mut proc =
+            ManagedProcess::new_config("override".into(), test_helpers::test_uuid(), cfg);
         proc.spawn().unwrap();
         let status = proc.wait().await.unwrap();
         assert_eq!(
@@ -760,9 +799,10 @@ pub mod tests {
     #[tokio::test]
     async fn test_spawn_fails_on_missing_environment_file() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.environment_file = Some("/nonexistent/env".to_string());
-        let mut proc = ManagedProcess::new_config("bad-envfile".into(), test_uuid(), cfg);
+        let mut proc =
+            ManagedProcess::new_config("bad-envfile".into(), test_helpers::test_uuid(), cfg);
         assert!(
             proc.spawn().is_err(),
             "spawn should fail if environment_file is missing without - prefix"
@@ -773,9 +813,10 @@ pub mod tests {
     #[tokio::test]
     async fn test_spawn_skips_missing_optional_environment_file() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.environment_file = Some("-/nonexistent/env".to_string());
-        let mut proc = ManagedProcess::new_config("optional-envfile".into(), test_uuid(), cfg);
+        let mut proc =
+            ManagedProcess::new_config("optional-envfile".into(), test_helpers::test_uuid(), cfg);
         proc.spawn().unwrap();
         let status = proc.wait().await.unwrap();
         assert!(
@@ -789,72 +830,76 @@ pub mod tests {
     #[test]
     fn test_should_restart_never() {
         let (cmd, args) = test_helpers::true_cmd();
-        let proc = ManagedProcess::new_config("t".into(), test_uuid(), make_config(cmd, args));
+        let proc = ManagedProcess::new_config(
+            "t".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         assert!(!proc.should_restart(&test_helpers::exit_status(1)));
     }
 
     #[test]
     fn test_should_restart_always_on_success() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
-        let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
+        let proc = ManagedProcess::new_config("t".into(), test_helpers::test_uuid(), cfg);
         assert!(proc.should_restart(&test_helpers::exit_status(0)));
     }
 
     #[test]
     fn test_should_restart_always_on_failure() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
-        let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
+        let proc = ManagedProcess::new_config("t".into(), test_helpers::test_uuid(), cfg);
         assert!(proc.should_restart(&test_helpers::exit_status(1)));
     }
 
     #[test]
     fn test_should_restart_on_failure_with_failure() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::OnFailure;
-        let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
+        let proc = ManagedProcess::new_config("t".into(), test_helpers::test_uuid(), cfg);
         assert!(proc.should_restart(&test_helpers::exit_status(1)));
     }
 
     #[test]
     fn test_should_restart_on_failure_with_success() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::OnFailure;
-        let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
+        let proc = ManagedProcess::new_config("t".into(), test_helpers::test_uuid(), cfg);
         assert!(!proc.should_restart(&test_helpers::exit_status(0)));
     }
 
     #[test]
     fn test_should_restart_on_success_with_success() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::OnSuccess;
-        let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
+        let proc = ManagedProcess::new_config("t".into(), test_helpers::test_uuid(), cfg);
         assert!(proc.should_restart(&test_helpers::exit_status(0)));
     }
 
     #[test]
     fn test_should_restart_on_success_with_failure() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::OnSuccess;
-        let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
+        let proc = ManagedProcess::new_config("t".into(), test_helpers::test_uuid(), cfg);
         assert!(!proc.should_restart(&test_helpers::exit_status(1)));
     }
 
     #[test]
     fn test_burst_limiting() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
         cfg.start_limit_burst = Some(3);
         cfg.start_limit_interval_sec = Some(60);
-        let mut proc = ManagedProcess::new_config("burst".into(), test_uuid(), cfg);
+        let mut proc = ManagedProcess::new_config("burst".into(), test_helpers::test_uuid(), cfg);
 
         let burst = proc.config.burst_limit();
         let interval = proc.config.burst_interval();
@@ -877,11 +922,11 @@ pub mod tests {
     #[test]
     fn test_backoff_increases() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
         cfg.restart_sec = Some(1.0);
         cfg.restart_max_delay_sec = Some(10.0);
-        let mut proc = ManagedProcess::new_config("backoff".into(), test_uuid(), cfg);
+        let mut proc = ManagedProcess::new_config("backoff".into(), test_helpers::test_uuid(), cfg);
 
         assert!((proc.restarts.current_delay - 1.0).abs() < 0.001);
         proc.restarts.advance_backoff(10.0);
@@ -900,11 +945,11 @@ pub mod tests {
     #[test]
     fn test_backoff_resets_on_long_runtime() {
         let (cmd, args) = test_helpers::true_cmd();
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
         cfg.restart_sec = Some(1.0);
         cfg.runtime_success_sec = Some(0);
-        let mut proc = ManagedProcess::new_config("reset".into(), test_uuid(), cfg);
+        let mut proc = ManagedProcess::new_config("reset".into(), test_helpers::test_uuid(), cfg);
 
         proc.restarts.last_spawn_time = Some(Instant::now() - Duration::from_secs(5));
         proc.restarts.current_delay = 16.0;
@@ -922,8 +967,11 @@ pub mod tests {
     #[test]
     fn test_restart_config_defaults() {
         let (cmd, args) = test_helpers::true_cmd();
-        let proc =
-            ManagedProcess::new_config("defaults".into(), test_uuid(), make_config(cmd, args));
+        let proc = ManagedProcess::new_config(
+            "defaults".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         assert_eq!(*proc.restart_policy(), RestartPolicy::Never);
         assert!((proc.restarts.current_delay - 1.0).abs() < 0.001);
         assert_eq!(proc.restarts.count, 0);
@@ -953,8 +1001,11 @@ runtime_success_sec: 5
     #[tokio::test]
     async fn test_stop_requested_transitions_to_stopped() {
         let (cmd, args) = test_helpers::sleep_cmd(60);
-        let mut proc =
-            ManagedProcess::new_config("svc".into(), test_uuid(), make_config(cmd, args));
+        let mut proc = ManagedProcess::new_config(
+            "svc".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         proc.spawn().unwrap();
         assert_eq!(proc.state(), ProcessState::Running);
 
@@ -969,9 +1020,9 @@ runtime_success_sec: 5
     #[tokio::test]
     async fn test_stop_requested_skips_restart() {
         let (cmd, args) = test_helpers::sleep_cmd(60);
-        let mut cfg = make_config(cmd, args);
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
-        let mut proc = ManagedProcess::new_config("svc".into(), test_uuid(), cfg);
+        let mut proc = ManagedProcess::new_config("svc".into(), test_helpers::test_uuid(), cfg);
         proc.spawn().unwrap();
 
         proc.request_stop();
@@ -989,8 +1040,11 @@ runtime_success_sec: 5
     #[tokio::test]
     async fn test_normal_exit_not_affected_by_stop_flag() {
         let (cmd, args) = test_helpers::exit_cmd(1);
-        let mut proc =
-            ManagedProcess::new_config("svc".into(), test_uuid(), make_config(cmd, args));
+        let mut proc = ManagedProcess::new_config(
+            "svc".into(),
+            test_helpers::test_uuid(),
+            test_helpers::make_config(cmd, args),
+        );
         proc.spawn().unwrap();
 
         let mut child = proc.take_child().unwrap();

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -492,49 +492,38 @@ fn stdio_from_str(s: &str) -> Stdio {
 pub mod tests {
     use super::*;
     use crate::config::ProcessConfig;
+    use crate::test_helpers;
+    #[cfg(unix)]
     use nix::sys::signal::Signal;
 
     pub fn test_uuid() -> String {
         "00000000-0000-0000-0000-000000000000".to_string()
     }
 
-    pub fn make_config(command: &str, args: Vec<&str>) -> ProcessConfig {
+    pub fn make_config<S: Into<String>>(command: &str, args: Vec<S>) -> ProcessConfig {
         ProcessConfig {
             command: command.to_string(),
-            args: args.into_iter().map(String::from).collect(),
+            args: args.into_iter().map(Into::into).collect(),
             stdout: "null".to_string(),
             stderr: "null".to_string(),
             ..Default::default()
         }
     }
 
-    fn exit_status(code: i32) -> std::process::ExitStatus {
-        std::process::Command::new("/bin/sh")
-            .args(["-c", &format!("exit {code}")])
-            .status()
-            .unwrap()
-    }
-
     // -- state lifecycle tests --
 
     #[test]
     fn test_initial_state_is_created() {
-        let proc = ManagedProcess::new_config(
-            "test".into(),
-            test_uuid(),
-            make_config("/bin/true", vec![]),
-        );
+        let (cmd, args) = test_helpers::true_cmd();
+        let proc = ManagedProcess::new_config("test".into(), test_uuid(), make_config(cmd, args));
         assert_eq!(proc.state(), ProcessState::Created);
         assert!(!proc.is_running());
     }
 
     #[tokio::test]
     async fn test_state_transitions_spawn_exit_success() {
-        let mut proc = ManagedProcess::new_config(
-            "t".into(),
-            test_uuid(),
-            make_config("/bin/sh", vec!["-c", "exit 0"]),
-        );
+        let (cmd, args) = test_helpers::exit_cmd(0);
+        let mut proc = ManagedProcess::new_config("t".into(), test_uuid(), make_config(cmd, args));
         assert_eq!(proc.state(), ProcessState::Created);
 
         proc.spawn().unwrap();
@@ -550,11 +539,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_state_transitions_spawn_exit_failure() {
-        let mut proc = ManagedProcess::new_config(
-            "t".into(),
-            test_uuid(),
-            make_config("/bin/sh", vec!["-c", "exit 1"]),
-        );
+        let (cmd, args) = test_helpers::exit_cmd(1);
+        let mut proc = ManagedProcess::new_config("t".into(), test_uuid(), make_config(cmd, args));
         proc.spawn().unwrap();
         assert_eq!(proc.state(), ProcessState::Running);
 
@@ -566,11 +552,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_state_after_take_child_still_running() {
-        let mut proc = ManagedProcess::new_config(
-            "t".into(),
-            test_uuid(),
-            make_config("/bin/sleep", vec!["60"]),
-        );
+        let (cmd, args) = test_helpers::sleep_cmd(60);
+        let mut proc = ManagedProcess::new_config("t".into(), test_uuid(), make_config(cmd, args));
         proc.spawn().unwrap();
         assert_eq!(proc.state(), ProcessState::Running);
 
@@ -583,19 +566,18 @@ pub mod tests {
         );
         assert!(proc.is_running());
 
-        // Clean up
-        proc.send_signal(Signal::SIGKILL);
+        if let Some(pid) = proc.pid() {
+            let _ = platform::send_force_kill(pid);
+        }
         let mut child = child.unwrap();
         let _ = child.wait().await;
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_send_signal_works_after_take_child() {
-        let mut proc = ManagedProcess::new_config(
-            "t".into(),
-            test_uuid(),
-            make_config("/bin/sleep", vec!["60"]),
-        );
+        let (cmd, args) = test_helpers::sleep_cmd(60);
+        let mut proc = ManagedProcess::new_config("t".into(), test_uuid(), make_config(cmd, args));
         proc.spawn().unwrap();
         let mut child = proc.take_child().unwrap();
 
@@ -611,17 +593,15 @@ pub mod tests {
 
     #[test]
     fn test_should_start_auto_start_true_no_condition() {
-        let proc = ManagedProcess::new_config(
-            "test".into(),
-            test_uuid(),
-            make_config("/usr/bin/true", vec![]),
-        );
+        let (cmd, args) = test_helpers::true_cmd();
+        let proc = ManagedProcess::new_config("test".into(), test_uuid(), make_config(cmd, args));
         assert!(proc.should_start());
     }
 
     #[test]
     fn test_should_start_auto_start_false() {
-        let mut cfg = make_config("/usr/bin/true", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.auto_start = false;
         let proc = ManagedProcess::new_config("test".into(), test_uuid(), cfg);
         assert!(!proc.should_start());
@@ -629,15 +609,18 @@ pub mod tests {
 
     #[test]
     fn test_should_start_condition_path_exists_met() {
-        let mut cfg = make_config("/usr/bin/true", vec![]);
-        cfg.condition_path_exists = Some("/usr/bin/true".to_string());
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
+        let exe = std::env::current_exe().unwrap();
+        cfg.condition_path_exists = Some(exe.to_str().unwrap().to_string());
         let proc = ManagedProcess::new_config("test".into(), test_uuid(), cfg);
         assert!(proc.should_start());
     }
 
     #[test]
     fn test_should_start_condition_path_exists_not_met() {
-        let mut cfg = make_config("/usr/bin/true", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.condition_path_exists = Some("/nonexistent/path/binary".to_string());
         let proc = ManagedProcess::new_config("test".into(), test_uuid(), cfg);
         assert!(!proc.should_start());
@@ -647,21 +630,22 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_spawn_and_is_running() {
-        let cfg = make_config("/bin/sleep", vec!["60"]);
-        let mut proc = ManagedProcess::new_config("sleeper".into(), test_uuid(), cfg);
+        let (cmd, args) = test_helpers::sleep_cmd(60);
+        let mut proc =
+            ManagedProcess::new_config("sleeper".into(), test_uuid(), make_config(cmd, args));
 
         assert!(!proc.is_running());
         proc.spawn().unwrap();
         assert!(proc.is_running());
 
-        proc.send_signal(Signal::SIGKILL);
+        proc.request_stop();
         let status = proc.wait().await.unwrap();
         assert!(!status.success());
     }
 
     #[tokio::test]
     async fn test_spawn_nonexistent_binary() {
-        let cfg = make_config("/nonexistent/binary", vec![]);
+        let cfg = make_config::<&str>("/nonexistent/binary", vec![]);
         let mut proc = ManagedProcess::new_config("bad".into(), test_uuid(), cfg);
         assert!(proc.spawn().is_err());
         assert!(!proc.is_running());
@@ -670,7 +654,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_spawn_with_env() {
-        let mut cfg = make_config("/bin/sh", vec!["-c", "exit $MY_EXIT_CODE"]);
+        let (cmd, args) = test_helpers::exit_env_cmd("MY_EXIT_CODE");
+        let mut cfg = make_config(cmd, args);
         cfg.env.insert("MY_EXIT_CODE".to_string(), "42".to_string());
 
         let mut proc = ManagedProcess::new_config("env-test".into(), test_uuid(), cfg);
@@ -681,19 +666,22 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_spawn_with_args() {
-        let cfg = make_config("/bin/sh", vec!["-c", "exit 7"]);
-        let mut proc = ManagedProcess::new_config("args-test".into(), test_uuid(), cfg);
+        let (cmd, args) = test_helpers::exit_cmd(7);
+        let mut proc =
+            ManagedProcess::new_config("args-test".into(), test_uuid(), make_config(cmd, args));
         proc.spawn().unwrap();
         let status = proc.wait().await.unwrap();
         assert_eq!(status.code(), Some(7));
     }
 
-    // -- signal tests --
+    // -- signal tests (Unix-only: test the raw send_signal API) --
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_send_signal_sigterm() {
-        let cfg = make_config("/bin/sleep", vec!["60"]);
-        let mut proc = ManagedProcess::new_config("sig-test".into(), test_uuid(), cfg);
+        let (cmd, args) = test_helpers::sleep_cmd(60);
+        let mut proc =
+            ManagedProcess::new_config("sig-test".into(), test_uuid(), make_config(cmd, args));
         proc.spawn().unwrap();
 
         proc.send_signal(Signal::SIGTERM);
@@ -701,13 +689,12 @@ pub mod tests {
         assert!(!status.success());
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_send_signal_no_child_does_not_panic() {
-        let proc = ManagedProcess::new_config(
-            "no-child".into(),
-            test_uuid(),
-            make_config("/usr/bin/true", vec![]),
-        );
+        let (cmd, args) = test_helpers::true_cmd();
+        let proc =
+            ManagedProcess::new_config("no-child".into(), test_uuid(), make_config(cmd, args));
         proc.send_signal(Signal::SIGTERM);
     }
 
@@ -717,13 +704,12 @@ pub mod tests {
     async fn test_spawn_does_not_inherit_parent_env() {
         // SAFETY: single-threaded test runtime; no concurrent env access.
         unsafe { std::env::set_var("PROCMGRD_TEST_SECRET", "leaked") };
-        let cfg = make_config(
-            "/bin/sh",
-            vec![
-                "-c",
-                "test -z \"$PROCMGRD_TEST_SECRET\" && exit 0 || exit 1",
-            ],
-        );
+        let (sh, flag) = test_helpers::shell_cmd();
+        #[cfg(unix)]
+        let script = "test -z \"$PROCMGRD_TEST_SECRET\" && exit 0 || exit 1";
+        #[cfg(windows)]
+        let script = "if defined PROCMGRD_TEST_SECRET (exit 1) else (exit 0)";
+        let cfg = make_config(sh, vec![flag, script]);
         let mut proc = ManagedProcess::new_config("clean-env".into(), test_uuid(), cfg);
         proc.spawn().unwrap();
         let status = proc.wait().await.unwrap();
@@ -741,10 +727,12 @@ pub mod tests {
         let env_file = dir.path().join("env");
         std::fs::write(&env_file, "# comment\nFROM_FILE=hello\nPATH=/usr/bin\n\n").unwrap();
 
-        let mut cfg = make_config(
-            "/bin/sh",
-            vec!["-c", "test \"$FROM_FILE\" = 'hello' && echo $PATH"],
-        );
+        let (sh, flag) = test_helpers::shell_cmd();
+        #[cfg(unix)]
+        let script = "test \"$FROM_FILE\" = 'hello' && echo $PATH";
+        #[cfg(windows)]
+        let script = "if \"%FROM_FILE%\"==\"hello\" (echo %PATH%)";
+        let mut cfg = make_config(sh, vec![flag, script]);
         cfg.environment_file = Some(env_file.to_str().unwrap().to_string());
 
         let mut proc = ManagedProcess::new_config("envfile".into(), test_uuid(), cfg);
@@ -763,13 +751,12 @@ pub mod tests {
         let env_file = dir.path().join("env");
         std::fs::write(&env_file, "MY_VAR=from_file\n").unwrap();
 
-        let mut cfg = make_config(
-            "/bin/sh",
-            vec![
-                "-c",
-                "exit $(test \"$MY_VAR\" = 'overridden' && echo 0 || echo 1)",
-            ],
-        );
+        let (sh, flag) = test_helpers::shell_cmd();
+        #[cfg(unix)]
+        let script = "exit $(test \"$MY_VAR\" = 'overridden' && echo 0 || echo 1)";
+        #[cfg(windows)]
+        let script = "if \"%MY_VAR%\"==\"overridden\" (exit 0) else (exit 1)";
+        let mut cfg = make_config(sh, vec![flag, script]);
         cfg.environment_file = Some(env_file.to_str().unwrap().to_string());
         cfg.env
             .insert("MY_VAR".to_string(), "overridden".to_string());
@@ -786,7 +773,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_spawn_fails_on_missing_environment_file() {
-        let mut cfg = make_config("/usr/bin/true", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.environment_file = Some("/nonexistent/env".to_string());
         let mut proc = ManagedProcess::new_config("bad-envfile".into(), test_uuid(), cfg);
         assert!(
@@ -798,7 +786,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_spawn_skips_missing_optional_environment_file() {
-        let mut cfg = make_config("/usr/bin/true", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.environment_file = Some("-/nonexistent/env".to_string());
         let mut proc = ManagedProcess::new_config("optional-envfile".into(), test_uuid(), cfg);
         proc.spawn().unwrap();
@@ -813,62 +802,69 @@ pub mod tests {
 
     #[test]
     fn test_should_restart_never() {
-        let cfg = make_config("/bin/sh", vec![]);
-        let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
-        assert!(!proc.should_restart(&exit_status(1)));
+        let (cmd, args) = test_helpers::true_cmd();
+        let proc = ManagedProcess::new_config("t".into(), test_uuid(), make_config(cmd, args));
+        assert!(!proc.should_restart(&test_helpers::exit_status(1)));
     }
 
     #[test]
     fn test_should_restart_always_on_success() {
-        let mut cfg = make_config("/bin/sh", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
         let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
-        assert!(proc.should_restart(&exit_status(0)));
+        assert!(proc.should_restart(&test_helpers::exit_status(0)));
     }
 
     #[test]
     fn test_should_restart_always_on_failure() {
-        let mut cfg = make_config("/bin/sh", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
         let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
-        assert!(proc.should_restart(&exit_status(1)));
+        assert!(proc.should_restart(&test_helpers::exit_status(1)));
     }
 
     #[test]
     fn test_should_restart_on_failure_with_failure() {
-        let mut cfg = make_config("/bin/sh", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.restart = RestartPolicy::OnFailure;
         let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
-        assert!(proc.should_restart(&exit_status(1)));
+        assert!(proc.should_restart(&test_helpers::exit_status(1)));
     }
 
     #[test]
     fn test_should_restart_on_failure_with_success() {
-        let mut cfg = make_config("/bin/sh", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.restart = RestartPolicy::OnFailure;
         let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
-        assert!(!proc.should_restart(&exit_status(0)));
+        assert!(!proc.should_restart(&test_helpers::exit_status(0)));
     }
 
     #[test]
     fn test_should_restart_on_success_with_success() {
-        let mut cfg = make_config("/bin/sh", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.restart = RestartPolicy::OnSuccess;
         let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
-        assert!(proc.should_restart(&exit_status(0)));
+        assert!(proc.should_restart(&test_helpers::exit_status(0)));
     }
 
     #[test]
     fn test_should_restart_on_success_with_failure() {
-        let mut cfg = make_config("/bin/sh", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.restart = RestartPolicy::OnSuccess;
         let proc = ManagedProcess::new_config("t".into(), test_uuid(), cfg);
-        assert!(!proc.should_restart(&exit_status(1)));
+        assert!(!proc.should_restart(&test_helpers::exit_status(1)));
     }
 
     #[test]
     fn test_burst_limiting() {
-        let mut cfg = make_config("/bin/true", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
         cfg.start_limit_burst = Some(3);
         cfg.start_limit_interval_sec = Some(60);
@@ -894,7 +890,8 @@ pub mod tests {
 
     #[test]
     fn test_backoff_increases() {
-        let mut cfg = make_config("/bin/true", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
         cfg.restart_sec = Some(1.0);
         cfg.restart_max_delay_sec = Some(10.0);
@@ -916,7 +913,8 @@ pub mod tests {
 
     #[test]
     fn test_backoff_resets_on_long_runtime() {
-        let mut cfg = make_config("/bin/true", vec![]);
+        let (cmd, args) = test_helpers::true_cmd();
+        let mut cfg = make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
         cfg.restart_sec = Some(1.0);
         cfg.runtime_success_sec = Some(0);
@@ -937,8 +935,9 @@ pub mod tests {
 
     #[test]
     fn test_restart_config_defaults() {
-        let cfg = make_config("/bin/true", vec![]);
-        let proc = ManagedProcess::new_config("defaults".into(), test_uuid(), cfg);
+        let (cmd, args) = test_helpers::true_cmd();
+        let proc =
+            ManagedProcess::new_config("defaults".into(), test_uuid(), make_config(cmd, args));
         assert_eq!(*proc.restart_policy(), RestartPolicy::Never);
         assert!((proc.restarts.current_delay - 1.0).abs() < 0.001);
         assert_eq!(proc.restarts.count, 0);
@@ -967,11 +966,9 @@ runtime_success_sec: 5
 
     #[tokio::test]
     async fn test_stop_requested_transitions_to_stopped() {
-        let mut proc = ManagedProcess::new_config(
-            "svc".into(),
-            test_uuid(),
-            make_config("/bin/sleep", vec!["60"]),
-        );
+        let (cmd, args) = test_helpers::sleep_cmd(60);
+        let mut proc =
+            ManagedProcess::new_config("svc".into(), test_uuid(), make_config(cmd, args));
         proc.spawn().unwrap();
         assert_eq!(proc.state(), ProcessState::Running);
 
@@ -985,7 +982,8 @@ runtime_success_sec: 5
 
     #[tokio::test]
     async fn test_stop_requested_skips_restart() {
-        let mut cfg = make_config("/bin/sleep", vec!["60"]);
+        let (cmd, args) = test_helpers::sleep_cmd(60);
+        let mut cfg = make_config(cmd, args);
         cfg.restart = RestartPolicy::Always;
         let mut proc = ManagedProcess::new_config("svc".into(), test_uuid(), cfg);
         proc.spawn().unwrap();
@@ -1004,11 +1002,9 @@ runtime_success_sec: 5
 
     #[tokio::test]
     async fn test_normal_exit_not_affected_by_stop_flag() {
-        let mut proc = ManagedProcess::new_config(
-            "svc".into(),
-            test_uuid(),
-            make_config("/bin/sh", vec!["-c", "exit 1"]),
-        );
+        let (cmd, args) = test_helpers::exit_cmd(1);
+        let mut proc =
+            ManagedProcess::new_config("svc".into(), test_uuid(), make_config(cmd, args));
         proc.spawn().unwrap();
 
         let mut child = proc.take_child().unwrap();

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -717,7 +717,7 @@ pub mod tests {
         #[cfg(unix)]
         let script = "test \"$FROM_FILE\" = 'hello' && echo $PATH";
         #[cfg(windows)]
-        let script = "if \"%FROM_FILE%\"==\"hello\" (echo %PATH%)";
+        let script = "if \"%FROM_FILE%\"==\"hello\" (echo %PATH%) else (exit 1)";
         let mut cfg = make_config(sh, vec![flag, script]);
         cfg.environment_file = Some(env_file.to_str().unwrap().to_string());
 

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -492,23 +492,9 @@ fn stdio_from_str(s: &str) -> Stdio {
 pub mod tests {
     use super::*;
     use crate::config::ProcessConfig;
-    use crate::test_helpers;
+    use crate::test_helpers::{self, make_config, test_uuid};
     #[cfg(unix)]
     use nix::sys::signal::Signal;
-
-    pub fn test_uuid() -> String {
-        "00000000-0000-0000-0000-000000000000".to_string()
-    }
-
-    pub fn make_config<S: Into<String>>(command: &str, args: Vec<S>) -> ProcessConfig {
-        ProcessConfig {
-            command: command.to_string(),
-            args: args.into_iter().map(Into::into).collect(),
-            stdout: "null".to_string(),
-            stderr: "null".to_string(),
-            ..Default::default()
-        }
-    }
 
     // -- state lifecycle tests --
 

--- a/pkg/procmgr/rust/src/shutdown.rs
+++ b/pkg/procmgr/rust/src/shutdown.rs
@@ -26,8 +26,8 @@ pub async fn shutdown_all(processes: &mut [ManagedProcess]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::process::tests::{make_config, test_uuid};
     use crate::state::ProcessState;
+    use crate::test_helpers::{make_config, test_uuid};
 
     #[tokio::test]
     async fn test_shutdown_all_graceful() {

--- a/pkg/procmgr/rust/src/test_helpers.rs
+++ b/pkg/procmgr/rust/src/test_helpers.rs
@@ -155,3 +155,19 @@ pub fn exit_cmd(code: i32) -> (&'static str, Vec<String>) {
     let (sh, flag) = shell_cmd();
     (sh, vec![flag.to_string(), format!("exit {code}")])
 }
+
+/// Fixed UUID for deterministic tests.
+pub fn test_uuid() -> String {
+    "00000000-0000-0000-0000-000000000000".to_string()
+}
+
+/// Build a `ProcessConfig` with null stdio, suitable for tests.
+pub fn make_config<S: Into<String>>(command: &str, args: Vec<S>) -> crate::config::ProcessConfig {
+    crate::config::ProcessConfig {
+        command: command.to_string(),
+        args: args.into_iter().map(Into::into).collect(),
+        stdout: "null".to_string(),
+        stderr: "null".to_string(),
+        ..Default::default()
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Ports the `process.rs` test module to be cross-platform by replacing all hardcoded Unix commands (`/bin/sh`, `/bin/sleep`, `/usr/bin/true`) with `test_helpers` functions, `#[cfg(unix)]`-gating three signal-specific tests, and centralizing `test_uuid`/`make_config` into the shared `test_helpers` module.

### Motivation

Part of the Windows port plan. The process.rs test suite used Unix-only binaries and paths, making it impossible to compile or run on Windows. This step makes all cross-platform tests pass on both targets while preserving Unix-only signal tests behind `#[cfg(unix)]`.

### Describe how you validated your changes

- All 131 unit tests pass (`cargo test --lib`)
- `cargo fmt --check` clean
- `cargo clippy --all-targets` clean
- Cross-compilation check: `#[cfg(windows)]` code compiles without errors

### Additional Notes