### PR TITLE
[procmgr] Refactor manager.rs: use platform::shutdown_signal()

### DIFF
--- a/pkg/procmgr/rust/src/manager.rs
+++ b/pkg/procmgr/rust/src/manager.rs
@@ -9,13 +9,13 @@ use crate::command::{Command, CreateResult, ReloadResult, StartResult, StopResul
 use crate::config::{self, ConfigLoader, ProcessDefinition};
 use crate::grpc;
 use crate::ordering;
+use crate::platform;
 use crate::process::{ManagedProcess, ProcessOrigin};
 use crate::shutdown;
 use crate::uuid_gen::UuidGenerator;
 use anyhow::Result;
 use log::{debug, info, warn};
 use std::sync::Arc;
-use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::{RwLock, mpsc, oneshot};
 use tonic::Status;
 
@@ -74,17 +74,12 @@ impl ProcessManager {
         let (restart_tx, mut restart_rx) = mpsc::channel::<String>(256);
         self.start(&exit_tx).await;
 
-        let mut sigterm = signal(SignalKind::terminate())?;
-        let mut sigint = signal(SignalKind::interrupt())?;
+        let shutdown = platform::shutdown_signal();
+        tokio::pin!(shutdown);
 
         loop {
             tokio::select! {
-                _ = sigterm.recv() => {
-                    info!("received SIGTERM");
-                    break;
-                }
-                _ = sigint.recv() => {
-                    info!("received SIGINT");
+                _ = &mut shutdown => {
                     break;
                 }
                 Some(event) = exit_rx.recv() => {


### PR DESCRIPTION
### What does this PR do?

Replaces direct `tokio::signal::unix` usage in `manager.rs` with the cross-platform `platform::shutdown_signal()` abstraction. The shutdown future is pinned outside the event loop so signal handlers persist across iterations.

### Motivation

Part of the Windows port plan. The `run()` method used `tokio::signal::unix::{SignalKind, signal}` directly, which doesn't compile on Windows. This delegates to the platform module which already provides `shutdown_signal()` for both Unix (SIGTERM/SIGINT) and Windows (Ctrl+C).

### Describe how you validated your changes

- All 131 unit tests pass (`cargo test --lib`)
- `cargo fmt --check` clean
- `cargo clippy --all-targets` clean

### Additional Notes