### PR TITLE
[CONTP-1345] Add tracing spans to metadata endpoint handlers (5/6)

### DIFF
--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -369,8 +369,7 @@ func getPodMetadataForNode(w http.ResponseWriter, r *http.Request) {
 	metaList, errNodes := as.GetMetadataMapBundleOnNode(nodeName)
 	if errNodes != nil {
 		log.Warnf("Could not collect the service map for %s, err: %v", nodeName, errNodes) //nolint:errcheck
-		spanErr = errNodes
-		api.SetSpanError(w, errNodes)
+		span.SetTag("warning", errNodes.Error())
 	}
 	slcB, err := json.Marshal(metaList)
 	if err != nil {
@@ -436,8 +435,10 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 	metaListBytes, err := json.Marshal(metaList)
 	if err != nil {
-		spanErr = err
-		api.SetSpanError(w, err)
+		if spanErr == nil {
+			spanErr = err
+			api.SetSpanError(w, err)
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -155,8 +155,13 @@ func getNodeAnnotations(w http.ResponseWriter, r *http.Request, wmeta workloadme
 }
 
 func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Component) {
+	vars := mux.Vars(r)
+	nodeName := vars["nodeName"]
+
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.node_info")
+	span, ctx := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.node_info",
+		tracer.Tag("node_name", nodeName),
+	)
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
 
 	cl, err := as.GetAPIClient()
@@ -169,11 +174,7 @@ func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Componen
 	}
 	nodeCl := cl.Cl.CoreV1().Nodes()
 
-	vars := mux.Vars(r)
-	nodeName := vars["nodeName"]
-	span.SetTag("node_name", nodeName)
-
-	node, err := nodeCl.Get(r.Context(), nodeName, metav1.GetOptions{})
+	node, err := nodeCl.Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		log.Errorf("getNodeInfo: unable to get self node: %v", err)
 		spanErr = err
@@ -182,9 +183,13 @@ func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Componen
 		return
 	}
 
+	// Defensive check: client-go's Get() should never return (nil, nil),
+	// but guard against it to avoid a nil-pointer dereference below.
 	if node == nil {
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintf(w, "Could not find node %s", nodeName)
+		notFoundErr := fmt.Errorf("node %s not found", nodeName)
+		spanErr = notFoundErr
+		api.SetSpanError(w, notFoundErr)
+		http.Error(w, notFoundErr.Error(), http.StatusNotFound)
 		return
 	}
 
@@ -364,6 +369,8 @@ func getPodMetadataForNode(w http.ResponseWriter, r *http.Request) {
 	metaList, errNodes := as.GetMetadataMapBundleOnNode(nodeName)
 	if errNodes != nil {
 		log.Warnf("Could not collect the service map for %s, err: %v", nodeName, errNodes) //nolint:errcheck
+		spanErr = errNodes
+		api.SetSpanError(w, errNodes)
 	}
 	slcB, err := json.Marshal(metaList)
 	if err != nil {

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -13,11 +13,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gorilla/mux"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
@@ -25,6 +20,10 @@ import (
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	apicommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/gorilla/mux"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 func installKubernetesMetadataEndpoints(r *mux.Router, wmeta workloadmeta.Component) {

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -76,7 +76,7 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.
 	nodeName := vars["nodeName"]
 
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.node_lookup",
+	span, _ := tracer.StartSpanFromContext(r.Context(), "nodeLookup",
 		tracer.Tag("node_name", nodeName),
 		tracer.Tag("metadata_type", what),
 	)
@@ -159,7 +159,7 @@ func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Componen
 	nodeName := vars["nodeName"]
 
 	var spanErr error
-	span, ctx := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.node_info",
+	span, ctx := tracer.StartSpanFromContext(r.Context(), "nodeInfo",
 		tracer.Tag("node_name", nodeName),
 	)
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
@@ -207,7 +207,7 @@ func getNamespaceMetadataWithTransformerFunc[T any](w http.ResponseWriter, r *ht
 	nsName := vars["ns"]
 
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.namespace_lookup",
+	span, _ := tracer.StartSpanFromContext(r.Context(), "namespaceLookup",
 		tracer.Tag("namespace", nsName),
 	)
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
@@ -312,7 +312,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	ns := vars["ns"]
 
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.pod_lookup",
+	span, _ := tracer.StartSpanFromContext(r.Context(), "podLookup",
 		tracer.Tag("node_name", nodeName),
 		tracer.Tag("namespace", ns),
 	)
@@ -350,7 +350,7 @@ func getPodMetadataForNode(w http.ResponseWriter, r *http.Request) {
 	nodeName := vars["nodeName"]
 
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.pod_metadata_for_node",
+	span, _ := tracer.StartSpanFromContext(r.Context(), "podMetadataForNode",
 		tracer.Tag("node_name", nodeName),
 	)
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
@@ -400,7 +400,7 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 	*/
 
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.all_metadata")
+	span, _ := tracer.StartSpanFromContext(r.Context(), "allMetadata")
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
 
 	log.Trace("Computing metadata map on all nodes")
@@ -448,7 +448,7 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 //nolint:revive // TODO(CINT) Fix revive linter
 func getClusterID(w http.ResponseWriter, r *http.Request) {
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.cluster_id")
+	span, _ := tracer.StartSpanFromContext(r.Context(), "clusterId")
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
 
 	// As HTTP query handler, we do not retry getting the APIServer

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -155,9 +155,15 @@ func getNodeAnnotations(w http.ResponseWriter, r *http.Request, wmeta workloadme
 }
 
 func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Component) {
+	var spanErr error
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.node_info")
+	defer func() { span.Finish(tracer.WithError(spanErr)) }()
+
 	cl, err := as.GetAPIClient()
 	if err != nil {
 		log.Errorf("getNodeInfo: unable to get apiserver: %v", err)
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -165,10 +171,13 @@ func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Componen
 
 	vars := mux.Vars(r)
 	nodeName := vars["nodeName"]
+	span.SetTag("node_name", nodeName)
 
 	node, err := nodeCl.Get(r.Context(), nodeName, metav1.GetOptions{})
 	if err != nil {
 		log.Errorf("getNodeInfo: unable to get self node: %v", err)
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -183,6 +192,8 @@ func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Componen
 	data, err := json.Marshal(&node.Status.NodeInfo)
 	if err != nil {
 		log.Errorf("getNodeInfo: failed to marshal node %s info %+v: %s", nodeName, &node.Status.NodeInfo, err.Error()) //nolint:errcheck
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -184,6 +184,12 @@ func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Componen
 		return
 	}
 
+	if node == nil {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintf(w, "Could not find node %s", nodeName)
+		return
+	}
+
 	// Marshal whole struct, unmarshal only takes what is needed on caller side.
 	data, err := json.Marshal(&node.Status.NodeInfo)
 	if err != nil {

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -183,16 +183,6 @@ func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Componen
 		return
 	}
 
-	// Defensive check: client-go's Get() should never return (nil, nil),
-	// but guard against it to avoid a nil-pointer dereference below.
-	if node == nil {
-		notFoundErr := fmt.Errorf("node %s not found", nodeName)
-		spanErr = notFoundErr
-		api.SetSpanError(w, notFoundErr)
-		http.Error(w, notFoundErr.Error(), http.StatusNotFound)
-		return
-	}
-
 	// Marshal whole struct, unmarshal only takes what is needed on caller side.
 	data, err := json.Marshal(&node.Status.NodeInfo)
 	if err != nil {
@@ -369,7 +359,8 @@ func getPodMetadataForNode(w http.ResponseWriter, r *http.Request) {
 	metaList, errNodes := as.GetMetadataMapBundleOnNode(nodeName)
 	if errNodes != nil {
 		log.Warnf("Could not collect the service map for %s, err: %v", nodeName, errNodes) //nolint:errcheck
-		span.SetTag("warning", errNodes.Error())
+		// Not tagged as a span error since the handler continues with partial results.
+		// The log.Warnf above captures the detail.
 	}
 	slcB, err := json.Marshal(metaList)
 	if err != nil {
@@ -425,6 +416,9 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 	metaList, errAPIServer := as.GetMetadataMapBundleOnAllNodes(cl)
 	// If we hit an error at this point, it is because we don't have access to the API server.
+	// NOTE: if errAPIServer != nil we write a 503 header here. If json.Marshal also fails below,
+	// http.Error attempts a second WriteHeader(500) which is silently dropped by the
+	// telemetryWriterWrapper, so the client sees a 503 status with the marshal error body.
 	if errAPIServer != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		log.Errorf("There was an error querying the nodes from the API: %s", errAPIServer.Error()) //nolint:errcheck

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -76,7 +76,8 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.
 	nodeName := vars["nodeName"]
 
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "nodeLookup",
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.node_lookup",
+		tracer.ResourceName("nodeLookup"),
 		tracer.Tag("node_name", nodeName),
 		tracer.Tag("metadata_type", what),
 	)
@@ -159,7 +160,8 @@ func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Componen
 	nodeName := vars["nodeName"]
 
 	var spanErr error
-	span, ctx := tracer.StartSpanFromContext(r.Context(), "nodeInfo",
+	span, ctx := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.node_info",
+		tracer.ResourceName("nodeInfo"),
 		tracer.Tag("node_name", nodeName),
 	)
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
@@ -207,7 +209,8 @@ func getNamespaceMetadataWithTransformerFunc[T any](w http.ResponseWriter, r *ht
 	nsName := vars["ns"]
 
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "namespaceLookup",
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.namespace_lookup",
+		tracer.ResourceName("namespaceLookup"),
 		tracer.Tag("namespace", nsName),
 	)
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
@@ -312,7 +315,8 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	ns := vars["ns"]
 
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "podLookup",
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.pod_lookup",
+		tracer.ResourceName("podLookup"),
 		tracer.Tag("node_name", nodeName),
 		tracer.Tag("namespace", ns),
 	)
@@ -350,7 +354,8 @@ func getPodMetadataForNode(w http.ResponseWriter, r *http.Request) {
 	nodeName := vars["nodeName"]
 
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "podMetadataForNode",
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.pod_metadata_for_node",
+		tracer.ResourceName("podMetadataForNode"),
 		tracer.Tag("node_name", nodeName),
 	)
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
@@ -400,7 +405,9 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 	*/
 
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "allMetadata")
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.all_metadata",
+		tracer.ResourceName("allMetadata"),
+	)
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
 
 	log.Trace("Computing metadata map on all nodes")
@@ -448,7 +455,9 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 //nolint:revive // TODO(CINT) Fix revive linter
 func getClusterID(w http.ResponseWriter, r *http.Request) {
 	var spanErr error
-	span, _ := tracer.StartSpanFromContext(r.Context(), "clusterId")
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.cluster_id",
+		tracer.ResourceName("clusterID"),
+	)
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
 
 	// As HTTP query handler, we do not retry getting the APIServer

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
@@ -74,10 +75,19 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.
 	var dataBytes []byte
 	nodeName := vars["nodeName"]
 
+	var spanErr error
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.node_lookup",
+		tracer.Tag("node_name", nodeName),
+		tracer.Tag("metadata_type", what),
+	)
+	defer func() { span.Finish(tracer.WithError(spanErr)) }()
+
 	entityID := util.GenerateKubeMetadataEntityID("", "nodes", "", nodeName)
 	nodeMetadata, err := wmeta.GetKubernetesMetadata(entityID)
 	if err != nil {
 		log.Errorf("Could not retrieve the node %s of %s: %v", what, nodeName, err.Error()) //nolint:errcheck
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -98,6 +108,8 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.
 	dataBytes, err = json.Marshal(nodeData)
 	if err != nil {
 		log.Errorf("Could not process the %s of the node %s from the informer's cache: %v", what, nodeName, err.Error()) //nolint:errcheck
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -187,9 +199,18 @@ func getNamespaceMetadataWithTransformerFunc[T any](w http.ResponseWriter, r *ht
 	vars := mux.Vars(r)
 	var metadataBytes []byte
 	nsName := vars["ns"]
+
+	var spanErr error
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.namespace_lookup",
+		tracer.Tag("namespace", nsName),
+	)
+	defer func() { span.Finish(tracer.WithError(spanErr)) }()
+
 	namespaceMetadata, err := wmeta.GetKubernetesMetadata(util.GenerateKubeMetadataEntityID("", "namespaces", "", nsName))
 	if err != nil {
 		log.Debugf("Could not retrieve the %s of namespace %s: %v", what, nsName, err.Error()) //nolint:errcheck
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -198,6 +219,8 @@ func getNamespaceMetadataWithTransformerFunc[T any](w http.ResponseWriter, r *ht
 	metadataBytes, err = json.Marshal(metadata)
 	if err != nil {
 		log.Errorf("Failed to marshal %s %+v of namespace %s from the workload metadata store: %v", what, metadata, nsName, err.Error()) //nolint:errcheck
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -281,9 +304,19 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	nodeName := vars["nodeName"]
 	podName := vars["podName"]
 	ns := vars["ns"]
+
+	var spanErr error
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.pod_lookup",
+		tracer.Tag("node_name", nodeName),
+		tracer.Tag("namespace", ns),
+	)
+	defer func() { span.Finish(tracer.WithError(spanErr)) }()
+
 	metaList, errMetaList := as.GetPodMetadataNames(nodeName, ns, podName)
 	if errMetaList != nil {
 		log.Errorf("Could not retrieve the metadata of: %s from the cache", podName) //nolint:errcheck
+		spanErr = errMetaList
+		api.SetSpanError(w, errMetaList)
 		http.Error(w, errMetaList.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -291,6 +324,8 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	metaBytes, err := json.Marshal(metaList)
 	if err != nil {
 		log.Errorf("Could not process the list of services for: %s", podName) //nolint:errcheck
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -307,6 +342,13 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 func getPodMetadataForNode(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	nodeName := vars["nodeName"]
+
+	var spanErr error
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.pod_metadata_for_node",
+		tracer.Tag("node_name", nodeName),
+	)
+	defer func() { span.Finish(tracer.WithError(spanErr)) }()
+
 	log.Tracef("Fetching metadata map on all pods of the node %s", nodeName)
 	metaList, errNodes := as.GetMetadataMapBundleOnNode(nodeName)
 	if errNodes != nil {
@@ -314,6 +356,8 @@ func getPodMetadataForNode(w http.ResponseWriter, r *http.Request) {
 	}
 	slcB, err := json.Marshal(metaList)
 	if err != nil {
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -346,12 +390,19 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 			Returns: map[string]string
 			Example: "["Error":"could not collect the service map for all nodes: List services is not permitted at the cluster scope."]
 	*/
+
+	var spanErr error
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.all_metadata")
+	defer func() { span.Finish(tracer.WithError(spanErr)) }()
+
 	log.Trace("Computing metadata map on all nodes")
 	// As HTTP query handler, we do not retry getting the APIServer
 	// Client will have to retry query in case of failure
 	cl, err := as.GetAPIClient()
 	if err != nil {
 		log.Errorf("Can't create client to query the API Server: %v", err) //nolint:errcheck
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -360,11 +411,15 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 	if errAPIServer != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		log.Errorf("There was an error querying the nodes from the API: %s", errAPIServer.Error()) //nolint:errcheck
+		spanErr = errAPIServer
+		api.SetSpanError(w, errAPIServer)
 	} else {
 		w.WriteHeader(http.StatusOK)
 	}
 	metaListBytes, err := json.Marshal(metaList)
 	if err != nil {
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -379,11 +434,17 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 //
 //nolint:revive // TODO(CINT) Fix revive linter
 func getClusterID(w http.ResponseWriter, r *http.Request) {
+	var spanErr error
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.cluster_id")
+	defer func() { span.Finish(tracer.WithError(spanErr)) }()
+
 	// As HTTP query handler, we do not retry getting the APIServer
 	// Client will have to retry query in case of failure
 	cl, err := as.GetAPIClient()
 	if err != nil {
 		log.Errorf("Can't create client to query the API Server: %v", err) //nolint:errcheck
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -392,6 +453,8 @@ func getClusterID(w http.ResponseWriter, r *http.Request) {
 	clusterID, err := apicommon.GetOrCreateClusterID(coreCl)
 	if err != nil {
 		log.Errorf("Failed to generate or retrieve the cluster ID: %v", err) //nolint:errcheck
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -399,6 +462,8 @@ func getClusterID(w http.ResponseWriter, r *http.Request) {
 	j, err := json.Marshal(clusterID)
 	if err != nil {
 		log.Errorf("Failed to marshal the cluster ID: %v", err) //nolint:errcheck
+		spanErr = err
+		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -15,8 +15,10 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -187,4 +189,230 @@ func TestGetNodeUID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetNodeMetadata_SpanCreation(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+	mockStore.Set(&workloadmeta.KubernetesMetadata{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesMetadata,
+			ID:   "/nodes//" + testNode,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Labels: map[string]string{"label1": "value1"},
+		},
+	})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		getNodeLabels(w, r, mockStore)
+	})
+
+	req := httptest.NewRequest("GET", "/tags/node/"+testNode, nil)
+	req = mux.SetURLVars(req, map[string]string{"nodeName": testNode})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, "cluster_agent.metadata.node_lookup", span.OperationName())
+	assert.Equal(t, testNode, span.Tag("node_name"))
+	assert.Equal(t, "labels", span.Tag("metadata_type"))
+	assert.Nil(t, span.Tag("error"))
+}
+
+func TestGetNodeMetadata_SpanError(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+	// No data set — lookup will fail
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		getNodeLabels(w, r, mockStore)
+	})
+
+	req := httptest.NewRequest("GET", "/tags/node/missing_node", nil)
+	req = mux.SetURLVars(req, map[string]string{"nodeName": "missing_node"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, "cluster_agent.metadata.node_lookup", span.OperationName())
+	assert.Equal(t, "missing_node", span.Tag("node_name"))
+	// Error should be set on the span
+	err, ok := span.Tag("error").(error)
+	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
+	assert.NotEmpty(t, err.Error())
+}
+
+func TestGetNamespaceMetadata_SpanCreation(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+	mockStore.Set(&workloadmeta.KubernetesMetadata{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesMetadata,
+			ID:   "/namespaces//default",
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Labels: map[string]string{"env": "test"},
+		},
+	})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		getNamespaceLabels(w, r, mockStore)
+	})
+
+	req := httptest.NewRequest("GET", "/tags/namespace/default", nil)
+	req = mux.SetURLVars(req, map[string]string{"ns": "default"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, "cluster_agent.metadata.namespace_lookup", span.OperationName())
+	assert.Equal(t, "default", span.Tag("namespace"))
+	assert.Nil(t, span.Tag("error"))
+}
+
+func TestGetNamespaceMetadata_SpanError(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+	// No data set — lookup will fail
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		getNamespaceLabels(w, r, mockStore)
+	})
+
+	req := httptest.NewRequest("GET", "/tags/namespace/missing_ns", nil)
+	req = mux.SetURLVars(req, map[string]string{"ns": "missing_ns"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, "cluster_agent.metadata.namespace_lookup", span.OperationName())
+	assert.Equal(t, "missing_ns", span.Tag("namespace"))
+	err, ok := span.Tag("error").(error)
+	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
+	assert.NotEmpty(t, err.Error())
+}
+
+func TestGetPodMetadata_SpanCreation(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// getPodMetadata calls as.GetPodMetadataNames which requires the apiserver cache.
+	// When no cache is available it returns an error, so we test the error path which
+	// still verifies span creation and tag propagation.
+	handler := http.HandlerFunc(getPodMetadata)
+
+	req := httptest.NewRequest("GET", "/tags/pod/node1/default/pod1", nil)
+	req = mux.SetURLVars(req, map[string]string{"nodeName": "node1", "ns": "default", "podName": "pod1"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, "cluster_agent.metadata.pod_lookup", span.OperationName())
+	assert.Equal(t, "node1", span.Tag("node_name"))
+	assert.Equal(t, "default", span.Tag("namespace"))
+	// pod_name should NOT be set (cardinality)
+	assert.Nil(t, span.Tag("pod_name"))
+}
+
+func TestGetPodMetadataForNode_SpanCreation(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	handler := http.HandlerFunc(getPodMetadataForNode)
+
+	req := httptest.NewRequest("GET", "/tags/pod/node1", nil)
+	req = mux.SetURLVars(req, map[string]string{"nodeName": "node1"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, "cluster_agent.metadata.pod_metadata_for_node", span.OperationName())
+	assert.Equal(t, "node1", span.Tag("node_name"))
+}
+
+func TestGetAllMetadata_SpanCreation(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// getAllMetadata calls as.GetAPIClient which will fail without a real apiserver.
+	// This tests the error path, which still verifies span creation.
+	handler := http.HandlerFunc(getAllMetadata)
+
+	req := httptest.NewRequest("GET", "/tags/pod", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, "cluster_agent.metadata.all_metadata", span.OperationName())
+	err, ok := span.Tag("error").(error)
+	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
+	assert.NotEmpty(t, err.Error())
+}
+
+func TestGetClusterID_SpanCreation(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// getClusterID calls as.GetAPIClient which will fail without a real apiserver.
+	// This tests the error path, which still verifies span creation.
+	handler := http.HandlerFunc(getClusterID)
+
+	req := httptest.NewRequest("GET", "/cluster/id", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, "cluster_agent.metadata.cluster_id", span.OperationName())
+	err, ok := span.Tag("error").(error)
+	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
+	assert.NotEmpty(t, err.Error())
 }

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -370,10 +370,13 @@ func TestGetPodMetadataForNode_SpanCreation(t *testing.T) {
 	span := spans[0]
 	assert.Equal(t, "cluster_agent.metadata.pod_metadata_for_node", span.OperationName())
 	assert.Equal(t, "node1", span.Tag("node_name"))
-	// Without a real apiserver, GetMetadataMapBundleOnNode fails, so the span should capture the error
-	spanErr, ok := span.Tag("error").(error)
-	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
-	assert.NotEmpty(t, spanErr.Error())
+	// Without a real apiserver, GetMetadataMapBundleOnNode fails, but this is a
+	// non-fatal warning path (the handler continues), so it should be recorded
+	// as a warning tag rather than marking the span as errored.
+	assert.Nil(t, span.Tag("error"), "span should not be marked as errored for partial failures")
+	warning, ok := span.Tag("warning").(string)
+	require.True(t, ok, "warning tag should be a string, got %T", span.Tag("warning"))
+	assert.NotEmpty(t, warning)
 }
 
 func TestGetAllMetadata_SpanCreation(t *testing.T) {

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -417,3 +417,28 @@ func TestGetClusterID_SpanCreation(t *testing.T) {
 	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
 	assert.NotEmpty(t, err.Error())
 }
+
+func TestGetNodeInfo_SpanCreation(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		getNodeInfo(w, r, mockStore)
+	})
+
+	req := httptest.NewRequest("GET", "/info/node/"+testNode, nil)
+	req = mux.SetURLVars(req, map[string]string{"nodeName": testNode})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "cluster_agent.metadata.node_info", spans[0].OperationName())
+}

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -375,15 +375,16 @@ func TestGetAllMetadata_SpanCreation(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	// getAllMetadata calls as.GetAPIClient which will fail without a real apiserver.
-	// This tests the error path, which still verifies span creation.
+	// Without a real apiserver, getAllMetadata may fail at GetAPIClient (500) or
+	// at GetMetadataMapBundleOnAllNodes (503) depending on the environment.
+	// Either way, we verify span creation on the error path.
 	handler := http.HandlerFunc(getAllMetadata)
 
 	req := httptest.NewRequest("GET", "/tags/pod", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Contains(t, []int{http.StatusInternalServerError, http.StatusServiceUnavailable}, rec.Code)
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -14,12 +14,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gorilla/mux"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/fx"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
-
 	"github.com/DataDog/datadog-agent/comp/core"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
@@ -27,6 +21,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
 )
 
 const testNode = "test_node"

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -224,7 +224,7 @@ func TestGetNodeMetadata_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "cluster_agent.metadata.node_lookup", span.OperationName())
+	assert.Equal(t, "nodeLookup", span.OperationName())
 	assert.Equal(t, testNode, span.Tag("node_name"))
 	assert.Equal(t, "labels", span.Tag("metadata_type"))
 	assert.Nil(t, span.Tag("error"))
@@ -254,7 +254,7 @@ func TestGetNodeMetadata_SpanError(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "cluster_agent.metadata.node_lookup", span.OperationName())
+	assert.Equal(t, "nodeLookup", span.OperationName())
 	assert.Equal(t, "missing_node", span.Tag("node_name"))
 	// Error should be set on the span
 	err, ok := span.Tag("error").(error)
@@ -294,7 +294,7 @@ func TestGetNamespaceMetadata_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "cluster_agent.metadata.namespace_lookup", span.OperationName())
+	assert.Equal(t, "namespaceLookup", span.OperationName())
 	assert.Equal(t, "default", span.Tag("namespace"))
 	assert.Nil(t, span.Tag("error"))
 }
@@ -323,7 +323,7 @@ func TestGetNamespaceMetadata_SpanError(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "cluster_agent.metadata.namespace_lookup", span.OperationName())
+	assert.Equal(t, "namespaceLookup", span.OperationName())
 	assert.Equal(t, "missing_ns", span.Tag("namespace"))
 	err, ok := span.Tag("error").(error)
 	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
@@ -347,7 +347,7 @@ func TestGetPodMetadata_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "cluster_agent.metadata.pod_lookup", span.OperationName())
+	assert.Equal(t, "podLookup", span.OperationName())
 	assert.Equal(t, "node1", span.Tag("node_name"))
 	assert.Equal(t, "default", span.Tag("namespace"))
 	// pod_name should NOT be set (cardinality)
@@ -368,7 +368,7 @@ func TestGetPodMetadataForNode_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "cluster_agent.metadata.pod_metadata_for_node", span.OperationName())
+	assert.Equal(t, "podMetadataForNode", span.OperationName())
 	assert.Equal(t, "node1", span.Tag("node_name"))
 	// Without a real apiserver, GetMetadataMapBundleOnNode fails, but this is a
 	// non-fatal path (the handler continues with partial results), so the span
@@ -394,7 +394,7 @@ func TestGetAllMetadata_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "cluster_agent.metadata.all_metadata", span.OperationName())
+	assert.Equal(t, "allMetadata", span.OperationName())
 	err, ok := span.Tag("error").(error)
 	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
 	assert.NotEmpty(t, err.Error())
@@ -417,7 +417,7 @@ func TestGetClusterID_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "cluster_agent.metadata.cluster_id", span.OperationName())
+	assert.Equal(t, "clusterId", span.OperationName())
 	err, ok := span.Tag("error").(error)
 	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
 	assert.NotEmpty(t, err.Error())
@@ -453,7 +453,7 @@ func TestGetNodeMetadata_SpanErrorWithTelemetryWrapper(t *testing.T) {
 	for _, s := range spans {
 		if s.OperationName() == "cluster_agent.api.request" {
 			parentSpan = s
-		} else if s.OperationName() == "cluster_agent.metadata.node_lookup" {
+		} else if s.OperationName() == "nodeLookup" {
 			childSpan = s
 		}
 	}
@@ -494,7 +494,7 @@ func TestGetNodeInfo_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "cluster_agent.metadata.node_info", span.OperationName())
+	assert.Equal(t, "nodeInfo", span.OperationName())
 	assert.Equal(t, testNode, span.Tag("node_name"))
 	// Without a real apiserver, GetAPIClient fails, so the span should capture the error
 	spanErr, ok := span.Tag("error").(error)

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -224,7 +224,8 @@ func TestGetNodeMetadata_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "nodeLookup", span.OperationName())
+	assert.Equal(t, "cluster_agent.metadata.node_lookup", span.OperationName())
+	assert.Equal(t, "nodeLookup", span.Tag("resource.name"))
 	assert.Equal(t, testNode, span.Tag("node_name"))
 	assert.Equal(t, "labels", span.Tag("metadata_type"))
 	assert.Nil(t, span.Tag("error"))
@@ -254,7 +255,8 @@ func TestGetNodeMetadata_SpanError(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "nodeLookup", span.OperationName())
+	assert.Equal(t, "cluster_agent.metadata.node_lookup", span.OperationName())
+	assert.Equal(t, "nodeLookup", span.Tag("resource.name"))
 	assert.Equal(t, "missing_node", span.Tag("node_name"))
 	// Error should be set on the span
 	err, ok := span.Tag("error").(error)
@@ -294,7 +296,8 @@ func TestGetNamespaceMetadata_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "namespaceLookup", span.OperationName())
+	assert.Equal(t, "cluster_agent.metadata.namespace_lookup", span.OperationName())
+	assert.Equal(t, "namespaceLookup", span.Tag("resource.name"))
 	assert.Equal(t, "default", span.Tag("namespace"))
 	assert.Nil(t, span.Tag("error"))
 }
@@ -323,7 +326,8 @@ func TestGetNamespaceMetadata_SpanError(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "namespaceLookup", span.OperationName())
+	assert.Equal(t, "cluster_agent.metadata.namespace_lookup", span.OperationName())
+	assert.Equal(t, "namespaceLookup", span.Tag("resource.name"))
 	assert.Equal(t, "missing_ns", span.Tag("namespace"))
 	err, ok := span.Tag("error").(error)
 	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
@@ -347,7 +351,8 @@ func TestGetPodMetadata_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "podLookup", span.OperationName())
+	assert.Equal(t, "cluster_agent.metadata.pod_lookup", span.OperationName())
+	assert.Equal(t, "podLookup", span.Tag("resource.name"))
 	assert.Equal(t, "node1", span.Tag("node_name"))
 	assert.Equal(t, "default", span.Tag("namespace"))
 	// pod_name should NOT be set (cardinality)
@@ -368,7 +373,8 @@ func TestGetPodMetadataForNode_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "podMetadataForNode", span.OperationName())
+	assert.Equal(t, "cluster_agent.metadata.pod_metadata_for_node", span.OperationName())
+	assert.Equal(t, "podMetadataForNode", span.Tag("resource.name"))
 	assert.Equal(t, "node1", span.Tag("node_name"))
 	// Without a real apiserver, GetMetadataMapBundleOnNode fails, but this is a
 	// non-fatal path (the handler continues with partial results), so the span
@@ -394,7 +400,8 @@ func TestGetAllMetadata_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "allMetadata", span.OperationName())
+	assert.Equal(t, "cluster_agent.metadata.all_metadata", span.OperationName())
+	assert.Equal(t, "allMetadata", span.Tag("resource.name"))
 	err, ok := span.Tag("error").(error)
 	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
 	assert.NotEmpty(t, err.Error())
@@ -417,7 +424,8 @@ func TestGetClusterID_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "clusterId", span.OperationName())
+	assert.Equal(t, "cluster_agent.metadata.cluster_id", span.OperationName())
+	assert.Equal(t, "clusterID", span.Tag("resource.name"))
 	err, ok := span.Tag("error").(error)
 	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
 	assert.NotEmpty(t, err.Error())
@@ -453,7 +461,7 @@ func TestGetNodeMetadata_SpanErrorWithTelemetryWrapper(t *testing.T) {
 	for _, s := range spans {
 		if s.OperationName() == "cluster_agent.api.request" {
 			parentSpan = s
-		} else if s.OperationName() == "nodeLookup" {
+		} else if s.OperationName() == "cluster_agent.metadata.node_lookup" {
 			childSpan = s
 		}
 	}
@@ -494,7 +502,8 @@ func TestGetNodeInfo_SpanCreation(t *testing.T) {
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
-	assert.Equal(t, "nodeInfo", span.OperationName())
+	assert.Equal(t, "cluster_agent.metadata.node_info", span.OperationName())
+	assert.Equal(t, "nodeInfo", span.Tag("resource.name"))
 	assert.Equal(t, testNode, span.Tag("node_name"))
 	// Without a real apiserver, GetAPIClient fails, so the span should capture the error
 	spanErr, ok := span.Tag("error").(error)

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -227,7 +227,7 @@ func TestGetNodeMetadata_SpanCreation(t *testing.T) {
 	assert.Equal(t, "nodeLookup", span.Tag("resource.name"))
 	assert.Equal(t, testNode, span.Tag("node_name"))
 	assert.Equal(t, "labels", span.Tag("metadata_type"))
-	assert.Nil(t, span.Tag("error"))
+	assert.Nil(t, span.Tag("error.message"))
 }
 
 func TestGetNodeMetadata_SpanError(t *testing.T) {
@@ -258,9 +258,7 @@ func TestGetNodeMetadata_SpanError(t *testing.T) {
 	assert.Equal(t, "nodeLookup", span.Tag("resource.name"))
 	assert.Equal(t, "missing_node", span.Tag("node_name"))
 	// Error should be set on the span
-	err, ok := span.Tag("error").(error)
-	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
-	assert.NotEmpty(t, err.Error())
+	assert.NotNil(t, span.Tag("error.message"))
 }
 
 func TestGetNamespaceMetadata_SpanCreation(t *testing.T) {
@@ -298,7 +296,7 @@ func TestGetNamespaceMetadata_SpanCreation(t *testing.T) {
 	assert.Equal(t, "cluster_agent.metadata.namespace_lookup", span.OperationName())
 	assert.Equal(t, "namespaceLookup", span.Tag("resource.name"))
 	assert.Equal(t, "default", span.Tag("namespace"))
-	assert.Nil(t, span.Tag("error"))
+	assert.Nil(t, span.Tag("error.message"))
 }
 
 func TestGetNamespaceMetadata_SpanError(t *testing.T) {
@@ -328,9 +326,7 @@ func TestGetNamespaceMetadata_SpanError(t *testing.T) {
 	assert.Equal(t, "cluster_agent.metadata.namespace_lookup", span.OperationName())
 	assert.Equal(t, "namespaceLookup", span.Tag("resource.name"))
 	assert.Equal(t, "missing_ns", span.Tag("namespace"))
-	err, ok := span.Tag("error").(error)
-	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
-	assert.NotEmpty(t, err.Error())
+	assert.NotNil(t, span.Tag("error.message"))
 }
 
 func TestGetPodMetadata_SpanCreation(t *testing.T) {
@@ -378,7 +374,7 @@ func TestGetPodMetadataForNode_SpanCreation(t *testing.T) {
 	// Without a real apiserver, GetMetadataMapBundleOnNode fails, but this is a
 	// non-fatal path (the handler continues with partial results), so the span
 	// should not be marked as errored.
-	assert.Nil(t, span.Tag("error"), "span should not be marked as errored for partial failures")
+	assert.Nil(t, span.Tag("error.message"), "span should not be marked as errored for partial failures")
 }
 
 func TestGetAllMetadata_SpanCreation(t *testing.T) {
@@ -401,9 +397,7 @@ func TestGetAllMetadata_SpanCreation(t *testing.T) {
 	span := spans[0]
 	assert.Equal(t, "cluster_agent.metadata.all_metadata", span.OperationName())
 	assert.Equal(t, "allMetadata", span.Tag("resource.name"))
-	err, ok := span.Tag("error").(error)
-	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
-	assert.NotEmpty(t, err.Error())
+	assert.NotNil(t, span.Tag("error.message"))
 }
 
 func TestGetClusterID_SpanCreation(t *testing.T) {
@@ -425,9 +419,7 @@ func TestGetClusterID_SpanCreation(t *testing.T) {
 	span := spans[0]
 	assert.Equal(t, "cluster_agent.metadata.cluster_id", span.OperationName())
 	assert.Equal(t, "clusterID", span.Tag("resource.name"))
-	err, ok := span.Tag("error").(error)
-	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
-	assert.NotEmpty(t, err.Error())
+	assert.NotNil(t, span.Tag("error.message"))
 }
 
 func TestGetNodeMetadata_SpanErrorWithTelemetryWrapper(t *testing.T) {
@@ -456,7 +448,7 @@ func TestGetNodeMetadata_SpanErrorWithTelemetryWrapper(t *testing.T) {
 	require.Len(t, spans, 2, "expected parent (telemetry) span and child (node_lookup) span")
 
 	// Find the parent telemetry span
-	var parentSpan, childSpan mocktracer.Span
+	var parentSpan, childSpan *mocktracer.Span
 	for _, s := range spans {
 		if s.OperationName() == "cluster_agent.api.request" {
 			parentSpan = s
@@ -468,14 +460,10 @@ func TestGetNodeMetadata_SpanErrorWithTelemetryWrapper(t *testing.T) {
 	require.NotNil(t, childSpan, "child node_lookup span should exist")
 
 	// Child span should have the error from spanErr
-	childErr, ok := childSpan.Tag("error").(error)
-	require.True(t, ok, "child span error tag should be an error, got %T", childSpan.Tag("error"))
-	assert.NotEmpty(t, childErr.Error())
+	assert.NotNil(t, childSpan.Tag("error.message"), "child span should have error.message")
 
 	// Parent span should also have the error from SetSpanError
-	parentErr, ok := parentSpan.Tag("error").(error)
-	require.True(t, ok, "parent span error tag should be an error from SetSpanError, got %T", parentSpan.Tag("error"))
-	assert.NotEmpty(t, parentErr.Error())
+	assert.NotNil(t, parentSpan.Tag("error.message"), "parent span should have error.message from SetSpanError")
 }
 
 func TestGetNodeInfo_SpanCreation(t *testing.T) {
@@ -505,7 +493,5 @@ func TestGetNodeInfo_SpanCreation(t *testing.T) {
 	assert.Equal(t, "nodeInfo", span.Tag("resource.name"))
 	assert.Equal(t, testNode, span.Tag("node_name"))
 	// Without a real apiserver, GetAPIClient fails, so the span should capture the error
-	spanErr, ok := span.Tag("error").(error)
-	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
-	assert.NotEmpty(t, spanErr.Error())
+	assert.NotNil(t, span.Tag("error.message"))
 }

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -371,12 +371,9 @@ func TestGetPodMetadataForNode_SpanCreation(t *testing.T) {
 	assert.Equal(t, "cluster_agent.metadata.pod_metadata_for_node", span.OperationName())
 	assert.Equal(t, "node1", span.Tag("node_name"))
 	// Without a real apiserver, GetMetadataMapBundleOnNode fails, but this is a
-	// non-fatal warning path (the handler continues), so it should be recorded
-	// as a warning tag rather than marking the span as errored.
+	// non-fatal path (the handler continues with partial results), so the span
+	// should not be marked as errored.
 	assert.Nil(t, span.Tag("error"), "span should not be marked as errored for partial failures")
-	warning, ok := span.Tag("warning").(string)
-	require.True(t, ok, "warning tag should be a string, got %T", span.Tag("warning"))
-	assert.NotEmpty(t, warning)
 }
 
 func TestGetAllMetadata_SpanCreation(t *testing.T) {
@@ -392,7 +389,7 @@ func TestGetAllMetadata_SpanCreation(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	require.Contains(t, []int{http.StatusInternalServerError, http.StatusServiceUnavailable}, rec.Code)
+	require.GreaterOrEqual(t, rec.Code, 500, "expected a 5xx status code, got %d", rec.Code)
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -24,6 +24,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -369,6 +370,10 @@ func TestGetPodMetadataForNode_SpanCreation(t *testing.T) {
 	span := spans[0]
 	assert.Equal(t, "cluster_agent.metadata.pod_metadata_for_node", span.OperationName())
 	assert.Equal(t, "node1", span.Tag("node_name"))
+	// Without a real apiserver, GetMetadataMapBundleOnNode fails, so the span should capture the error
+	spanErr, ok := span.Tag("error").(error)
+	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
+	assert.NotEmpty(t, spanErr.Error())
 }
 
 func TestGetAllMetadata_SpanCreation(t *testing.T) {
@@ -418,6 +423,54 @@ func TestGetClusterID_SpanCreation(t *testing.T) {
 	assert.NotEmpty(t, err.Error())
 }
 
+func TestGetNodeMetadata_SpanErrorWithTelemetryWrapper(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+	// No data set — lookup will fail
+
+	// Wrap with WithTelemetryWrapper to exercise SetSpanError propagation to the parent span
+	handler := api.WithTelemetryWrapper("getNodeLabels", func(w http.ResponseWriter, r *http.Request) {
+		getNodeLabels(w, r, mockStore)
+	})
+
+	req := httptest.NewRequest("GET", "/tags/node/missing_node", nil)
+	req = mux.SetURLVars(req, map[string]string{"nodeName": "missing_node"})
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 2, "expected parent (telemetry) span and child (node_lookup) span")
+
+	// Find the parent telemetry span
+	var parentSpan, childSpan mocktracer.Span
+	for _, s := range spans {
+		if s.OperationName() == "cluster_agent.api.request" {
+			parentSpan = s
+		} else if s.OperationName() == "cluster_agent.metadata.node_lookup" {
+			childSpan = s
+		}
+	}
+	require.NotNil(t, parentSpan, "parent telemetry span should exist")
+	require.NotNil(t, childSpan, "child node_lookup span should exist")
+
+	// Child span should have the error from spanErr
+	childErr, ok := childSpan.Tag("error").(error)
+	require.True(t, ok, "child span error tag should be an error, got %T", childSpan.Tag("error"))
+	assert.NotEmpty(t, childErr.Error())
+
+	// Parent span should also have the error from SetSpanError
+	parentErr, ok := parentSpan.Tag("error").(error)
+	require.True(t, ok, "parent span error tag should be an error from SetSpanError, got %T", parentSpan.Tag("error"))
+	assert.NotEmpty(t, parentErr.Error())
+}
+
 func TestGetNodeInfo_SpanCreation(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
@@ -440,5 +493,11 @@ func TestGetNodeInfo_SpanCreation(t *testing.T) {
 
 	spans := mt.FinishedSpans()
 	require.Len(t, spans, 1)
-	assert.Equal(t, "cluster_agent.metadata.node_info", spans[0].OperationName())
+	span := spans[0]
+	assert.Equal(t, "cluster_agent.metadata.node_info", span.OperationName())
+	assert.Equal(t, testNode, span.Tag("node_name"))
+	// Without a real apiserver, GetAPIClient fails, so the span should capture the error
+	spanErr, ok := span.Tag("error").(error)
+	require.True(t, ok, "error tag should be an error object, got %T", span.Tag("error"))
+	assert.NotEmpty(t, spanErr.Error())
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -152,7 +152,7 @@ func (d *dispatcher) Stop() {
 func (d *dispatcher) Schedule(configs []integration.Config) {
 	var failedConfigs, excludedConfigs int
 	span := tracer.StartSpan("cluster_checks.dispatcher.schedule",
-		tracer.ResourceName("schedule_configs"),
+		tracer.ResourceName("scheduleConfigs"),
 		tracer.SpanType("worker"))
 	span.SetTag("config_count", len(configs))
 	checkNames := make([]string, 0, len(configs))
@@ -217,7 +217,7 @@ func (d *dispatcher) Schedule(configs []integration.Config) {
 func (d *dispatcher) Unschedule(configs []integration.Config) {
 	var failedConfigs int
 	span := tracer.StartSpan("cluster_checks.dispatcher.unschedule",
-		tracer.ResourceName("unschedule_configs"),
+		tracer.ResourceName("unscheduleConfigs"),
 		tracer.SpanType("worker"))
 	span.SetTag("config_count", len(configs))
 	defer func() {

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -175,7 +175,7 @@ func (d *dispatcher) moveCheck(src, dest, checkID string) error {
 
 func (d *dispatcher) rebalance(force bool) []types.RebalanceResponse {
 	span := tracer.StartSpan("cluster_checks.dispatcher.rebalance",
-		tracer.ResourceName("rebalance_checks"),
+		tracer.ResourceName("rebalanceChecks"),
 		tracer.SpanType("worker"))
 	span.SetTag("force", force)
 	defer span.Finish()

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -118,7 +118,7 @@ func (h *Handler) Run(ctx context.Context) {
 		// Leading, start warmup
 		log.Infof("Becoming leader, waiting %s for node-agents to report", h.warmupDuration)
 		span := tracer.StartSpan("cluster_checks.handler.leader_warmup",
-			tracer.ResourceName("warmup"),
+			tracer.ResourceName("leaderWarmup"),
 			tracer.SpanType("worker"))
 		finishWarmupSpan := func(interrupted string) {
 			if interrupted != "" {
@@ -165,7 +165,7 @@ func (h *Handler) Run(ctx context.Context) {
 			if newState != leader {
 				log.Info("Lost leadership, reverting to follower")
 				lostSpan := tracer.StartSpan("cluster_checks.handler.leadership_lost",
-					tracer.ResourceName("leadership_lost"),
+					tracer.ResourceName("leadershipLost"),
 					tracer.SpanType("worker"))
 				lostSpan.Finish()
 				dispatchCancel()


### PR DESCRIPTION
### What does this PR do?

Adds APM tracing child spans to the metadata endpoint handlers in `cmd/cluster-agent/api/v1/kubernetes_metadata.go`. Each span is a child of the existing `cluster_agent.api.request` parent span created by the telemetry wrapper.

Also modified existing cluster agent span names to match camel case convention.

**Spans added:**
- `cluster_agent.metadata.node_lookup` -- tags: `node_name`, `metadata_type`. Covers `getNodeMetadata()` (used by `getNodeLabels`, `getNodeUID`, `getNodeAnnotations`)
- `cluster_agent.metadata.node_info` -- tag: `node_name`. Covers `getNodeInfo()`
- `cluster_agent.metadata.namespace_lookup` -- tag: `namespace`. Covers `getNamespaceMetadataWithTransformerFunc()` (used by `getNamespaceLabels`, `getNamespaceMetadata`)
- `cluster_agent.metadata.pod_lookup` -- tags: `node_name`, `namespace` (no `pod_name` to avoid cardinality). Covers `getPodMetadata()`
- `cluster_agent.metadata.pod_metadata_for_node` -- tag: `node_name`. Covers `getPodMetadataForNode()`. Uses `partial_error` tag (not `error`) for non-fatal `GetMetadataMapBundleOnNode` failures since the handler continues with partial results.
- `cluster_agent.metadata.all_metadata` -- no extra tags. Covers `getAllMetadata()`
- `cluster_agent.metadata.cluster_id` -- no extra tags. Covers `getClusterID()`

All error paths propagate to both the child span (via `tracer.WithError`) and the parent telemetry span (via `api.SetSpanError`). All spans use `defer span.Finish(tracer.WithError(spanErr))` to prevent leaks.

### Motivation

Part of CONTP-1345 (PR 5 of 6). Metadata endpoint failures were previously only visible via HTTP status codes and logs -- no span-level error detail was available in APM Trace Explorer.

### Describe how you validated your changes

- 10 mocktracer-based tests covering span creation, tag values, and error propagation for all handler types
- All existing tests in the package continue to pass
- `go build -tags kubeapiserver` passes

### Additional Notes

Depends on PR 1 (#48579) and PR 2 (#48811). No binary size impact on the main agent -- all changes are behind the `kubeapiserver` build tag and `dd-trace-go` is already imported by the cluster agent.