### PR TITLE
[logs-agent] Add payload flush reason telemetry to batch strategy

### DIFF
--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -128,7 +128,7 @@ var (
 
 	// TlmPayloadFlushed is the total number of payloads flushed by the batch strategy.
 	// Tags: pipeline, flush_reason (max_count, max_bytes, timer, flush, shutdown)
-	TlmPayloadFlushed = telemetry.NewCounter("logs_sender", "payload_flushed",
+	TlmPayloadFlushed = telemetry.NewCounter("logs", "batch_payload_flushed",
 		[]string{"pipeline", "flush_reason"}, "Total number of payloads flushed, tagged by the reason the flush was triggered")
 
 	// TlmHTTPConnectivityCheck tracks HTTP connectivity check results

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -126,6 +126,11 @@ var (
 	TlmRotationSizeDifferences = telemetry.NewHistogram("logs", "rotation_size_differences",
 		nil, "Distribution of absolute file size differences observed between consecutive file rotation checks", []float64{256, 1024, 4096, 16384, 65536, 262144, 1048576, 10485760, 104857600})
 
+	// TlmPayloadFlushed is the total number of payloads flushed by the batch strategy.
+	// Tags: pipeline, flush_reason (max_count, max_bytes, timer, flush, shutdown)
+	TlmPayloadFlushed = telemetry.NewCounter("logs_sender", "payload_flushed",
+		[]string{"pipeline", "flush_reason"}, "Total number of payloads flushed, tagged by the reason the flush was triggered")
+
 	// TlmHTTPConnectivityCheck tracks HTTP connectivity check results
 	// Tags: status (success/failure)
 	TlmHTTPConnectivityCheck = telemetry.NewCounter("logs", "http_connectivity_check",

--- a/pkg/logs/sender/batch.go
+++ b/pkg/logs/sender/batch.go
@@ -93,7 +93,11 @@ func (b *batch) processMessage(m *message.Message, outputChan chan *message.Payl
 		return
 	}
 	if !added || b.buffer.IsFull() {
-		b.flushBuffer(outputChan)
+		reason := "max_bytes"
+		if b.buffer.IsCountFull() {
+			reason = "max_count"
+		}
+		b.flushBuffer(outputChan, reason)
 	}
 	if !added {
 		// it's possible that the m could not be added because the buffer was full
@@ -128,7 +132,7 @@ func (b *batch) addMessage(m *message.Message) (bool, error) {
 
 // flushBuffer sends all of the messages that are stored in the buffer and
 // forwards them to the the next stage of the pipeline
-func (b *batch) flushBuffer(outputChan chan *message.Payload) {
+func (b *batch) flushBuffer(outputChan chan *message.Payload, reason string) {
 	if b.buffer.IsEmpty() {
 		return
 	}
@@ -148,10 +152,10 @@ func (b *batch) flushBuffer(outputChan chan *message.Payload) {
 	if b.pipelineName == "dbm-samples" || b.pipelineName == "dbm-metrics" || b.pipelineName == "dbm-activity" {
 		log.Debugf("Flushing buffer and sending %d messages for pipeline %s", len(messagesMetadata), b.pipelineName)
 	}
-	b.sendMessages(messagesMetadata, outputChan)
+	b.sendMessages(messagesMetadata, outputChan, reason)
 }
 
-func (b *batch) sendMessages(messagesMetadata []*message.MessageMetadata, outputChan chan *message.Payload) {
+func (b *batch) sendMessages(messagesMetadata []*message.MessageMetadata, outputChan chan *message.Payload, reason string) {
 	defer b.resetBatch()
 
 	if err := b.compressor.Close(); err != nil {
@@ -162,6 +166,7 @@ func (b *batch) sendMessages(messagesMetadata []*message.MessageMetadata, output
 
 	unencodedSize := b.writeCounter.getWrittenBytes()
 	log.Debugf("Send messages for pipeline %s (msg_count:%d, content_size=%d, avg_msg_size=%.2f)", b.pipelineName, len(messagesMetadata), unencodedSize, float64(unencodedSize)/float64(len(messagesMetadata)))
+	metrics.TlmPayloadFlushed.Inc(b.pipelineName, reason)
 
 	if b.serverlessMeta.IsEnabled() {
 		// Increment the wait group so the flush doesn't finish until all payloads are sent to all destinations

--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -103,7 +103,7 @@ func (s *batchStrategy) Start() {
 	go func() {
 		flushTicker := s.clock.Ticker(s.batchWait)
 		defer func() {
-			s.flushAllBatches()
+			s.flushAllBatches("shutdown")
 			flushTicker.Stop()
 			close(s.stopChan)
 		}()
@@ -123,10 +123,10 @@ func (s *batchStrategy) Start() {
 				}
 			case <-flushTicker.C:
 				// flush the payloads at a regular interval so pending messages don't wait here for too long.
-				s.flushAllBatches()
+				s.flushAllBatches("timer")
 			case <-s.flushChan:
 				// flush payloads on demand, used for infrequently running serverless functions
-				s.flushAllBatches()
+				s.flushAllBatches("flush")
 			}
 		}
 	}()
@@ -142,8 +142,8 @@ func (s *batchStrategy) getBatch(key string) *batch {
 	return s.batches[key]
 }
 
-func (s *batchStrategy) flushAllBatches() {
+func (s *batchStrategy) flushAllBatches(reason string) {
 	for _, batch := range s.batches {
-		batch.flushBuffer(s.outputChan)
+		batch.flushBuffer(s.outputChan, reason)
 	}
 }

--- a/pkg/logs/sender/batch_test.go
+++ b/pkg/logs/sender/batch_test.go
@@ -101,7 +101,7 @@ func TestBatchFlushBuffer(t *testing.T) {
 	b.addMessage(msg)
 
 	// Flush the buffer
-	b.flushBuffer(output)
+	b.flushBuffer(output, "timer")
 
 	// Should receive payload
 	payload := <-output
@@ -119,7 +119,7 @@ func TestBatchFlushEmptyBuffer(t *testing.T) {
 	output := make(chan *message.Payload, 1)
 
 	// Flush empty buffer
-	b.flushBuffer(output)
+	b.flushBuffer(output, "timer")
 
 	// Should not receive anything
 	select {
@@ -206,7 +206,7 @@ func TestBatchSendMessages(t *testing.T) {
 	b.serializer.Serialize(msg, b.writeCounter)
 
 	// Send messages
-	b.sendMessages(metadata, output)
+	b.sendMessages(metadata, output, "timer")
 
 	// Should receive payload
 	payload := <-output

--- a/pkg/logs/sender/message_buffer.go
+++ b/pkg/logs/sender/message_buffer.go
@@ -51,7 +51,17 @@ func (p *MessageBuffer) GetMessages() []*message.MessageMetadata {
 
 // IsFull returns true if the buffer is full.
 func (p *MessageBuffer) IsFull() bool {
-	return len(p.messageBuffer) == cap(p.messageBuffer) || p.contentSize == p.contentSizeLimit
+	return p.IsCountFull() || p.IsBytesFull()
+}
+
+// IsCountFull returns true if the buffer is full due to the message count limit.
+func (p *MessageBuffer) IsCountFull() bool {
+	return len(p.messageBuffer) == cap(p.messageBuffer)
+}
+
+// IsBytesFull returns true if the buffer is full due to the content size limit.
+func (p *MessageBuffer) IsBytesFull() bool {
+	return p.contentSize == p.contentSizeLimit
 }
 
 // IsEmpty returns true if the buffer is empty.


### PR DESCRIPTION
## Summary

- Adds `logs.batch_payload_flushed` counter (tags: `pipeline`, `flush_reason`) to the logs agent batch strategy
- `flush_reason` is one of: `max_count`, `max_bytes`, `timer`, `flush`, `shutdown` — distinguishing whether payloads are filling up or being sent by the periodic timer
- Refactors `MessageBuffer.IsFull()` to delegate to new `IsCountFull()` / `IsBytesFull()` helpers used at the flush call site to determine the reason

## Motivation

Previously there was no way to know what was driving batch flushes in the logs pipeline. With `rate(logs_batch_payload_flushed_total[5m])` broken down by `flush_reason`, you can see whether agents are consistently filling batches (backpressure signal) or flushing mostly on the timer (pipeline is under-loaded).

## QA

Tested locally against a running agent with a file log source. Verified all three actively-triggerable flush reasons appear in the Prometheus telemetry endpoint (`http://localhost:5000/telemetry`):

| flush_reason | How triggered | Confirmed |
|---|---|---|
| `timer` | 2 lines written, waited >5s for batch tick | ✅ |
| `max_count` | batch_max_size=5, accumulated 5 messages | ✅ |
| `max_bytes` | batch_max_content_size=600, messages filled content limit | ✅ |
| `flush` | serverless on-demand path, code review only | — |
| `shutdown` | fires on agent stop before scrape, code review only | — |

## Test plan

- [x] Linters pass (`dda inv linter.go --targets=./pkg/logs/...`)
- [x] Existing unit tests pass with updated `flushBuffer`/`sendMessages` signatures
- [x] Manual end-to-end verification of metric emission via Prometheus endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)