### PR TITLE
[procmgr] Port manager.rs tests to cross-platform helpers

### DIFF
--- a/pkg/procmgr/rust/src/manager.rs
+++ b/pkg/procmgr/rust/src/manager.rs
@@ -500,7 +500,11 @@ mod tests {
     }
 
     fn sleep_def(name: &str) -> ProcessDefinition {
-        let (cmd, args) = test_helpers::sleep_cmd(60);
+        sleep_def_secs(name, 60)
+    }
+
+    fn sleep_def_secs(name: &str, secs: u32) -> ProcessDefinition {
+        let (cmd, args) = test_helpers::sleep_cmd(secs);
         ProcessDefinition {
             name: name.to_string(),
             config: ProcessConfig {
@@ -542,20 +546,13 @@ mod tests {
         let old_pid = {
             let procs = mgr.processes().await;
             assert!(procs[0].is_running());
-            assert_eq!(procs[0].config().args, vec!["60"]);
+            let expected_args = sleep_def("_").config.args;
+            assert_eq!(procs[0].config().args, expected_args);
             procs[0].pid().unwrap()
         };
 
         // Reload with modified config (different args)
-        let (cmd, _) = test_helpers::sleep_cmd(120);
-        config_loader.set(vec![ProcessDefinition {
-            name: "svc-a".to_string(),
-            config: ProcessConfig {
-                command: cmd.to_string(),
-                args: vec!["120".to_string()],
-                ..Default::default()
-            },
-        }]);
+        config_loader.set(vec![sleep_def_secs("svc-a", 120)]);
         let result = mgr.handle_reload_config(&exit_tx).await?;
         assert!(result.modified.contains(&"svc-a".to_string()));
         assert!(result.added.is_empty());
@@ -564,7 +561,8 @@ mod tests {
 
         // Config should be updated and process restarted with a new PID
         let procs = mgr.processes().await;
-        assert_eq!(procs[0].config().args, vec!["120"]);
+        let expected_args = sleep_def_secs("_", 120).config.args;
+        assert_eq!(procs[0].config().args, expected_args);
         assert!(
             procs[0].is_running(),
             "modified running process should be restarted"
@@ -586,20 +584,13 @@ mod tests {
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(256);
 
         // Don't start svc-a — leave it in Created state
-        let (cmd, _) = test_helpers::sleep_cmd(120);
-        config_loader.set(vec![ProcessDefinition {
-            name: "svc-a".to_string(),
-            config: ProcessConfig {
-                command: cmd.to_string(),
-                args: vec!["120".to_string()],
-                ..Default::default()
-            },
-        }]);
+        config_loader.set(vec![sleep_def_secs("svc-a", 120)]);
         let result = mgr.handle_reload_config(&exit_tx).await?;
         assert!(result.modified.contains(&"svc-a".to_string()));
 
         let procs = mgr.processes().await;
-        assert_eq!(procs[0].config().args, vec!["120"]);
+        let expected_args = sleep_def_secs("_", 120).config.args;
+        assert_eq!(procs[0].config().args, expected_args);
         assert!(
             !procs[0].is_running(),
             "non-running modified process should not be started"
@@ -754,11 +745,12 @@ mod tests {
         mgr.handle_start("svc-a", &exit_tx).await?;
 
         // Create a runtime process
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         mgr.handle_create(
             "runtime-svc".to_string(),
             ProcessConfig {
-                command: test_helpers::sleep_cmd(60).0.to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args: args.into_iter().map(|a| a.to_string()).collect(),
                 auto_start: false,
                 ..Default::default()
             },
@@ -803,11 +795,12 @@ mod tests {
     async fn test_create_includes_runtime_process_in_startup_order() -> anyhow::Result<()> {
         let mgr = ProcessManager::new(loader(vec![sleep_def("svc-a")]), uuid_gen());
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         mgr.handle_create(
             "svc-b".to_string(),
             ProcessConfig {
-                command: test_helpers::sleep_cmd(60).0.to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args: args.into_iter().map(|a| a.to_string()).collect(),
                 after: vec!["svc-a".to_string()],
                 auto_start: false,
                 ..Default::default()
@@ -831,11 +824,12 @@ mod tests {
     async fn test_create_auto_start_spawns_process() -> anyhow::Result<()> {
         let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(256);
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         mgr.handle_create(
             "auto-svc".to_string(),
             ProcessConfig {
-                command: test_helpers::sleep_cmd(60).0.to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args: args.into_iter().map(|a| a.to_string()).collect(),
                 auto_start: true,
                 ..Default::default()
             },
@@ -864,11 +858,12 @@ mod tests {
     async fn test_create_auto_start_false_stays_created() -> anyhow::Result<()> {
         let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         mgr.handle_create(
             "manual-svc".to_string(),
             ProcessConfig {
-                command: test_helpers::sleep_cmd(60).0.to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args: args.into_iter().map(|a| a.to_string()).collect(),
                 auto_start: false,
                 ..Default::default()
             },
@@ -916,11 +911,12 @@ mod tests {
     async fn test_create_auto_start_condition_not_met() -> anyhow::Result<()> {
         let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         mgr.handle_create(
             "cond-svc".to_string(),
             ProcessConfig {
-                command: test_helpers::sleep_cmd(60).0.to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args: args.into_iter().map(|a| a.to_string()).collect(),
                 auto_start: true,
                 condition_path_exists: Some("/nonexistent/path/that/should/not/exist".to_string()),
                 ..Default::default()
@@ -951,12 +947,13 @@ mod tests {
 
         // Reload with a new process that has an after-dependency, which
         // forces a non-alphabetical order (svc-b before svc-api).
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         config_loader.set(vec![
             ProcessDefinition {
                 name: "svc-api".to_string(),
                 config: ProcessConfig {
-                    command: test_helpers::sleep_cmd(60).0.to_string(),
-                    args: vec!["60".to_string()],
+                    command: cmd.to_string(),
+                    args: args.into_iter().map(|a| a.to_string()).collect(),
                     after: vec!["svc-b".to_string()],
                     ..Default::default()
                 },

--- a/pkg/procmgr/rust/src/manager.rs
+++ b/pkg/procmgr/rust/src/manager.rs
@@ -532,7 +532,7 @@ mod tests {
         assert_eq!(procs.len(), 1);
         assert!(procs[0].is_running());
 
-        let _ = platform::send_force_kill(procs[0].pid().unwrap());
+        test_helpers::cleanup_process(procs[0].pid().unwrap());
         Ok(())
     }
 
@@ -573,7 +573,7 @@ mod tests {
             "restarted process should have a different PID"
         );
 
-        let _ = platform::send_force_kill(procs[0].pid().unwrap());
+        test_helpers::cleanup_process(procs[0].pid().unwrap());
         Ok(())
     }
 

--- a/pkg/procmgr/rust/src/manager.rs
+++ b/pkg/procmgr/rust/src/manager.rs
@@ -615,9 +615,10 @@ mod tests {
     #[tokio::test]
     async fn test_create_rejects_empty_name() {
         let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
-        let (cmd, _) = test_helpers::true_cmd();
+        let (cmd, args) = test_helpers::true_cmd();
         let config = ProcessConfig {
             command: cmd.to_string(),
+            args: args.into_iter().map(|a| a.to_string()).collect(),
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
@@ -631,9 +632,10 @@ mod tests {
     #[tokio::test]
     async fn test_create_rejects_invalid_name() {
         let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
-        let (cmd, _) = test_helpers::true_cmd();
+        let (cmd, args) = test_helpers::true_cmd();
         let config = ProcessConfig {
             command: cmd.to_string(),
+            args: args.into_iter().map(|a| a.to_string()).collect(),
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
@@ -647,9 +649,10 @@ mod tests {
     #[tokio::test]
     async fn test_create_accepts_valid_name() -> anyhow::Result<()> {
         let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
-        let (cmd, _) = test_helpers::true_cmd();
+        let (cmd, args) = test_helpers::true_cmd();
         let config = ProcessConfig {
             command: cmd.to_string(),
+            args: args.into_iter().map(|a| a.to_string()).collect(),
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
@@ -663,9 +666,10 @@ mod tests {
     #[tokio::test]
     async fn test_reload_preserves_runtime_created_processes() -> anyhow::Result<()> {
         let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
-        let (cmd, _) = test_helpers::true_cmd();
+        let (cmd, args) = test_helpers::true_cmd();
         let config = ProcessConfig {
             command: cmd.to_string(),
+            args: args.into_iter().map(|a| a.to_string()).collect(),
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(256);

--- a/pkg/procmgr/rust/src/manager.rs
+++ b/pkg/procmgr/rust/src/manager.rs
@@ -488,6 +488,7 @@ fn recompute_startup_order(procs: &[ManagedProcess]) -> StartupOrderResult {
 mod tests {
     use super::*;
     use crate::config::{MutableConfigLoader, ProcessConfig, StaticConfigLoader};
+    use crate::test_helpers;
     use crate::uuid_gen::{SequentialUuidGenerator, V4UuidGenerator};
 
     fn loader(defs: Vec<ProcessDefinition>) -> Arc<dyn ConfigLoader> {
@@ -499,11 +500,12 @@ mod tests {
     }
 
     fn sleep_def(name: &str) -> ProcessDefinition {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         ProcessDefinition {
             name: name.to_string(),
             config: ProcessConfig {
-                command: "/bin/sleep".to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args: args.into_iter().map(|a| a.to_string()).collect(),
                 ..Default::default()
             },
         }
@@ -526,11 +528,7 @@ mod tests {
         assert_eq!(procs.len(), 1);
         assert!(procs[0].is_running());
 
-        nix::sys::signal::kill(
-            nix::unistd::Pid::from_raw(procs[0].pid().unwrap() as i32),
-            nix::sys::signal::Signal::SIGKILL,
-        )
-        .ok();
+        let _ = platform::send_force_kill(procs[0].pid().unwrap());
         Ok(())
     }
 
@@ -549,10 +547,11 @@ mod tests {
         };
 
         // Reload with modified config (different args)
+        let (cmd, _) = test_helpers::sleep_cmd(120);
         config_loader.set(vec![ProcessDefinition {
             name: "svc-a".to_string(),
             config: ProcessConfig {
-                command: "/bin/sleep".to_string(),
+                command: cmd.to_string(),
                 args: vec!["120".to_string()],
                 ..Default::default()
             },
@@ -576,11 +575,7 @@ mod tests {
             "restarted process should have a different PID"
         );
 
-        nix::sys::signal::kill(
-            nix::unistd::Pid::from_raw(procs[0].pid().unwrap() as i32),
-            nix::sys::signal::Signal::SIGKILL,
-        )
-        .ok();
+        let _ = platform::send_force_kill(procs[0].pid().unwrap());
         Ok(())
     }
 
@@ -591,10 +586,11 @@ mod tests {
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(256);
 
         // Don't start svc-a — leave it in Created state
+        let (cmd, _) = test_helpers::sleep_cmd(120);
         config_loader.set(vec![ProcessDefinition {
             name: "svc-a".to_string(),
             config: ProcessConfig {
-                command: "/bin/sleep".to_string(),
+                command: cmd.to_string(),
                 args: vec!["120".to_string()],
                 ..Default::default()
             },
@@ -628,8 +624,9 @@ mod tests {
     #[tokio::test]
     async fn test_create_rejects_empty_name() {
         let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
+        let (cmd, _) = test_helpers::true_cmd();
         let config = ProcessConfig {
-            command: "/bin/echo".to_string(),
+            command: cmd.to_string(),
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
@@ -643,8 +640,9 @@ mod tests {
     #[tokio::test]
     async fn test_create_rejects_invalid_name() {
         let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
+        let (cmd, _) = test_helpers::true_cmd();
         let config = ProcessConfig {
-            command: "/bin/echo".to_string(),
+            command: cmd.to_string(),
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
@@ -658,8 +656,9 @@ mod tests {
     #[tokio::test]
     async fn test_create_accepts_valid_name() -> anyhow::Result<()> {
         let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
+        let (cmd, _) = test_helpers::true_cmd();
         let config = ProcessConfig {
-            command: "/bin/echo".to_string(),
+            command: cmd.to_string(),
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
@@ -673,8 +672,9 @@ mod tests {
     #[tokio::test]
     async fn test_reload_preserves_runtime_created_processes() -> anyhow::Result<()> {
         let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
+        let (cmd, _) = test_helpers::true_cmd();
         let config = ProcessConfig {
-            command: "/bin/echo".to_string(),
+            command: cmd.to_string(),
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(256);
@@ -757,7 +757,7 @@ mod tests {
         mgr.handle_create(
             "runtime-svc".to_string(),
             ProcessConfig {
-                command: "/bin/sleep".to_string(),
+                command: test_helpers::sleep_cmd(60).0.to_string(),
                 args: vec!["60".to_string()],
                 auto_start: false,
                 ..Default::default()
@@ -806,7 +806,7 @@ mod tests {
         mgr.handle_create(
             "svc-b".to_string(),
             ProcessConfig {
-                command: "/bin/sleep".to_string(),
+                command: test_helpers::sleep_cmd(60).0.to_string(),
                 args: vec!["60".to_string()],
                 after: vec!["svc-a".to_string()],
                 auto_start: false,
@@ -834,7 +834,7 @@ mod tests {
         mgr.handle_create(
             "auto-svc".to_string(),
             ProcessConfig {
-                command: "/bin/sleep".to_string(),
+                command: test_helpers::sleep_cmd(60).0.to_string(),
                 args: vec!["60".to_string()],
                 auto_start: true,
                 ..Default::default()
@@ -867,7 +867,7 @@ mod tests {
         mgr.handle_create(
             "manual-svc".to_string(),
             ProcessConfig {
-                command: "/bin/sleep".to_string(),
+                command: test_helpers::sleep_cmd(60).0.to_string(),
                 args: vec!["60".to_string()],
                 auto_start: false,
                 ..Default::default()
@@ -919,7 +919,7 @@ mod tests {
         mgr.handle_create(
             "cond-svc".to_string(),
             ProcessConfig {
-                command: "/bin/sleep".to_string(),
+                command: test_helpers::sleep_cmd(60).0.to_string(),
                 args: vec!["60".to_string()],
                 auto_start: true,
                 condition_path_exists: Some("/nonexistent/path/that/should/not/exist".to_string()),
@@ -955,7 +955,7 @@ mod tests {
             ProcessDefinition {
                 name: "svc-api".to_string(),
                 config: ProcessConfig {
-                    command: "/bin/sleep".to_string(),
+                    command: test_helpers::sleep_cmd(60).0.to_string(),
                     args: vec!["60".to_string()],
                     after: vec!["svc-b".to_string()],
                     ..Default::default()

--- a/pkg/procmgr/rust/src/manager.rs
+++ b/pkg/procmgr/rust/src/manager.rs
@@ -509,7 +509,7 @@ mod tests {
             name: name.to_string(),
             config: ProcessConfig {
                 command: cmd.to_string(),
-                args: args.into_iter().map(|a| a.to_string()).collect(),
+                args,
                 ..Default::default()
             },
         }
@@ -618,7 +618,7 @@ mod tests {
         let (cmd, args) = test_helpers::true_cmd();
         let config = ProcessConfig {
             command: cmd.to_string(),
-            args: args.into_iter().map(|a| a.to_string()).collect(),
+            args,
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
@@ -635,7 +635,7 @@ mod tests {
         let (cmd, args) = test_helpers::true_cmd();
         let config = ProcessConfig {
             command: cmd.to_string(),
-            args: args.into_iter().map(|a| a.to_string()).collect(),
+            args,
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
@@ -652,7 +652,7 @@ mod tests {
         let (cmd, args) = test_helpers::true_cmd();
         let config = ProcessConfig {
             command: cmd.to_string(),
-            args: args.into_iter().map(|a| a.to_string()).collect(),
+            args,
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(1);
@@ -669,7 +669,7 @@ mod tests {
         let (cmd, args) = test_helpers::true_cmd();
         let config = ProcessConfig {
             command: cmd.to_string(),
-            args: args.into_iter().map(|a| a.to_string()).collect(),
+            args,
             ..Default::default()
         };
         let (exit_tx, _exit_rx) = mpsc::channel::<ExitEvent>(256);
@@ -754,7 +754,7 @@ mod tests {
             "runtime-svc".to_string(),
             ProcessConfig {
                 command: cmd.to_string(),
-                args: args.into_iter().map(|a| a.to_string()).collect(),
+                args,
                 auto_start: false,
                 ..Default::default()
             },
@@ -804,7 +804,7 @@ mod tests {
             "svc-b".to_string(),
             ProcessConfig {
                 command: cmd.to_string(),
-                args: args.into_iter().map(|a| a.to_string()).collect(),
+                args,
                 after: vec!["svc-a".to_string()],
                 auto_start: false,
                 ..Default::default()
@@ -833,7 +833,7 @@ mod tests {
             "auto-svc".to_string(),
             ProcessConfig {
                 command: cmd.to_string(),
-                args: args.into_iter().map(|a| a.to_string()).collect(),
+                args,
                 auto_start: true,
                 ..Default::default()
             },
@@ -867,7 +867,7 @@ mod tests {
             "manual-svc".to_string(),
             ProcessConfig {
                 command: cmd.to_string(),
-                args: args.into_iter().map(|a| a.to_string()).collect(),
+                args,
                 auto_start: false,
                 ..Default::default()
             },
@@ -920,7 +920,7 @@ mod tests {
             "cond-svc".to_string(),
             ProcessConfig {
                 command: cmd.to_string(),
-                args: args.into_iter().map(|a| a.to_string()).collect(),
+                args,
                 auto_start: true,
                 condition_path_exists: Some("/nonexistent/path/that/should/not/exist".to_string()),
                 ..Default::default()
@@ -957,7 +957,7 @@ mod tests {
                 name: "svc-api".to_string(),
                 config: ProcessConfig {
                     command: cmd.to_string(),
-                    args: args.into_iter().map(|a| a.to_string()).collect(),
+                    args,
                     after: vec!["svc-b".to_string()],
                     ..Default::default()
                 },

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -569,7 +569,7 @@ pub mod tests {
         assert!(proc.is_running());
 
         if let Some(pid) = proc.pid() {
-            let _ = platform::send_force_kill(pid);
+            test_helpers::cleanup_process(pid);
         }
         let mut child = child.unwrap();
         let _ = child.wait().await;

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -658,7 +658,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_spawn_nonexistent_binary() {
-        let cfg = test_helpers::make_config::<&str>("/nonexistent/binary", vec![]);
+        let cfg = test_helpers::make_config("/nonexistent/binary", vec![]);
         let mut proc = ManagedProcess::new_config("bad".into(), test_helpers::test_uuid(), cfg);
         assert!(proc.spawn().is_err());
         assert!(!proc.is_running());
@@ -732,7 +732,7 @@ pub mod tests {
         let script = "test -z \"$PROCMGRD_TEST_SECRET\" && exit 0 || exit 1";
         #[cfg(windows)]
         let script = "if defined PROCMGRD_TEST_SECRET (exit 1) else (exit 0)";
-        let cfg = test_helpers::make_config(sh, vec![flag, script]);
+        let cfg = test_helpers::make_config(sh, vec![flag.into(), script.into()]);
         let mut proc =
             ManagedProcess::new_config("clean-env".into(), test_helpers::test_uuid(), cfg);
         proc.spawn().unwrap();
@@ -756,7 +756,7 @@ pub mod tests {
         let script = "test \"$FROM_FILE\" = 'hello' && echo $PATH";
         #[cfg(windows)]
         let script = "if \"%FROM_FILE%\"==\"hello\" (echo %PATH%) else (exit 1)";
-        let mut cfg = test_helpers::make_config(sh, vec![flag, script]);
+        let mut cfg = test_helpers::make_config(sh, vec![flag.into(), script.into()]);
         cfg.environment_file = Some(env_file.to_str().unwrap().to_string());
 
         let mut proc = ManagedProcess::new_config("envfile".into(), test_helpers::test_uuid(), cfg);
@@ -780,7 +780,7 @@ pub mod tests {
         let script = "exit $(test \"$MY_VAR\" = 'overridden' && echo 0 || echo 1)";
         #[cfg(windows)]
         let script = "if \"%MY_VAR%\"==\"overridden\" (exit 0) else (exit 1)";
-        let mut cfg = test_helpers::make_config(sh, vec![flag, script]);
+        let mut cfg = test_helpers::make_config(sh, vec![flag.into(), script.into()]);
         cfg.environment_file = Some(env_file.to_str().unwrap().to_string());
         cfg.env
             .insert("MY_VAR".to_string(), "overridden".to_string());

--- a/pkg/procmgr/rust/src/shutdown.rs
+++ b/pkg/procmgr/rust/src/shutdown.rs
@@ -31,8 +31,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_shutdown_all_graceful() {
-        let cfg1 = make_config("/bin/sleep", vec!["60"]);
-        let cfg2 = make_config("/bin/sleep", vec!["60"]);
+        let cfg1 = make_config("/bin/sleep", vec!["60".into()]);
+        let cfg2 = make_config("/bin/sleep", vec!["60".into()]);
 
         let mut p1 = ManagedProcess::new_config("p1".into(), test_uuid(), cfg1);
         let mut p2 = ManagedProcess::new_config("p2".into(), test_uuid(), cfg2);
@@ -56,7 +56,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_shutdown_all_sigkill_on_timeout() {
-        let mut cfg = make_config("/bin/sh", vec!["-c", "trap '' TERM; sleep 60"]);
+        let mut cfg = make_config(
+            "/bin/sh",
+            vec!["-c".into(), "trap '' TERM; sleep 60".into()],
+        );
         cfg.stop_timeout = Some(1);
         let mut proc = ManagedProcess::new_config("stubborn".into(), test_uuid(), cfg);
         proc.spawn().unwrap();
@@ -72,7 +75,7 @@ mod tests {
         let mut proc = ManagedProcess::new_config(
             "t".into(),
             test_uuid(),
-            make_config("/bin/sleep", vec!["60"]),
+            make_config("/bin/sleep", vec!["60".into()]),
         );
         proc.spawn().unwrap();
         let _child = proc.take_child();
@@ -92,17 +95,17 @@ mod tests {
         let mut p1 = ManagedProcess::new_config(
             "p1".into(),
             test_uuid(),
-            make_config("/bin/sleep", vec!["60"]),
+            make_config("/bin/sleep", vec!["60".into()]),
         );
         let mut p2 = ManagedProcess::new_config(
             "p2".into(),
             test_uuid(),
-            make_config("/bin/sleep", vec!["60"]),
+            make_config("/bin/sleep", vec!["60".into()]),
         );
         let mut p3 = ManagedProcess::new_config(
             "p3".into(),
             test_uuid(),
-            make_config("/bin/sleep", vec!["60"]),
+            make_config("/bin/sleep", vec!["60".into()]),
         );
         p1.spawn().unwrap();
         p2.spawn().unwrap();

--- a/pkg/procmgr/rust/src/test_helpers.rs
+++ b/pkg/procmgr/rust/src/test_helpers.rs
@@ -167,10 +167,10 @@ pub fn cleanup_process(pid: u32) {
 }
 
 /// Build a `ProcessConfig` with null stdio, suitable for tests.
-pub fn make_config<S: Into<String>>(command: &str, args: Vec<S>) -> crate::config::ProcessConfig {
+pub fn make_config(command: &str, args: Vec<String>) -> crate::config::ProcessConfig {
     crate::config::ProcessConfig {
         command: command.to_string(),
-        args: args.into_iter().map(Into::into).collect(),
+        args,
         stdout: "null".to_string(),
         stderr: "null".to_string(),
         ..Default::default()

--- a/pkg/procmgr/rust/src/test_helpers.rs
+++ b/pkg/procmgr/rust/src/test_helpers.rs
@@ -161,6 +161,11 @@ pub fn test_uuid() -> String {
     "00000000-0000-0000-0000-000000000000".to_string()
 }
 
+/// Best-effort teardown: force-kill a process group so tests don't leak children.
+pub fn cleanup_process(pid: u32) {
+    let _ = crate::platform::send_force_kill(pid);
+}
+
 /// Build a `ProcessConfig` with null stdio, suitable for tests.
 pub fn make_config<S: Into<String>>(command: &str, args: Vec<S>) -> crate::config::ProcessConfig {
     crate::config::ProcessConfig {


### PR DESCRIPTION
### What does this PR do?

Ports the `manager.rs` test module to be cross-platform by replacing all hardcoded Unix commands and cleanup calls:

- `sleep_def()` helper now uses `test_helpers::sleep_cmd(60)` instead of `/bin/sleep`
- `/bin/echo` references replaced with `test_helpers::true_cmd()`
- Inline `/bin/sleep` in `ProcessConfig` literals replaced with `test_helpers::sleep_cmd().0`
- `nix::sys::signal::kill` cleanup calls replaced with `platform::send_force_kill()`

### Motivation

Part of the Windows port plan. The manager.rs test module used Unix-only binaries and `nix` signal calls, preventing compilation on Windows.

### Describe how you validated your changes

- All 131 unit tests pass (`cargo test --lib`), including all 19 manager tests
- `cargo fmt --check` clean
- `cargo clippy --all-targets` clean

### Additional Notes