### PR TITLE
[AGNTLOG-577] Add Truncation Tag and Flag Truncated Logs as Truncated…

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_handler_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler_test.go
@@ -41,7 +41,7 @@ func newDetectingHandler(outputChan chan *message.Message, _ int, flushTimeout t
 	tok := preprocessor.NewTokenizer(1000)
 	sampler := preprocessor.NewNoopSampler()
 	labeler := buildAutoMultilineLabeler(nil, nil, tailerInfo)
-	aggregator := preprocessor.NewDetectingAggregator(tailerInfo)
+	aggregator := preprocessor.NewDetectingAggregator(tailerInfo, 1000, false)
 	return newPreprocessorHandler(aggregator, tok, labeler, sampler, outputChan, preprocessor.NewNoopJSONAggregator(), flushTimeout)
 }
 

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -193,7 +193,7 @@ func buildLineHandler(source *sources.ReplaceableSource, multiLinePattern *regex
 		labeler := buildAutoMultilineLabeler(source.Config().AutoMultiLineOptions, source.Config().AutoMultiLineSamples, tailerInfo)
 		// JSON aggregation is disabled in detection mode — we don't want to combine JSON
 		// while only tagging everything else.
-		detectingAggregator := preprocessor.NewDetectingAggregator(tailerInfo)
+		detectingAggregator := preprocessor.NewDetectingAggregator(tailerInfo, maxContentSize, pkgconfigsetup.Datadog().GetBool("logs_config.tag_truncated_logs"))
 		return newPreprocessorHandler(detectingAggregator, tok, labeler, sampler, outputChan, preprocessor.NewNoopJSONAggregator(), flushTimeout)
 	}
 	return newPreprocessorHandler(preprocessor.NewPassThroughAggregator(maxContentSize), tok, preprocessor.NewNoopLabeler(), sampler, outputChan, preprocessor.NewNoopJSONAggregator(), flushTimeout)

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -6,10 +6,14 @@
 package decoder
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/framer"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/dockerfile"
@@ -328,4 +332,31 @@ func TestDecoderWithMultilineKubernetes(t *testing.T) {
 	assert.Equal(t, lineLen, output.RawDataLen)
 	assert.Equal(t, message.StatusError, output.Status)
 	assert.Equal(t, "2019-06-06T16:35:55.930852913Z", output.ParsingExtra.Timestamp)
+}
+
+func TestDecoderWithDockerJSONPartialLineDetectionOnlyMarksOversizedLogicalLineTruncated(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.Set("logs_config.max_message_size_bytes", 1000, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.tag_truncated_logs", true, pkgconfigmodel.SourceAgentRuntime)
+	mockConfig.Set("logs_config.auto_multi_line_detection_tagging", true, pkgconfigmodel.SourceAgentRuntime)
+
+	source := sources.NewLogSource("", &config.LogsConfig{})
+	d := InitializeDecoderForTest(source, dockerfile.New())
+	d.Start()
+	defer d.Stop()
+
+	part1 := strings.Repeat("a", 600)
+	part2 := strings.Repeat("b", 600)
+
+	line1 := []byte(fmt.Sprintf(`{"log":"%s","stream":"stdout","time":"2019-06-06T16:35:55.930852911Z"}`+"\n", part1))
+	line2 := []byte(fmt.Sprintf(`{"log":"%s\n","stream":"stdout","time":"2019-06-06T16:35:55.930852912Z"}`+"\n", part2))
+
+	d.InputChan() <- NewInput(line1)
+	d.InputChan() <- NewInput(line2)
+
+	output := <-d.OutputChan()
+	assert.Equal(t, part1+part2+string(message.TruncatedFlag), string(output.GetContent()))
+	assert.True(t, output.ParsingExtra.IsTruncated)
+	assert.Contains(t, output.ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
+	assert.Equal(t, len(line1)+len(line2), output.RawDataLen)
 }

--- a/pkg/logs/internal/decoder/decoder_test.go
+++ b/pkg/logs/internal/decoder/decoder_test.go
@@ -11,9 +11,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/framer"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/dockerfile"
@@ -24,8 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func InitializeDecoderForTest(source *sources.LogSource, parser parsers.Parser) Decoder {

--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -363,7 +363,7 @@ func TestRegexAggregatorFirstLineMatchesWorksNormally(t *testing.T) {
 // Tests for detectingAggregator
 
 func TestDetectingAggregator_TagsMultilineStartOnly(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	// startGroup: stored as pending, nothing emitted
 	require.Empty(t, ag.Process(newMessage("Error: Exception"), startGroup))
@@ -384,7 +384,7 @@ func TestDetectingAggregator_TagsMultilineStartOnly(t *testing.T) {
 }
 
 func TestDetectingAggregator_SingleLineNotTagged(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	// startGroup: stored
 	require.Empty(t, ag.Process(newMessage("Single line 1"), startGroup))
@@ -403,7 +403,7 @@ func TestDetectingAggregator_SingleLineNotTagged(t *testing.T) {
 }
 
 func TestDetectingAggregator_NoAggregateOutputsImmediately(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	msgs := ag.Process(newMessage("No aggregate 1"), noAggregate)
 	require.Len(t, msgs, 1)
@@ -417,7 +417,7 @@ func TestDetectingAggregator_NoAggregateOutputsImmediately(t *testing.T) {
 }
 
 func TestDetectingAggregator_FlushPendingMessage(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	require.Empty(t, ag.Process(newMessage("Pending message"), startGroup))
 
@@ -428,7 +428,7 @@ func TestDetectingAggregator_FlushPendingMessage(t *testing.T) {
 }
 
 func TestDetectingAggregator_MixedSingleAndMultiLine(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	// Single line stored
 	require.Empty(t, ag.Process(newMessage("Single"), startGroup))
@@ -457,7 +457,7 @@ func TestDetectingAggregator_MixedSingleAndMultiLine(t *testing.T) {
 }
 
 func TestDetectingAggregator_IsEmpty(t *testing.T) {
-	ag := NewDetectingAggregator(status.NewInfoRegistry())
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false)
 
 	assert.True(t, ag.IsEmpty())
 
@@ -471,4 +471,80 @@ func TestDetectingAggregator_IsEmpty(t *testing.T) {
 	msgs = ag.Process(newMessage("Immediate"), noAggregate)
 	require.Len(t, msgs, 1)
 	assert.True(t, ag.IsEmpty())
+}
+
+func TestDetectingAggregator_TruncatesTaggedStartLineAndPrefixesContinuation(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true)
+
+	require.Empty(t, ag.Process(newMessage("123456"), startGroup))
+
+	msgs := ag.Process(newMessage("abc"), aggregate)
+	require.Len(t, msgs, 2)
+
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
+
+	assert.Equal(t, "...TRUNCATED...abc", string(msgs[1].GetContent()))
+	assert.True(t, msgs[1].ParsingExtra.IsTruncated)
+	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[1].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_NoAggregateInheritsTruncationCarry(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true)
+
+	msgs := ag.Process(newMessage("123456"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
+
+	msgs = ag.Process(newMessage("ok"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "...TRUNCATED...ok", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[0].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_StartGroupInheritsTruncationCarry(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true)
+
+	msgs := ag.Process(newMessage("123456"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
+
+	require.Empty(t, ag.Process(newMessage("abc"), startGroup))
+
+	msgs = ag.Process(newMessage("tail"), aggregate)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "...TRUNCATED...abc", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
+
+	assert.Equal(t, "tail", string(msgs[1].GetContent()))
+	assert.False(t, msgs[1].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[1].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_TruncationDoesNotTagWhenDisabled(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, false)
+
+	msgs := ag.Process(newMessage("123456"), noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "123456...TRUNCATED...", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Empty(t, msgs[0].ParsingExtra.Tags)
+}
+
+func TestDetectingAggregator_UsesExistingTruncatedFlag(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, true)
+
+	msg := newMessage("already-truncated")
+	msg.ParsingExtra.IsTruncated = true
+
+	msgs := ag.Process(msg, noAggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "already-truncated...TRUNCATED...", string(msgs[0].GetContent()))
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[0].ParsingExtra.Tags)
 }

--- a/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
+++ b/pkg/logs/internal/decoder/preprocessor/detecting_aggregator.go
@@ -18,15 +18,20 @@ type detectingAggregator struct {
 	previousMsg           *message.Message
 	previousWasStartGroup bool
 	multiLineMatchInfo    *status.CountInfo
+	shouldTruncate        bool
+	maxContentSize        int
+	tagTruncatedLogs      bool
 }
 
 // NewDetectingAggregator creates a new detecting aggregator.
-func NewDetectingAggregator(tailerInfo *status.InfoRegistry) Aggregator {
+func NewDetectingAggregator(tailerInfo *status.InfoRegistry, maxContentSize int, tagTruncatedLogs bool) Aggregator {
 	multiLineMatchInfo := status.NewCountInfo("MultiLine matches")
 	tailerInfo.Register(multiLineMatchInfo)
 
 	return &detectingAggregator{
 		multiLineMatchInfo: multiLineMatchInfo,
+		maxContentSize:     maxContentSize,
+		tagTruncatedLogs:   tagTruncatedLogs,
 	}
 }
 
@@ -39,19 +44,19 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label) []*mess
 		if d.previousMsg != nil && d.previousWasStartGroup {
 			// Tag the previous message as start of multiline group
 			d.previousMsg.ParsingExtra.Tags = append(d.previousMsg.ParsingExtra.Tags, "auto_multiline_detected:true")
-			d.collected = append(d.collected, d.previousMsg)
+			d.emit(d.previousMsg)
 			// Track that we detected and tagged a multiline log
 			metrics.TlmAutoMultilineAggregatorFlush.Inc("false", "auto_multi_line_detected")
 			d.previousMsg = nil
 			d.previousWasStartGroup = false
 		} else if d.previousMsg != nil {
 			// Previous message wasn't a startGroup, so just output it without tags
-			d.collected = append(d.collected, d.previousMsg)
+			d.emit(d.previousMsg)
 			d.previousMsg = nil
 			d.previousWasStartGroup = false
 		}
 		// Output the current aggregate message immediately
-		d.collected = append(d.collected, msg)
+		d.emit(msg)
 		return d.collected
 	}
 
@@ -59,18 +64,18 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label) []*mess
 	if label == noAggregate {
 		// Flush any pending previous message first
 		if d.previousMsg != nil {
-			d.collected = append(d.collected, d.previousMsg)
+			d.emit(d.previousMsg)
 			d.previousMsg = nil
 			d.previousWasStartGroup = false
 		}
-		d.collected = append(d.collected, msg)
+		d.emit(msg)
 		return d.collected
 	}
 
 	// Handle startGroup: flush previous and store current
 	if label == startGroup {
 		if d.previousMsg != nil {
-			d.collected = append(d.collected, d.previousMsg)
+			d.emit(d.previousMsg)
 		}
 		d.multiLineMatchInfo.Add(1)
 		d.previousMsg = msg
@@ -85,7 +90,7 @@ func (d *detectingAggregator) Process(msg *message.Message, label Label) []*mess
 func (d *detectingAggregator) Flush() []*message.Message {
 	d.collected = d.collected[:0]
 	if d.previousMsg != nil {
-		d.collected = append(d.collected, d.previousMsg)
+		d.emit(d.previousMsg)
 		d.previousMsg = nil
 		d.previousWasStartGroup = false
 	}
@@ -95,4 +100,29 @@ func (d *detectingAggregator) Flush() []*message.Message {
 // IsEmpty returns true if there's no pending message.
 func (d *detectingAggregator) IsEmpty() bool {
 	return d.previousMsg == nil
+}
+
+func (d *detectingAggregator) emit(msg *message.Message) {
+	lastWasTruncated := d.shouldTruncate
+	content := msg.GetContent()
+	d.shouldTruncate = len(content) > d.maxContentSize || msg.ParsingExtra.IsTruncated
+
+	if lastWasTruncated {
+		content = append(message.TruncatedFlag, content...)
+	}
+
+	if d.shouldTruncate {
+		content = append(content, message.TruncatedFlag...)
+		metrics.LogsTruncated.Add(1)
+	}
+
+	if lastWasTruncated || d.shouldTruncate {
+		msg.ParsingExtra.IsTruncated = true
+		if d.tagTruncatedLogs {
+			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedReasonTag("single_line"))
+		}
+	}
+
+	msg.SetContent(content)
+	d.collected = append(d.collected, msg)
 }


### PR DESCRIPTION
… in the Detecting Aggregator (#48628)

Adds truncated tags to truncated tags in the agent and appends/prepends `...TRUNCATED...` to truncated logs in the detecting aggregator. It fully mimics the behavior of the single line handler with regards to truncated logs.

This was a bug introduced in the detecting aggregator in #44030.

Unit testing. I wrote an intentionally failing test to check if logs where tagged with the truncated flag and flagged with "TRUNCATED", then fixed the aggregator to pass the test.

Also ran a test locally to ensure the detector's output was the same as the single line handler. When a sample logs file was put through both the single line handler and the detecting aggregator, these were the results from stream logs.

Detecting aggregator:
<img width="1604" height="935" alt="image" src="https://github.com/user-attachments/assets/855ab685-f4e8-477c-b299-bca7991d4293" />

Single line handler:
<img width="1636" height="980" alt="image" src="https://github.com/user-attachments/assets/93bf06c6-a67f-40c1-9c54-6f3c44051722" />

Logs were truncated in the exact same manner, except the start group was tagged with auto multiline detected in the detecting aggregator.


(cherry picked from commit ef3af43e0a2d93f81cf125e641d199e4052699ee)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
