### PR TITLE
[CONTP-1407] enhance(webhook): Add admission controller to readiness probe

### DIFF
--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	stdLog "log"
+	"net"
 	"net/http"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 	admicommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -123,8 +125,9 @@ func (s *Server) Run(mainCtx context.Context) error {
 	}
 
 	logWriter, _ := pkglogsetup.NewTLSHandshakeErrorWriter(4, log.WarnLvl)
+	addr := fmt.Sprintf(":%d", pkgconfigsetup.Datadog().GetInt("admission_controller.port"))
 	server := &http.Server{
-		Addr:     fmt.Sprintf(":%d", pkgconfigsetup.Datadog().GetInt("admission_controller.port")),
+		Addr:     addr,
 		Handler:  s.mux,
 		ErrorLog: stdLog.New(logWriter, "Error from the admission controller http API server: ", 0),
 		TLSConfig: &tls.Config{
@@ -140,15 +143,33 @@ func (s *Server) Run(mainCtx context.Context) error {
 			MinVersion: tlsMinVersion,
 		},
 	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("could not listen on %s: %w", addr, err)
+	}
+
+	tlsListener := tls.NewListener(listener, server.TLSConfig)
+
+	healthHandle := health.RegisterReadiness("admission-controller-webhook")
+	defer healthHandle.Deregister() //nolint:errcheck
+
 	go func() error {
-		return log.Error(server.ListenAndServeTLS("", ""))
+		return log.Error(server.Serve(tlsListener))
 	}() //nolint:errcheck
 
-	<-mainCtx.Done()
+	log.Infof("Admission controller webhook server started on %s", addr)
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	return server.Shutdown(shutdownCtx)
+	for {
+		select {
+		case <-mainCtx.Done():
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			return server.Shutdown(shutdownCtx)
+		case <-healthHandle.C:
+			// Drain the health check channel to stay healthy
+		}
+	}
 }
 
 // handle contains the main logic responsible for handling admission requests.

--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	stdLog "log"
@@ -79,6 +80,7 @@ type Server struct {
 	decoder       runtime.Decoder
 	mux           *http.ServeMux
 	secretsLister corelisters.SecretLister
+	healthHandle  *health.Handle
 }
 
 // NewServer creates an admission webhook server.
@@ -86,6 +88,7 @@ func NewServer(secretsLister corelisters.SecretLister) *Server {
 	s := &Server{
 		mux:           http.NewServeMux(),
 		secretsLister: secretsLister,
+		healthHandle:  health.RegisterReadiness("admission-controller-webhook"),
 	}
 
 	s.initDecoder()
@@ -151,12 +154,13 @@ func (s *Server) Run(mainCtx context.Context) error {
 
 	tlsListener := tls.NewListener(listener, server.TLSConfig)
 
-	healthHandle := health.RegisterReadiness("admission-controller-webhook")
-	defer healthHandle.Deregister() //nolint:errcheck
-
-	go func() error {
-		return log.Error(server.Serve(tlsListener))
-	}() //nolint:errcheck
+	servErrCh := make(chan error, 1)
+	go func() {
+		if err := server.Serve(tlsListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Errorf("Admission controller webhook server error: %v", err)
+			servErrCh <- err
+		}
+	}()
 
 	log.Infof("Admission controller webhook server started on %s", addr)
 
@@ -166,7 +170,9 @@ func (s *Server) Run(mainCtx context.Context) error {
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
 			return server.Shutdown(shutdownCtx)
-		case <-healthHandle.C:
+		case err := <-servErrCh:
+			return fmt.Errorf("admission controller webhook server stopped unexpectedly: %w", err)
+		case <-s.healthHandle.C:
 			// Drain the health check channel to stay healthy
 		}
 	}

--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -169,6 +169,7 @@ func (s *Server) Run(mainCtx context.Context) error {
 		case <-mainCtx.Done():
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
+			s.healthHandle.Deregister() //nolint:errcheck
 			return server.Shutdown(shutdownCtx)
 		case err := <-servErrCh:
 			return fmt.Errorf("admission controller webhook server stopped unexpectedly: %w", err)

--- a/cmd/cluster-agent/admission/server_test.go
+++ b/cmd/cluster-agent/admission/server_test.go
@@ -8,21 +8,14 @@
 package admission
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admiv1 "k8s.io/api/admission/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	corelisters "k8s.io/client-go/listers/core/v1"
 
 	admicommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
-	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
-	"github.com/DataDog/datadog-agent/pkg/status/health"
 )
 
 func TestIsProbe(t *testing.T) {
@@ -90,79 +83,4 @@ func TestProbeResponse_ProbeObject(t *testing.T) {
 	annotations, ok := patch[0]["value"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "true", annotations[admicommon.ProbeReceivedAnnotationKey])
-}
-
-// fakeSecretLister is a minimal SecretLister implementation for testing.
-type fakeSecretLister struct{}
-
-func (f *fakeSecretLister) List(_ labels.Selector) ([]*corev1.Secret, error) { return nil, nil }
-func (f *fakeSecretLister) Secrets(_ string) corelisters.SecretNamespaceLister {
-	return &fakeSecretNamespaceLister{}
-}
-
-type fakeSecretNamespaceLister struct{}
-
-func (f *fakeSecretNamespaceLister) List(_ labels.Selector) ([]*corev1.Secret, error) {
-	return nil, nil
-}
-func (f *fakeSecretNamespaceLister) Get(_ string) (*corev1.Secret, error) { return nil, nil }
-
-func TestRunRegistersReadinessCheck(t *testing.T) {
-	configmock.New(t)
-
-	server := NewServer(&fakeSecretLister{})
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// Verify that the admission controller webhook is NOT in the readiness status before Run.
-	readyBefore := health.GetReady()
-	for _, name := range readyBefore.Healthy {
-		assert.NotEqual(t, "admission-controller-webhook", name)
-	}
-	for _, name := range readyBefore.Unhealthy {
-		assert.NotEqual(t, "admission-controller-webhook", name)
-	}
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- server.Run(ctx)
-	}()
-
-	// Give the server time to start and register the health check.
-	time.Sleep(200 * time.Millisecond)
-
-	// Verify that the admission controller webhook IS registered in the readiness status.
-	readyAfter := health.GetReady()
-	found := false
-	for _, name := range readyAfter.Healthy {
-		if name == "admission-controller-webhook" {
-			found = true
-			break
-		}
-	}
-	for _, name := range readyAfter.Unhealthy {
-		if name == "admission-controller-webhook" {
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "admission-controller-webhook should be registered in readiness checks")
-
-	// Cancel and verify clean shutdown.
-	cancel()
-	select {
-	case err := <-errCh:
-		assert.NoError(t, err)
-	case <-time.After(5 * time.Second):
-		t.Fatal("server did not shut down in time")
-	}
-
-	// Verify deregistration after shutdown.
-	readyFinal := health.GetReady()
-	for _, name := range readyFinal.Healthy {
-		assert.NotEqual(t, "admission-controller-webhook", name)
-	}
-	for _, name := range readyFinal.Unhealthy {
-		assert.NotEqual(t, "admission-controller-webhook", name)
-	}
 }

--- a/cmd/cluster-agent/admission/server_test.go
+++ b/cmd/cluster-agent/admission/server_test.go
@@ -8,14 +8,21 @@
 package admission
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admiv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corelisters "k8s.io/client-go/listers/core/v1"
 
 	admicommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
 )
 
 func TestIsProbe(t *testing.T) {
@@ -83,4 +90,79 @@ func TestProbeResponse_ProbeObject(t *testing.T) {
 	annotations, ok := patch[0]["value"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "true", annotations[admicommon.ProbeReceivedAnnotationKey])
+}
+
+// fakeSecretLister is a minimal SecretLister implementation for testing.
+type fakeSecretLister struct{}
+
+func (f *fakeSecretLister) List(_ labels.Selector) ([]*corev1.Secret, error) { return nil, nil }
+func (f *fakeSecretLister) Secrets(_ string) corelisters.SecretNamespaceLister {
+	return &fakeSecretNamespaceLister{}
+}
+
+type fakeSecretNamespaceLister struct{}
+
+func (f *fakeSecretNamespaceLister) List(_ labels.Selector) ([]*corev1.Secret, error) {
+	return nil, nil
+}
+func (f *fakeSecretNamespaceLister) Get(_ string) (*corev1.Secret, error) { return nil, nil }
+
+func TestRunRegistersReadinessCheck(t *testing.T) {
+	configmock.New(t)
+
+	server := NewServer(&fakeSecretLister{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Verify that the admission controller webhook is NOT in the readiness status before Run.
+	readyBefore := health.GetReady()
+	for _, name := range readyBefore.Healthy {
+		assert.NotEqual(t, "admission-controller-webhook", name)
+	}
+	for _, name := range readyBefore.Unhealthy {
+		assert.NotEqual(t, "admission-controller-webhook", name)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Run(ctx)
+	}()
+
+	// Give the server time to start and register the health check.
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify that the admission controller webhook IS registered in the readiness status.
+	readyAfter := health.GetReady()
+	found := false
+	for _, name := range readyAfter.Healthy {
+		if name == "admission-controller-webhook" {
+			found = true
+			break
+		}
+	}
+	for _, name := range readyAfter.Unhealthy {
+		if name == "admission-controller-webhook" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "admission-controller-webhook should be registered in readiness checks")
+
+	// Cancel and verify clean shutdown.
+	cancel()
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not shut down in time")
+	}
+
+	// Verify deregistration after shutdown.
+	readyFinal := health.GetReady()
+	for _, name := range readyFinal.Healthy {
+		assert.NotEqual(t, "admission-controller-webhook", name)
+	}
+	for _, name := range readyFinal.Unhealthy {
+		assert.NotEqual(t, "admission-controller-webhook", name)
+	}
 }

--- a/releasenotes/notes/addmission-webhook-readiness-probe-ae27a43028f01b3d.yaml
+++ b/releasenotes/notes/addmission-webhook-readiness-probe-ae27a43028f01b3d.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The cluster agent readiness probe now includes the admission controller webhook server.
+    Newly started cluster agents will not be marked as ready until the webhook can serve requests,
+    preventing missed pod mutations during rollouts.


### PR DESCRIPTION
### What does this PR do?

Registers the admission controller webhook server as a readiness health check (`health.RegisterReadiness`) so the cluster agent pod is not marked `Ready` until the webhook is listening and serving. If the webhook fails to start, the pod stays not-ready.

### Motivation

[CONTP-1407](https://datadoghq.atlassian.net/browse/CONTP-1407)

During rollouts, new DCA replicas could be marked `Ready` before the webhook server started, causing missed mutations when `failurePolicy: Ignore`.

### Describe how you validated your changes

#### 1. Positive case — webhook starts normally

Deploy using the scenario with the port override commented out:

```yaml
platform:
  type: "minikube"
  name: "webhook-readiness"
  reset: false
helm:
  versions:
    agent:
      build:
        repository: "registry.datadoghq.com"
    cluster_agent:
      build:
        repository: "registry.datadoghq.com"
  config:
    datadog:
      clusterName: mathewe-webhook-dev
      operator:
        enabled: false
      csi:
        enabled: false
      kubelet:
        tlsVerify: false
    clusterAgent:
      enabled: true
      admissionController:
        enabled: true
        mutateUnlabelled: false
```

```bash
injector-dev apply -f workloads/webhook/scenario.yaml --build
kubectl get pods -l app=datadog-cluster-agent -w
```

The cluster-agent pod should reach `1/1 READY`.

#### 2. Negative case — webhook fails to start (port clash)

Override the env to force the webhook onto port `5005`, which is already bound by the cluster agent's cmd API server:

```yaml
    clusterAgent:
      env:
        - name: DD_ADMISSION_CONTROLLER_PORT
          value: "5005"
```

```bash
injector-dev apply -f workloads/webhook/scenario.yaml --build
kubectl get pods -l app=datadog-cluster-agent -w
```

The cluster-agent pod stays at `0/1 READY` indefinitely because the webhook listener fails with "address already in use" and the readiness health check is never satisfied.

<img width="734" height="301" alt="image" src="https://github.com/user-attachments/assets/2bbb01f9-3626-47a8-b634-521bde9f937a" />

[CONTP-1407]: https://datadoghq.atlassian.net/browse/CONTP-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ