### PR TITLE
[auto-jira][AGENTCFG-74] rework collector status provider to use check.GetMetadata directly

### DIFF
--- a/comp/collector/collector/collectorimpl/collector.go
+++ b/comp/collector/collector/collectorimpl/collector.go
@@ -118,7 +118,7 @@ func newProvides(deps dependencies) provides {
 
 	return provides{
 		Comp:             c,
-		StatusProvider:   status.NewInformationProvider(collectorStatus.NewProvider(c, deps.Config)),
+		StatusProvider:   status.NewInformationProvider(collectorStatus.NewProvider(c)),
 		MetadataProvider: agentCheckMetadata,
 		APIGetPyStatus:   api.NewAgentEndpointProvider(getPythonStatus, "/py/status", "GET"),
 	}

--- a/comp/collector/collector/collectorimpl/collector.go
+++ b/comp/collector/collector/collectorimpl/collector.go
@@ -118,7 +118,7 @@ func newProvides(deps dependencies) provides {
 
 	return provides{
 		Comp:             c,
-		StatusProvider:   status.NewInformationProvider(collectorStatus.Provider{}),
+		StatusProvider:   status.NewInformationProvider(collectorStatus.NewProvider(c, deps.Config)),
 		MetadataProvider: agentCheckMetadata,
 		APIGetPyStatus:   api.NewAgentEndpointProvider(getPythonStatus, "/py/status", "GET"),
 	}

--- a/pkg/status/collector/status.go
+++ b/pkg/status/collector/status.go
@@ -14,20 +14,33 @@ import (
 	"io"
 	"sort"
 
+	collectorcomp "github.com/DataDog/datadog-agent/comp/collector/collector"
 	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
-// GetStatusInfo retrives collector information
-func GetStatusInfo() map[string]interface{} {
+// Provider provides the functionality to populate the status output with the collector information
+type Provider struct {
+	coll   collectorcomp.Component
+	config pkgconfigmodel.Reader
+}
+
+// NewProvider creates a Provider that reads check metadata directly from the collector
+// instead of relying on the inventories expvar published by the inventorychecks component.
+func NewProvider(coll collectorcomp.Component, config pkgconfigmodel.Reader) Provider {
+	return Provider{coll: coll, config: config}
+}
+
+// GetStatusInfo retrieves collector information
+func (p Provider) GetStatusInfo() map[string]interface{} {
 	stats := make(map[string]interface{})
-
-	PopulateStatus(stats)
-
+	p.PopulateStatus(stats)
 	return stats
 }
 
 // PopulateStatus populates stats with collector information
-func PopulateStatus(stats map[string]interface{}) {
+func (p Provider) PopulateStatus(stats map[string]interface{}) {
 	runnerVar := expvar.Get("runner")
 	if runnerVar != nil {
 		runnerStatsJSON := []byte(runnerVar.String())
@@ -99,9 +112,9 @@ func PopulateStatus(stats map[string]interface{}) {
 					}
 					workerStats["TopWorkers"] = topWorkers
 				}
-			}
 
-			stats["workerStats"] = workerStats
+				stats["workerStats"] = workerStats
+			}
 		}
 	}
 
@@ -137,14 +150,62 @@ func PopulateStatus(stats map[string]interface{}) {
 		stats["pythonInit"] = nil
 	}
 
-	inventories := expvar.Get("inventories")
-	var inventoriesStats map[string]interface{}
-	if inventories != nil {
-		inventoriesStatsJSON := []byte(inventories.String())
-		_ = json.Unmarshal(inventoriesStatsJSON, &inventoriesStats)
+	stats["inventories"] = p.collectCheckMetadata()
+}
+
+// collectCheckMetadata builds a map of check-hash → metadata by calling check.GetMetadata
+// directly on each check registered with the collector. Falls back to reading the
+// inventories expvar when the collector is not available (e.g. in tests or CLI commands).
+func (p Provider) collectCheckMetadata() map[string]map[string]string {
+	checkMetadata := map[string]map[string]string{}
+
+	if p.coll == nil {
+		// Fall back to the inventories expvar published by the inventorychecks component.
+		return collectCheckMetadataFromExpvar()
 	}
 
+	invChecksEnabled := p.config != nil && p.config.GetBool("inventories_checks_configuration_enabled")
+
+	p.coll.MapOverChecks(func(checks []check.Info) {
+		for _, c := range checks {
+			metadata := check.GetMetadata(c, invChecksEnabled)
+			checkHash := ""
+			result := map[string]string{}
+			for k, v := range metadata {
+				if vStr, ok := v.(string); ok {
+					switch k {
+					case "config.hash":
+						checkHash = vStr
+					case "config.provider":
+						// excluded from the status output (same as the expvar path)
+					default:
+						result[k] = vStr
+					}
+				}
+			}
+			if checkHash != "" && len(result) != 0 {
+				checkMetadata[checkHash] = result
+			}
+		}
+	})
+
+	return checkMetadata
+}
+
+// collectCheckMetadataFromExpvar reads check metadata from the inventories expvar,
+// which is published by the inventorychecks component. Used as a fallback when the
+// collector component is not wired into the status provider.
+func collectCheckMetadataFromExpvar() map[string]map[string]string {
 	checkMetadata := map[string]map[string]string{}
+
+	inventories := expvar.Get("inventories")
+	if inventories == nil {
+		return checkMetadata
+	}
+
+	var inventoriesStats map[string]interface{}
+	_ = json.Unmarshal([]byte(inventories.String()), &inventoriesStats)
+
 	if data, ok := inventoriesStats["check_metadata"]; ok {
 		for _, instances := range data.(map[string]interface{}) {
 			for _, instance := range instances.([]interface{}) {
@@ -165,14 +226,12 @@ func PopulateStatus(stats map[string]interface{}) {
 			}
 		}
 	}
-	stats["inventories"] = checkMetadata
+
+	return checkMetadata
 }
 
 //go:embed status_templates
 var templatesFS embed.FS
-
-// Provider provides the functionality to populate the status output with the collector information
-type Provider struct{}
 
 // Name returns the name
 func (Provider) Name() string {
@@ -185,24 +244,24 @@ func (Provider) Section() string {
 }
 
 // JSON populates the status map
-func (Provider) JSON(_ bool, stats map[string]interface{}) error {
-	PopulateStatus(stats)
+func (p Provider) JSON(_ bool, stats map[string]interface{}) error {
+	p.PopulateStatus(stats)
 
 	return nil
 }
 
 // Text renders the text output
-func (Provider) Text(_ bool, buffer io.Writer) error {
-	return status.RenderText(templatesFS, "collector.tmpl", buffer, GetStatusInfo())
+func (p Provider) Text(_ bool, buffer io.Writer) error {
+	return status.RenderText(templatesFS, "collector.tmpl", buffer, p.GetStatusInfo())
 }
 
 // HTML renders the html output
-func (Provider) HTML(_ bool, buffer io.Writer) error {
-	return status.RenderHTML(templatesFS, "collectorHTML.tmpl", buffer, GetStatusInfo())
+func (p Provider) HTML(_ bool, buffer io.Writer) error {
+	return status.RenderHTML(templatesFS, "collectorHTML.tmpl", buffer, p.GetStatusInfo())
 }
 
-// TextWithData allows to render the human reaadable version with custom data
-// This is a hack only needed for the agent check subcommand
+// TextWithData allows to render the human readable version with custom data.
+// This is a hack only needed for the agent check subcommand.
 func (Provider) TextWithData(buffer io.Writer, data any) error {
 	return status.RenderText(templatesFS, "collector.tmpl", buffer, data)
 }

--- a/pkg/status/collector/status.go
+++ b/pkg/status/collector/status.go
@@ -153,9 +153,9 @@ func (p Provider) PopulateStatus(stats map[string]interface{}) {
 	stats["inventories"] = p.collectCheckMetadata()
 }
 
-// collectCheckMetadata builds a map of check-hash → metadata by calling check.GetMetadata
-// directly on each check registered with the collector. Falls back to reading the
-// inventories expvar when the collector is not available (e.g. in tests or CLI commands).
+// collectCheckMetadata builds a map of check-hash → metadata. When the collector is
+// available it reads via check.GetMetadata, supplemented by per-instance metadata from
+// the inventories expvar (e.g. version.raw). Falls back to the expvar alone otherwise.
 func (p Provider) collectCheckMetadata() map[string]map[string]string {
 	checkMetadata := map[string]map[string]string{}
 
@@ -183,11 +183,28 @@ func (p Provider) collectCheckMetadata() map[string]map[string]string {
 					}
 				}
 			}
-			if checkHash != "" && len(result) != 0 {
+			if checkHash != "" {
 				checkMetadata[checkHash] = result
 			}
 		}
 	})
+
+	// Overlay per-instance metadata from inventorychecks.Set (e.g. version.raw).
+	// Only merge into known hashes to avoid stale data from unscheduled checks.
+	for checkHash, expvarFields := range collectCheckMetadataFromExpvar() {
+		if result, ok := checkMetadata[checkHash]; ok {
+			for k, v := range expvarFields {
+				result[k] = v
+			}
+		}
+	}
+
+	// Drop entries that have no displayable metadata fields after merging.
+	for checkHash, result := range checkMetadata {
+		if len(result) == 0 {
+			delete(checkMetadata, checkHash)
+		}
+	}
 
 	return checkMetadata
 }

--- a/pkg/status/collector/status.go
+++ b/pkg/status/collector/status.go
@@ -17,19 +17,17 @@ import (
 	collectorcomp "github.com/DataDog/datadog-agent/comp/collector/collector"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
 // Provider provides the functionality to populate the status output with the collector information
 type Provider struct {
-	coll   collectorcomp.Component
-	config pkgconfigmodel.Reader
+	coll collectorcomp.Component
 }
 
 // NewProvider creates a Provider that reads check metadata directly from the collector
 // instead of relying on the inventories expvar published by the inventorychecks component.
-func NewProvider(coll collectorcomp.Component, config pkgconfigmodel.Reader) Provider {
-	return Provider{coll: coll, config: config}
+func NewProvider(coll collectorcomp.Component) Provider {
+	return Provider{coll: coll}
 }
 
 // GetStatusInfo retrieves collector information
@@ -153,9 +151,11 @@ func (p Provider) PopulateStatus(stats map[string]interface{}) {
 	stats["inventories"] = p.collectCheckMetadata()
 }
 
-// collectCheckMetadata builds a map of check-hash → metadata. When the collector is
-// available it reads via check.GetMetadata, supplemented by per-instance metadata from
-// the inventories expvar (e.g. version.raw). Falls back to the expvar alone otherwise.
+// collectCheckMetadata builds a map of check-hash → metadata from the collector,
+// supplemented by per-instance fields from the inventories expvar (e.g. version.raw).
+// Falls back to the expvar alone when the collector is not wired.
+// Config fields (instance_config, init_config) are always excluded — they belong in
+// the inventorychecks backend payload, not status output.
 func (p Provider) collectCheckMetadata() map[string]map[string]string {
 	checkMetadata := map[string]map[string]string{}
 
@@ -164,11 +164,9 @@ func (p Provider) collectCheckMetadata() map[string]map[string]string {
 		return collectCheckMetadataFromExpvar()
 	}
 
-	invChecksEnabled := p.config != nil && p.config.GetBool("inventories_checks_configuration_enabled")
-
 	p.coll.MapOverChecks(func(checks []check.Info) {
 		for _, c := range checks {
-			metadata := check.GetMetadata(c, invChecksEnabled)
+			metadata := check.GetMetadata(c, false)
 			checkHash := ""
 			result := map[string]string{}
 			for k, v := range metadata {

--- a/pkg/status/collector/status.go
+++ b/pkg/status/collector/status.go
@@ -110,9 +110,9 @@ func (p Provider) PopulateStatus(stats map[string]interface{}) {
 					}
 					workerStats["TopWorkers"] = topWorkers
 				}
-
-				stats["workerStats"] = workerStats
 			}
+
+			stats["workerStats"] = workerStats
 		}
 	}
 
@@ -187,10 +187,13 @@ func (p Provider) collectCheckMetadata() map[string]map[string]string {
 
 	// Overlay per-instance metadata from inventorychecks.Set (e.g. version.raw).
 	// Only merge into known hashes to avoid stale data from unscheduled checks.
+	// Only set keys not already present so that GetMetadata values take precedence.
 	for checkHash, expvarFields := range collectCheckMetadataFromExpvar() {
 		if result, ok := checkMetadata[checkHash]; ok {
 			for k, v := range expvarFields {
-				result[k] = v
+				if _, exists := result[k]; !exists {
+					result[k] = v
+				}
 			}
 		}
 	}

--- a/pkg/status/collector/status.go
+++ b/pkg/status/collector/status.go
@@ -154,8 +154,6 @@ func (p Provider) PopulateStatus(stats map[string]interface{}) {
 // collectCheckMetadata builds a map of check-hash → metadata from the collector,
 // supplemented by per-instance fields from the inventories expvar (e.g. version.raw).
 // Falls back to the expvar alone when the collector is not wired.
-// Config fields (instance_config, init_config) are always excluded — they belong in
-// the inventorychecks backend payload, not status output.
 func (p Provider) collectCheckMetadata() map[string]map[string]string {
 	checkMetadata := map[string]map[string]string{}
 

--- a/pkg/status/collector/status_test.go
+++ b/pkg/status/collector/status_test.go
@@ -8,14 +8,61 @@ package collector
 import (
 	"bytes"
 	"encoding/json"
+	"expvar"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/comp/core/status"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	collectorcomp "github.com/DataDog/datadog-agent/comp/collector/collector"
+	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 )
+
+type mockCollector struct {
+	checks []check.Info
+}
+
+func (m *mockCollector) RunCheck(_ check.Check) (checkid.ID, error) { return "", nil }
+func (m *mockCollector) StopCheck(_ checkid.ID) error               { return nil }
+func (m *mockCollector) MapOverChecks(cb func([]check.Info))        { cb(m.checks) }
+func (m *mockCollector) GetChecks() []check.Check                   { return nil }
+func (m *mockCollector) ReloadAllCheckInstances(_ string, _ []check.Check) ([]checkid.ID, error) {
+	return nil, nil
+}
+func (m *mockCollector) AddEventReceiver(_ collectorcomp.EventReceiver) {}
+
+var (
+	testInventoriesMu   sync.RWMutex
+	testInventoriesData interface{} = map[string]interface{}{}
+)
+
+func TestMain(m *testing.M) {
+	// Register the inventories expvar once using expvar.Func, matching how the
+	// inventorychecks component publishes it in production (raw JSON object, not a quoted string).
+	expvar.Publish("inventories", expvar.Func(func() interface{} {
+		testInventoriesMu.RLock()
+		defer testInventoriesMu.RUnlock()
+		return testInventoriesData
+	}))
+	os.Exit(m.Run())
+}
+
+func setInventories(checkMetadata map[string][]map[string]string) {
+	testInventoriesMu.Lock()
+	defer testInventoriesMu.Unlock()
+	testInventoriesData = map[string]interface{}{"check_metadata": checkMetadata}
+}
+
+func clearInventories() {
+	testInventoriesMu.Lock()
+	defer testInventoriesMu.Unlock()
+	testInventoriesData = map[string]interface{}{}
+}
 
 func TestRender(t *testing.T) {
 	// We're checking that some dates are correctly formatted in the HTML
@@ -58,4 +105,106 @@ func TestRender(t *testing.T) {
 			require.Equal(t, result, stringOutput, "HTML rendering is not as expected")
 		})
 	}
+}
+
+func TestCollectCheckMetadata_NilCollector(t *testing.T) {
+	t.Cleanup(clearInventories)
+	setInventories(map[string][]map[string]string{
+		"cpu": {
+			{"config.hash": "hash1", "version.raw": "1.0.0"},
+		},
+	})
+
+	p := Provider{coll: nil}
+	result := p.collectCheckMetadata()
+
+	require.Contains(t, result, "hash1")
+	assert.Equal(t, "1.0.0", result["hash1"]["version.raw"])
+}
+
+func TestCollectCheckMetadata_WithCollector(t *testing.T) {
+	t.Cleanup(clearInventories)
+
+	coll := &mockCollector{
+		checks: []check.Info{
+			check.MockInfo{
+				Name:    "cpu",
+				CheckID: checkid.ID("hash2"),
+				Source:  "file:conf.d/cpu.d/conf.yaml",
+			},
+		},
+	}
+	p := Provider{coll: coll}
+	result := p.collectCheckMetadata()
+
+	require.Contains(t, result, "hash2")
+	assert.Equal(t, "conf.d/cpu.d/conf.yaml", result["hash2"]["config.source"])
+}
+
+func TestCollectCheckMetadata_ExpvarOverlayAddsFields(t *testing.T) {
+	// Expvar-only fields (e.g. version.raw) should be merged in for known hashes.
+	setInventories(map[string][]map[string]string{
+		"cpu": {
+			{"config.hash": "hash3", "version.raw": "2.0.0"},
+		},
+	})
+	t.Cleanup(clearInventories)
+
+	coll := &mockCollector{
+		checks: []check.Info{
+			check.MockInfo{
+				Name:    "cpu",
+				CheckID: checkid.ID("hash3"),
+				Source:  "file:conf.d/cpu.d/conf.yaml",
+			},
+		},
+	}
+	p := Provider{coll: coll}
+	result := p.collectCheckMetadata()
+
+	require.Contains(t, result, "hash3")
+	assert.Equal(t, "2.0.0", result["hash3"]["version.raw"], "expvar-only field should be overlaid")
+	assert.Equal(t, "conf.d/cpu.d/conf.yaml", result["hash3"]["config.source"], "GetMetadata value should be preserved")
+}
+
+func TestCollectCheckMetadata_CollectorPrecedenceOverExpvar(t *testing.T) {
+	// GetMetadata keys must not be overwritten by expvar values.
+	setInventories(map[string][]map[string]string{
+		"cpu": {
+			{"config.hash": "hash4", "config.source": "expvar-source", "version.raw": "3.0.0"},
+		},
+	})
+	t.Cleanup(clearInventories)
+
+	coll := &mockCollector{
+		checks: []check.Info{
+			check.MockInfo{
+				Name:    "cpu",
+				CheckID: checkid.ID("hash4"),
+				Source:  "file:collector-source",
+			},
+		},
+	}
+	p := Provider{coll: coll}
+	result := p.collectCheckMetadata()
+
+	require.Contains(t, result, "hash4")
+	assert.Equal(t, "collector-source", result["hash4"]["config.source"], "GetMetadata value must not be overwritten by expvar")
+	assert.Equal(t, "3.0.0", result["hash4"]["version.raw"], "expvar-only field should still be added")
+}
+
+func TestCollectCheckMetadata_UnknownHashesNotAdded(t *testing.T) {
+	// Expvar entries for hashes not in the collector result must not be added.
+	setInventories(map[string][]map[string]string{
+		"some-check": {
+			{"config.hash": "stale-hash", "version.raw": "1.0.0"},
+		},
+	})
+	t.Cleanup(clearInventories)
+
+	coll := &mockCollector{checks: []check.Info{}}
+	p := Provider{coll: coll}
+	result := p.collectCheckMetadata()
+
+	assert.NotContains(t, result, "stale-hash", "stale hashes from expvar should not appear in collector path")
 }


### PR DESCRIPTION
## What does this PR do?

Refactors `pkg/status/collector/status.go` to read check metadata directly from the collector component via `check.GetMetadata()` and `collector.Component.MapOverChecks()`, instead of relying on the `inventories` expvar published at runtime by the `inventorychecks` component.

Key changes:
- `Provider` gains a `coll collectorcomp.Component` field; `NewProvider(coll)` wires it in
- `PopulateStatus` / `GetStatusInfo` are now methods on `Provider` (no exported free functions were called externally)
- A nil-`coll` fallback path preserves the old expvar-based behavior for `Provider{}` callers (e.g. the `agent check` subcommand)
- Per-instance metadata set via `inventorychecks.Set` (e.g. `version.raw`) is overlaid from the expvar after the `GetMetadata` pass
- `instance_config`/`init_config` are always excluded from status output — `inventories_checks_configuration_enabled` controls the backend payload only
- `collectorimpl.newProvides` passes the constructed collector to `NewProvider`

## Motivation

The previous approach created a runtime dependency on the `inventorychecks` component: if it wasn't running (or hadn't published yet), the status page showed no inventory metadata. Reading directly from the collector eliminates that dependency.

See https://datadoghq.atlassian.net/browse/AGENTCFG-74

## Validation

- `dda inv test --targets=./pkg/status/collector` passes
- `dda inv test --targets=./comp/collector/collector/collectorimpl` passes (24 tests)
- `dda inv linter.go --targets=./pkg/status/collector,./comp/collector/collector/collectorimpl` passes
- Tested on a locally built and running agent (`agent status`):
  - `config.provider` is correctly excluded from the inventories output
  - `config.source` is present for all scheduled checks
  - Checks with non-default configs use `checkname:hash` keys (e.g. `disk:bf4e24ad900b42a5`)
  - The `Check Worker Utilization` section renders correctly
  - The `Running Checks` section shows per-check metadata

_Created by [Auto-JIRA](https://github.com/DataDog/datadog-agent/blob/main/.claude/skills/auto-jira/SKILL.md)._