### PR TITLE
[ AGNTLOG-585 ] Add IP allow/deny lists to TCP and UDP log listeners

### DIFF
--- a/comp/logs-library/utils/ipfilter/BUILD.bazel
+++ b/comp/logs-library/utils/ipfilter/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "ipfilter",
+    srcs = [
+        "denial_info.go",
+        "filter.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/logs-library/utils/ipfilter",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "ipfilter_test",
+    srcs = ["filter_test.go"],
+    embed = [":ipfilter"],
+    gotags = ["test"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/comp/logs-library/utils/ipfilter/denial_info.go
+++ b/comp/logs-library/utils/ipfilter/denial_info.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ipfilter
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// DenialInfo tracks per-reason denial counts for display in agent status.
+// It implements the InfoProvider interface from pkg/logs/status/utils.
+type DenialInfo struct {
+	mu      sync.Mutex
+	reasons map[string]int64
+}
+
+// NewDenialInfo creates a new DenialInfo instance.
+func NewDenialInfo() *DenialInfo {
+	return &DenialInfo{
+		reasons: make(map[string]int64),
+	}
+}
+
+// Record increments the counter for the given denial reason.
+func (d *DenialInfo) Record(reason string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.reasons[reason]++
+}
+
+// InfoKey returns the label used in agent status output.
+func (d *DenialInfo) InfoKey() string {
+	return "IP Filter"
+}
+
+// Info returns denial statistics as a sorted list of strings.
+func (d *DenialInfo) Info() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if len(d.reasons) == 0 {
+		return []string{"No denials"}
+	}
+
+	info := make([]string, 0, len(d.reasons))
+	for reason, count := range d.reasons {
+		info = append(info, fmt.Sprintf("%s: %d", reason, count))
+	}
+	sort.Strings(info)
+	return info
+}

--- a/comp/logs-library/utils/ipfilter/filter.go
+++ b/comp/logs-library/utils/ipfilter/filter.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package ipfilter provides IP-based allow/deny filtering for network listeners.
+package ipfilter
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+)
+
+// Denial describes the outcome of an IP filter check. A zero-value Denial
+// means the address was allowed.
+type Denial struct {
+	allowed bool
+	reason  string
+}
+
+// Allowed returns true when the address passed the filter.
+func (d Denial) Allowed() bool { return d.allowed }
+
+// Reason returns a human-readable explanation when the address was denied.
+// Empty when allowed.
+func (d Denial) Reason() string { return d.reason }
+
+// Filter evaluates incoming connection addresses against allow and deny lists.
+//
+// Evaluation order (standard firewall semantics):
+//  1. If the IP matches any denied prefix, reject.
+//  2. If the allow list is non-empty and the IP matches no allowed prefix, reject.
+//  3. Otherwise, accept.
+type Filter struct {
+	allowed       []netip.Prefix
+	denied        []netip.Prefix
+	deniedReasons []string // pre-computed reason string per denied prefix, parallel to denied
+}
+
+// New parses the allow and deny string slices into a Filter. Each entry may be
+// a bare IP address (e.g. "10.0.0.1") or CIDR notation (e.g. "10.0.0.0/24").
+func New(allowed, denied []string) (*Filter, error) {
+	a, err := parsePrefixes(allowed)
+	if err != nil {
+		return nil, fmt.Errorf("allowed_ips: %w", err)
+	}
+	d, err := parsePrefixes(denied)
+	if err != nil {
+		return nil, fmt.Errorf("denied_ips: %w", err)
+	}
+	reasons := make([]string, len(d))
+	for i, prefix := range d {
+		reasons[i] = fmt.Sprintf("denied by %s", prefix)
+	}
+	return &Filter{allowed: a, denied: d, deniedReasons: reasons}, nil
+}
+
+// Allow returns true if the address should be permitted.
+func (f *Filter) Allow(addr net.Addr) bool {
+	return f.Check(addr).Allowed()
+}
+
+// Check evaluates the address and returns a Denial describing the outcome.
+// When the address is denied, Denial.Reason() identifies which rule matched.
+func (f *Filter) Check(addr net.Addr) Denial {
+	ip := addrToIP(addr)
+	if !ip.IsValid() {
+		return Denial{reason: "invalid address"}
+	}
+	for i, prefix := range f.denied {
+		if prefix.Contains(ip) {
+			return Denial{reason: f.deniedReasons[i]}
+		}
+	}
+	if len(f.allowed) == 0 {
+		return Denial{allowed: true}
+	}
+	for _, prefix := range f.allowed {
+		if prefix.Contains(ip) {
+			return Denial{allowed: true}
+		}
+	}
+	return Denial{reason: "not in allow list"}
+}
+
+func parsePrefixes(entries []string) ([]netip.Prefix, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	prefixes := make([]netip.Prefix, 0, len(entries))
+	for _, raw := range entries {
+		entry := strings.TrimSpace(raw)
+		prefix, err := netip.ParsePrefix(entry)
+		if err != nil {
+			addr, addrErr := netip.ParseAddr(entry)
+			if addrErr != nil {
+				return nil, fmt.Errorf("invalid IP or CIDR %q: %w", entry, err)
+			}
+			prefix = netip.PrefixFrom(addr, addr.BitLen())
+		}
+		prefix = unmapPrefix(prefix)
+		prefixes = append(prefixes, prefix)
+	}
+	return prefixes, nil
+}
+
+// unmapPrefix normalises an IPv4-mapped IPv6 prefix (e.g. ::ffff:10.0.0.0/104)
+// to its IPv4 equivalent (10.0.0.0/8) so that Contains() works correctly
+// against unmapped incoming addresses.
+func unmapPrefix(p netip.Prefix) netip.Prefix {
+	addr := p.Addr().Unmap()
+	if addr == p.Addr() {
+		return p
+	}
+	// IPv4-mapped IPv6 addresses are 128 bits; native IPv4 are 32 bits.
+	// Adjust prefix length by the 96-bit difference.
+	bits := p.Bits() - 96
+	if bits < 0 {
+		bits = 0
+	}
+	return netip.PrefixFrom(addr, bits)
+}
+
+func addrToIP(addr net.Addr) netip.Addr {
+	switch a := addr.(type) {
+	case *net.TCPAddr:
+		ip, _ := netip.AddrFromSlice(a.IP)
+		return ip.Unmap()
+	case *net.UDPAddr:
+		ip, _ := netip.AddrFromSlice(a.IP)
+		return ip.Unmap()
+	default:
+		ap, err := netip.ParseAddrPort(addr.String())
+		if err != nil {
+			return netip.Addr{}
+		}
+		return ap.Addr().Unmap()
+	}
+}

--- a/comp/logs-library/utils/ipfilter/filter_test.go
+++ b/comp/logs-library/utils/ipfilter/filter_test.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ipfilter
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func tcpAddr(ip string) *net.TCPAddr {
+	return &net.TCPAddr{IP: net.ParseIP(ip), Port: 1234}
+}
+
+func udpAddr(ip string) *net.UDPAddr {
+	return &net.UDPAddr{IP: net.ParseIP(ip), Port: 1234}
+}
+
+func TestEmptyFilterAllowsAll(t *testing.T) {
+	f, err := New(nil, nil)
+	require.NoError(t, err)
+	assert.True(t, f.Allow(tcpAddr("10.0.0.1")))
+	assert.True(t, f.Allow(tcpAddr("192.168.1.1")))
+	assert.True(t, f.Allow(udpAddr("::1")))
+}
+
+func TestAllowListSingleIP(t *testing.T) {
+	f, err := New([]string{"10.0.0.1"}, nil)
+	require.NoError(t, err)
+	assert.True(t, f.Allow(tcpAddr("10.0.0.1")))
+	assert.False(t, f.Allow(tcpAddr("10.0.0.2")))
+}
+
+func TestAllowListCIDR(t *testing.T) {
+	f, err := New([]string{"10.0.0.0/24"}, nil)
+	require.NoError(t, err)
+	assert.True(t, f.Allow(tcpAddr("10.0.0.1")))
+	assert.True(t, f.Allow(tcpAddr("10.0.0.254")))
+	assert.False(t, f.Allow(tcpAddr("10.0.1.1")))
+}
+
+func TestDenyListSingleIP(t *testing.T) {
+	f, err := New(nil, []string{"10.0.0.99"})
+	require.NoError(t, err)
+	assert.False(t, f.Allow(tcpAddr("10.0.0.99")))
+	assert.True(t, f.Allow(tcpAddr("10.0.0.1")))
+}
+
+func TestDenyListCIDR(t *testing.T) {
+	f, err := New(nil, []string{"192.168.0.0/16"})
+	require.NoError(t, err)
+	assert.False(t, f.Allow(tcpAddr("192.168.1.1")))
+	assert.False(t, f.Allow(tcpAddr("192.168.255.255")))
+	assert.True(t, f.Allow(tcpAddr("10.0.0.1")))
+}
+
+func TestDenyTakesPrecedenceOverAllow(t *testing.T) {
+	f, err := New([]string{"10.0.0.0/24"}, []string{"10.0.0.99"})
+	require.NoError(t, err)
+	assert.True(t, f.Allow(tcpAddr("10.0.0.1")))
+	assert.False(t, f.Allow(tcpAddr("10.0.0.99")))
+	assert.False(t, f.Allow(tcpAddr("192.168.1.1")))
+}
+
+func TestIPv6(t *testing.T) {
+	f, err := New([]string{"::1", "fd00::/64"}, nil)
+	require.NoError(t, err)
+	assert.True(t, f.Allow(tcpAddr("::1")))
+	assert.True(t, f.Allow(tcpAddr("fd00::1")))
+	assert.False(t, f.Allow(tcpAddr("fd01::1")))
+}
+
+func TestIPv4MappedIPv6PrefixIsNormalized(t *testing.T) {
+	f, err := New([]string{"::ffff:10.0.0.0/104"}, nil)
+	require.NoError(t, err)
+	assert.True(t, f.Allow(tcpAddr("10.0.0.1")), "native IPv4 should match unmapped prefix")
+	assert.True(t, f.Allow(tcpAddr("10.255.255.255")), "top of /8 range should match")
+	assert.False(t, f.Allow(tcpAddr("11.0.0.1")), "outside range should not match")
+}
+
+func TestUDPAddr(t *testing.T) {
+	f, err := New([]string{"10.0.0.0/8"}, nil)
+	require.NoError(t, err)
+	assert.True(t, f.Allow(udpAddr("10.0.0.1")))
+	assert.False(t, f.Allow(udpAddr("192.168.1.1")))
+}
+
+func TestInvalidCIDRRejected(t *testing.T) {
+	_, err := New([]string{"not-an-ip"}, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "allowed_ips")
+
+	_, err = New(nil, []string{"999.999.999.999"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "denied_ips")
+}
+
+func TestInvalidAddrReturnsFalse(t *testing.T) {
+	f, err := New(nil, nil)
+	require.NoError(t, err)
+
+	badAddr := &net.UnixAddr{Name: "/tmp/sock", Net: "unix"}
+	assert.False(t, f.Allow(badAddr))
+}
+
+func TestMultipleEntries(t *testing.T) {
+	f, err := New(
+		[]string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"},
+		[]string{"10.0.0.0/24"},
+	)
+	require.NoError(t, err)
+	assert.False(t, f.Allow(tcpAddr("10.0.0.5")))
+	assert.True(t, f.Allow(tcpAddr("10.0.1.5")))
+	assert.True(t, f.Allow(tcpAddr("172.16.0.1")))
+	assert.True(t, f.Allow(tcpAddr("192.168.1.1")))
+	assert.False(t, f.Allow(tcpAddr("8.8.8.8")))
+}
+
+func TestTrimSpaceInEntries(t *testing.T) {
+	f, err := New([]string{" 10.0.0.0/8 ", "  192.168.1.1  "}, nil)
+	require.NoError(t, err)
+	assert.True(t, f.Allow(tcpAddr("10.0.0.1")))
+	assert.True(t, f.Allow(tcpAddr("192.168.1.1")))
+	assert.False(t, f.Allow(tcpAddr("172.16.0.1")))
+}
+
+// --- Check() / Denial tests ---
+
+func TestCheckDeniedByPrefix(t *testing.T) {
+	f, err := New(nil, []string{"192.168.0.0/16"})
+	require.NoError(t, err)
+
+	d := f.Check(tcpAddr("192.168.1.1"))
+	assert.False(t, d.Allowed())
+	assert.Equal(t, "denied by 192.168.0.0/16", d.Reason())
+}
+
+func TestCheckNotInAllowList(t *testing.T) {
+	f, err := New([]string{"10.0.0.0/8"}, nil)
+	require.NoError(t, err)
+
+	d := f.Check(tcpAddr("192.168.1.1"))
+	assert.False(t, d.Allowed())
+	assert.Equal(t, "not in allow list", d.Reason())
+}
+
+func TestCheckAllowed(t *testing.T) {
+	f, err := New([]string{"10.0.0.0/8"}, nil)
+	require.NoError(t, err)
+
+	d := f.Check(tcpAddr("10.0.0.1"))
+	assert.True(t, d.Allowed())
+	assert.Empty(t, d.Reason())
+}
+
+func TestCheckAllowedNoLists(t *testing.T) {
+	f, err := New(nil, nil)
+	require.NoError(t, err)
+
+	d := f.Check(tcpAddr("10.0.0.1"))
+	assert.True(t, d.Allowed())
+	assert.Empty(t, d.Reason())
+}
+
+func TestCheckInvalidAddr(t *testing.T) {
+	f, err := New(nil, nil)
+	require.NoError(t, err)
+
+	d := f.Check(&net.UnixAddr{Name: "/tmp/sock", Net: "unix"})
+	assert.False(t, d.Allowed())
+	assert.Equal(t, "invalid address", d.Reason())
+}
+
+func TestCheckDenyPrecedenceShowsDenyRule(t *testing.T) {
+	f, err := New([]string{"10.0.0.0/24"}, []string{"10.0.0.99/32"})
+	require.NoError(t, err)
+
+	d := f.Check(tcpAddr("10.0.0.99"))
+	assert.False(t, d.Allowed())
+	assert.Equal(t, "denied by 10.0.0.99/32", d.Reason())
+}
+
+// --- DenialInfo tests ---
+
+func TestDenialInfoEmpty(t *testing.T) {
+	di := NewDenialInfo()
+	assert.Equal(t, "IP Filter", di.InfoKey())
+	assert.Equal(t, []string{"No denials"}, di.Info())
+}
+
+func TestDenialInfoRecordsReasons(t *testing.T) {
+	di := NewDenialInfo()
+	di.Record("denied by 10.0.0.0/24")
+	di.Record("denied by 10.0.0.0/24")
+	di.Record("not in allow list")
+
+	info := di.Info()
+	assert.Len(t, info, 2)
+	assert.Contains(t, info, "denied by 10.0.0.0/24: 2")
+	assert.Contains(t, info, "not in allow list: 1")
+}
+
+func TestDenialInfoSorted(t *testing.T) {
+	di := NewDenialInfo()
+	di.Record("denied by 192.168.0.0/16")
+	di.Record("denied by 10.0.0.0/8")
+
+	info := di.Info()
+	require.Len(t, info, 2)
+	assert.Equal(t, "denied by 10.0.0.0/8: 1", info[0])
+	assert.Equal(t, "denied by 192.168.0.0/16: 1", info[1])
+}
+
+func TestDenialInfoConcurrentAccess(t *testing.T) {
+	di := NewDenialInfo()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			di.Record("denied by 10.0.0.0/8")
+		}()
+	}
+	wg.Wait()
+
+	info := di.Info()
+	require.Len(t, info, 1)
+	assert.Equal(t, "denied by 10.0.0.0/8: 100", info[0])
+}

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/netip"
 	"strings"
 	"sync"
 
@@ -52,8 +53,10 @@ type LogsConfig struct {
 	IdleTimeout    string `mapstructure:"idle_timeout" json:"idle_timeout" yaml:"idle_timeout"`          // Network (tcp)
 	MaxConnections int    `mapstructure:"max_connections" json:"max_connections" yaml:"max_connections"` // Network (tcp)
 	// TLS is under active security review and is not ready for general use.
-	TLS  *TLSListenerConfig `mapstructure:"tls" json:"tls,omitempty" yaml:"tls,omitempty"`
-	Path string             // File, Journald
+	TLS        *TLSListenerConfig `mapstructure:"tls" json:"tls,omitempty" yaml:"tls,omitempty"`
+	AllowedIPs StringSliceField   `mapstructure:"allowed_ips" json:"allowed_ips,omitempty" yaml:"allowed_ips,omitempty"` // Network (tcp, udp)
+	DeniedIPs  StringSliceField   `mapstructure:"denied_ips" json:"denied_ips,omitempty" yaml:"denied_ips,omitempty"`    // Network (tcp, udp)
+	Path       string             // File, Journald
 
 	Encoding     string           `mapstructure:"encoding" json:"encoding" yaml:"encoding"`                   // File
 	ExcludePaths StringSliceField `mapstructure:"exclude_paths" json:"exclude_paths" yaml:"exclude_paths"`    // File
@@ -315,6 +318,12 @@ func (c *LogsConfig) Dump(multiline bool) string {
 		fmt.Fprintf(&b, ws("ChannelTags: %#v,"), c.ChannelTags)
 		c.ChannelTagsMutex.Unlock()
 	}
+	if len(c.AllowedIPs) > 0 {
+		fmt.Fprintf(&b, ws("AllowedIPs: %#v,"), []string(c.AllowedIPs))
+	}
+	if len(c.DeniedIPs) > 0 {
+		fmt.Fprintf(&b, ws("DeniedIPs: %#v,"), []string(c.DeniedIPs))
+	}
 	fmt.Fprintf(&b, ws("Service: %#v,"), c.Service)
 	fmt.Fprintf(&b, ws("Source: %#v,"), c.Source)
 	fmt.Fprintf(&b, ws("SourceCategory: %#v,"), c.SourceCategory)
@@ -445,6 +454,10 @@ func (c *LogsConfig) Validate() error {
 		return err
 	}
 
+	if err := c.validateIPFilter(); err != nil {
+		return err
+	}
+
 	// Validate fingerprint configuration
 	err := ValidateFingerprintConfig(c.FingerprintConfig)
 	if err != nil {
@@ -495,6 +508,37 @@ func (c *LogsConfig) validateTLS() error {
 	}
 	tlsutil.WarnKeyFilePermissions(c.TLS.KeyFile)
 	return nil
+}
+
+func (c *LogsConfig) validateIPFilter() error {
+	if len(c.AllowedIPs) == 0 && len(c.DeniedIPs) == 0 {
+		return nil
+	}
+	if c.Type != TCPType && c.Type != UDPType {
+		return fmt.Errorf("allowed_ips/denied_ips are only supported for %s and %s sources, got %s", TCPType, UDPType, c.Type)
+	}
+	for _, entry := range c.AllowedIPs {
+		if err := validateIPOrCIDR(entry); err != nil {
+			return fmt.Errorf("invalid allowed_ips entry %q: %w", entry, err)
+		}
+	}
+	for _, entry := range c.DeniedIPs {
+		if err := validateIPOrCIDR(entry); err != nil {
+			return fmt.Errorf("invalid denied_ips entry %q: %w", entry, err)
+		}
+	}
+	return nil
+}
+
+func validateIPOrCIDR(s string) error {
+	s = strings.TrimSpace(s)
+	if _, err := netip.ParsePrefix(s); err == nil {
+		return nil
+	}
+	if _, err := netip.ParseAddr(s); err == nil {
+		return nil
+	}
+	return errors.New("not a valid IP address or CIDR")
 }
 
 // LegacyAutoMultiLineEnabled determines whether the agent has fallen back to legacy auto multi line detection

--- a/comp/logs/agent/config/integration_config_test.go
+++ b/comp/logs/agent/config/integration_config_test.go
@@ -44,6 +44,7 @@ func TestValidateShouldFailWithInvalidConfigs(t *testing.T) {
 		{Type: TCPType, Port: 6514, TLS: &TLSListenerConfig{CertFile: "/cert"}},
 		{Type: UDPType, Port: 514, TLS: &TLSListenerConfig{CertFile: "/cert", KeyFile: "/key"}},
 		{Type: TCPType, Port: 6514, TLS: &TLSListenerConfig{CertFile: "/cert", KeyFile: "/key", ClientAuth: "bogus"}},
+		{Type: TCPType, Port: 6514, AllowedIPs: StringSliceField{"not-an-ip"}},
 		{Type: TCPType, Port: 6514, TLS: &TLSListenerConfig{CertFile: "/cert", KeyFile: "/key", MinTLSVersion: "tls1.2"}},
 		{Type: DockerType, ProcessingRules: []*ProcessingRule{{Name: "foo"}}},
 		{Type: DockerType, ProcessingRules: []*ProcessingRule{{Name: "foo", Type: "bar"}}},
@@ -489,4 +490,100 @@ func TestValidateWildcardWithBeginningMode(t *testing.T) {
 		err := config.Validate()
 		assert.Nil(t, err, "Wildcard path %s with tailing mode %s should be valid", config.Path, config.TailingMode)
 	}
+}
+
+func TestValidateIPFilter(t *testing.T) {
+	t.Run("valid CIDR entries pass", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type:       TCPType,
+			Port:       6514,
+			AllowedIPs: StringSliceField{"10.0.0.0/8", "192.168.1.0/24"},
+			DeniedIPs:  StringSliceField{"10.0.0.99"},
+		}
+		err := cfg.validateIPFilter()
+		assert.Nil(t, err)
+	})
+
+	t.Run("valid single IPs pass", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type:       UDPType,
+			Port:       514,
+			AllowedIPs: StringSliceField{"10.0.0.1", "::1"},
+		}
+		err := cfg.validateIPFilter()
+		assert.Nil(t, err)
+	})
+
+	t.Run("invalid allowed IP fails", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type:       TCPType,
+			Port:       6514,
+			AllowedIPs: StringSliceField{"not-an-ip"},
+		}
+		err := cfg.validateIPFilter()
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "allowed_ips")
+	})
+
+	t.Run("invalid denied IP fails", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type:      TCPType,
+			Port:      6514,
+			DeniedIPs: StringSliceField{"999.999.999.999"},
+		}
+		err := cfg.validateIPFilter()
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "denied_ips")
+	})
+
+	t.Run("IP filter on file type fails", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type:       FileType,
+			Path:       "/var/log/test.log",
+			AllowedIPs: StringSliceField{"10.0.0.1"},
+		}
+		err := cfg.validateIPFilter()
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "only supported for")
+	})
+
+	t.Run("empty lists pass", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type: TCPType,
+			Port: 6514,
+		}
+		err := cfg.validateIPFilter()
+		assert.Nil(t, err)
+	})
+
+	t.Run("both allowed and denied coexist", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type:       TCPType,
+			Port:       6514,
+			AllowedIPs: StringSliceField{"10.0.0.0/8"},
+			DeniedIPs:  StringSliceField{"10.0.0.0/24"},
+		}
+		err := cfg.validateIPFilter()
+		assert.Nil(t, err)
+	})
+
+	t.Run("IPv6 CIDR passes", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type:       TCPType,
+			Port:       6514,
+			AllowedIPs: StringSliceField{"fd00::/64"},
+		}
+		err := cfg.validateIPFilter()
+		assert.Nil(t, err)
+	})
+
+	t.Run("UDP type passes", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type:      UDPType,
+			Port:      514,
+			DeniedIPs: StringSliceField{"10.0.0.99"},
+		}
+		err := cfg.validateIPFilter()
+		assert.Nil(t, err)
+	})
 }

--- a/pkg/logs/launchers/listener/launcher.go
+++ b/pkg/logs/launchers/listener/launcher.go
@@ -56,7 +56,12 @@ func (l *Launcher) run() {
 			listener.Start()
 			l.listeners = append(l.listeners, listener)
 		case source := <-l.udpSources:
-			listener := NewUDPListener(l.pipelineProvider, source, l.frameSize)
+			listener, err := NewUDPListener(l.pipelineProvider, source, l.frameSize)
+			if err != nil {
+				log.Errorf("Can't create UDP listener: %v", err)
+				source.Status.Error(err)
+				continue
+			}
 			listener.Start()
 			l.listeners = append(l.listeners, listener)
 		case <-l.stop:

--- a/pkg/logs/launchers/listener/tcp.go
+++ b/pkg/logs/launchers/listener/tcp.go
@@ -15,9 +15,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
+	"github.com/DataDog/datadog-agent/comp/logs-library/utils/ipfilter"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/socket"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
@@ -37,6 +39,8 @@ type TCPListener struct {
 	frameSize        int
 	maxConnections   int
 	tlsCredentials   *tls.Config
+	ipFilter         *ipfilter.Filter
+	denialInfo       *ipfilter.DenialInfo
 	listener         net.Listener
 	tailers          []*tailer.Tailer
 	mu               sync.Mutex
@@ -48,7 +52,7 @@ type TCPListener struct {
 }
 
 // NewTCPListener returns an initialized TCPListener or an error if critical
-// configuration (TLS credentials) fails to build.
+// configuration (TLS credentials, IP filter) fails to build.
 func NewTCPListener(pipelineProvider pipeline.Provider, source *sources.LogSource, frameSize int) (*TCPListener, error) {
 	var idleTimeout time.Duration
 	if source.Config.IdleTimeout != "" {
@@ -79,6 +83,19 @@ func NewTCPListener(pipelineProvider pipeline.Provider, source *sources.LogSourc
 		maxConns = defaultMaxConnections
 	}
 
+	var ipF *ipfilter.Filter
+	var denialInfo *ipfilter.DenialInfo
+	if len(source.Config.AllowedIPs) > 0 || len(source.Config.DeniedIPs) > 0 {
+		var err error
+		ipF, err = ipfilter.New(source.Config.AllowedIPs, source.Config.DeniedIPs)
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("failed to build IP filter for TCP listener on port %d: %w", source.Config.Port, err)
+		}
+		denialInfo = ipfilter.NewDenialInfo()
+		source.RegisterInfo(denialInfo)
+	}
+
 	return &TCPListener{
 		pipelineProvider: pipelineProvider,
 		source:           source,
@@ -86,6 +103,8 @@ func NewTCPListener(pipelineProvider pipeline.Provider, source *sources.LogSourc
 		frameSize:        frameSize,
 		maxConnections:   maxConns,
 		tlsCredentials:   tlsCreds,
+		ipFilter:         ipF,
+		denialInfo:       denialInfo,
 		tailers:          []*tailer.Tailer{},
 		connSem:          make(chan struct{}, maxConns),
 		stop:             make(chan struct{}, 1),
@@ -157,6 +176,15 @@ func (l *TCPListener) run() {
 				l.source.Status.Success()
 				continue
 			default:
+				if l.ipFilter != nil {
+					if d := l.ipFilter.Check(conn.RemoteAddr()); !d.Allowed() {
+						log.Debugf("Rejected connection from %s on port %d: %s", conn.RemoteAddr(), l.source.Config.Port, d.Reason())
+						metrics.TlmListenerIPDenied.Inc("tcp")
+						l.denialInfo.Record(d.Reason())
+						conn.Close()
+						continue
+					}
+				}
 				select {
 				case l.connSem <- struct{}{}:
 					go l.handleConnection(conn)

--- a/pkg/logs/launchers/listener/tcp_test.go
+++ b/pkg/logs/launchers/listener/tcp_test.go
@@ -634,6 +634,123 @@ func TestTCPMTLSOptionalAcceptsNoClientCert(t *testing.T) {
 	listener.Stop()
 }
 
+func TestTCPAllowedIPsAcceptsMatchingConnection(t *testing.T) {
+	pp := mock.NewMockProvider()
+	msgChan := pp.NextPipelineChan()
+	source := sources.NewLogSource("", &config.LogsConfig{
+		Port:       tcpTestPort,
+		AllowedIPs: config.StringSliceField{"127.0.0.0/8", "::1"},
+	})
+	listener, err := NewTCPListener(pp, source, 9000)
+	require.NoError(t, err)
+	listener.Start()
+	defer listener.Stop()
+
+	conn, err := net.Dial("tcp", listener.listener.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	fmt.Fprint(conn, "allowed\n")
+	msg := <-msgChan
+	assert.Equal(t, "allowed", string(msg.GetContent()))
+}
+
+func TestTCPDeniedIPsRejectsMatchingConnection(t *testing.T) {
+	pp := mock.NewMockProvider()
+	source := sources.NewLogSource("", &config.LogsConfig{
+		Port:      tcpTestPort,
+		DeniedIPs: config.StringSliceField{"127.0.0.0/8", "::1"},
+	})
+	listener, err := NewTCPListener(pp, source, 9000)
+	require.NoError(t, err)
+	listener.Start()
+	defer listener.Stop()
+
+	conn, err := net.Dial("tcp", listener.listener.Addr().String())
+	require.NoError(t, err)
+
+	fmt.Fprint(conn, "denied\n")
+	conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, err = conn.Read(buf)
+	assert.Error(t, err, "connection from denied IP should be closed by server")
+}
+
+func TestTCPDenialInfoAppearsInSourceStatus(t *testing.T) {
+	pp := mock.NewMockProvider()
+	source := sources.NewLogSource("", &config.LogsConfig{
+		Port:      tcpTestPort,
+		DeniedIPs: config.StringSliceField{"127.0.0.0/8", "::1/128"},
+	})
+	listener, err := NewTCPListener(pp, source, 9000)
+	require.NoError(t, err)
+	listener.Start()
+	defer listener.Stop()
+
+	conn, err := net.Dial("tcp", listener.listener.Addr().String())
+	require.NoError(t, err)
+	conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1)
+	conn.Read(buf) //nolint:errcheck
+
+	time.Sleep(200 * time.Millisecond)
+
+	infoStatus := source.GetInfoStatus()
+	ipFilterInfo, ok := infoStatus["IP Filter"]
+	require.True(t, ok, "IP Filter info should be registered with the source")
+	require.NotEmpty(t, ipFilterInfo)
+	found := false
+	for _, line := range ipFilterInfo {
+		if line != "No denials" {
+			found = true
+		}
+	}
+	assert.True(t, found, "at least one denial should be recorded in IP Filter info, got: %v", ipFilterInfo)
+}
+
+func TestTCPDeniedTakesPrecedenceOverAllow(t *testing.T) {
+	pp := mock.NewMockProvider()
+	source := sources.NewLogSource("", &config.LogsConfig{
+		Port:       tcpTestPort,
+		AllowedIPs: config.StringSliceField{"127.0.0.0/8", "::1"},
+		DeniedIPs:  config.StringSliceField{"127.0.0.1", "::1"},
+	})
+	listener, err := NewTCPListener(pp, source, 9000)
+	require.NoError(t, err)
+	listener.Start()
+	defer listener.Stop()
+
+	conn, err := net.Dial("tcp", listener.listener.Addr().String())
+	require.NoError(t, err)
+
+	fmt.Fprint(conn, "should be denied\n")
+	conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, err = conn.Read(buf)
+	assert.Error(t, err, "connection from denied IP should be closed even if it matches allow list")
+}
+
+func TestTCPAllowedIPsRejectsNonMatchingConnection(t *testing.T) {
+	pp := mock.NewMockProvider()
+	source := sources.NewLogSource("", &config.LogsConfig{
+		Port:       tcpTestPort,
+		AllowedIPs: config.StringSliceField{"192.168.1.0/24"},
+	})
+	listener, err := NewTCPListener(pp, source, 9000)
+	require.NoError(t, err)
+	listener.Start()
+	defer listener.Stop()
+
+	conn, err := net.Dial("tcp", listener.listener.Addr().String())
+	require.NoError(t, err)
+
+	fmt.Fprint(conn, "should be rejected\n")
+	conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, err = conn.Read(buf)
+	assert.Error(t, err, "connection from non-allowed IP should be rejected")
+}
+
 func TestTCPMTLSRejectsExpiredClientCert(t *testing.T) {
 	pki := generateTestPKI(t)
 	serverCert, serverKey := pki.issueServerCert(t)

--- a/pkg/logs/launchers/listener/udp.go
+++ b/pkg/logs/launchers/listener/udp.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
+	"github.com/DataDog/datadog-agent/comp/logs-library/utils/ipfilter"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/socket"
 )
@@ -32,17 +34,33 @@ type UDPListener struct {
 	pipelineProvider pipeline.Provider
 	source           *sources.LogSource
 	frameSize        int
+	ipFilter         *ipfilter.Filter
+	denialInfo       *ipfilter.DenialInfo
 	tailer           *tailer.Tailer
 	Conn             net.UDPConn
 }
 
-// NewUDPListener returns an initialized UDPListener
-func NewUDPListener(pipelineProvider pipeline.Provider, source *sources.LogSource, frameSize int) *UDPListener {
+// NewUDPListener returns an initialized UDPListener or an error if critical
+// configuration (IP filter) fails to build.
+func NewUDPListener(pipelineProvider pipeline.Provider, source *sources.LogSource, frameSize int) (*UDPListener, error) {
+	var ipF *ipfilter.Filter
+	var denialInfo *ipfilter.DenialInfo
+	if len(source.Config.AllowedIPs) > 0 || len(source.Config.DeniedIPs) > 0 {
+		var err error
+		ipF, err = ipfilter.New(source.Config.AllowedIPs, source.Config.DeniedIPs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build IP filter for UDP listener on port %d: %w", source.Config.Port, err)
+		}
+		denialInfo = ipfilter.NewDenialInfo()
+		source.RegisterInfo(denialInfo)
+	}
 	return &UDPListener{
 		pipelineProvider: pipelineProvider,
 		source:           source,
 		frameSize:        frameSize,
-	}
+		ipFilter:         ipF,
+		denialInfo:       denialInfo,
+	}, nil
 }
 
 // Start opens a new UDP connection and starts a tailer.
@@ -91,28 +109,39 @@ func (l *UDPListener) newUDPConnection() (net.Conn, error) {
 	return udpConn, nil
 }
 
-// read reads data from the tailer connection, returns an error if it failed and reset the tailer.
+// read reads data from the tailer connection, returns an error if it failed
+// and resets the tailer. When an IP filter is active, denied datagrams are
+// consumed in a loop so that no nil/empty data reaches the decoder pipeline.
 func (l *UDPListener) read(_ *tailer.Tailer) ([]byte, string, error) {
 	frame := make([]byte, l.frameSize+1)
-	// Add casting to UDPConn
-	n, udpAddr, err := l.Conn.ReadFromUDP(frame)
-	switch {
-	case err != nil && isClosedConnError(err):
-		return nil, "", err
-	case err != nil:
-		go l.resetTailer()
-		return nil, "", err
-	default:
-		// make sure all logs are separated by line feeds, otherwise they don't get properly split downstream
-		if n > l.frameSize {
-			// the message is bigger than the length of the read buffer,
-			// the trailing part of the content will be dropped.
-			frame[l.frameSize] = '\n'
-		} else if n > 0 && frame[n-1] != '\n' {
-			frame[n] = '\n'
-			n++
+	for {
+		n, udpAddr, err := l.Conn.ReadFromUDP(frame)
+		switch {
+		case err != nil && isClosedConnError(err):
+			return nil, "", err
+		case err != nil:
+			go l.resetTailer()
+			return nil, "", err
+		default:
+			if l.ipFilter != nil {
+				if d := l.ipFilter.Check(udpAddr); !d.Allowed() {
+					metrics.TlmListenerIPDenied.Inc("udp")
+					l.denialInfo.Record(d.Reason())
+					continue
+				}
+			}
+			// Make sure all logs are separated by line feeds so they
+			// get properly split downstream.
+			if n > l.frameSize {
+				// the message is bigger than the length of the read buffer,
+				// the trailing part of the content will be dropped.
+				frame[l.frameSize] = '\n'
+			} else if n > 0 && frame[n-1] != '\n' {
+				frame[n] = '\n'
+				n++
+			}
+			return frame[:n], udpAddr.IP.String(), nil
 		}
-		return frame[:n], udpAddr.IP.String(), nil
 	}
 }
 

--- a/pkg/logs/launchers/listener/udp_nix_test.go
+++ b/pkg/logs/launchers/listener/udp_nix_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline/mock"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -25,7 +26,8 @@ func TestUDPShoulProperlyCollectLogSplitPerDatadgram(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
 	frameSize := 100
-	listener := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), frameSize)
+	listener, err := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), frameSize)
+	require.NoError(t, err)
 	listener.Start()
 
 	conn, err := net.Dial("udp", listener.tailer.Conn.LocalAddr().String())
@@ -60,7 +62,8 @@ func TestUDPShouldProperlyTruncateBigMessages(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
 	frameSize := 100
-	listener := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), frameSize)
+	listener, err := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), frameSize)
+	require.NoError(t, err)
 	listener.Start()
 
 	conn, err := net.Dial("udp", listener.tailer.Conn.LocalAddr().String())
@@ -91,7 +94,8 @@ func TestUDPShoulDropTooBigMessages(t *testing.T) {
 
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
-	listener := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), maxUDPFrameLen)
+	listener, err := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), maxUDPFrameLen)
+	require.NoError(t, err)
 	listener.Start()
 
 	conn, err := net.Dial("udp", listener.tailer.Conn.LocalAddr().String())

--- a/pkg/logs/launchers/listener/udp_test.go
+++ b/pkg/logs/launchers/listener/udp_test.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline/mock"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -21,10 +23,16 @@ import (
 // use a randomly assigned port
 var udpTestPort = 0
 
+// localhostDenyCIDRs covers both IPv4 and IPv6 loopback since the OS may
+// deliver datagrams from either address family depending on the socket type.
+var localhostDenyCIDRs = []string{"127.0.0.0/8", "::1/128"}
+var localhostAllowCIDRs = []string{"127.0.0.0/8", "::1/128"}
+
 func TestUDPShouldReceiveMessage(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
-	listener := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), 9000)
+	listener, err := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), 9000)
+	require.NoError(t, err)
 	listener.Start()
 
 	conn, err := net.Dial("udp", listener.tailer.Conn.LocalAddr().String())
@@ -39,9 +47,80 @@ func TestUDPShouldReceiveMessage(t *testing.T) {
 	listener.Stop()
 }
 
-func TestUDPShouldStopWhenNotStarted(_ *testing.T) {
+func TestUDPShouldStopWhenNotStarted(t *testing.T) {
 	pp := mock.NewMockProvider()
-	listener := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), 9000)
-	// Don't call start, this is similar to if `startNewTailer` fails when start is called (such as if the port is already in use)
+	listener, err := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), 9000)
+	require.NoError(t, err)
+	listener.Stop()
+}
+
+func TestUDPAllowedIPsAcceptsMatchingDatagram(t *testing.T) {
+	pp := mock.NewMockProvider()
+	msgChan := pp.NextPipelineChan()
+	listener, err := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{
+		Port:       udpTestPort,
+		AllowedIPs: localhostAllowCIDRs,
+	}), 9000)
+	require.NoError(t, err)
+	listener.Start()
+
+	conn, err := net.Dial("udp", listener.tailer.Conn.LocalAddr().String())
+	require.NoError(t, err)
+
+	fmt.Fprint(conn, "allowed\n")
+	msg := <-msgChan
+	assert.Equal(t, "allowed", string(msg.GetContent()))
+
+	listener.Stop()
+}
+
+func TestUDPDeniedIPsDropsMatchingDatagram(t *testing.T) {
+	pp := mock.NewMockProvider()
+	msgChan := pp.NextPipelineChan()
+	listener, err := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{
+		Port:      udpTestPort,
+		DeniedIPs: localhostDenyCIDRs,
+	}), 9000)
+	require.NoError(t, err)
+	listener.Start()
+
+	conn, err := net.Dial("udp", listener.tailer.Conn.LocalAddr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	fmt.Fprint(conn, "should be dropped\n")
+
+	select {
+	case <-msgChan:
+		t.Fatal("expected datagram from denied IP to be dropped")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	listener.Stop()
+}
+
+func TestUDPDenyTakesPrecedenceOverAllow(t *testing.T) {
+	pp := mock.NewMockProvider()
+	msgChan := pp.NextPipelineChan()
+	listener, err := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{
+		Port:       udpTestPort,
+		AllowedIPs: localhostAllowCIDRs,
+		DeniedIPs:  localhostDenyCIDRs,
+	}), 9000)
+	require.NoError(t, err)
+	listener.Start()
+
+	conn, err := net.Dial("udp", listener.tailer.Conn.LocalAddr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	fmt.Fprint(conn, "denied takes precedence\n")
+
+	select {
+	case <-msgChan:
+		t.Fatal("expected datagram to be dropped (deny takes precedence over allow)")
+	case <-time.After(200 * time.Millisecond):
+	}
+
 	listener.Stop()
 }

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -165,6 +165,11 @@ var (
 	// individually oversized are excluded (they'd be truncated regardless).
 	TlmAutoMultilineWouldTruncate = telemetryimpl.GetCompatComponent().NewCounter("logs", "auto_multi_line_default_would_truncate",
 		nil, "Lines belonging to groups that would be truncated if auto multiline were the default")
+
+	// TlmListenerIPDenied counts connections or datagrams rejected by IP allow/deny filters.
+	// Tags: listener_type (tcp, udp)
+	TlmListenerIPDenied = telemetryimpl.GetCompatComponent().NewCounter("logs", "listener_ip_denied",
+		[]string{"listener_type"}, "Count of connections or datagrams rejected by IP allow/deny filters")
 )
 
 func init() {


### PR DESCRIPTION
## What does this PR do?

Adds IP allow-list and deny-list support to both the TCP and UDP log listeners. New `allowed_ips` and `denied_ips` fields accept lists of IPs or CIDR ranges in the integration config. A new `comp/logs-library/utils/ipfilter` package implements the filtering logic using `net/netip` with standard firewall semantics: deny takes precedence over allow; if an allow-list is configured, only matching IPs are accepted; if neither list is set, all traffic is accepted. The TCP listener rejects connections at accept time, and the UDP listener silently drops denied datagrams before decoding.

This PR also refactors `NewUDPListener` to return an error on construction failure (matching the `NewTCPListener` pattern established in tls-v1), ensuring listeners cannot start with misconfigured security controls.

This is part 4 of a 4-part stack.

## Motivation

TLS protects data in transit and authenticates clients, but does not restrict which network hosts may connect. IP-based filtering provides an additional defense-in-depth layer, allowing operators to limit log submission to known infrastructure ranges and block traffic from untrusted sources.

## Describe how you validated your changes

- Unit tests for `ipfilter.Filter`: empty filters, single IPs, CIDR ranges, IPv6, IPv4-mapped IPv6, UDP addresses, deny precedence over allow, and invalid CIDR strings.
- Config validation tests: invalid IP/CIDR entries are rejected; `allowed_ips`/`denied_ips` are only permitted on TCP and UDP source types.
- TCP listener integration tests: connections from allowed IPs are accepted; connections from non-allowed or denied IPs are rejected; deny takes precedence over allow.
- UDP listener tests: construction fails on invalid IP filter config.
- Existing TCP/UDP tests pass with no IP filter configured.

## Additional Notes

- The `ipfilter` package uses `netip.Addr.Unmap()` to normalise IPv4-mapped IPv6 addresses, ensuring `::ffff:127.0.0.1` correctly matches a `127.0.0.0/8` rule.
- Stacked PR: `ryan.hall/tls-v4` → `ryan.hall/tls-v3`