### PR TITLE
[noisy_neighbor] Combine all feature improvements into unified check

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern-user.h
@@ -6,8 +6,13 @@
 typedef struct {
     __u64 sum_latencies_ns;
     __u64 event_count;
-    __u64 preemption_count;
+    __u64 foreign_preemption_count;
+    __u64 self_preemption_count;
     __u64 pid_count;
+    __u64 latency_bucket_lt_100us;
+    __u64 latency_bucket_100us_1ms;
+    __u64 latency_bucket_1ms_10ms;
+    __u64 latency_bucket_gt_10ms;
 } cgroup_agg_stats_t;
 
 #endif

--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -95,11 +95,20 @@ int tp_sched_switch(u64 *ctx) {
         enqueue_timestamp(prev);
     }
 
+    // Hoist next cgroup lookup — used by both preemption classification and latency recording
+    u64 next_cgroup_id = 0;
+    if (next_pid) {
+        next_cgroup_id = get_task_cgroup_id(next);
+    }
+
     if (preempted && prev_pid) {
         u64 prev_cgroup_id = get_task_cgroup_id(prev);
         cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(prev_cgroup_id);
         if (stats) {
-            stats->preemption_count += 1;
+            if (prev_cgroup_id != next_cgroup_id)
+                stats->foreign_preemption_count += 1;
+            else
+                stats->self_preemption_count += 1;
         }
     }
 
@@ -115,12 +124,20 @@ int tp_sched_switch(u64 *ctx) {
     u64 runq_lat = bpf_ktime_get_ns() - *tsp;
     bpf_task_storage_delete(&runq_enqueued, next);
 
-    u64 cgroup_id = get_task_cgroup_id(next);
-    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(cgroup_id);
+    cgroup_agg_stats_t *stats = get_or_create_cgroup_stats(next_cgroup_id);
     if (stats) {
         stats->sum_latencies_ns += runq_lat;
         stats->event_count += 1;
         stats->pid_count = get_cgroup_pids_count(next);
+
+        if (runq_lat < 100000)
+            stats->latency_bucket_lt_100us += 1;
+        else if (runq_lat < 1000000)
+            stats->latency_bucket_100us_1ms += 1;
+        else if (runq_lat < 10000000)
+            stats->latency_bucket_1ms_10ms += 1;
+        else
+            stats->latency_bucket_gt_10ms += 1;
     }
 
     return 0;

--- a/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
+++ b/pkg/collector/corechecks/ebpf/noisyneighbor/noisy_neighbor.go
@@ -9,6 +9,7 @@ package noisyneighbor
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"go.yaml.in/yaml/v2"
@@ -29,14 +30,21 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
+// maxNonContainerCgroups caps the number of non-container cgroups emitted per
+// check run to prevent tag cardinality explosion from transient systemd scopes
+// or other short-lived cgroup hierarchies.
+const maxNonContainerCgroups = 100
+
 type NoisyNeighborConfig struct{}
 
+// NoisyNeighborCheck collects scheduling-latency metrics per cgroup.
 type NoisyNeighborCheck struct {
 	core.CheckBase
-	config         *NoisyNeighborConfig
-	tagger         tagger.Component
-	sysProbeClient *sysprobeclient.CheckClient
-	cgroupReader   *cgroups.Reader
+	config          *NoisyNeighborConfig
+	tagger          tagger.Component
+	sysProbeClient  *sysprobeclient.CheckClient
+	cgroupReader    *cgroups.Reader // container-only cgroups (ContainerFilter)
+	allCgroupReader *cgroups.Reader // all cgroups (DefaultFilter) for non-container fallback
 }
 
 func Factory(tagger tagger.Component) option.Option[func() check.Check] {
@@ -70,6 +78,13 @@ func (n *NoisyNeighborCheck) Configure(senderManager sender.SenderManager, _ uin
 		return fmt.Errorf("noisy_neighbor: cgroup reader init failed: %s", err)
 	}
 	n.cgroupReader = reader
+
+	allReader, err := cgroups.NewReader()
+	if err != nil {
+		return fmt.Errorf("noisy_neighbor: all-cgroup reader init failed: %s", err)
+	}
+	n.allCgroupReader = allReader
+
 	return nil
 }
 
@@ -88,20 +103,35 @@ func (n *NoisyNeighborCheck) Run() error {
 	if err != nil {
 		return fmt.Errorf("unable to refresh cgroups: %s", err)
 	}
+	err = n.allCgroupReader.RefreshCgroups(0)
+	if err != nil {
+		return fmt.Errorf("unable to refresh all-cgroup reader: %s", err)
+	}
 
 	var totalCgroups uint64
+	var nonContainerCount int
 	for _, stat := range stats {
 		totalCgroups++
-		tags := n.getContainerTags(stat)
+		tags, isContainer := n.getContainerTags(stat)
+		if !isContainer {
+			nonContainerCount++
+			if nonContainerCount > maxNonContainerCgroups {
+				continue
+			}
+		}
 		n.submitPrimaryMetrics(sender, stat, tags)
 		n.submitRawCounters(sender, stat, tags)
+		n.submitLatencyBuckets(sender, stat, tags)
 	}
 	sender.Gauge("noisy_neighbor.system.cgroups_tracked", float64(totalCgroups), "", nil)
 	sender.Commit()
 	return nil
 }
 
-func (n *NoisyNeighborCheck) getContainerTags(stat model.NoisyNeighborStats) []string {
+// getContainerTags returns tags for the given stat and whether the tags came
+// from a known container (true) or the cgroup-path fallback (false).
+func (n *NoisyNeighborCheck) getContainerTags(stat model.NoisyNeighborStats) ([]string, bool) {
+	// Try container-based tag lookup first.
 	if cg := n.cgroupReader.GetCgroupByInode(stat.CgroupID); cg != nil {
 		containerID := cg.Identifier()
 		if containerID != "" {
@@ -111,29 +141,58 @@ func (n *NoisyNeighborCheck) getContainerTags(stat model.NoisyNeighborStats) []s
 				if err != nil {
 					log.Warnf("noisy_neighbor: tagger error for container %s: %v", containerID, err)
 				} else {
-					return taggerTags
+					return taggerTags, true
 				}
 			}
 		}
 	}
-	return []string{}
+
+	// Fallback: use the cgroup path as a tag for non-container workloads
+	// (e.g. systemd services).
+	if cg := n.allCgroupReader.GetCgroupByInode(stat.CgroupID); cg != nil {
+		cgroupPath := cg.Identifier()
+		if cgroupPath != "" {
+			// Use the last path component for a concise, human-readable tag
+			// (e.g. "sshd.service" from "/system.slice/sshd.service").
+			name := filepath.Base(cgroupPath)
+			return []string{fmt.Sprintf("cgroup_name:%s", name)}, false
+		}
+	}
+
+	return []string{}, false
 }
 
 // submitPrimaryMetrics sends the main PSL and PSP metrics
 // Note: "process" in metric names follows kernel convention, but these are thread-level measurements
 func (n *NoisyNeighborCheck) submitPrimaryMetrics(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
-	if stat.UniquePidCount == 0 {
+	if stat.CgroupTaskCount == 0 {
 		return
 	}
 
-	psl := float64(stat.SumLatenciesNs) / float64(stat.UniquePidCount)
+	psl := float64(stat.SumLatenciesNs) / float64(stat.CgroupTaskCount)
 	sender.Gauge("noisy_neighbor.process_scheduling_latency.per_process", psl, "", tags)
 
-	psp := float64(stat.PreemptionCount) / float64(stat.UniquePidCount)
-	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.per_process", psp, "", tags)
+	foreignPsp := float64(stat.ForeignPreemptionCount) / float64(stat.CgroupTaskCount)
+	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.foreign.per_process", foreignPsp, "", tags)
+
+	selfPsp := float64(stat.SelfPreemptionCount) / float64(stat.CgroupTaskCount)
+	sender.Gauge("noisy_neighbor.process_scheduler_preemptions.self.per_process", selfPsp, "", tags)
+
+	totalPreemptions := stat.ForeignPreemptionCount + stat.SelfPreemptionCount
+	if totalPreemptions > 0 {
+		latPerPreempt := float64(stat.SumLatenciesNs) / float64(totalPreemptions)
+		sender.Gauge("noisy_neighbor.latency_per_preemption", latPerPreempt, "", tags)
+	}
 }
 
 func (n *NoisyNeighborCheck) submitRawCounters(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
 	sender.Count("noisy_neighbor.events.total", float64(stat.EventCount), "", tags)
-	sender.Gauge("noisy_neighbor.unique_processes", float64(stat.UniquePidCount), "", tags)
+	sender.Gauge("noisy_neighbor.cgroup_task_count", float64(stat.CgroupTaskCount), "", tags)
+}
+
+func (n *NoisyNeighborCheck) submitLatencyBuckets(sender sender.Sender, stat model.NoisyNeighborStats, tags []string) {
+	sender.Count("noisy_neighbor.scheduling_latency.bucket.lt_100us", float64(stat.LatencyBucketLt100us), "", tags)
+	sender.Count("noisy_neighbor.scheduling_latency.bucket.100us_1ms", float64(stat.LatencyBucket100us1ms), "", tags)
+	sender.Count("noisy_neighbor.scheduling_latency.bucket.1ms_10ms", float64(stat.LatencyBucket1ms10ms), "", tags)
+	sender.Count("noisy_neighbor.scheduling_latency.bucket.gt_10ms", float64(stat.LatencyBucketGt10ms), "", tags)
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/ebpf_types_linux.go
@@ -4,8 +4,13 @@
 package noisyneighbor
 
 type ebpfCgroupAggStats struct {
-	Sum_latencies_ns uint64
-	Event_count      uint64
-	Preemption_count uint64
-	Pid_count        uint64
+	Sum_latencies_ns         uint64
+	Event_count              uint64
+	Foreign_preemption_count uint64
+	Self_preemption_count    uint64
+	Pid_count                uint64
+	Latency_bucket_lt_100us  uint64
+	Latency_bucket_100us_1ms uint64
+	Latency_bucket_1ms_10ms  uint64
+	Latency_bucket_gt_10ms   uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/model/types.go
@@ -8,9 +8,14 @@ package model
 
 // NoisyNeighborStats contains the statistics from the noisy neighbor check
 type NoisyNeighborStats struct {
-	CgroupID        uint64
-	SumLatenciesNs  uint64
-	EventCount      uint64
-	PreemptionCount uint64
-	UniquePidCount  uint64 // kernel task_struct->pid (TID) count
+	CgroupID               uint64
+	SumLatenciesNs         uint64
+	EventCount             uint64
+	ForeignPreemptionCount uint64
+	SelfPreemptionCount    uint64
+	CgroupTaskCount        uint64 // total tasks in cgroup from pids_cgroup->counter, not unique active PIDs
+	LatencyBucketLt100us   uint64
+	LatencyBucket100us1ms  uint64
+	LatencyBucket1ms10ms   uint64
+	LatencyBucketGt10ms    uint64
 }

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -104,11 +104,17 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 	var cgroupsToDelete []uint64
 
 	for iter.Next(&cgroupID, &perCPUStats) {
-		var cgroupLatencies, cgroupEvents, cgroupPreemptions, pidCount uint64
+		var cgroupLatencies, cgroupEvents, cgroupForeignPreemptions, cgroupSelfPreemptions, pidCount uint64
+		var bucketLt100us, bucket100us1ms, bucket1ms10ms, bucketGt10ms uint64
 		for _, cpuStat := range perCPUStats {
 			cgroupLatencies += cpuStat.Sum_latencies_ns
 			cgroupEvents += cpuStat.Event_count
-			cgroupPreemptions += cpuStat.Preemption_count
+			cgroupForeignPreemptions += cpuStat.Foreign_preemption_count
+			cgroupSelfPreemptions += cpuStat.Self_preemption_count
+			bucketLt100us += cpuStat.Latency_bucket_lt_100us
+			bucket100us1ms += cpuStat.Latency_bucket_100us_1ms
+			bucket1ms10ms += cpuStat.Latency_bucket_1ms_10ms
+			bucketGt10ms += cpuStat.Latency_bucket_gt_10ms
 			// pid_count is a global cgroup value (not per-CPU), so take the max rather than summing
 			if cpuStat.Pid_count > pidCount {
 				pidCount = cpuStat.Pid_count
@@ -122,11 +128,16 @@ func (p *Probe) GetAndFlush() []model.NoisyNeighborStats {
 		}
 
 		stat := model.NoisyNeighborStats{
-			CgroupID:        cgroupID,
-			SumLatenciesNs:  cgroupLatencies,
-			EventCount:      cgroupEvents,
-			PreemptionCount: cgroupPreemptions,
-			UniquePidCount:  pidCount,
+			CgroupID:               cgroupID,
+			SumLatenciesNs:         cgroupLatencies,
+			EventCount:             cgroupEvents,
+			ForeignPreemptionCount: cgroupForeignPreemptions,
+			SelfPreemptionCount:    cgroupSelfPreemptions,
+			CgroupTaskCount:        pidCount,
+			LatencyBucketLt100us:   bucketLt100us,
+			LatencyBucket100us1ms:  bucket100us1ms,
+			LatencyBucket1ms10ms:   bucket1ms10ms,
+			LatencyBucketGt10ms:    bucketGt10ms,
 		}
 
 		nnstats = append(nnstats, stat)

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe_test.go
@@ -42,7 +42,7 @@ func TestNoisyNeighborProbe(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			for _, r := range probe.GetAndFlush() {
-				if r.EventCount > 0 || r.PreemptionCount > 0 {
+				if r.EventCount > 0 || r.ForeignPreemptionCount > 0 || r.SelfPreemptionCount > 0 {
 					return true
 				}
 			}


### PR DESCRIPTION
Merges five feature branches into a single coherent implementation:
- Foreign/self preemption split: preemption_count is now split into foreign_preemption_count (preempted by different cgroup) and self_preemption_count (preempted by same cgroup) in both eBPF and Go
- Latency histogram buckets: four eBPF-side latency buckets (<100us, 100us-1ms, 1ms-10ms, >10ms) emitted as count metrics
- Latency-per-preemption derived metric: agent computes sum_latencies / (foreign + self preemptions) as a composite gauge
- CgroupTaskCount rename: UniquePidCount renamed to CgroupTaskCount with metric name noisy_neighbor.cgroup_task_count to reflect that the value comes from pids_cgroup->counter
- Non-container cgroup fallback tags: cgroups without a container ID fall back to a cgroup_name tag derived from the cgroup path, with a cardinality cap of 100 non-container cgroups per check run

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
