### PR TITLE
[SMP] ci: add break-glass path for old baselines

### DIFF
--- a/.gitlab/test/functional_test/regression_detector.yml
+++ b/.gitlab/test/functional_test/regression_detector.yml
@@ -44,15 +44,6 @@ single_machine_performance-regression_detector-merge_base_check:
           BASELINE_SHA="${SMP_MERGE_BASE}"
       fi
     - BASELINE_COMMIT_TIME=$(git -c log.showSignature=false show --no-patch --format=%ct ${BASELINE_SHA})
-    # Check if baseline SHA is too old
-    - |
-      if [[ ${BASELINE_COMMIT_TIME} -le ${FOUR_DAYS_BEFORE_NOW} ]]
-      then
-          echo "ERROR: Merge-base of this branch is too old for SMP. Please update your branch by merging an up-to-date main branch into your branch or by rebasing it on an up-to-date main branch."
-          datadog-ci tag --level job --tags smp_merge_base_failure_reason:"branch_too_old"
-          exit 1
-      fi
-    - echo "Commit ${BASELINE_SHA} is recent enough"
     # Setup AWS credentials for single-machine-performance AWS account to check ECR images
     - AWS_NAMED_PROFILE="single-machine-performance"
     - SMP_ACCOUNT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SMP_ACCOUNT account_id) || exit $?
@@ -63,7 +54,20 @@ single_machine_performance-regression_detector-merge_base_check:
     - aws configure set aws_secret_access_key "$SMP_BOT_KEY" --profile ${AWS_NAMED_PROFILE}
     - aws configure set region us-west-2 --profile ${AWS_NAMED_PROFILE}
 
-    # Check if image exists for the baseline SHA
+    # Check if image exists for the baseline SHA, walking backwards on the
+    # commit graph until a container corresponding to the possible baseline is
+    # found, or the possible baseline commit is too old. If the commit is too
+    # old, the container corresponding to that commit has probably expired.
+    #
+    # We intentionally omit checking whether the baseline commit is too old
+    # *before* the loop in order to provide ourselves with a break-glass option
+    # in scenarios where we would like to use an old commit as a baseline (e.g.,
+    # backporting bugfixes to a release branch). In such a scenario, we could
+    # run CI on the release branch to generate a baseline image, even if the
+    # commit is too old. However, we also only omit the commit age check once so
+    # that we can still use it on predecessor commits that are usually older than
+    # the current commit under test -- this check gives us a fast-fail condition so
+    # we avoid wasting time checking for expired images in common cases.
     - echo "Checking if image exists for commit ${BASELINE_SHA}..."
     - |
       while [[ ! $(aws ecr describe-images --region us-west-2 --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-full-amd64") ]]


### PR DESCRIPTION
### What does this PR do?

There are scenarios such as release branches where the "natural" baseline commit -- the HEAD of the release branch -- is "too old" relative to a PR. In those scenarios, the commit age check before walking the commit graph backwards from the merge-base prevents us from doing the simple thing to unblock a PR to the release branch blocked on an SMP test -- run CI on the HEAD of the release branch to generate a baseline container for performance comparisons. To make unblocking this scenario easier -- and self-service! -- this commit removes the first commit age check so that we have one opportunity to compare against an old baseline that might be present.

### Motivation

See above; we'd like to run SMP jobs on PRs that backport changes to release branches.

### Describe how you validated your changes

n/a

### Additional Notes

We preserve the commit age check inside the commit graph walking loop in order to preserve a common fast-fail path in this CI job. If the merge-base commit is too old, predecessor commits are also likely to be too old (but not guaranteed, because commit predecessor relationships are topological, not chronological).