### PR TITLE
[macOS] Fix sysprobe plist PathState

### DIFF
--- a/packages/macos/app/launchd.sysprobe.plist.example.in
+++ b/packages/macos/app/launchd.sysprobe.plist.example.in
@@ -8,7 +8,7 @@
             <false/>
             <key>PathState</key>
             <dict>
-              <key>{conf_dir}/system-probe.yaml</key>
+              <key>/opt/datadog-agent/etc/system-probe.yaml</key>
               <true/>
             </dict>
         </dict>
@@ -24,7 +24,7 @@
             <string>/opt/datadog-agent/embedded/bin/system-probe</string>
             <string>run</string>
             <string>-c</string>
-            <string>/opt/datadog-agent/{conf_dir}</string>
+            <string>/opt/datadog-agent/etc</string>
         </array>
         <key>StandardOutPath</key>
         <string>/opt/datadog-agent/logs/launchd_sysprobe.log</string>


### PR DESCRIPTION
### What does this PR do?
This commit https://github.com/DataDog/datadog-agent/commit/f970069a291fce4c44d6222d41a1440e2069ad35 changed the {conf_dir} template variable to be just `etc` causing the PathState in sysprobe plist to be a relative path. This broke sysprobe from loading after agent installation. Need to fix to absolute path. Might as well hardcode the paths in the plist.

Relates to https://github.com/DataDog/datadog-agent/pull/48141 which forgot to make this fix.

### Motivation
[WINA-2510](https://datadoghq.atlassian.net/browse/WINA-2510)

### Describe how you validated your changes
Local testing on VM to make sure sysprobe plist loads after installation

### Additional Notes


[WINA-2510]: https://datadoghq.atlassian.net/browse/WINA-2510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ