### PR TITLE
[ AGNTLOG-626 ] fix(logs/journald): first journal entry dropped when tailing from beginning

### DIFF
--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -53,6 +53,10 @@ type Tailer struct {
 	// instead of on the logs content.
 	processRawMessage bool
 
+	// entryReady is true when seek() has already positioned the journal on a
+	// readable entry (via SeekHead+Next). tail() should read this entry before
+	// calling Next() again.
+	entryReady bool
 	// tagProvider provides additional tags to be attached to each log message.  It
 	// is called once for each log message.
 	tagProvider            tag.Provider
@@ -229,7 +233,10 @@ func (t *Tailer) seek(cursor string) error {
 		if err := t.journal.SeekHead(); err != nil {
 			return err
 		}
-		_, err := t.journal.Next() // SeekHead must be followed by Next
+		// SeekHead must be followed by Next before any Get* call.
+		// Set entryReady so tail() reads this entry before calling Next().
+		n, err := t.journal.Next()
+		t.entryReady = n > 0
 		return err
 	}
 	seekTail := func() error {
@@ -277,17 +284,22 @@ func (t *Tailer) tail() {
 		case <-t.stop:
 			return
 		default:
-			n, err := t.journal.Next()
-			if err != nil && err != io.EOF {
-				err := fmt.Errorf("cant't tail journal %s: %s", t.journalPath(), err)
-				t.source.Status.Error(err)
-				log.Error(err)
-				return
-			}
-			if n < 1 {
-				// no new entry
-				t.journal.Wait(defaultWaitDuration)
-				continue
+			if t.entryReady {
+				// seek() already positioned the journal on a readable entry.
+				t.entryReady = false
+			} else {
+				n, err := t.journal.Next()
+				if err != nil && err != io.EOF {
+					err := fmt.Errorf("cant't tail journal %s: %s", t.journalPath(), err)
+					t.source.Status.Error(err)
+					log.Error(err)
+					return
+				}
+				if n < 1 {
+					// no new entry
+					t.journal.Wait(defaultWaitDuration)
+					continue
+				}
 			}
 			entry, err := t.journal.GetEntry()
 			if err != nil {

--- a/pkg/logs/tailers/journald/tailer_test.go
+++ b/pkg/logs/tailers/journald/tailer_test.go
@@ -33,6 +33,11 @@ type MockJournal struct {
 	previous int
 	cursor   string
 	entries  []*sdjournal.JournalEntry
+	// idx tracks the current journal cursor position, mirroring real journald
+	// semantics: -1 means before the first entry (set by SeekHead),
+	// len(entries) means after the last entry (set by SeekTail).
+	// When creating a mock to read entries, initialize with idx: -1.
+	idx int
 }
 
 func (m *MockJournal) AddMatch(_ string) error {
@@ -45,11 +50,13 @@ func (m *MockJournal) AddDisjunction() error {
 
 func (m *MockJournal) SeekTail() error {
 	m.seekTail++
+	m.idx = len(m.entries)
 	return nil
 }
 
 func (m *MockJournal) SeekHead() error {
 	m.seekHead++
+	m.idx = -1
 	return nil
 }
 
@@ -75,28 +82,31 @@ func (m *MockJournal) Next() (uint64, error) {
 	m.m.Lock()
 	defer m.m.Unlock()
 	m.next++
-	return uint64(len(m.entries)), nil
+	m.idx++
+	if m.idx < len(m.entries) {
+		return 1, nil
+	}
+	return 0, nil
 }
 
 func (m *MockJournal) Previous() (uint64, error) {
 	m.m.Lock()
 	defer m.m.Unlock()
 	m.previous++
-	return uint64(len(m.entries)), nil
+	m.idx--
+	if m.idx >= 0 && m.idx < len(m.entries) {
+		return 1, nil
+	}
+	return 0, nil
 }
 
 func (m *MockJournal) GetEntry() (*sdjournal.JournalEntry, error) {
 	m.m.Lock()
 	defer m.m.Unlock()
-	defer func() {
-		m.entries = m.entries[1:]
-	}()
-
-	if len(m.entries) == 0 {
+	if m.idx < 0 || m.idx >= len(m.entries) {
 		return nil, nil
 	}
-
-	return m.entries[0], nil
+	return m.entries[m.idx], nil
 }
 
 func (m *MockJournal) GetCursor() (string, error) {
@@ -566,8 +576,8 @@ func TestTailingMode(t *testing.T) {
 
 func TestTailerCanTailJournal(t *testing.T) {
 
-	mockJournal := &MockJournal{m: &sync.Mutex{}}
-	source := sources.NewLogSource("", &config.LogsConfig{})
+	mockJournal := &MockJournal{m: &sync.Mutex{}, idx: -1}
+	source := sources.NewLogSource("", &config.LogsConfig{TailingMode: "beginning"})
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	fakeRegistry := auditorMock.NewMockAuditor()
 	tailer := NewTailer(source, make(chan *message.Message, 1), mockJournal, true, fakeTagger, fakeRegistry)
@@ -585,11 +595,38 @@ func TestTailerCanTailJournal(t *testing.T) {
 	tailer.Stop()
 }
 
+func TestSeekHeadReadsFirstEntry(t *testing.T) {
+	mockJournal := &MockJournal{m: &sync.Mutex{}, idx: -1}
+	source := sources.NewLogSource("", &config.LogsConfig{TailingMode: "beginning"})
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	fakeRegistry := auditorMock.NewMockAuditor()
+	tailer := NewTailer(source, make(chan *message.Message, 2), mockJournal, true, fakeTagger, fakeRegistry)
+
+	mockJournal.entries = []*sdjournal.JournalEntry{
+		{Fields: map[string]string{"MESSAGE": "first"}},
+		{Fields: map[string]string{"MESSAGE": "second"}},
+	}
+
+	tailer.Start("")
+
+	msg1 := <-tailer.outputChan
+	var parsed1 map[string]interface{}
+	json.Unmarshal(msg1.GetContent(), &parsed1)
+	assert.Equal(t, "first", parsed1["message"])
+
+	msg2 := <-tailer.outputChan
+	var parsed2 map[string]interface{}
+	json.Unmarshal(msg2.GetContent(), &parsed2)
+	assert.Equal(t, "second", parsed2["message"])
+
+	tailer.Stop()
+}
+
 func TestTailerWithStructuredMessage(t *testing.T) {
 	assert := assert.New(t)
 
-	mockJournal := &MockJournal{m: &sync.Mutex{}}
-	source := sources.NewLogSource("", &config.LogsConfig{})
+	mockJournal := &MockJournal{m: &sync.Mutex{}, idx: -1}
+	source := sources.NewLogSource("", &config.LogsConfig{TailingMode: "beginning"})
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	fakeRegistry := auditorMock.NewMockAuditor()
 	tailer := NewTailer(source, make(chan *message.Message, 1), mockJournal, false, fakeTagger, fakeRegistry)
@@ -614,8 +651,8 @@ func TestTailerCompareUnstructuredAndStructured(t *testing.T) {
 
 	// v1 behavior tailer
 
-	mockJournalV1 := &MockJournal{m: &sync.Mutex{}}
-	sourceV1 := sources.NewLogSource("", &config.LogsConfig{})
+	mockJournalV1 := &MockJournal{m: &sync.Mutex{}, idx: -1}
+	sourceV1 := sources.NewLogSource("", &config.LogsConfig{TailingMode: "beginning"})
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	fakeRegistry := auditorMock.NewMockAuditor()
 	tailerV1 := NewTailer(sourceV1, make(chan *message.Message, 1), mockJournalV1, true, fakeTagger, fakeRegistry)
@@ -629,8 +666,8 @@ func TestTailerCompareUnstructuredAndStructured(t *testing.T) {
 
 	// v2 behavior tailer
 
-	mockJournalV2 := &MockJournal{m: &sync.Mutex{}}
-	sourceV2 := sources.NewLogSource("", &config.LogsConfig{})
+	mockJournalV2 := &MockJournal{m: &sync.Mutex{}, idx: -1}
+	sourceV2 := sources.NewLogSource("", &config.LogsConfig{TailingMode: "beginning"})
 	tailerV2 := NewTailer(sourceV2, make(chan *message.Message, 1), mockJournalV2, false, fakeTagger, fakeRegistry)
 	mockJournalV2.entries = append(mockJournalV2.entries, &sdjournal.JournalEntry{Fields: map[string]string{
 		sdjournal.SD_JOURNAL_FIELD_MESSAGE: "journald log message content",
@@ -663,8 +700,8 @@ func TestExpectedTagDuration(t *testing.T) {
 	// test, even with the race detector enabled, don't hit that time limit.
 	mockConfig.SetWithoutSource("logs_config.expected_tags_duration", "1h")
 
-	mockJournal := &MockJournal{m: &sync.Mutex{}}
-	source := sources.NewLogSource("", &config.LogsConfig{})
+	mockJournal := &MockJournal{m: &sync.Mutex{}, idx: -1}
+	source := sources.NewLogSource("", &config.LogsConfig{TailingMode: "beginning"})
 	fakeRegistry := auditorMock.NewMockAuditor()
 	tailer := NewTailer(source, make(chan *message.Message, 1), mockJournal, true, fakeTagger, fakeRegistry)
 

--- a/releasenotes/notes/fix-journald-seekhead-skips-first-entry-4db4f9253bee85e0.yaml
+++ b/releasenotes/notes/fix-journald-seekhead-skips-first-entry-4db4f9253bee85e0.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes the journald log tailer skipping the first journal entry when
+    ``start_position`` is set to ``beginning`` or ``forceBeginning``.


### PR DESCRIPTION
### What does this PR do?

  Fixes the journald log tailer skipping the first journal entry when `start_position` is set to `beginning` or
  `forceBeginning`.

  `seekHead()` calls `SeekHead()` + `Next()` to satisfy the [journald API contract](https://pkg.go.dev/github.com/coreos/go-systemd/v22@v22.5.0/sdjournal#Journal.SeekHead), positioning the cursor on the first
  entry. But `tail()` also calls `Next()` before `GetEntry()`, advancing past that first entry without reading it.

  The fix adds an `entryReady` flag so that `tail()` skips its initial `Next()` when `seek()` has already positioned on
   a readable entry.

  ### Motivation

  When using journald log collection with `start_position: beginning`, the very first journal entry for each tailer is
  silently dropped on the first agent start (before any cursor is persisted). This affects any config using `beginning`
   on first run, or `forceBeginning` on every restart.

  The bug was introduced in #20417 (Nov 2023), which correctly fixed `seekTail` behavior but inadvertently added a
  redundant `Next()` call to `seekHead`.

  ### Describe how you validated your changes

  - Added `TestSeekHeadReadsFirstEntry` which inserts two entries and asserts both are read in order. This test
  deadlocks without the fix.
  - Made `MockJournal` position-aware to accurately model journald cursor semantics (`SeekHead` -> idx before first,
  `SeekTail` -> idx after last, `Next`/`Previous` advance the index).
  - Full test suite passes: all 22 tests in `pkg/logs/tailers/journald/`.
  - Built a datadog-agent binary and tested that with the new logic, the first log appears, whereas with the previously installed version, it would not.  

  ### Additional Notes

  The existing tests didn't catch this because `MockJournal` wasn't position-aware — `Next()` was just a counter and
  `GetEntry()` always popped the front of the slice, so double-calling `Next()` had no effect. Four existing tests were
   updated to use `TailingMode: "beginning"` since they rely on reading pre-existing entries, which the now-accurate
  mock correctly prevents under the default `seekTail` mode.