### PR TITLE
Migrate gohai/cpu to bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -251,7 +251,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/eventmonitor
 # gazelle:exclude pkg/flare
 # gazelle:exclude pkg/fleet/daemon
-# gazelle:exclude pkg/gohai/cpu
 # gazelle:exclude pkg/gpu
 # gazelle:exclude pkg/hosttags
 # gazelle:exclude pkg/inventory

--- a/pkg/gohai/cpu/BUILD.bazel
+++ b/pkg/gohai/cpu/BUILD.bazel
@@ -1,0 +1,123 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "cpu",
+    srcs = [
+        "cpu.go",
+        "cpu_darwin.go",
+        "cpu_linux_arm64.go",
+        "cpu_linux_default.go",
+        "cpu_windows.c",
+        "cpu_windows.go",
+        "cpu_windows.h",
+        "lscpu_linux_arm64.go",
+        "util_linux.go",
+    ],
+    cgo = True,
+    clinkopts = select({
+        "@rules_go//go/platform:windows": [
+            "-lkernel32",
+        ],
+        "//conditions:default": [],
+    }),
+    # keep
+    copts = select({
+        # Without -mpopcnt, MinGW falls back to a software implentation for
+        # __popcountdi2, which pulls in a dependency to libgcc_s_seh-1.dll.
+        # Forcing -mpopcnt ensures we use the dedicated CPU instruction, without
+        # any additional dependency
+        "@rules_go//go/platform:windows": [
+            "-mpopcnt",
+        ],
+        "//conditions:default": [],
+    }),
+    importpath = "github.com/DataDog/datadog-agent/pkg/gohai/cpu",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/gohai/utils",
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:ios": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:windows": [
+            "//pkg/util/log",
+            "@org_golang_x_sys//windows/registry",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "cpu_test",
+    srcs = [
+        "cpu_linux_default_test.go",
+        "cpu_test.go",
+        "util_linux_test.go",
+    ],
+    embed = [":cpu"],
+    gotags = ["test"],
+    deps = [
+        "//pkg/gohai/utils",
+        "//pkg/util/log",
+        "@com_github_stretchr_testify//assert",
+    ] + select({
+        "@rules_go//go/platform:android_386": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:android_amd64": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:android_arm": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:android_arm64": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_386": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_amd64": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_arm": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_arm64": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_mips": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_mips64": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_mips64le": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_mipsle": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_ppc64": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_ppc64le": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_riscv64": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux_s390x": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
+)


### PR DESCRIPTION
### What does this PR do?

Migrate gohai/cpu to bazel

### Motivation

https://datadoghq.atlassian.net/browse/ABLD-425

### Describe how you validated your changes

Local gazelle run & bazel test invocation

### Additional Notes

The main change from this PR is the introduction of the `-mpopcnt` CFLAGS in the BUILD file.
If  `-mpopcnt` isn't provided, mingw-w64 will use a software implementation for `__popcnt64`, which makes the resulting binary depend on `libgcc_s_seh-1.dll` which we'd have to ship in order for the test (and ultimately, the actual code, but currently only the tests)
We could additionally provide `-mpopcnt` as a `cgo CFLAGS` directive, but it's rejected by golang's default cflags safelist.