### PR TITLE
fix(autoscaling): use `is_leader` tag instead of `join_leader` on DPA metrics

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/metrics/generator.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator.go
@@ -46,7 +46,7 @@ func baseAutoscalerTags(internal *model.PodAutoscalerInternal) []string {
 		"target_kind:" + targetKind,
 		"autoscaler_name:" + name, // keep it for backward compatibility, even if it's redundant with "name"
 		"name:" + name,
-		le.JoinLeaderLabel + ":" + le.JoinLeaderValue,
+		le.IsLeaderLabel + ":" + le.JoinLeaderValue,
 	}
 	tags = append(tags, keyTagsFromObjectMetadata(internal)...)
 	// Cap to prevent slice aliasing when callers append to this slice multiple times

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
@@ -48,7 +48,7 @@ func TestBaseAutoscalerTags(t *testing.T) {
 	assert.Contains(t, tags, "target_kind:deployment")
 	assert.Contains(t, tags, "autoscaler_name:test-autoscaler")
 	assert.Contains(t, tags, "name:test-autoscaler")
-	assert.Contains(t, tags, le.JoinLeaderLabel+":"+le.JoinLeaderValue)
+	assert.Contains(t, tags, le.IsLeaderLabel+":"+le.JoinLeaderValue)
 }
 
 func TestConditionTags(t *testing.T) {
@@ -73,7 +73,7 @@ func TestConditionTags(t *testing.T) {
 	assert.Contains(t, tags, "autoscaler_name:test-autoscaler")
 	assert.Contains(t, tags, "name:test-autoscaler")
 	assert.Contains(t, tags, "type:Active")
-	assert.Contains(t, tags, le.JoinLeaderLabel+":"+le.JoinLeaderValue)
+	assert.Contains(t, tags, le.IsLeaderLabel+":"+le.JoinLeaderValue)
 }
 
 func TestGeneratePodAutoscalerMetrics(t *testing.T) {

--- a/pkg/util/kubernetes/apiserver/leaderelection/metrics/metrics.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/metrics/metrics.go
@@ -25,7 +25,7 @@ func NewLeaderMetric() telemetry.Gauge {
 	return telemetry.NewGaugeWithOpts(
 		"leader_election",
 		"is_leader",
-		[]string{JoinLeaderLabel, IsLeaderLabel}, // join_leader is for label joins
+		[]string{JoinLeaderLabel, IsLeaderLabel}, // join_leader is for label joins, is_leader indicates if the pod is the current leader.
 		"The label is_leader is true if the reporting pod is leader, equals false otherwise.",
 		telemetry.Options{NoDoubleUnderscoreSep: true},
 	)

--- a/pkg/util/kubernetes/apiserver/leaderelection/metrics/metrics.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/metrics/metrics.go
@@ -16,8 +16,8 @@ const (
 	JoinLeaderLabel = "join_leader"
 	// JoinLeaderValue is the static value of the label join_leader
 	JoinLeaderValue = "true"
-	// isLeaderLabel represents the is_leader label
-	isLeaderLabel = "is_leader"
+	// IsLeaderLabel represents the is_leader label
+	IsLeaderLabel = "is_leader"
 )
 
 // NewLeaderMetric returns the leader_election_is_leader metric
@@ -25,7 +25,7 @@ func NewLeaderMetric() telemetry.Gauge {
 	return telemetry.NewGaugeWithOpts(
 		"leader_election",
 		"is_leader",
-		[]string{JoinLeaderLabel, isLeaderLabel}, // join_leader is for label joins
+		[]string{JoinLeaderLabel, IsLeaderLabel}, // join_leader is for label joins
 		"The label is_leader is true if the reporting pod is leader, equals false otherwise.",
 		telemetry.Options{NoDoubleUnderscoreSep: true},
 	)


### PR DESCRIPTION
### What does this PR do?

- Export IsLeaderLabel constant from leaderelection/metrics package
- Replace `le.JoinLeaderLabel` with `le.IsLeaderLabel` in baseAutoscalerTags
- Update TestBaseAutoscalerTags and TestConditionTags assertions accordingly

### Motivation

Fix regression introduced by https://github.com/DataDog/datadog-agent/pull/47138 in the 7.78.0 futur release.

DPA metrics were tagged with `join_leader:true` instead of `is_leader:true`.
The join_leader tag is a label-join anchor for Datadog metric joins, not the actual
leader indicator. Since the autoscaling workload controller only runs on the leader,
metrics should carry is_leader:true directly so consumers see the correct tag without
needing a label join configuration.

### Describe how you validated your changes

Unit-tests update,
Run locally the cluster-agent with the fix and saw the tag on the new metrics 

### Additional Notes
