### PR TITLE
[procmgr] Port shutdown.rs tests to cross-platform helpers

### DIFF
--- a/pkg/procmgr/rust/src/shutdown.rs
+++ b/pkg/procmgr/rust/src/shutdown.rs
@@ -27,15 +27,20 @@ pub async fn shutdown_all(processes: &mut [ManagedProcess]) {
 mod tests {
     use super::*;
     use crate::state::ProcessState;
-    use crate::test_helpers::{make_config, test_uuid};
+    use crate::test_helpers;
+
+    fn sleep_config() -> crate::config::ProcessConfig {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
+        test_helpers::make_config(cmd, args)
+    }
 
     #[tokio::test]
     async fn test_shutdown_all_graceful() {
-        let cfg1 = make_config("/bin/sleep", vec!["60".into()]);
-        let cfg2 = make_config("/bin/sleep", vec!["60".into()]);
+        let cfg1 = sleep_config();
+        let cfg2 = sleep_config();
 
-        let mut p1 = ManagedProcess::new_config("p1".into(), test_uuid(), cfg1);
-        let mut p2 = ManagedProcess::new_config("p2".into(), test_uuid(), cfg2);
+        let mut p1 = ManagedProcess::new_config("p1".into(), test_helpers::test_uuid(), cfg1);
+        let mut p2 = ManagedProcess::new_config("p2".into(), test_helpers::test_uuid(), cfg2);
         p1.spawn().unwrap();
         p2.spawn().unwrap();
 
@@ -56,12 +61,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_shutdown_all_sigkill_on_timeout() {
-        let mut cfg = make_config(
-            "/bin/sh",
-            vec!["-c".into(), "trap '' TERM; sleep 60".into()],
-        );
+        let (cmd, args) = test_helpers::trap_term_sleep();
+        let mut cfg = test_helpers::make_config(cmd, args);
         cfg.stop_timeout = Some(1);
-        let mut proc = ManagedProcess::new_config("stubborn".into(), test_uuid(), cfg);
+        let mut proc =
+            ManagedProcess::new_config("stubborn".into(), test_helpers::test_uuid(), cfg);
         proc.spawn().unwrap();
 
         let mut procs = vec![proc];
@@ -72,11 +76,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_shutdown_all_after_take_child() {
-        let mut proc = ManagedProcess::new_config(
-            "t".into(),
-            test_uuid(),
-            make_config("/bin/sleep", vec!["60".into()]),
-        );
+        let mut proc =
+            ManagedProcess::new_config("t".into(), test_helpers::test_uuid(), sleep_config());
         proc.spawn().unwrap();
         let _child = proc.take_child();
 
@@ -92,21 +93,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_shutdown_ordered_reverse() {
-        let mut p1 = ManagedProcess::new_config(
-            "p1".into(),
-            test_uuid(),
-            make_config("/bin/sleep", vec!["60".into()]),
-        );
-        let mut p2 = ManagedProcess::new_config(
-            "p2".into(),
-            test_uuid(),
-            make_config("/bin/sleep", vec!["60".into()]),
-        );
-        let mut p3 = ManagedProcess::new_config(
-            "p3".into(),
-            test_uuid(),
-            make_config("/bin/sleep", vec!["60".into()]),
-        );
+        let mut p1 =
+            ManagedProcess::new_config("p1".into(), test_helpers::test_uuid(), sleep_config());
+        let mut p2 =
+            ManagedProcess::new_config("p2".into(), test_helpers::test_uuid(), sleep_config());
+        let mut p3 =
+            ManagedProcess::new_config("p3".into(), test_helpers::test_uuid(), sleep_config());
         p1.spawn().unwrap();
         p2.spawn().unwrap();
         p3.spawn().unwrap();


### PR DESCRIPTION
### What does this PR do?

Ports the `shutdown.rs` test module to be cross-platform by replacing all hardcoded Unix commands with `test_helpers` helpers:

- Added local `sleep_config()` helper using `test_helpers::sleep_cmd(60)` + `test_helpers::make_config()`
- Replaced `/bin/sh -c "trap '' TERM; sleep 60"` with `test_helpers::trap_term_sleep()`
- Updated all `make_config`/`test_uuid` calls to use `test_helpers::` prefix

### Motivation

Part of the dd-procmgrd Windows port. Ensures shutdown tests compile and run correctly on both Unix and Windows by removing hardcoded `/bin/sleep` and `/bin/sh` paths.

### Describe how you validated your changes

- All 6 shutdown tests pass (`cargo test --lib -- shutdown`)
- Full test suite passes (131 tests)
- `cargo fmt --check` and `cargo clippy --all-targets` clean

### Additional Notes