### PR TITLE
AGTMETRICS-502 Add support for v3beta validation endpoint

### DIFF
--- a/comp/forwarder/defaultforwarder/endpoints/endpoints.go
+++ b/comp/forwarder/defaultforwarder/endpoints/endpoints.go
@@ -27,6 +27,8 @@ var (
 	SeriesEndpoint = transaction.Endpoint{Route: "/api/v2/series", Name: "series_v2"}
 	// V3SeriesEndpoint is the v3 endpoint used to send series
 	V3SeriesEndpoint = transaction.Endpoint{Route: "/api/intake/metrics/v3/series", Name: "series_v3"}
+	// V3BetaSeriesEndpoint is the v3 beta endpoint used to send series
+	V3BetaSeriesEndpoint = transaction.Endpoint{Route: "/api/intake/metrics/v3beta/series", Name: "series_v3beta"}
 	// EventsEndpoint is the v2 endpoint used to send events
 	EventsEndpoint = transaction.Endpoint{Route: "/api/v2/events", Name: "events_v2"}
 	// ServiceChecksEndpoint is the v2 endpoint used to send service checks

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1449,6 +1449,8 @@ func serializer(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.validate", false)
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.sketches.validate", false)
 	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.compression_level", 0)
+	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.use_beta", false)
+	config.BindEnvAndSetDefault("serializer_experimental_use_v3_api.series.beta_route", "/api/intake/metrics/v3beta/series")
 
 	config.BindEnvAndSetDefault("use_v2_api.series", true)
 	// Serializer: allow user to blacklist any kind of payload to be sent

--- a/pkg/serializer/metrics.go
+++ b/pkg/serializer/metrics.go
@@ -46,10 +46,14 @@ func metricsValidateV3(config config.Component, kind metricsKind) bool {
 	return config.GetBool(fmt.Sprintf("serializer_experimental_use_v3_api.%s.validate", kind))
 }
 
-func metricsEndpointFor(kind metricsKind, useV3 bool) transaction.Endpoint {
+func metricsEndpointFor(kind metricsKind, useV3 bool, config config.Component) transaction.Endpoint {
 	switch kind {
 	case metricsKindSeries:
 		if useV3 {
+			if config.GetBool("serializer_experimental_use_v3_api.series.use_beta") {
+				route := config.GetString("serializer_experimental_use_v3_api.series.beta_route")
+				return transaction.Endpoint{Route: route, Name: endpoints.V3BetaSeriesEndpoint.Name}
+			}
 			return endpoints.V3SeriesEndpoint
 		}
 		return endpoints.SeriesEndpoint
@@ -80,7 +84,7 @@ func (s *Serializer) buildPipelines(kind metricsKind) metrics.PipelineSet {
 
 		dest := metrics.PipelineDestination{
 			Resolver:          resolver,
-			Endpoint:          metricsEndpointFor(kind, useV3),
+			Endpoint:          metricsEndpointFor(kind, useV3, s.config),
 			ValidationBatchID: batchID,
 		}
 
@@ -117,7 +121,7 @@ func (s *Serializer) buildPipelines(kind metricsKind) metrics.PipelineSet {
 				}
 				vdest := metrics.PipelineDestination{
 					Resolver:          resolver,
-					Endpoint:          metricsEndpointFor(kind, false),
+					Endpoint:          metricsEndpointFor(kind, false, s.config),
 					ValidationBatchID: batchID,
 				}
 				pipelines.Add(vconf, vdest)

--- a/pkg/serializer/metrics_test.go
+++ b/pkg/serializer/metrics_test.go
@@ -425,3 +425,57 @@ outer:
 		},
 	)
 }
+
+func TestBuildPipelinesWithV3Beta(t *testing.T) {
+	logger := logmock.New(t)
+	config := configmock.New(t)
+
+	config.SetWithoutSource("dd_url", "http://example.test")
+	config.SetWithoutSource("api_key", "test_key")
+	config.SetWithoutSource("serializer_experimental_use_v3_api.series.endpoints", []string{"http://example.test"})
+	config.SetWithoutSource("serializer_experimental_use_v3_api.series.use_beta", true)
+
+	f, err := defaultforwarder.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
+	require.NoError(t, err)
+	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	s := NewSerializer(f, nil, compressor, config, logger, "")
+
+	pipelines := s.buildPipelines(metricsKindSeries)
+	require.Len(t, pipelines, 1)
+
+	for conf, ctx := range pipelines {
+		require.Len(t, ctx.Destinations, 1)
+		dest := ctx.Destinations[0]
+		assert.Equal(t, metrics.AllowAllFilter{}, conf.Filter)
+		assert.True(t, conf.V3)
+		assert.Equal(t, endpoints.V3BetaSeriesEndpoint, dest.Endpoint)
+	}
+}
+
+func TestBuildPipelinesWithV3BetaCustomRoute(t *testing.T) {
+	logger := logmock.New(t)
+	config := configmock.New(t)
+
+	config.SetWithoutSource("dd_url", "http://example.test")
+	config.SetWithoutSource("api_key", "test_key")
+	config.SetWithoutSource("serializer_experimental_use_v3_api.series.endpoints", []string{"http://example.test"})
+	config.SetWithoutSource("serializer_experimental_use_v3_api.series.use_beta", true)
+	config.SetWithoutSource("serializer_experimental_use_v3_api.series.beta_route", "/api/intake/metrics/custom/series")
+
+	f, err := defaultforwarder.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
+	require.NoError(t, err)
+	compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: config}).Comp
+	s := NewSerializer(f, nil, compressor, config, logger, "")
+
+	pipelines := s.buildPipelines(metricsKindSeries)
+	require.Len(t, pipelines, 1)
+
+	for conf, ctx := range pipelines {
+		require.Len(t, ctx.Destinations, 1)
+		dest := ctx.Destinations[0]
+		assert.Equal(t, metrics.AllowAllFilter{}, conf.Filter)
+		assert.True(t, conf.V3)
+		assert.Equal(t, "/api/intake/metrics/custom/series", dest.Endpoint.Route)
+		assert.Equal(t, endpoints.V3BetaSeriesEndpoint.Name, dest.Endpoint.Name)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Add v3beta endpoint that is used exclusively for validating if v3 payloads match v2, without processing them further. The endpoint is behind a new feature flag, which, once the validation phase is complete can be removed.

### Motivation

Improve validation for v3 metrics payloads.

### Describe how you validated your changes

### Additional Notes
