### PR TITLE
[EBPF] kmt: match setup and upload job timeouts

### DIFF
--- a/.gitlab/test/kernel_matrix_testing/common.yml
+++ b/.gitlab/test/kernel_matrix_testing/common.yml
@@ -22,7 +22,19 @@
   # Touch .instance_not_found to mark the failure reason to the tag-ci-job task later
   - |
     COUNTER=0
-    while [[ $(aws ec2 describe-instances --filters $FILTER_TEAM $FILTER_MANAGED $FILTER_STATE $FILTER_PIPELINE $FILTER_TEST_COMPONENT $FILTER_INSTANCE_TYPE --output text --query $QUERY_INSTANCE_IDS  | wc -l ) != "1" && $COUNTER -le 80 ]]; do COUNTER=$[$COUNTER +1]; echo "[${COUNTER}] Waiting for instance"; sleep 30; done
+    WAIT_INTERVAL_SECONDS=${KMT_SETUP_WAIT_INTERVAL_SECONDS:-30}
+    WAIT_TIMEOUT_MINUTES=${KMT_SETUP_WAIT_TIMEOUT_MINUTES:-90}
+    WAIT_TIMEOUT_SECONDS=$((WAIT_TIMEOUT_MINUTES * 60))
+    START_TIME_SECONDS=$(date +%s)
+    while [[ $(aws ec2 describe-instances --filters $FILTER_TEAM $FILTER_MANAGED $FILTER_STATE $FILTER_PIPELINE $FILTER_TEST_COMPONENT $FILTER_INSTANCE_TYPE --output text --query $QUERY_INSTANCE_IDS | wc -l ) != "1" ]]; do
+        ELAPSED_SECONDS=$(( $(date +%s) - START_TIME_SECONDS ))
+        if [[ $ELAPSED_SECONDS -ge $WAIT_TIMEOUT_SECONDS ]]; then
+            break
+        fi
+        COUNTER=$((COUNTER + 1))
+        echo "[${COUNTER}] Waiting for instance (${ELAPSED_SECONDS}s/${WAIT_TIMEOUT_SECONDS}s)"
+        sleep $WAIT_INTERVAL_SECONDS
+    done
     # check that instance is ready, or fail
     if [ $(aws ec2 describe-instances --filters $FILTER_TEAM $FILTER_MANAGED $FILTER_STATE $FILTER_PIPELINE $FILTER_TEST_COMPONENT $FILTER_INSTANCE_TYPE --output text --query $QUERY_INSTANCE_IDS | wc -l) -ne "1" ]; then
         echo "Instance NOT found"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e223b123-9181-41d7-b522-f28404a1d37f","source":"chat","resourceId":"98938680-d461-4981-952d-777d63b520c0","workflowId":"b65816b4-09d6-466d-804d-abb4a51f20f5","codeChangeId":"b65816b4-09d6-466d-804d-abb4a51f20f5","sourceType":"slack"} -->
### What does this PR do?

Replaces the fixed counter-based timeout in the KMT setup job with a time-based timeout mechanism that matches the upload job timeout, and increases the timeout to 1h30m.

### Motivation

The setup job was using a fixed counter-based loop (80 iterations × 30 seconds) that didn't align with the setup job, causing inconsistent behavior and unnecessary retry cycles if the setup job takes longer. The new time-based approach makes sure that the times are aligned.

#incident-52374

### Describe how you validated your changes

CI passing

### Additional Notes

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/98938680-d461-4981-952d-777d63b520c0)

Comment @datadog to request changes