### PR TITLE
[EBPF-1051] gpu: use NVML collector in GPU metric generation tests

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -321,7 +321,7 @@ func (c *WorkloadMetaCollector) handleProcess(ev workloadmeta.Event) []*types.Ta
 			continue
 		}
 
-		c.extractGPUTags(gpu, tagList)
+		ExtractGPUTags(gpu, tagList)
 	}
 
 	low, orch, high, standard := tagList.Compute()
@@ -746,7 +746,7 @@ func (c *WorkloadMetaCollector) handleGPU(ev workloadmeta.Event) []*types.TagInf
 	gpu := ev.Entity.(*workloadmeta.GPU)
 
 	tagList := taglist.NewTagList()
-	c.extractGPUTags(gpu, tagList)
+	ExtractGPUTags(gpu, tagList)
 
 	low, orch, high, standard := tagList.Compute()
 
@@ -769,8 +769,8 @@ func (c *WorkloadMetaCollector) handleGPU(ev workloadmeta.Event) []*types.TagInf
 	return tagInfos
 }
 
-// extractGPUTags extracts GPU tags from a GPU entity and adds them to the provided tagList
-func (c *WorkloadMetaCollector) extractGPUTags(gpu *workloadmeta.GPU, tagList *taglist.TagList) {
+// ExtractGPUTags extracts GPU tags from a GPU entity and adds them to the provided tagList
+func ExtractGPUTags(gpu *workloadmeta.GPU, tagList *taglist.TagList) {
 	gpuUUID := strings.ToLower(gpu.ID)
 	tagList.AddLow(tags.KubeGPUVendor, strings.ToLower(gpu.Vendor))
 	tagList.AddLow(tags.KubeGPUDevice, strings.ToLower(strings.ReplaceAll(gpu.Device, " ", "_")))

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -43,7 +43,7 @@ func TestPull(t *testing.T) {
 		foundIDs[gpu.ID] = true
 		var expectedName string
 		if gpu.DeviceType == workloadmeta.GPUDeviceTypeMIG {
-			expectedName = "MIG " + testutil.DefaultGPUName
+			expectedName = testutil.DefaultGPUName + " MIG 3g.40gb"
 		} else if gpu.DeviceType == workloadmeta.GPUDeviceTypePhysical {
 			expectedName = testutil.DefaultGPUName
 			//for now, we test totalMemory only for physical devices
@@ -462,8 +462,8 @@ func TestPullWithMIGDevices(t *testing.T) {
 			// Verify MIG device properties
 			require.Equal(t, workloadmeta.GPUDeviceTypeMIG, migGPU.DeviceType)
 			require.Equal(t, parentUUID, migGPU.ParentGPUUUID, "MIG device %s should have parent %s", childUUID, parentUUID)
-			require.Equal(t, "MIG "+testutil.DefaultGPUName, migGPU.Name)
-			require.Equal(t, "MIG "+testutil.DefaultGPUName, migGPU.Device)
+			require.Equal(t, testutil.DefaultGPUName+" MIG 3g.40gb", migGPU.Name)
+			require.Equal(t, testutil.DefaultGPUName+" MIG 3g.40gb", migGPU.Device)
 			require.Equal(t, testutil.DefaultNvidiaDriverVersion, migGPU.DriverVersion)
 			require.Equal(t, nvidiaVendor, migGPU.Vendor)
 			require.Equal(t, "hopper", migGPU.Architecture)

--- a/comp/core/workloadmeta/collectors/testutil.go
+++ b/comp/core/workloadmeta/collectors/testutil.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build test
+//go:build test && linux && nvml
 
 // Package collectors contains collectors for the workloadmeta component
 package collectors

--- a/comp/core/workloadmeta/collectors/testutil.go
+++ b/comp/core/workloadmeta/collectors/testutil.go
@@ -5,6 +5,7 @@
 
 //go:build test
 
+// package collectors contains collectors for the workloadmeta component
 package collectors
 
 import (
@@ -17,6 +18,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
+// GetNvmlCollector creates the NVML collector, exposed here for testing purposes only
 func GetNvmlCollector(t *testing.T, config config.Component) workloadmeta.Collector {
 	collector, err := nvml.NewCollector(config)
 	require.NoError(t, err, "failed to create NVML collector")

--- a/comp/core/workloadmeta/collectors/testutil.go
+++ b/comp/core/workloadmeta/collectors/testutil.go
@@ -5,7 +5,7 @@
 
 //go:build test
 
-// package collectors contains collectors for the workloadmeta component
+// Package collectors contains collectors for the workloadmeta component
 package collectors
 
 import (

--- a/comp/core/workloadmeta/collectors/testutil.go
+++ b/comp/core/workloadmeta/collectors/testutil.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package collectors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/nvml"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+func GetNvmlCollector(t *testing.T, config config.Component) workloadmeta.Collector {
+	collector, err := nvml.NewCollector(config)
+	require.NoError(t, err, "failed to create NVML collector")
+	return collector.Collector
+}

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -837,8 +837,9 @@ func TestDisabledCollectorsConfiguration(t *testing.T) {
 }
 
 func TestMetricsFollowSpec(t *testing.T) {
-	// required to emit gpu.devices.unhealthy metric
-	env.SetFeatures(t, env.KubernetesDevicePlugins)
+	// - KubernetesDevicePlugins required for gpu.device.unhealthy metric
+	// - NVML required to ensure the NVML workloadmeta collector starts up
+	env.SetFeatures(t, env.KubernetesDevicePlugins, env.NVML)
 
 	metricsSpec, err := gpuspec.LoadMetricsSpec()
 	require.NoError(t, err)
@@ -947,13 +948,10 @@ func setupMockCheckForMetricCollection(t *testing.T, archName string, mode gpusp
 
 	wmeta := testutil.GetWorkloadMetaMock(t)
 
-	// Ensure that the NVML collector can start, prepare config
-	env.SetFeatures(t, env.NVML)
+	// Create the NVML collector to ensure we get the data in the same way as with real checks
 	cfg := config.NewMockWithOverrides(t, map[string]interface{}{
 		"gpu.integrate_with_workloadmeta_processes": false,
 	})
-
-	// Create the NVML collector to ensure we get the data in the same way as with real checks
 	nvmlCollector := collectors.GetNvmlCollector(t, cfg)
 	ctx := t.Context()
 	require.NoError(t, nvmlCollector.Start(ctx, wmeta), "failed to start NVML collector")
@@ -1040,7 +1038,6 @@ func setupMockCheckForMetricCollection(t *testing.T, archName string, mode gpusp
 
 	// Known values are defined at the same place where the mock behavior/data is configured.
 	knownTagValues := map[string]string{
-		"gpu_device":         strings.ToLower(strings.ReplaceAll(testutil.DefaultGPUName, " ", "_")),
 		"gpu_vendor":         "nvidia",
 		"gpu_driver_version": testutil.DefaultNvidiaDriverVersion,
 		"type":               "31",
@@ -1094,7 +1091,6 @@ func getEmittedGPUMetricsWithTags(mockSender *mocksender.MockSender) map[string]
 }
 
 func validateMetricTagsAgainstSpec(t *testing.T, spec *gpuspec.MetricsSpec, metricName string, metricSpec gpuspec.MetricSpec, emittedMetrics []metric, knownTagValues map[string]string) {
-	t.Helper()
 	require.NotEmpty(t, emittedMetrics, "metric %s has no emitted samples to validate tags", metricName)
 
 	requiredTags := make(map[string]struct{})

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -959,7 +959,12 @@ func setupMockCheckForMetricCollection(t *testing.T, archName string, mode gpusp
 
 	// Iterate all GPUs from workloadmeta and set the tags in the tagger
 	wmetaGpus := wmeta.ListGPUs()
-	require.Len(t, wmetaGpus, 1, "expected 1 GPU")
+
+	if mode == gpuspec.DeviceModeMIG {
+		require.Len(t, wmetaGpus, 2, "expected 2 GPUs in MIG mode (parent + child)")
+	} else {
+		require.Len(t, wmetaGpus, 1, "expected 1 GPU in non-MIG mode")
+	}
 	for _, gpu := range wmetaGpus {
 		tags := taglist.NewTagList()
 		taggercollectors.ExtractGPUTags(gpu, tags)

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -959,6 +959,7 @@ func setupMockCheckForMetricCollection(t *testing.T, archName string, mode gpusp
 
 	// Iterate all GPUs from workloadmeta and set the tags in the tagger
 	wmetaGpus := wmeta.ListGPUs()
+	require.Len(t, wmetaGpus, 1, "expected 1 GPU")
 	for _, gpu := range wmetaGpus {
 		tags := taglist.NewTagList()
 		taggercollectors.ExtractGPUTags(gpu, tags)

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -25,10 +25,14 @@ import (
 	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	taggercollectors "github.com/DataDog/datadog-agent/comp/core/tagger/collectors"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	taggermock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/taglist"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
@@ -908,46 +912,6 @@ type metricCollectionSetup struct {
 	knownTagValues map[string]string
 }
 
-func seedPhysicalGPUs(wmeta workloadmetamock.Mock, fakeTagger taggermock.Mock) {
-	for idx, uuid := range testutil.GPUUUIDs {
-		gpu := newMockWorkloadMetaGPU(uuid, idx, workloadmeta.GPUDeviceTypePhysical, "")
-		wmeta.Set(gpu)
-		fakeTagger.SetTags(
-			taggertypes.NewEntityID(taggertypes.GPU, uuid),
-			"spec-test",
-			gpuTagsFromWorkloadMetaGPU(gpu),
-			nil,
-			nil,
-			nil,
-		)
-	}
-}
-
-func seedMIGGPUs(wmeta workloadmetamock.Mock, fakeTagger taggermock.Mock) {
-	for parentIdx, uuids := range testutil.MIGChildrenUUIDs {
-		parentUUID := testutil.GPUUUIDs[parentIdx]
-		for migIdx, uuid := range uuids {
-			gpu := newMockWorkloadMetaGPU(uuid, migIdx, workloadmeta.GPUDeviceTypeMIG, parentUUID)
-			wmeta.Set(gpu)
-			fakeTagger.SetTags(
-				taggertypes.NewEntityID(taggertypes.GPU, uuid),
-				"spec-test",
-				gpuTagsFromWorkloadMetaGPU(gpu),
-				nil,
-				nil,
-				nil,
-			)
-		}
-	}
-}
-
-func seedGPUsForMode(wmeta workloadmetamock.Mock, fakeTagger taggermock.Mock, mode gpuspec.DeviceMode) {
-	seedPhysicalGPUs(wmeta, fakeTagger)
-	if mode == gpuspec.DeviceModeMIG {
-		seedMIGGPUs(wmeta, fakeTagger)
-	}
-}
-
 func seedContainersForPIDMapping(wmeta workloadmetamock.Mock, fakeTagger taggermock.Mock, pidToContainerID map[int]string) {
 	for _, containerID := range pidToContainerID {
 		wmeta.Set(&workloadmeta.Container{
@@ -982,7 +946,34 @@ func setupMockCheckForMetricCollection(t *testing.T, archName string, mode gpusp
 	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(opts...))
 
 	wmeta := testutil.GetWorkloadMetaMock(t)
-	seedGPUsForMode(wmeta, fakeTagger, mode)
+
+	// Ensure that the NVML collector can start, prepare config
+	env.SetFeatures(t, env.NVML)
+	cfg := config.NewMockWithOverrides(t, map[string]interface{}{
+		"gpu.integrate_with_workloadmeta_processes": false,
+	})
+
+	// Create the NVML collector to ensure we get the data in the same way as with real checks
+	nvmlCollector := collectors.GetNvmlCollector(t, cfg)
+	ctx := t.Context()
+	require.NoError(t, nvmlCollector.Start(ctx, wmeta), "failed to start NVML collector")
+	require.NoError(t, nvmlCollector.Pull(ctx), "failed to pull NVML collector")
+
+	// Iterate all GPUs from workloadmeta and set the tags in the tagger
+	wmetaGpus := wmeta.ListGPUs()
+	for _, gpu := range wmetaGpus {
+		tags := taglist.NewTagList()
+		taggercollectors.ExtractGPUTags(gpu, tags)
+		low, orch, high, standard := tags.Compute()
+		fakeTagger.SetTags(
+			taggertypes.NewEntityID(taggertypes.GPU, gpu.ID),
+			"spec-test",
+			low,
+			orch,
+			high,
+			standard,
+		)
+	}
 
 	pidToContainerID := map[int]string{
 		1:    "container-1",
@@ -1100,39 +1091,6 @@ func getEmittedGPUMetricsWithTags(mockSender *mocksender.MockSender) map[string]
 	}
 
 	return metricsByName
-}
-
-func newMockWorkloadMetaGPU(uuid string, index int, deviceType workloadmeta.GPUDeviceType, parentUUID string) *workloadmeta.GPU {
-	gpu := &workloadmeta.GPU{
-		EntityID: workloadmeta.EntityID{
-			Kind: workloadmeta.KindGPU,
-			ID:   uuid,
-		},
-		EntityMeta: workloadmeta.EntityMeta{
-			Name: testutil.DefaultGPUName,
-		},
-		Vendor:             "nvidia",
-		Device:             testutil.DefaultGPUName,
-		DriverVersion:      testutil.DefaultNvidiaDriverVersion,
-		Index:              index,
-		DeviceType:         deviceType,
-		VirtualizationMode: "none",
-	}
-
-	if parentUUID != "" {
-		gpu.ParentGPUUUID = parentUUID
-	}
-
-	return gpu
-}
-
-func gpuTagsFromWorkloadMetaGPU(gpu *workloadmeta.GPU) []string {
-	return []string{
-		"gpu_uuid:" + gpu.ID,
-		"gpu_device:" + strings.ToLower(strings.ReplaceAll(gpu.Device, " ", "_")),
-		"gpu_vendor:" + strings.ToLower(gpu.Vendor),
-		"gpu_driver_version:" + gpu.DriverVersion,
-	}
 }
 
 func validateMetricTagsAgainstSpec(t *testing.T, spec *gpuspec.MetricsSpec, metricName string, metricSpec gpuspec.MetricSpec, emittedMetrics []metric, knownTagValues map[string]string) {

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -20,6 +20,11 @@ tagsets:
       - gpu_device
       - gpu_vendor
       - gpu_driver_version
+      - gpu_virtualization_mode
+      - gpu_architecture
+      - gpu_slicing_mode
+      - gpu_parent_uuid
+      - gpu_type
   process:
     tags:
       - pid

--- a/pkg/collector/corechecks/gpu/spec/spec_test.go
+++ b/pkg/collector/corechecks/gpu/spec/spec_test.go
@@ -123,3 +123,71 @@ func TestMockCapabilitiesMatchArchitectureSpec(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildMockOptionsCreatesCorrectDevices(t *testing.T) {
+	modes := []DeviceMode{DeviceModePhysical, DeviceModeMIG, DeviceModeVGPU}
+	archSpec, err := LoadArchitecturesSpec()
+	require.NoError(t, err)
+	archName := "blackwell"
+	require.Contains(t, archSpec.Architectures, archName)
+	arch := archSpec.Architectures[archName]
+
+	for _, mode := range modes {
+		require.True(t, IsModeSupportedByArchitecture(arch, mode))
+
+		t.Run(string(mode), func(t *testing.T) {
+			opts := BuildMockOptionsForArchAndMode(t, archName, mode, arch)
+			ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(opts...))
+
+			lib, err := ddnvml.GetSafeNvmlLib()
+			require.NoError(t, err, "should be able to get NVML lib")
+
+			count, err := lib.DeviceGetCount()
+			require.NoError(t, err, "should be able to get device count")
+			assert.Equal(t, 1, count, "should be 1 device for physical and vgpu modes")
+
+			for i := 0; i < count; i++ {
+				dev, err := lib.DeviceGetHandleByIndex(i)
+				require.NoError(t, err, "should be able to get device %d", i)
+
+				isMig, err := dev.IsMigDeviceHandle()
+				require.NoError(t, err, "should be able to check if device is a MIG device")
+				assert.False(t, isMig, "top-level devices should not be MIG devices")
+
+				virtMode, err := dev.GetVirtualizationMode()
+				require.NoError(t, err, "should be able to get virtualization mode")
+
+				migEnabled, _, err := dev.GetMigMode()
+				require.NoError(t, err, "should be able to get MIG mode")
+
+				if mode != DeviceModeMIG {
+					assert.False(t, isMig, "device %d should not be a MIG device", i)
+					if mode == DeviceModeVGPU {
+						assert.Equal(t, nvml.GPU_VIRTUALIZATION_MODE_VGPU, virtMode, "virtualization mode should be vGPU for vgpu mode")
+					} else {
+						assert.Equal(t, nvml.GPU_VIRTUALIZATION_MODE_NONE, virtMode, "virtualization mode should be none for physical device")
+					}
+				} else {
+					assert.Equal(t, nvml.DEVICE_MIG_ENABLE, migEnabled, "MIG mode should be enabled on the parent GPU")
+					migChildrenCount, err := dev.GetMaxMigDeviceCount()
+					require.NoError(t, err, "should be able to get MIG children count")
+					assert.Equal(t, 1, migChildrenCount, "should have 1 MIG child for mig mode")
+
+					for j := 0; j < migChildrenCount; j++ {
+						migChild, err := dev.GetMigDeviceHandleByIndex(j)
+						require.NoError(t, err, "should be able to get MIG child %d", j)
+
+						migChildIsMig, err := migChild.IsMigDeviceHandle()
+						require.NoError(t, err, "should be able to check if MIG child is a MIG device")
+						assert.True(t, migChildIsMig, "MIG child %d should be a MIG device", j)
+
+						migChildVirtMode, err := migChild.GetVirtualizationMode()
+						require.NoError(t, err, "should be able to get virtualization mode for MIG child")
+						assert.Equal(t, nvml.GPU_VIRTUALIZATION_MODE_NONE, migChildVirtMode, "virtualization mode should be none for MIG child")
+					}
+				}
+
+			}
+		})
+	}
+}

--- a/pkg/collector/corechecks/gpu/spec/testutil.go
+++ b/pkg/collector/corechecks/gpu/spec/testutil.go
@@ -82,15 +82,14 @@ func BuildMockOptionsForArchAndMode(t *testing.T, archName string, mode DeviceMo
 		testutil.WithArchitecture(archName),
 		testutil.WithCapabilities(caps),
 		testutil.WithMockAllFunctions(),
+		testutil.WithDeviceCount(1),
+		testutil.WithDeviceFeatureMode(testMode),
 	}
 
-	switch mode {
-	case DeviceModePhysical:
-		opts = append([]testutil.NvmlMockOption{testutil.WithDeviceCount(1), testutil.WithMIGDisabled()}, opts...)
-	case DeviceModeMIG:
-		opts = append([]testutil.NvmlMockOption{testutil.WithDeviceFeatureMode(testMode)}, opts...)
-	case DeviceModeVGPU:
-		opts = append([]testutil.NvmlMockOption{testutil.WithDeviceCount(1), testutil.WithDeviceFeatureMode(testMode)}, opts...)
+	if mode == DeviceModeMIG {
+		opts = append(opts, testutil.WithMIGChildCount(1))
+	} else {
+		opts = append(opts, testutil.WithMIGDisabled())
 	}
 
 	return opts

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -217,7 +217,7 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 		},
 		GetNameFunc: func() (string, nvml.Return) {
 			if opts.isMIGChild() {
-				return "MIG " + DefaultGPUName, nvml.SUCCESS
+				return DefaultGPUName + " MIG 3g.40gb", nvml.SUCCESS
 			}
 			return DefaultGPUName, nvml.SUCCESS
 		},

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -121,6 +121,7 @@ type deviceOptions struct {
 	processInfoCB      func(uuid string) ([]nvml.ProcessInfo, nvml.Return)
 	gpmSupported       *bool
 	unsupportedFields  map[uint32]struct{}
+	migChildCount      int
 }
 
 func (o deviceOptions) isMIGChild() bool {
@@ -254,6 +255,9 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 		GetMaxMigDeviceCountFunc: func() (int, nvml.Return) {
 			if opts.isMIGChild() || opts.migDisabled {
 				return 0, nvml.SUCCESS
+			}
+			if opts.migChildCount > 0 {
+				return opts.migChildCount, nvml.SUCCESS
 			}
 			return MIGChildrenPerDevice[deviceIdx], nvml.SUCCESS
 		},
@@ -492,7 +496,7 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 		},
 		GetVirtualizationModeFunc: func() (nvml.GpuVirtualizationMode, nvml.Return) {
 			if opts.isVGPU() {
-				return nvml.GPU_VIRTUALIZATION_MODE_HOST_VGPU, nvml.SUCCESS
+				return nvml.GPU_VIRTUALIZATION_MODE_VGPU, nvml.SUCCESS
 			}
 			return nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS
 		},
@@ -568,6 +572,12 @@ func WithDeviceCount(count int) NvmlMockOption {
 				return getDeviceMockWithOptions(index, o.deviceOptions), nvml.SUCCESS
 			}
 		})
+	}
+}
+
+func WithMIGChildCount(count int) NvmlMockOption {
+	return func(o *nvmlMockOptions) {
+		o.deviceOptions.migChildCount = count
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds new code so that the NVML collector in workloadmeta and the workloadmeta tag extractor function can be used in external test packages. The new functions are used in the GPU tests that ensure that the check emits metrics according to the specification.

### Motivation

Eliminate divergence between how metrics are emitted in production and in the tests. This ensures that any change in the NVML collector or the tag extraction code will be validated against the metric specification.

### Describe how you validated your changes

Existing tests passing.

### Additional Notes
