### PR TITLE
move the test k8s cluster dump and ssh function to infra package

### DIFF
--- a/test/e2e-framework/common/config/environment.go
+++ b/test/e2e-framework/common/config/environment.go
@@ -245,7 +245,7 @@ func (e *CommonEnvironment) KubeNodeURL() string {
 }
 
 func (e *CommonEnvironment) DefaultResourceTags() map[string]string {
-	return map[string]string{"managed-by": "pulumi", "username": e.username}
+	return map[string]string{"managed-by": "pulumi", "username": e.username, "stack": e.Ctx().Stack()}
 }
 
 func (e *CommonEnvironment) InitOnly() bool {

--- a/test/e2e-framework/resources/gcp/compute/vm.go
+++ b/test/e2e-framework/resources/gcp/compute/vm.go
@@ -6,14 +6,15 @@
 package compute
 
 import (
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/compute"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/gcp"
-	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/compute"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func NewLinuxInstance(e gcp.Environment, name string, imageName string, startupScript string, instanceType string, nestedVirt bool, opts ...pulumi.ResourceOption) (*compute.Instance, error) {
+func NewLinuxInstance(e gcp.Environment, name string, imageName string, startupScript string, instanceType string, nestedVirt bool, labels map[string]string, opts ...pulumi.ResourceOption) (*compute.Instance, error) {
 
 	sshPublicKey, err := utils.GetSSHPublicKey(e.DefaultPublicKeyPath())
 	if err != nil {
@@ -42,6 +43,7 @@ func NewLinuxInstance(e gcp.Environment, name string, imageName string, startupS
 		},
 		Name:        e.Namer.DisplayName(63, pulumi.String(name)),
 		MachineType: pulumi.String(instanceType),
+		Labels:      pulumi.ToStringMap(labels),
 		AdvancedMachineFeatures: &compute.InstanceAdvancedMachineFeaturesArgs{
 			EnableNestedVirtualization: pulumi.BoolPtr(nestedVirt),
 		},

--- a/test/e2e-framework/scenarios/gcp/compute/vm.go
+++ b/test/e2e-framework/scenarios/gcp/compute/vm.go
@@ -49,7 +49,16 @@ func NewVM(e gcp.Environment, name string, option ...VMOption) (*remote.Host, er
 
 	return components.NewComponent(&e, name, func(h *remote.Host) error {
 		h.CloudProvider = pulumi.String(components.CloudProviderGCP).ToStringOutput()
-		vm, err := compute.NewLinuxInstance(e, e.Namer.ResourceName(name), imageName, startupScript, params.instanceType, params.nestedVirt, pulumi.Parent(h))
+		vm, err := compute.NewLinuxInstance(
+			e,
+			e.Namer.ResourceName(name),
+			imageName,
+			startupScript,
+			params.instanceType,
+			params.nestedVirt,
+			params.labels,
+			pulumi.Parent(h),
+		)
 		if err != nil {
 			return err
 		}

--- a/test/e2e-framework/scenarios/gcp/compute/vmargs.go
+++ b/test/e2e-framework/scenarios/gcp/compute/vmargs.go
@@ -6,6 +6,8 @@
 package compute
 
 import (
+	"maps"
+
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
@@ -16,6 +18,7 @@ type vmArgs struct {
 	instanceType string
 	imageName    string
 	nestedVirt   bool
+	labels       map[string]string
 }
 
 type VMOption = func(*vmArgs) error
@@ -57,6 +60,15 @@ func WithOSArch(osDesc os.Descriptor, arch os.Architecture) VMOption {
 func WithNestedVirt(enabled bool) VMOption {
 	return func(p *vmArgs) error {
 		p.nestedVirt = enabled
+		return nil
+	}
+}
+
+// WithLabels adds labels to the VM
+// This is usefull to identify the VM later
+func WithLabels(labels map[string]string) VMOption {
+	return func(p *vmArgs) error {
+		p.labels = maps.Clone(labels)
 		return nil
 	}
 }

--- a/test/e2e-framework/testing/e2e/suite.go
+++ b/test/e2e-framework/testing/e2e/suite.go
@@ -434,12 +434,18 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners provisioners.Provision
 					diagnoseResult, diagnoseErr := diagnosableProvisioner.Diagnose(ctx, stackName)
 					if diagnoseErr != nil {
 						utils.Logf(bs.T(), "WARNING: Diagnose failed: %v", diagnoseErr)
-					} else if diagnoseResult != "" {
+					}
+
+					// some diagnose calls/commands could fail, we still need any previous output that succeeded.
+					if diagnoseResult != "" {
 						utils.Logf(bs.T(), "Diagnose result: %s", diagnoseResult)
 					}
 				}
 
 			}
+
+			// set the env here so the tearDown can call diagnose too if it fails
+			bs.env = newEnv
 			return fmt.Errorf("your stack '%s' provisioning failed, check logs above. Provisioner was %s, failed with err: %v", bs.params.stackName, id, err)
 		}
 
@@ -757,7 +763,10 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 			diagnoseResult, diagnoseErr := diagnosableProvisioner.Diagnose(ctx, stackName)
 			if diagnoseErr != nil {
 				utils.Logf(bs.T(), "WARNING: Diagnose failed: %v", diagnoseErr)
-			} else if diagnoseResult != "" {
+			}
+
+			// some diagnose calls/commands could fail, we still need any previous output that succeeded.
+			if diagnoseResult != "" {
 				utils.Logf(bs.T(), "Diagnose result: %s", diagnoseResult)
 			}
 		}

--- a/test/e2e-framework/testing/provisioners/aws/kubernetes/kubernetes_dump.go
+++ b/test/e2e-framework/testing/provisioners/aws/kubernetes/kubernetes_dump.go
@@ -12,8 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
-	"os"
 	"os/user"
 	"strings"
 	"sync"
@@ -23,19 +21,12 @@ import (
 	awsec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
 	awsekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	kubectlget "k8s.io/kubectl/pkg/cmd/get"
-	kubectlutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	k8sutils "github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/k8s"
+	sshutils "github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/ssh"
 )
 
 func DumpEKSClusterState(ctx context.Context, name string) (ret string, err error) {
@@ -90,7 +81,7 @@ func DumpEKSClusterState(ctx context.Context, name string) (ret string, err erro
 	}
 	kubeconfig.CurrentContext = name
 
-	err = dumpK8sClusterState(ctx, kubeconfig, &out)
+	err = k8sutils.DumpK8sClusterState(ctx, kubeconfig, &out)
 	if err != nil {
 		return ret, fmt.Errorf("failed to dump cluster state: %v", err)
 	}
@@ -144,37 +135,7 @@ func DumpKindClusterState(ctx context.Context, name string) (ret string, err err
 		return ret, errors.New("failed to get private IP of instance")
 	}
 
-	auth := []ssh.AuthMethod{}
-
-	if sshAgentSocket, found := os.LookupEnv("SSH_AUTH_SOCK"); found {
-		sshAgent, err := net.Dial("unix", sshAgentSocket)
-		if err != nil {
-			return "", fmt.Errorf("failed to dial SSH agent: %v", err)
-		}
-		defer sshAgent.Close()
-
-		auth = append(auth, ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers))
-	}
-
-	if sshKeyPath, found := os.LookupEnv("E2E_AWS_PRIVATE_KEY_PATH"); found {
-		sshKey, err := os.ReadFile(sshKeyPath)
-		if err != nil {
-			return ret, fmt.Errorf("failed to read SSH key: %v", err)
-		}
-
-		signer, err := ssh.ParsePrivateKey(sshKey)
-		if err != nil {
-			return ret, fmt.Errorf("failed to parse SSH key: %v", err)
-		}
-
-		auth = append(auth, ssh.PublicKeys(signer))
-	}
-
-	sshClient, err := ssh.Dial("tcp", *instanceIP+":22", &ssh.ClientConfig{
-		User:            "ubuntu",
-		Auth:            auth,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-	})
+	sshClient, err := sshutils.SshConnectToInstance(*instanceIP, "22", "ubuntu")
 	if err != nil {
 		return ret, fmt.Errorf("failed to dial SSH server %s: %v", *instanceIP, err)
 	}
@@ -245,96 +206,10 @@ func DumpKindClusterState(ctx context.Context, name string) (ret string, err err
 		cluster.InsecureSkipTLSVerify = true
 	}
 
-	err = dumpK8sClusterState(ctx, kubeconfig, &out)
+	err = k8sutils.DumpK8sClusterState(ctx, kubeconfig, &out)
 	if err != nil {
 		return ret, fmt.Errorf("failed to dump cluster state: %v", err)
 	}
 
 	return ret, nil
-}
-
-func dumpK8sClusterState(ctx context.Context, kubeconfig *clientcmdapi.Config, out *strings.Builder) error {
-	kubeconfigFile, err := os.CreateTemp("", "kubeconfig")
-	if err != nil {
-		return fmt.Errorf("failed to create kubeconfig temporary file: %v", err)
-	}
-	defer os.Remove(kubeconfigFile.Name())
-
-	if err := clientcmd.WriteToFile(*kubeconfig, kubeconfigFile.Name()); err != nil {
-		return fmt.Errorf("failed to write kubeconfig file: %v", err)
-	}
-
-	if err := kubeconfigFile.Close(); err != nil {
-		return fmt.Errorf("failed to close kubeconfig file: %v", err)
-	}
-
-	fmt.Fprintf(out, "\n")
-
-	configFlags := genericclioptions.NewConfigFlags(false)
-	kubeconfigFileName := kubeconfigFile.Name()
-	configFlags.KubeConfig = &kubeconfigFileName
-
-	factory := kubectlutil.NewFactory(configFlags)
-
-	streams := genericiooptions.IOStreams{
-		Out:    out,
-		ErrOut: out,
-	}
-
-	getCmd := kubectlget.NewCmdGet("", factory, streams)
-	getCmd.SetOut(out)
-	getCmd.SetErr(out)
-	getCmd.SetContext(ctx)
-	getCmd.SetArgs([]string{
-		"nodes,all",
-		"--all-namespaces",
-		"-o",
-		"wide",
-	})
-	if err := getCmd.ExecuteContext(ctx); err != nil {
-		return fmt.Errorf("failed to execute kubectl get: %v", err)
-	}
-
-	// Get the logs of containers that have restarted
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile.Name())
-	if err != nil {
-		fmt.Fprintf(out, "Failed to build Kubernetes config: %v\n", err)
-		return nil
-	}
-	k8sClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		fmt.Fprintf(out, "Failed to create Kubernetes client: %v\n", err)
-		return nil
-	}
-
-	pods, err := k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
-	if err != nil {
-		fmt.Fprintf(out, "Failed to list pods: %v\n", err)
-		return nil
-	}
-
-	for _, pod := range pods.Items {
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if containerStatus.RestartCount > 0 {
-				fmt.Fprintf(out, "\nLOGS FOR POD %s/%s CONTAINER %s:\n", pod.Namespace, pod.Name, containerStatus.Name)
-				logs, err := k8sClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
-					Container: containerStatus.Name,
-					Previous:  true,
-					TailLines: pointer.Ptr(int64(100)),
-				}).Stream(ctx)
-				if err != nil {
-					fmt.Fprintf(out, "Failed to get logs: %v\n", err)
-					continue
-				}
-
-				_, err = io.Copy(out, logs)
-				logs.Close()
-				if err != nil {
-					fmt.Fprintf(out, "Failed to copy logs: %v\n", err)
-					continue
-				}
-			}
-		}
-	}
-	return nil
 }

--- a/test/e2e-framework/testing/provisioners/pulumi_provisioner.go
+++ b/test/e2e-framework/testing/provisioners/pulumi_provisioner.go
@@ -123,7 +123,7 @@ func (pp *PulumiProvisioner[Env]) Diagnose(ctx context.Context, stackName string
 	if pp.diagnoseFunc != nil {
 		return pp.diagnoseFunc(ctx, stackName)
 	}
-	return "", nil
+	return "\n\n--- No Diagnose function set ---\n\n", nil
 }
 
 // SetDiagnoseFunc sets the diagnose function.

--- a/test/e2e-framework/testing/utils/k8s/k8s.go
+++ b/test/e2e-framework/testing/utils/k8s/k8s.go
@@ -14,6 +14,21 @@ import (
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
+
+	"io"
+	"os"
+	"strings"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+
+	corev1 "k8s.io/api/core/v1"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	kubectlget "k8s.io/kubectl/pkg/cmd/get"
+	kubectlutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 // CheckJobErrors checks if a job has failed and returns an error with more details about the failure, such as the pod that failed and the error code.
@@ -50,4 +65,90 @@ func CheckJobErrors(ctx context.Context, client kubernetes.Interface, namespace,
 
 	// Could not find a specific pod that failed, so return a generic error
 	return fmt.Errorf("workload job %s failed. Kubernetes reports %d failed pods, but we could not find a specific one with the failure", jobName, job.Status.Failed)
+}
+
+func DumpK8sClusterState(ctx context.Context, kubeconfig *clientcmdapi.Config, out *strings.Builder) error {
+	kubeconfigFile, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		return fmt.Errorf("failed to create kubeconfig temporary file: %v", err)
+	}
+	defer os.Remove(kubeconfigFile.Name())
+
+	if err := clientcmd.WriteToFile(*kubeconfig, kubeconfigFile.Name()); err != nil {
+		return fmt.Errorf("failed to write kubeconfig file: %v", err)
+	}
+
+	if err := kubeconfigFile.Close(); err != nil {
+		return fmt.Errorf("failed to close kubeconfig file: %v", err)
+	}
+
+	fmt.Fprintf(out, "\n---------- All resources ----------\n")
+
+	configFlags := genericclioptions.NewConfigFlags(false)
+	kubeconfigFileName := kubeconfigFile.Name()
+	configFlags.KubeConfig = &kubeconfigFileName
+
+	factory := kubectlutil.NewFactory(configFlags)
+
+	streams := genericiooptions.IOStreams{
+		Out:    out,
+		ErrOut: out,
+	}
+
+	getCmd := kubectlget.NewCmdGet("", factory, streams)
+	getCmd.SetOut(out)
+	getCmd.SetErr(out)
+	getCmd.SetContext(ctx)
+	getCmd.SetArgs([]string{
+		"nodes,all",
+		"--all-namespaces",
+		"-o",
+		"wide",
+	})
+	if err := getCmd.ExecuteContext(ctx); err != nil {
+		return fmt.Errorf("failed to execute kubectl get: %v", err)
+	}
+
+	// Get the logs of containers that have restarted
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile.Name())
+	if err != nil {
+		fmt.Fprintf(out, "Failed to build Kubernetes config: %v\n", err)
+		return nil
+	}
+	k8sClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		fmt.Fprintf(out, "Failed to create Kubernetes client: %v\n", err)
+		return nil
+	}
+
+	pods, err := k8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(out, "Failed to list pods: %v\n", err)
+		return nil
+	}
+
+	for _, pod := range pods.Items {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.RestartCount > 0 || !containerStatus.Ready {
+				fmt.Fprintf(out, "\nLOGS FOR POD %s/%s CONTAINER %s:\n", pod.Namespace, pod.Name, containerStatus.Name)
+				logs, err := k8sClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+					Container: containerStatus.Name,
+					Previous:  true,
+					TailLines: pointer.Ptr(int64(100)),
+				}).Stream(ctx)
+				if err != nil {
+					fmt.Fprintf(out, "Failed to get logs: %v\n", err)
+					continue
+				}
+
+				_, err = io.Copy(out, logs)
+				logs.Close()
+				if err != nil {
+					fmt.Fprintf(out, "Failed to copy logs: %v\n", err)
+					continue
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/test/e2e-framework/testing/utils/ssh/ssh.go
+++ b/test/e2e-framework/testing/utils/ssh/ssh.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package infra implements utilities to interact with a Pulumi infrastructure
+package ssh
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+const (
+	NR_SSH_COMMAND_RETRIES = 3
+)
+
+// SshConnectToInstance connects using ssh protocol to the given ip:port using
+// the given user.
+func SshConnectToInstance(ip, port, user string) (*ssh.Client, error) {
+	auth := []ssh.AuthMethod{}
+
+	if sshAgentSocket, found := os.LookupEnv("SSH_AUTH_SOCK"); found {
+		sshAgent, err := net.Dial("unix", sshAgentSocket)
+		if err != nil {
+			return nil, fmt.Errorf("failed to dial SSH agent: %w", err)
+		}
+		defer sshAgent.Close()
+
+		auth = append(auth, ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers))
+	}
+
+	if sshKeyPath, found := os.LookupEnv("E2E_AWS_PRIVATE_KEY_PATH"); found {
+		sshKey, err := os.ReadFile(sshKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read SSH key: %w", err)
+		}
+
+		signer, err := ssh.ParsePrivateKey(sshKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse SSH key: %w", err)
+		}
+
+		auth = append(auth, ssh.PublicKeys(signer))
+	}
+
+	if sshKeyPath, found := os.LookupEnv("E2E_GCP_PRIVATE_KEY_PATH"); found {
+		sshKey, err := os.ReadFile(sshKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read SSH key: %w", err)
+		}
+
+		signer, err := ssh.ParsePrivateKey(sshKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse SSH key: %w", err)
+		}
+
+		auth = append(auth, ssh.PublicKeys(signer))
+	}
+
+	return ssh.Dial("tcp", ip+":"+port, &ssh.ClientConfig{
+		User:            user,
+		Auth:            auth,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+}
+
+// SshRunCommand runs the given command using the given ssh client.
+// retries on error. Returns the last error if retries exceeded.
+func SshRunCommand(sshClient *ssh.Client, command string, logger io.Writer) ([]byte, error) {
+	fmt.Fprintf(logger, "Command: '%s'\n", command)
+
+	var err error
+	for range NR_SSH_COMMAND_RETRIES {
+		sshSession, err := sshClient.NewSession()
+		if err != nil {
+			return nil, err
+		}
+
+		output, err := sshSession.CombinedOutput(command)
+		if err == nil {
+			return output, nil
+		}
+	}
+
+	return nil, err
+}


### PR DESCRIPTION
### What does this PR do?

This will allow all provisioners (gcp, ...) to benefit from the generic ssh function to run ssh commands on the provisioned VMs and call the dumpCluster function to dump any k8s cluster.


### Motivation

### Describe how you validated your changes

### Additional Notes
