### PR TITLE
[Backport 7.78.x] [macOS] Fix sysprobe plist PathState

### DIFF
--- a/packages/macos/app/launchd.sysprobe.plist.example.in
+++ b/packages/macos/app/launchd.sysprobe.plist.example.in
@@ -8,7 +8,7 @@
             <false/>
             <key>PathState</key>
             <dict>
-              <key>{conf_dir}/system-probe.yaml</key>
+              <key>/opt/datadog-agent/etc/system-probe.yaml</key>
               <true/>
             </dict>
         </dict>
@@ -24,7 +24,7 @@
             <string>/opt/datadog-agent/embedded/bin/system-probe</string>
             <string>run</string>
             <string>-c</string>
-            <string>/opt/datadog-agent/{conf_dir}</string>
+            <string>/opt/datadog-agent/etc</string>
         </array>
         <key>StandardOutPath</key>
         <string>/opt/datadog-agent/logs/launchd_sysprobe.log</string>


### PR DESCRIPTION
## Summary
- Backport of #48931 to 7.78.x
- Fixes sysprobe plist PathState to use absolute paths instead of relative paths, which broke sysprobe from loading after agent installation on macOS
- Related to PR https://github.com/DataDog/datadog-agent/pull/48141 also backported in 7.78.x https://github.com/DataDog/datadog-agent/pull/48148 which forgot to make this fix

## Motivation
[WINA-2510](https://datadoghq.atlassian.net/browse/WINA-2510)

## Original PR
https://github.com/DataDog/datadog-agent/pull/48931