### PR TITLE
[procmgr] Port grpc/service.rs tests to cross-platform helpers

### DIFF
--- a/pkg/procmgr/rust/src/grpc/service.rs
+++ b/pkg/procmgr/rust/src/grpc/service.rs
@@ -340,7 +340,7 @@ fn process_detail(proc: &ManagedProcess) -> proto::ProcessDetail {
 mod tests {
     use super::*;
     use crate::config::ProcessConfig;
-    use crate::test_helpers::test_uuid;
+    use crate::test_helpers;
 
     #[test]
     fn test_state_to_proto_mapping() {
@@ -376,24 +376,29 @@ mod tests {
 
     #[test]
     fn test_process_to_proto() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
+        let expected_args = args.clone();
         let cfg = ProcessConfig {
-            command: "/usr/bin/sleep".to_string(),
-            args: vec!["60".to_string()],
+            command: cmd.to_string(),
+            args,
             ..Default::default()
         };
-        let proc = ManagedProcess::new_config("test-proc".to_string(), test_uuid(), cfg);
+        let proc =
+            ManagedProcess::new_config("test-proc".to_string(), test_helpers::test_uuid(), cfg);
         let proto = process_to_proto(&proc);
         assert_eq!(proto.name, "test-proc");
-        assert_eq!(proto.command, "/usr/bin/sleep");
-        assert_eq!(proto.args, vec!["60"]);
+        assert_eq!(proto.command, cmd);
+        assert_eq!(proto.args, expected_args);
         assert_eq!(proto.pid, 0);
         assert_eq!(proto.state, proto::ProcessState::Created as i32);
     }
 
     #[test]
     fn test_process_detail() {
+        let (cmd, args) = test_helpers::true_cmd();
         let cfg = ProcessConfig {
-            command: "/usr/bin/test".to_string(),
+            command: cmd.to_string(),
+            args: args.into_iter().map(|a| a.to_string()).collect(),
             description: Some("A test process".to_string()),
             working_dir: Some("/tmp".to_string()),
             auto_start: false,
@@ -401,7 +406,8 @@ mod tests {
             before: vec!["dep-b".to_string()],
             ..Default::default()
         };
-        let proc = ManagedProcess::new_config("detail-proc".to_string(), test_uuid(), cfg);
+        let proc =
+            ManagedProcess::new_config("detail-proc".to_string(), test_helpers::test_uuid(), cfg);
         let detail = process_detail(&proc);
         assert_eq!(detail.name, "detail-proc");
         assert_eq!(detail.description, "A test process");
@@ -413,36 +419,37 @@ mod tests {
 
     #[tokio::test]
     async fn test_process_to_proto_running_with_pid() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
+        let expected_args = args.clone();
         let cfg = ProcessConfig {
-            command: "/bin/sleep".to_string(),
-            args: vec!["60".to_string()],
+            command: cmd.to_string(),
+            args,
             ..Default::default()
         };
-        let mut proc = ManagedProcess::new_config("sleeper".to_string(), test_uuid(), cfg);
+        let mut proc =
+            ManagedProcess::new_config("sleeper".to_string(), test_helpers::test_uuid(), cfg);
         proc.spawn().unwrap();
 
         let proto = process_to_proto(&proc);
         assert_eq!(proto.name, "sleeper");
         assert_eq!(proto.state, proto::ProcessState::Running as i32);
         assert!(proto.pid > 0, "running process should have a non-zero pid");
-        assert_eq!(proto.command, "/bin/sleep");
-        assert_eq!(proto.args, vec!["60"]);
+        assert_eq!(proto.command, cmd);
+        assert_eq!(proto.args, expected_args);
 
-        nix::sys::signal::kill(
-            nix::unistd::Pid::from_raw(proto.pid as i32),
-            nix::sys::signal::Signal::SIGKILL,
-        )
-        .ok();
+        test_helpers::cleanup_process(proto.pid);
     }
 
     #[tokio::test]
     async fn test_process_to_proto_failed() {
+        let (cmd, args) = test_helpers::exit_cmd(1);
         let cfg = ProcessConfig {
-            command: "/bin/sh".to_string(),
-            args: vec!["-c".to_string(), "exit 1".to_string()],
+            command: cmd.to_string(),
+            args,
             ..Default::default()
         };
-        let mut proc = ManagedProcess::new_config("fail-proc".to_string(), test_uuid(), cfg);
+        let mut proc =
+            ManagedProcess::new_config("fail-proc".to_string(), test_helpers::test_uuid(), cfg);
         proc.spawn().unwrap();
 
         let mut child = proc.take_child().unwrap();


### PR DESCRIPTION
### What does this PR do?

Replaces hardcoded Unix commands and `nix` cleanup calls in `grpc/service.rs` tests with cross-platform `test_helpers` functions, continuing the Windows port.

- `test_process_to_proto`: `/usr/bin/sleep` → `test_helpers::sleep_cmd(60)`
- `test_process_detail`: `/usr/bin/test` → `test_helpers::true_cmd()`
- `test_process_to_proto_running_with_pid`: `/bin/sleep` → `test_helpers::sleep_cmd(60)`, `nix::sys::signal::kill` → `test_helpers::cleanup_process()`
- `test_process_to_proto_failed`: `/bin/sh -c exit 1` → `test_helpers::exit_cmd(1)`
- Standardises imports to `use crate::test_helpers` (module prefix)

### Motivation

Part of the `dd-procmgrd` Windows port. Makes the gRPC service tests compile on both Unix and Windows by removing hardcoded Unix paths.

### Describe how you validated your changes

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --features test-helpers -- -D warnings` — clean
- `cargo test --all-targets --features test-helpers` — 86/86 pass

### Additional Notes