### PR TITLE
feat(orchestrator): add OOTB CRD collection for Gateway API, service mesh, and ingress controllers

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -560,11 +560,11 @@ func newBuiltinCRDConfigs() []builtinCRDConfig {
 		newBuiltinCRDConfig(GatewayAPIGroup, "listenersets", isGatewayAPIEnabled, "v1alpha1"),
 
 		// Service mesh — Istio (resource-specific to avoid over-collection)
-		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "virtualservices", isServiceMeshEnabled, "v1", "v1beta1"),
-		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "gateways", isServiceMeshEnabled, "v1", "v1beta1"),
-		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "destinationrules", isServiceMeshEnabled, "v1", "v1beta1"),
-		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "serviceentries", isServiceMeshEnabled, "v1", "v1beta1"),
-		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "sidecars", isServiceMeshEnabled, "v1", "v1beta1"),
+		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "virtualservices", isServiceMeshEnabled, "v1", "v1beta1", "v1alpha3"),
+		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "gateways", isServiceMeshEnabled, "v1", "v1beta1", "v1alpha3"),
+		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "destinationrules", isServiceMeshEnabled, "v1", "v1beta1", "v1alpha3"),
+		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "serviceentries", isServiceMeshEnabled, "v1", "v1beta1", "v1alpha3"),
+		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "sidecars", isServiceMeshEnabled, "v1", "v1beta1", "v1alpha3"),
 
 		// Service mesh — other vendors (group-level, empty kind = all resources in group)
 		newBuiltinCRDConfig(EnvoyGatewayAPIGroup, "", isServiceMeshEnabled, "v1alpha1"),

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -45,6 +45,25 @@ const (
 	KarpenterAWSAPIGroup    = "karpenter.k8s.aws"
 	KarpenterAzureAPIGroup  = "karpenter.azure.com"
 	EKSAPIGroup             = "eks.amazonaws.com"
+
+	// Gateway API
+	GatewayAPIGroup = "gateway.networking.k8s.io"
+
+	// Service mesh
+	IstioNetworkingAPIGroup = "networking.istio.io"
+	EnvoyGatewayAPIGroup    = "gateway.envoyproxy.io"
+	TraefikLegacyAPIGroup   = "traefik.containo.us"
+	LinkerdPolicyAPIGroup   = "policy.linkerd.io"
+	ConsulAPIGroup          = "consul.hashicorp.com"
+	ConsulMeshAPIGroup      = "mesh.consul.hashicorp.com"
+	KumaAPIGroup            = "kuma.io"
+
+	// Ingress controllers
+	NginxAPIGroup            = "k8s.nginx.org"
+	TraefikAPIGroup          = "traefik.io"
+	KongAPIGroup             = "configuration.konghq.com"
+	HAProxyCoreAPIGroup      = "core.haproxy.org"
+	HAProxyIngressV1APIGroup = "ingress.v1.haproxy.org"
 )
 
 var (
@@ -496,6 +515,9 @@ func newBuiltinCRDConfig(group, kind string, enabled bool, preferredVersion stri
 // newBuiltinCRDConfigs returns the configuration for all built-in CRDs.
 func newBuiltinCRDConfigs() []builtinCRDConfig {
 	isOOTBCRDEnabled := pkgconfigsetup.Datadog().GetBool("orchestrator_explorer.custom_resources.ootb.enabled")
+	isGatewayAPIEnabled := isOOTBCRDEnabled && pkgconfigsetup.Datadog().GetBool("orchestrator_explorer.custom_resources.ootb.gateway_api")
+	isServiceMeshEnabled := isOOTBCRDEnabled && pkgconfigsetup.Datadog().GetBool("orchestrator_explorer.custom_resources.ootb.service_mesh")
+	isIngressControllersEnabled := isOOTBCRDEnabled && pkgconfigsetup.Datadog().GetBool("orchestrator_explorer.custom_resources.ootb.ingress_controllers")
 
 	return []builtinCRDConfig{
 		// Datadog resources
@@ -529,6 +551,40 @@ func newBuiltinCRDConfigs() []builtinCRDConfig {
 
 		// EKS Auto Mode resources (for now only nodeclasses, but we can easily add more in the future if needed)
 		newBuiltinCRDConfig(EKSAPIGroup, "nodeclasses", isOOTBCRDEnabled, "v1", "v1beta1"),
+
+		// Gateway API resources
+		newBuiltinCRDConfig(GatewayAPIGroup, "gateways", isGatewayAPIEnabled, "v1", "v1beta1"),
+		newBuiltinCRDConfig(GatewayAPIGroup, "httproutes", isGatewayAPIEnabled, "v1", "v1beta1"),
+		newBuiltinCRDConfig(GatewayAPIGroup, "grpcroutes", isGatewayAPIEnabled, "v1", "v1alpha2"),
+		newBuiltinCRDConfig(GatewayAPIGroup, "tlsroutes", isGatewayAPIEnabled, "v1alpha2"),
+		newBuiltinCRDConfig(GatewayAPIGroup, "listenersets", isGatewayAPIEnabled, "v1alpha1"),
+
+		// Service mesh — Istio (resource-specific to avoid over-collection)
+		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "virtualservices", isServiceMeshEnabled, "v1", "v1beta1"),
+		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "gateways", isServiceMeshEnabled, "v1", "v1beta1"),
+		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "destinationrules", isServiceMeshEnabled, "v1", "v1beta1"),
+		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "serviceentries", isServiceMeshEnabled, "v1", "v1beta1"),
+		newBuiltinCRDConfig(IstioNetworkingAPIGroup, "sidecars", isServiceMeshEnabled, "v1", "v1beta1"),
+
+		// Service mesh — other vendors (group-level, empty kind = all resources in group)
+		newBuiltinCRDConfig(EnvoyGatewayAPIGroup, "", isServiceMeshEnabled, "v1alpha1"),
+		newBuiltinCRDConfig(TraefikLegacyAPIGroup, "", isServiceMeshEnabled, "v1alpha1"),
+		newBuiltinCRDConfig(LinkerdPolicyAPIGroup, "", isServiceMeshEnabled, "v1beta3", "v1beta2", "v1beta1"),
+		newBuiltinCRDConfig(ConsulAPIGroup, "", isServiceMeshEnabled, "v1alpha1"),
+		newBuiltinCRDConfig(ConsulMeshAPIGroup, "", isServiceMeshEnabled, "v2beta1"),
+		newBuiltinCRDConfig(KumaAPIGroup, "", isServiceMeshEnabled, "v1alpha1"),
+
+		// Ingress controllers — NGINX (resource-specific)
+		newBuiltinCRDConfig(NginxAPIGroup, "virtualservers", isIngressControllersEnabled, "v1"),
+		newBuiltinCRDConfig(NginxAPIGroup, "virtualserverroutes", isIngressControllersEnabled, "v1"),
+
+		// Ingress controllers — Traefik (resource-specific)
+		newBuiltinCRDConfig(TraefikAPIGroup, "ingressroutes", isIngressControllersEnabled, "v1alpha1"),
+
+		// Ingress controllers — other vendors (group-level, empty kind = all resources in group)
+		newBuiltinCRDConfig(KongAPIGroup, "", isIngressControllersEnabled, "v1", "v1beta1"),
+		newBuiltinCRDConfig(HAProxyCoreAPIGroup, "", isIngressControllersEnabled, "v1alpha2"),
+		newBuiltinCRDConfig(HAProxyIngressV1APIGroup, "", isIngressControllersEnabled, "v1"),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
@@ -428,6 +428,40 @@ func TestNewBuiltinCRDConfigs(t *testing.T) {
 
 		// EKS Auto Mode NodeClass resource
 		"eks.amazonaws.com/v1/nodeclasses",
+
+		// Gateway API
+		"gateway.networking.k8s.io/v1/gateways",
+		"gateway.networking.k8s.io/v1/httproutes",
+		"gateway.networking.k8s.io/v1/grpcroutes",
+		"gateway.networking.k8s.io/v1alpha2/tlsroutes",
+		"gateway.networking.k8s.io/v1alpha1/listenersets",
+
+		// Service mesh — Istio
+		"networking.istio.io/v1/virtualservices",
+		"networking.istio.io/v1/gateways",
+		"networking.istio.io/v1/destinationrules",
+		"networking.istio.io/v1/serviceentries",
+		"networking.istio.io/v1/sidecars",
+
+		// Service mesh — other vendors (group-level)
+		"gateway.envoyproxy.io/v1alpha1/",
+		"traefik.containo.us/v1alpha1/",
+		"policy.linkerd.io/v1beta3/",
+		"consul.hashicorp.com/v1alpha1/",
+		"mesh.consul.hashicorp.com/v2beta1/",
+		"kuma.io/v1alpha1/",
+
+		// Ingress controllers — NGINX
+		"k8s.nginx.org/v1/virtualservers",
+		"k8s.nginx.org/v1/virtualserverroutes",
+
+		// Ingress controllers — Traefik
+		"traefik.io/v1alpha1/ingressroutes",
+
+		// Ingress controllers — other vendors (group-level)
+		"configuration.konghq.com/v1/",
+		"core.haproxy.org/v1alpha2/",
+		"ingress.v1.haproxy.org/v1/",
 	}
 
 	// Verify all expected configs are present
@@ -442,6 +476,110 @@ func TestNewBuiltinCRDConfigs(t *testing.T) {
 	}
 
 	require.ElementsMatch(t, expectedConfigs, foundConfigs)
+}
+
+func TestNewBuiltinCRDConfigsPerFamilyFlags(t *testing.T) {
+	for _, testCase := range []struct {
+		name                string
+		ootbEnabled         bool
+		gatewayAPI          bool
+		serviceMesh         bool
+		ingressControllers  bool
+		expectedGatewayAPI  int // 5 entries
+		expectedServiceMesh int // 11 entries (5 Istio + 6 group-level)
+		expectedIngress     int // 6 entries (2 NGINX + 1 Traefik + 3 group-level)
+	}{
+		{
+			name:                "all families enabled",
+			ootbEnabled:         true,
+			gatewayAPI:          true,
+			serviceMesh:         true,
+			ingressControllers:  true,
+			expectedGatewayAPI:  5,
+			expectedServiceMesh: 11,
+			expectedIngress:     6,
+		},
+		{
+			name:                "gateway_api disabled",
+			ootbEnabled:         true,
+			gatewayAPI:          false,
+			serviceMesh:         true,
+			ingressControllers:  true,
+			expectedGatewayAPI:  0,
+			expectedServiceMesh: 11,
+			expectedIngress:     6,
+		},
+		{
+			name:                "service_mesh disabled",
+			ootbEnabled:         true,
+			gatewayAPI:          true,
+			serviceMesh:         false,
+			ingressControllers:  true,
+			expectedGatewayAPI:  5,
+			expectedServiceMesh: 0,
+			expectedIngress:     6,
+		},
+		{
+			name:                "ingress_controllers disabled",
+			ootbEnabled:         true,
+			gatewayAPI:          true,
+			serviceMesh:         true,
+			ingressControllers:  false,
+			expectedGatewayAPI:  5,
+			expectedServiceMesh: 11,
+			expectedIngress:     0,
+		},
+		{
+			name:                "global ootb disabled overrides all",
+			ootbEnabled:         false,
+			gatewayAPI:          true,
+			serviceMesh:         true,
+			ingressControllers:  true,
+			expectedGatewayAPI:  0,
+			expectedServiceMesh: 0,
+			expectedIngress:     0,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := mockconfig.New(t)
+			cfg.SetWithoutSource("orchestrator_explorer.custom_resources.ootb.enabled", testCase.ootbEnabled)
+			cfg.SetWithoutSource("orchestrator_explorer.custom_resources.ootb.gateway_api", testCase.gatewayAPI)
+			cfg.SetWithoutSource("orchestrator_explorer.custom_resources.ootb.service_mesh", testCase.serviceMesh)
+			cfg.SetWithoutSource("orchestrator_explorer.custom_resources.ootb.ingress_controllers", testCase.ingressControllers)
+
+			configs := newBuiltinCRDConfigs()
+
+			gatewayAPIGroups := map[string]bool{GatewayAPIGroup: true}
+			serviceMeshGroups := map[string]bool{
+				IstioNetworkingAPIGroup: true, EnvoyGatewayAPIGroup: true,
+				TraefikLegacyAPIGroup: true, LinkerdPolicyAPIGroup: true,
+				ConsulAPIGroup: true, ConsulMeshAPIGroup: true, KumaAPIGroup: true,
+			}
+			ingressGroups := map[string]bool{
+				NginxAPIGroup: true, TraefikAPIGroup: true, KongAPIGroup: true,
+				HAProxyCoreAPIGroup: true, HAProxyIngressV1APIGroup: true,
+			}
+
+			var gatewayCount, meshCount, ingressCount int
+			for _, c := range configs {
+				if !c.enabled {
+					continue
+				}
+				switch {
+				case gatewayAPIGroups[c.group]:
+					gatewayCount++
+				case serviceMeshGroups[c.group]:
+					meshCount++
+				case ingressGroups[c.group]:
+					ingressCount++
+				}
+			}
+
+			require.Equal(t, testCase.expectedGatewayAPI, gatewayCount, "gateway API count mismatch")
+			require.Equal(t, testCase.expectedServiceMesh, meshCount, "service mesh count mismatch")
+			require.Equal(t, testCase.expectedIngress, ingressCount, "ingress controllers count mismatch")
+		})
+	}
 }
 
 func TestFilterCRCollectorsByPermission(t *testing.T) {

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -733,6 +733,9 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("orchestrator_explorer.terminated_pods.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.terminated_pods_improved.enabled", false)
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.enabled", true)
+	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.gateway_api", true)
+	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.service_mesh", true)
+	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.ingress_controllers", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.kubelet_config_check.enabled", true, "DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED")
 	config.BindEnvAndSetDefault("auto_team_tag_collection", true)
 

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -733,9 +733,9 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("orchestrator_explorer.terminated_pods.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.terminated_pods_improved.enabled", false)
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.enabled", true)
-	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.gateway_api", true)
-	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.service_mesh", true)
-	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.ingress_controllers", true)
+	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.gateway_api", false)
+	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.service_mesh", false)
+	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.ootb.ingress_controllers", false)
 	config.BindEnvAndSetDefault("orchestrator_explorer.kubelet_config_check.enabled", true, "DD_ORCHESTRATOR_EXPLORER_KUBELET_CONFIG_CHECK_ENABLED")
 	config.BindEnvAndSetDefault("auto_team_tag_collection", true)
 

--- a/releasenotes-dca/notes/ootb-crd-gateway-mesh-ingress-7a4c5b769e1d4345.yaml
+++ b/releasenotes-dca/notes/ootb-crd-gateway-mesh-ingress-7a4c5b769e1d4345.yaml
@@ -1,0 +1,18 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add OOTB CRD collection for Gateway API, service mesh (Istio, Envoy Gateway,
+    Traefik, Linkerd, Consul, Kuma), and ingress controller (NGINX, Traefik, Kong,
+    HAProxy) custom resources. Three new per-family config flags allow operators to
+    enable collection independently:
+    ``orchestrator_explorer.custom_resources.ootb.gateway_api``,
+    ``orchestrator_explorer.custom_resources.ootb.service_mesh``, and
+    ``orchestrator_explorer.custom_resources.ootb.ingress_controllers``
+    (all default to false).


### PR DESCRIPTION
### What does this PR do?

Adds 22 new builtin CRD entries to the orchestrator explorer so Cloud Security can determine internet-reachability paths for k8s workloads. Uses a hybrid collection strategy: resource-specific entries for high-volume vendors (Istio, NGINX, Traefik) and group-level entries for less common vendors.

Three new per-family config flags (all **opt-in, default: false**):
- `orchestrator_explorer.custom_resources.ootb.gateway_api`
- `orchestrator_explorer.custom_resources.ootb.service_mesh`
- `orchestrator_explorer.custom_resources.ootb.ingress_controllers`

**New families:**
- **Gateway API** (5 resource-specific): gateways, httproutes, grpcroutes, tlsroutes, listenersets
- **Service mesh — Istio** (5 resource-specific): virtualservices, gateways, destinationrules, serviceentries, sidecars (with v1beta1 fallback)
- **Service mesh — others** (6 group-level): Envoy Gateway, Traefik (legacy), Linkerd, Consul, Consul Mesh, Kuma
- **Ingress controllers — NGINX** (2 resource-specific): virtualservers, virtualserverroutes
- **Ingress controllers — Traefik** (1 resource-specific): ingressroutes
- **Ingress controllers — others** (3 group-level): Kong, HAProxy Core, HAProxy v1

### Motivation

Cloud Security needs to tell customers which container workloads are internet-reachable. Today, the agent collects standard Ingress and Service objects, covering ~16% of EKS customers. Over 36% use service meshes or non-standard ingress controllers whose exposure paths go through CRDs we don't collect.

RFC: https://datadoghq.atlassian.net/wiki/x/4IOyfAE
Technical implementation: https://datadoghq.atlassian.net/wiki/x/EgO6fAE

### Describe how you validated your changes

- All existing tests pass: `TestNewBuiltinCRDConfigs`, `TestImportBuiltinCollectors`, `TestGetDatadogCustomResourceCollectors`, `TestFilterCRCollectorsByPermission`
- New test `TestNewBuiltinCRDConfigsPerFamilyFlags` verifies each per-family flag independently disables its family, and the global OOTB flag disables everything
- Package compiles cleanly with `go build -tags "kubeapiserver orchestrator"`

### Additional Notes

**All three flags default to `false` (opt-in).** Collection is only activated when RBAC is granted (via helm/operator) and the corresponding flag is set to `true`.

**Merge order:** The backend allowlist PR (dd-go) must be deployed before this PR merges, otherwise collected CRs will be silently dropped.

- [ ] Backend allowlist deployed: DataDog/dd-go#230589
- [ ] Helm chart RBAC merged: DataDog/helm-charts#2541
- [ ] Operator RBAC merged: DataDog/datadog-operator#2874

## Related PRs

| Repo | PR | Purpose |
|------|----|---------|
| DataDog/dd-go | DataDog/dd-go#230589 | Backend allowlist (deploy FIRST) |
| DataDog/helm-charts | DataDog/helm-charts#2541 | Helm chart RBAC |
| DataDog/datadog-operator | DataDog/datadog-operator#2874 | Operator RBAC |