### PR TITLE
feat(trace): honor _dd.measured:0 as explicit opt-out for OTLP spans

### DIFF
--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -2438,6 +2438,53 @@ func testOTelSpanToDDSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 				"_top_level": 1,
 			},
 		},
+		{
+			// A CLIENT span with explicit _dd.measured:0 must not have _dd.measured set to 1
+			// by the topLevelByKind fallback, even when enable_otlp_compute_top_level_by_span_kind is enabled.
+			rattr: map[string]string{
+				"service.name":           "pylons",
+				"deployment.environment": "prod",
+			},
+			libname: "ddtracer",
+			libver:  "v2",
+			in: testutil.NewOTLPSpan(&testutil.OTLPSpan{
+				TraceID:  otlpTestTraceID,
+				SpanID:   otlpTestSpanID,
+				ParentID: [8]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
+				Name:     "/path",
+				Kind:     ptrace.SpanKindClient,
+				Start:    now,
+				End:      now + 200000000,
+				Attributes: map[string]interface{}{
+					"_dd.measured": 0,
+				},
+			}),
+			operationNameV1: "ddtracer.client",
+			operationNameV2: "client.request",
+			resourceNameV1:  "/path",
+			resourceNameV2:  "/path",
+			out: &pb.Span{
+				Service:  "pylons",
+				TraceID:  2594128270069917171,
+				SpanID:   2594128270069917171,
+				ParentID: 0x102030405060708,
+				Start:    int64(now),
+				Duration: 200000000,
+				Meta: map[string]string{
+					"env":                    "prod",
+					"deployment.environment": "prod",
+					"otel.trace_id":          "72df520af2bde7a5240031ead750e5f3",
+					"otel.status_code":       "Unset",
+					"otel.library.name":      "ddtracer",
+					"otel.library.version":   "v2",
+					"span.kind":              "client",
+				},
+				Type:    "http",
+				Metrics: map[string]float64{"_dd.measured": 0},
+			},
+			// With topLevelByKind enabled, _dd.measured:0 must still be respected — not overridden to 1.
+			topLevelOutMetrics: map[string]float64{"_dd.measured": 0},
+		},
 	} {
 		t.Run("", func(t *testing.T) {
 			o := NewOTLPReceiver(nil, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -2485,6 +2485,52 @@ func testOTelSpanToDDSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 			// With topLevelByKind enabled, _dd.measured:0 must still be respected — not overridden to 1.
 			topLevelOutMetrics: map[string]float64{"_dd.measured": 0},
 		},
+		{
+			// A root SERVER span with explicit _dd.top_level:0 must not have _top_level set to 1
+			// by the isTopLevel path, even when enable_otlp_compute_top_level_by_span_kind is enabled.
+			rattr: map[string]string{
+				"service.name":           "pylons",
+				"deployment.environment": "prod",
+			},
+			libname: "ddtracer",
+			libver:  "v2",
+			in: testutil.NewOTLPSpan(&testutil.OTLPSpan{
+				TraceID: otlpTestTraceID,
+				SpanID:  otlpTestSpanID,
+				Name:    "/path",
+				Kind:    ptrace.SpanKindServer,
+				Start:   now,
+				End:     now + 200000000,
+				Attributes: map[string]interface{}{
+					"_dd.top_level": 0,
+				},
+			}),
+			operationNameV1: "ddtracer.server",
+			operationNameV2: "server.request",
+			resourceNameV1:  "/path",
+			resourceNameV2:  "/path",
+			out: &pb.Span{
+				Service:  "pylons",
+				TraceID:  2594128270069917171,
+				SpanID:   2594128270069917171,
+				ParentID: 0,
+				Start:    int64(now),
+				Duration: 200000000,
+				Meta: map[string]string{
+					"env":                    "prod",
+					"deployment.environment": "prod",
+					"otel.trace_id":          "72df520af2bde7a5240031ead750e5f3",
+					"otel.status_code":       "Unset",
+					"otel.library.name":      "ddtracer",
+					"otel.library.version":   "v2",
+					"span.kind":              "server",
+				},
+				Type:    "web",
+				Metrics: map[string]float64{"_dd.top_level": 0},
+			},
+			// With topLevelByKind enabled, _dd.top_level:0 must still be respected — not overridden to _top_level:1.
+			topLevelOutMetrics: map[string]float64{"_dd.top_level": 0},
+		},
 	} {
 		t.Run("", func(t *testing.T) {
 			o := NewOTLPReceiver(nil, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})

--- a/pkg/trace/semantics/mappings.json
+++ b/pkg/trace/semantics/mappings.json
@@ -285,7 +285,7 @@
     "_dd.top_level": {
       "canonical": "_dd.top_level",
       "fallbacks": [
-        {"name": "_dd.top_level", "provider": "datadog", "type": "float64"},
+        {"name": "_dd.top_level", "provider": "datadog", "type": "int64"},
         {"name": "_top_level", "provider": "datadog", "type": "float64"}
       ]
     },

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -903,6 +903,36 @@ func TestComputeStatsThroughSpanKindCheck(t *testing.T) {
 		}
 		assert.Equal(map[string]struct{}{"http.server.request": {}, "internal.op1": {}, "internal.op2": {}, "postgres.query": {}}, opNames)
 	})
+	t.Run("enabled_explicit_opt_out", func(_ *testing.T) {
+		// A CLIENT span with _dd.measured=0 must not get stats computed via the eligibleSpanKind
+		// path even when computeStatsBySpanKind is enabled.
+		optOutClientSpan := &pb.Span{
+			ParentID: sp.SpanID,
+			SpanID:   5,
+			Service:  "myservice",
+			Name:     "postgres.query",
+			Resource: "SELECT id FROM opted_out",
+			Duration: 50,
+			Metrics:  map[string]float64{"_dd.measured": 0},
+			Meta:     map[string]string{"span.kind": "client"},
+		}
+		spans := []*pb.Span{sp, topLevelInternalSpan, measuredInternalSpan, clientSpan, optOutClientSpan}
+		traceutil.ComputeTopLevel(spans)
+		testTrace := toProcessedTrace(spans, "none", "", "", "", "", "")
+		c := NewTestConcentrator(now)
+		c.spanConcentrator.computeStatsBySpanKind = true
+		c.addNow(testTrace, infraTags{})
+		stats := c.flushNow(now.UnixNano()+int64(c.spanConcentrator.bufferLen)*testBucketInterval, false)
+		// optOutClientSpan should not appear — still 4 stats entries, not 5
+		assert.Len(stats.Stats[0].Stats[0].Stats, 4)
+		for _, s := range stats.Stats {
+			for _, b := range s.Stats {
+				for _, g := range b.Stats {
+					assert.NotEqual("SELECT id FROM opted_out", g.Resource)
+				}
+			}
+		}
+	})
 }
 
 func TestVersionData(t *testing.T) {

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -933,6 +933,36 @@ func TestComputeStatsThroughSpanKindCheck(t *testing.T) {
 			}
 		}
 	})
+	t.Run("enabled_explicit_top_level_opt_out", func(_ *testing.T) {
+		// A SERVER span with _dd.top_level=0 must not get stats computed via the eligibleSpanKind
+		// path even when computeStatsBySpanKind is enabled.
+		optOutServerSpan := &pb.Span{
+			ParentID: sp.SpanID,
+			SpanID:   6,
+			Service:  "myservice",
+			Name:     "http.server.request",
+			Resource: "GET /opted-out",
+			Duration: 60,
+			Metrics:  map[string]float64{"_dd.top_level": 0},
+			Meta:     map[string]string{"span.kind": "server"},
+		}
+		spans := []*pb.Span{sp, topLevelInternalSpan, measuredInternalSpan, clientSpan, optOutServerSpan}
+		traceutil.ComputeTopLevel(spans)
+		testTrace := toProcessedTrace(spans, "none", "", "", "", "", "")
+		c := NewTestConcentrator(now)
+		c.spanConcentrator.computeStatsBySpanKind = true
+		c.addNow(testTrace, infraTags{})
+		stats := c.flushNow(now.UnixNano()+int64(c.spanConcentrator.bufferLen)*testBucketInterval, false)
+		// optOutServerSpan should not appear — still 4 stats entries, not 5
+		assert.Len(stats.Stats[0].Stats[0].Stats, 4)
+		for _, s := range stats.Stats {
+			for _, b := range s.Stats {
+				for _, g := range b.Stats {
+					assert.NotEqual("GET /opted-out", g.Resource)
+				}
+			}
+		}
+	})
 }
 
 func TestVersionData(t *testing.T) {

--- a/pkg/trace/stats/span_concentrator.go
+++ b/pkg/trace/stats/span_concentrator.go
@@ -213,7 +213,7 @@ func (sc *SpanConcentrator) NewStatSpanWithConfig(config StatSpanConfig) (statSp
 	}
 	a := semantics.NewDDSpanAccessor(config.Meta, config.Metrics)
 	spanKind := semantics.LookupString(ddRegistry, a, semantics.ConceptSpanKind)
-	eligibleSpanKind := sc.computeStatsBySpanKind && computeStatsForSpanKind(spanKind)
+	eligibleSpanKind := sc.computeStatsBySpanKind && computeStatsForSpanKind(spanKind) && !traceutil.IsExplicitlyUnmeasuredMetrics(config.Metrics)
 	isTopLevel := traceutil.HasTopLevelMetrics(config.Metrics)
 	if !(isTopLevel || traceutil.IsMeasuredMetrics(config.Metrics) || eligibleSpanKind) {
 		return nil, false

--- a/pkg/trace/stats/span_concentrator.go
+++ b/pkg/trace/stats/span_concentrator.go
@@ -213,8 +213,8 @@ func (sc *SpanConcentrator) NewStatSpanWithConfig(config StatSpanConfig) (statSp
 	}
 	a := semantics.NewDDSpanAccessor(config.Meta, config.Metrics)
 	spanKind := semantics.LookupString(ddRegistry, a, semantics.ConceptSpanKind)
-	eligibleSpanKind := sc.computeStatsBySpanKind && computeStatsForSpanKind(spanKind) && !traceutil.IsExplicitlyUnmeasuredMetrics(config.Metrics)
-	isTopLevel := traceutil.HasTopLevelMetrics(config.Metrics)
+	eligibleSpanKind := sc.computeStatsBySpanKind && computeStatsForSpanKind(spanKind) && !traceutil.IsExplicitlyUnmeasuredMetrics(config.Metrics) && !traceutil.IsExplicitlyNotTopLevelMetrics(config.Metrics)
+	isTopLevel := traceutil.HasTopLevelMetrics(config.Metrics) && !traceutil.IsExplicitlyNotTopLevelMetrics(config.Metrics)
 	if !(isTopLevel || traceutil.IsMeasuredMetrics(config.Metrics) || eligibleSpanKind) {
 		return nil, false
 	}

--- a/pkg/trace/traceutil/span.go
+++ b/pkg/trace/traceutil/span.go
@@ -74,6 +74,13 @@ func IsMeasuredMetrics(metrics map[string]float64) bool {
 	return metrics[measuredKey] == 1
 }
 
+// IsExplicitlyUnmeasuredMetrics returns true if _dd.measured is explicitly set to 0,
+// indicating an explicit opt-out from stats computation that overrides span-kind-based eligibility.
+func IsExplicitlyUnmeasuredMetrics(metrics map[string]float64) bool {
+	v, ok := metrics[measuredKey]
+	return ok && v == 0
+}
+
 // IsMeasuredMetricsV1 returns true if a span should be measured (i.e., it should get trace metrics calculated).
 func IsMeasuredMetricsV1(s *idx.InternalSpan) bool {
 	measured, ok := s.GetAttributeAsFloat64(measuredKey)
@@ -118,6 +125,12 @@ func SetTopLevel(s *pb.Span, topLevel bool) {
 	// Setting the metrics value, so that code downstream in the pipeline
 	// can identify this as top-level without recomputing everything.
 	SetMetric(s, topLevelKey, 1)
+}
+
+// MarkExplicitlyUnmeasured sets _dd.measured to 0, recording an explicit opt-out from stats
+// computation. This is distinct from the key being absent (which means no explicit preference).
+func MarkExplicitlyUnmeasured(s *pb.Span) {
+	SetMetric(s, measuredKey, 0)
 }
 
 // SetMeasured sets the measured attribute of the span.

--- a/pkg/trace/traceutil/span.go
+++ b/pkg/trace/traceutil/span.go
@@ -133,6 +133,19 @@ func MarkExplicitlyUnmeasured(s *pb.Span) {
 	SetMetric(s, measuredKey, 0)
 }
 
+// MarkExplicitlyNotTopLevel sets _dd.top_level to 0, recording an explicit opt-out from
+// top-level stats computation. This is distinct from the key being absent.
+func MarkExplicitlyNotTopLevel(s *pb.Span) {
+	SetMetric(s, tracerTopLevelKey, 0)
+}
+
+// IsExplicitlyNotTopLevelMetrics returns true if _dd.top_level is explicitly set to 0,
+// indicating an explicit opt-out from top-level stats computation.
+func IsExplicitlyNotTopLevelMetrics(metrics map[string]float64) bool {
+	v, ok := metrics[tracerTopLevelKey]
+	return ok && v == 0
+}
+
 // SetMeasured sets the measured attribute of the span.
 func SetMeasured(s *pb.Span, measured bool) {
 	if !measured {

--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -94,8 +94,14 @@ func otelSpanToDDSpanMinimal(
 	if isTopLevel {
 		traceutil.SetTopLevel(ddspan, true)
 	}
-	if v, ok := semantics.LookupInt64(reg, spanAccessor, semantics.ConceptDDMeasured); ok && v == 1 {
-		traceutil.SetMeasured(ddspan, true)
+	if v, ok := semantics.LookupInt64(reg, spanAccessor, semantics.ConceptDDMeasured); ok {
+		if v == 1 {
+			traceutil.SetMeasured(ddspan, true)
+		} else {
+			// Explicit opt-out: write _dd.measured=0 so the concentrator can distinguish this from
+			// "not set" and skip eligibleSpanKind-based stats for this span.
+			traceutil.MarkExplicitlyUnmeasured(ddspan)
+		}
 	} else if topLevelByKind && (spanKind == ptrace.SpanKindClient || spanKind == ptrace.SpanKindProducer) {
 		// When enable_otlp_compute_top_level_by_span_kind is true, compute stats for client-side spans
 		traceutil.SetMeasured(ddspan, true)

--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -91,7 +91,15 @@ func otelSpanToDDSpanMinimal(
 	if code, ok := semantics.LookupInt64(reg, spanAccessor, semantics.ConceptHTTPStatusCode); ok && code >= 0 {
 		ddspan.Metrics[traceutil.TagStatusCode] = float64(code)
 	}
-	if isTopLevel {
+	if v, ok := semantics.LookupInt64(reg, spanAccessor, semantics.ConceptDDTopLevel); ok {
+		if v == 1 {
+			traceutil.SetTopLevel(ddspan, true)
+		} else {
+			// Explicit opt-out: write _dd.top_level=0 so the concentrator can distinguish this from
+			// "not set" and skip top-level-based stats for this span.
+			traceutil.MarkExplicitlyNotTopLevel(ddspan)
+		}
+	} else if isTopLevel {
 		traceutil.SetTopLevel(ddspan, true)
 	}
 	if v, ok := semantics.LookupInt64(reg, spanAccessor, semantics.ConceptDDMeasured); ok {

--- a/releasenotes/notes/apm-otlp-dd-measured-opt-out-b0fa2de1b1715e41.yaml
+++ b/releasenotes/notes/apm-otlp-dd-measured-opt-out-b0fa2de1b1715e41.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    APM : OTLP spans that carry the ``_dd.measured`` attribute set to ``0`` now
+    explicitly opt out of APM stats computation. Previously, when the
+    ``enable_otlp_compute_top_level_by_span_kind`` feature flag was enabled,
+    ``CLIENT`` and ``PRODUCER`` spans with ``_dd.measured: 0`` would still have
+    stats computed via span-kind-based eligibility, ignoring the opt-out signal.

--- a/releasenotes/notes/apm-otlp-dd-measured-opt-out-b0fa2de1b1715e41.yaml
+++ b/releasenotes/notes/apm-otlp-dd-measured-opt-out-b0fa2de1b1715e41.yaml
@@ -1,8 +1,10 @@
 ---
 enhancements:
   - |
-    APM : OTLP spans that carry the ``_dd.measured`` attribute set to ``0`` now
-    explicitly opt out of APM stats computation. Previously, when the
-    ``enable_otlp_compute_top_level_by_span_kind`` feature flag was enabled,
-    ``CLIENT`` and ``PRODUCER`` spans with ``_dd.measured: 0`` would still have
-    stats computed via span-kind-based eligibility, ignoring the opt-out signal.
+    APM : OTLP spans that carry the ``_dd.measured`` attribute set to ``0`` or the
+    ``_dd.top_level`` attribute set to ``0`` now explicitly opt out of APM stats
+    computation. Previously, when the ``enable_otlp_compute_top_level_by_span_kind``
+    feature flag was enabled, ``CLIENT`` and ``PRODUCER`` spans with ``_dd.measured: 0``
+    would still have stats computed via span-kind-based eligibility, and ``SERVER`` and
+    ``CONSUMER`` spans with ``_dd.top_level: 0`` would still have stats computed via
+    the top-level path, ignoring the opt-out signal.


### PR DESCRIPTION
## Summary

- When an OTLP span has `_dd.measured:0`, it should opt out of stats computation even when `enable_otlp_compute_top_level_by_span_kind` is enabled. Two paths previously ignored this signal:
  1. `OtelSpanToDDSpanMinimal` would still call `SetMeasured(true)` on CLIENT/PRODUCER spans via the `topLevelByKind` fallback
  2. `SpanConcentrator.NewStatSpanWithConfig` would still compute stats via `eligibleSpanKind` regardless of any explicit `_dd.measured` value
- Added `MarkExplicitlyUnmeasured` (writes `_dd.measured=0` as a distinguishable sentinel) and `IsExplicitlyUnmeasuredMetrics` (detects it) to `traceutil`
- `OtelSpanToDDSpanMinimal` now calls `MarkExplicitlyUnmeasured` when the attribute is `"0"`, and skips the `topLevelByKind` fallback
- `SpanConcentrator.NewStatSpanWithConfig` now gates `eligibleSpanKind` on `!IsExplicitlyUnmeasuredMetrics`, so `_dd.measured:0` blocks span-kind-based stats

## Test plan

- [ ] Existing `TestOTelSpanToDDSpan` / `TestOTLPConvertSpan` pass with new test case asserting `_dd.measured` stays `0` for a CLIENT span with the attribute set, both with and without `enable_otlp_compute_top_level_by_span_kind`
- [ ] New `TestComputeStatsThroughSpanKindCheck/enabled_explicit_opt_out` verifies the concentrator skips stats for a CLIENT span with `_dd.measured:0` even when `computeStatsBySpanKind=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)