### PR TITLE
[gensim-eks] RetainOnDelete on build VM resources to prevent SSH hangs

### DIFF
--- a/test/e2e-framework/components/command/filemanager.go
+++ b/test/e2e-framework/components/command/filemanager.go
@@ -168,7 +168,7 @@ func (fm *FileManager) CopyFSFolder(
 			return nil, err
 		}
 		remotePath := path.Join(remoteFolder, destFolder)
-		resources, err := fm.CreateDirectory(remotePath, useSudo, pulumi.DependsOn([]pulumi.Resource{folderCommand}))
+		resources, err := fm.CreateDirectory(remotePath, useSudo, append(opts, pulumi.DependsOn([]pulumi.Resource{folderCommand}))...)
 		if err != nil {
 			return nil, err
 		}
@@ -189,7 +189,7 @@ func (fm *FileManager) CopyFSFolder(
 		fileCommand, err := fm.CopyInlineFile(
 			pulumi.String(fileContent),
 			path.Join(remoteFolder, destFile),
-			pulumi.DependsOn(folderResources))
+			append(opts, pulumi.DependsOn(folderResources))...)
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e-framework/scenarios/aws/gensim-eks/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/run.go
@@ -627,6 +627,7 @@ func provisionBuildVM(ctx *pulumi.Context, awsEnv resAws.Environment) (*remote.H
 			Create: pulumi.String(`yum install -y awscli`),
 			Sudo:   true,
 		},
+		pulumi.RetainOnDelete(true),
 	)
 	if err != nil {
 		return nil, nil, err
@@ -653,9 +654,15 @@ func buildEpisodeImages(
 ) error {
 	buildDir := "/tmp/gensim-build-" + episodeName
 
+	// Build VM resources are ephemeral — the VM is discarded after images are pushed.
+	// RetainOnDelete prevents Pulumi from SSH-ing back into a potentially-dead VM
+	// to "delete" these resources on subsequent runs; dropping them from state is enough.
+	retainOnDelete := pulumi.RetainOnDelete(true)
+
 	// Copy the episode's docker-compose.yaml and services/ directory to the build VM.
 	servicesCopy, err := buildHost.OS.FileManager().CopyAbsoluteFolder(
 		filepath.Join(episodePath, "services"), buildDir+"/",
+		retainOnDelete,
 	)
 	if err != nil {
 		return err
@@ -675,6 +682,7 @@ func buildEpisodeImages(
 			Sudo:   true,
 		},
 		utils.PulumiDependsOn(servicesCopy...),
+		retainOnDelete,
 	)
 	if err != nil {
 		return err
@@ -688,6 +696,7 @@ func buildEpisodeImages(
 			Sudo:   true,
 		},
 		utils.PulumiDependsOn(append(servicesCopy, dockerComposeCopy)...),
+		retainOnDelete,
 	)
 	if err != nil {
 		return err
@@ -792,6 +801,7 @@ fi`,
 			),
 		},
 		utils.PulumiDependsOn(installDep, fixPermsCmd),
+		retainOnDelete,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What

Add \`pulumi.RetainOnDelete(true)\` to all build VM resources in \`buildEpisodeImages\` and \`provisionBuildVM\`. Also fixes \`CopyFSFolder\` to propagate caller-provided \`ResourceOption\`s to child resources, so \`RetainOnDelete\` reaches every file and directory created by \`CopyAbsoluteFolder\` — not just the top-level directory.

### Why

Build VM resources are ephemeral by design. Each episode submission copies source files to \`tmp/gensim-build-<episode>\` on the build VM, builds Docker images, and pushes them to ECR. Once the push completes, those files have no further purpose — the VM may be stopped or destroyed by the time the next submission runs.

Pulumi doesn't know this. When a new submission declares a different episode, Pulumi sees the old episode's resources as "no longer needed" and tries to delete them — which means SSHing back into the build VM. If that VM is unreachable, each resource hangs for 100 retries. With ~60 resources per episode, one stale episode adds ~16 minutes of dead time to every subsequent submit.

\`RetainOnDelete\` tells Pulumi to remove these resources from state without executing deletion. Nothing is lost. The files were already throwaway.

**No performance impact on reruns.** The five affected resource groups are:

1. \`yum install awscli\` — idempotent; exits immediately if already installed
2. \`CopyAbsoluteFolder\` (services) — expands to one Pulumi resource per file and subdirectory in \`services/\`; \`RetainOnDelete\` propagates to all of them via the \`CopyFSFolder\` fix
3. \`write-compose-<episode>\` — a single \`tee\` command
4. \`fix-build-dir-perms-<episode>\` — a single \`chown\`
5. \`build-push-images-<episode>\` — checks ECR for a content-addressed hash tag before building; if all images are already present it skips \`docker buildx bake\` entirely

None of these depend on Pulumi state to avoid redundant work. Dropping them from state on delete changes nothing about rerun speed.

### Test Plan

- [x] Submit two different episodes sequentially and confirm the second submit does not attempt to delete the first episode's build resources.