### PR TITLE
[CNM] Reduce TCP congestion test flakiness.

### DIFF
--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -3385,10 +3385,12 @@ func (s *TracerSuite) TestTCPRetransmitSyncOnClose() {
 func (s *TracerSuite) TestTCPCongestionSyncOnClose() {
 	t := s.T()
 	cfg := testConfig()
-	if isPrebuilt(cfg) {
+	switch ebpftest.GetBuildMode() {
+	case ebpftest.Prebuilt:
 		t.Skip("TCP congestion signals not available on prebuilt")
+	case ebpftest.Ebpfless:
+		t.Skip("TCP congestion signals not available on ebpfless")
 	}
-	skipOnEbpflessNotSupported(t, cfg)
 	if kv < kernel.VersionCode(4, 19, 0) {
 		t.Skip("reord_seen requires kernel 4.19+")
 	}
@@ -3442,10 +3444,12 @@ func (s *TracerSuite) TestTCPCongestionSyncOnClose() {
 func (s *TracerSuite) TestTCPEventStatsSyncOnClose() {
 	t := s.T()
 	cfg := testConfig()
-	if isPrebuilt(cfg) {
+	switch ebpftest.GetBuildMode() {
+	case ebpftest.Prebuilt:
 		t.Skip("TCP congestion signals not available on prebuilt")
+	case ebpftest.Ebpfless:
+		t.Skip("TCP congestion signals not available on ebpfless")
 	}
-	skipOnEbpflessNotSupported(t, cfg)
 
 	tr := setupTracer(t, cfg)
 
@@ -3582,10 +3586,12 @@ func (env *netemTestEnv) dialInNs(t *testing.T) net.Conn {
 func (s *TracerSuite) TestTCPRTOCount() {
 	t := s.T()
 	cfg := testConfig()
-	if isPrebuilt(cfg) {
+	switch ebpftest.GetBuildMode() {
+	case ebpftest.Prebuilt:
 		t.Skip("TCP congestion signals not available on prebuilt")
+	case ebpftest.Ebpfless:
+		t.Skip("TCP congestion signals not available on ebpfless")
 	}
-	skipOnEbpflessNotSupported(t, cfg)
 
 	tr := setupTracer(t, cfg)
 
@@ -3692,10 +3698,12 @@ func runNetemCongestionTest(
 func (s *TracerSuite) TestTCPRecoveryCount() {
 	t := s.T()
 	cfg := testConfig()
-	if isPrebuilt(cfg) {
+	switch ebpftest.GetBuildMode() {
+	case ebpftest.Prebuilt:
 		t.Skip("TCP congestion signals not available on prebuilt")
+	case ebpftest.Ebpfless:
+		t.Skip("TCP congestion signals not available on ebpfless")
 	}
-	skipOnEbpflessNotSupported(t, cfg)
 
 	tr := setupTracer(t, cfg)
 
@@ -3718,6 +3726,14 @@ func (s *TracerSuite) TestTCPRecoveryCount() {
 		c.SetWriteDeadline(time.Now().Add(2 * time.Second))
 		c.Write(make([]byte, 64*1024)) //nolint:errcheck
 	}
+
+	// Ensure the tracer has registered the connection before spiking loss.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		conns, cleanup := getConnections(ct, tr)
+		defer cleanup()
+		_, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
+		assert.True(ct, ok, "connection not found during calibration")
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Spike loss — delay stays low so RTO doesn't fire, but frequent
 	// correlated drops trigger SACK-based fast recovery.
@@ -3744,10 +3760,12 @@ func (s *TracerSuite) TestTCPRecoveryCount() {
 func (s *TracerSuite) TestTCPReordSeen() {
 	t := s.T()
 	cfg := testConfig()
-	if isPrebuilt(cfg) {
+	switch ebpftest.GetBuildMode() {
+	case ebpftest.Prebuilt:
 		t.Skip("TCP congestion signals not available on prebuilt")
+	case ebpftest.Ebpfless:
+		t.Skip("TCP congestion signals not available on ebpfless")
 	}
-	skipOnEbpflessNotSupported(t, cfg)
 
 	if kv < kernel.VersionCode(4, 19, 0) {
 		t.Skip("reord_seen requires kernel 4.19+")
@@ -3767,10 +3785,12 @@ func (s *TracerSuite) TestTCPReordSeen() {
 func (s *TracerSuite) TestTCPRcvOOOPack() {
 	t := s.T()
 	cfg := testConfig()
-	if isPrebuilt(cfg) {
+	switch ebpftest.GetBuildMode() {
+	case ebpftest.Prebuilt:
 		t.Skip("TCP congestion signals not available on prebuilt")
+	case ebpftest.Ebpfless:
+		t.Skip("TCP congestion signals not available on ebpfless")
 	}
-	skipOnEbpflessNotSupported(t, cfg)
 
 	if kv < kernel.VersionCode(5, 4, 0) {
 		t.Skip("rcv_ooopack requires kernel 5.4+")
@@ -3828,10 +3848,12 @@ func (s *TracerSuite) TestTCPRcvOOOPack() {
 func (s *TracerSuite) TestTCPDeliveredCE() {
 	t := s.T()
 	cfg := testConfig()
-	if isPrebuilt(cfg) {
+	switch ebpftest.GetBuildMode() {
+	case ebpftest.Prebuilt:
 		t.Skip("TCP congestion signals not available on prebuilt")
+	case ebpftest.Ebpfless:
+		t.Skip("TCP congestion signals not available on ebpfless")
 	}
-	skipOnEbpflessNotSupported(t, cfg)
 
 	if kv < kernel.VersionCode(4, 19, 0) {
 		t.Skip("delivered_ce requires kernel 4.19+")
@@ -3860,10 +3882,12 @@ func (s *TracerSuite) TestTCPDeliveredCE() {
 func (s *TracerSuite) TestTCPZeroWindowProbe() {
 	t := s.T()
 	cfg := testConfig()
-	if isPrebuilt(cfg) {
+	switch ebpftest.GetBuildMode() {
+	case ebpftest.Prebuilt:
 		t.Skip("TCP congestion signals not available on prebuilt")
+	case ebpftest.Ebpfless:
+		t.Skip("TCP congestion signals not available on ebpfless")
 	}
-	skipOnEbpflessNotSupported(t, cfg)
 
 	tr := setupTracer(t, cfg)
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -3691,10 +3691,10 @@ func runNetemCongestionTest(
 	}, 30*time.Second, 200*time.Millisecond)
 }
 
-// TestTCPRecoveryCount validates the recovery_count signal.
-// Strategy: calibrate with low loss so SACK is active and the kernel
-// has enough in-flight data, then spike loss so SACK detects gaps and
-// triggers fast recovery. Delay stays low to avoid RTO.
+// TestTCPRecoveryCount validates the recovery_count signal. Uses escalating
+// netem configs to handle test variability — delay keeps enough segments
+// in-flight for SACK to detect gaps, while moderate loss triggers fast
+// recovery rather than full RTO timeout.
 func (s *TracerSuite) TestTCPRecoveryCount() {
 	t := s.T()
 	cfg := testConfig()
@@ -3707,50 +3707,36 @@ func (s *TracerSuite) TestTCPRecoveryCount() {
 
 	tr := setupTracer(t, cfg)
 
-	doneCh := make(chan struct{})
-	env := setupNetemTestEnv(t, func(c net.Conn) {
-		io.Copy(io.Discard, c) //nolint:errcheck
-		<-doneCh
-	})
-	t.Cleanup(func() { close(doneCh) })
-
-	// Dial on a clean link, then apply low loss so SACK is active and
-	// the kernel builds up enough in-flight segments.
-	c := env.dialInNs(t)
-	defer c.Close()
-	env.addNetem(t, "delay", "5ms", "loss", "5%")
-
-	// Send calibration packets so the kernel has in-flight data and
-	// SACK state established.
-	for i := 0; i < 10; i++ {
-		c.SetWriteDeadline(time.Now().Add(2 * time.Second))
-		c.Write(make([]byte, 64*1024)) //nolint:errcheck
+	netemConfigs := [][]string{
+		{"delay", "50ms", "loss", "15%", "50%"},
+		{"delay", "50ms", "loss", "20%", "50%"},
+		{"delay", "50ms", "loss", "25%", "75%"},
 	}
+	for _, netemArgs := range netemConfigs {
+		c := setupNetemCongestionTest(t, netemArgs, nil)
+		triggered := false
+		deadline := time.Now().Add(20 * time.Second)
+		for time.Now().Before(deadline) {
+			c.SetWriteDeadline(time.Now().Add(2 * time.Second))
+			c.Write(make([]byte, 64*1024)) //nolint:errcheck
+			time.Sleep(200 * time.Millisecond)
 
-	// Ensure the tracer has registered the connection before spiking loss.
-	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		conns, cleanup := getConnections(ct, tr)
-		defer cleanup()
-		_, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-		assert.True(ct, ok, "connection not found during calibration")
-	}, 10*time.Second, 200*time.Millisecond)
-
-	// Spike loss — delay stays low so RTO doesn't fire, but frequent
-	// correlated drops trigger SACK-based fast recovery.
-	env.changeNetem(t, "delay", "5ms", "loss", "30%", "50%")
-
-	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		c.SetWriteDeadline(time.Now().Add(2 * time.Second))
-		c.Write(make([]byte, 64*1024)) //nolint:errcheck
-
-		conns, cleanup := getConnections(ct, tr)
-		defer cleanup()
-		conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-		if !assert.True(ct, ok, "connection not found") {
+			conns, cleanup := getConnections(t, tr)
+			conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
+			if ok && conn.Last.TCPRecoveryCount > 0 {
+				triggered = true
+				cleanup()
+				break
+			}
+			cleanup()
+		}
+		c.Close()
+		if triggered {
 			return
 		}
-		assert.Greater(ct, conn.Last.TCPRecoveryCount, uint32(0), "recovery_count should be > 0")
-	}, 30*time.Second, 200*time.Millisecond)
+		t.Logf("netem config %v did not trigger recovery, trying next", netemArgs)
+	}
+	require.Fail(t, "no netem configuration triggered recovery_count > 0")
 }
 
 // TestTCPReordSeen validates the reord_seen signal by introducing packet


### PR DESCRIPTION
### What does this PR do?
Harden some of the TestTracerSuite TCP congestion tests.

### Motivation
Reduce flaky test failures.

### Describe how you validated your changes
Ran the unit tests.

### Additional Notes
