### PR TITLE
[CONTP-1582] cluster check execution status collection in DCA

### DIFF
--- a/comp/metadata/clusterchecks/impl/clusterchecks.go
+++ b/comp/metadata/clusterchecks/impl/clusterchecks.go
@@ -256,7 +256,8 @@ func (cc *clusterChecksImpl) collectClusterCheckMetadata(payload *Payload) {
 
 	// Process configs from all nodes
 	for _, node := range state.Nodes {
-		for _, config := range node.Configs {
+		for _, configResp := range node.Configs {
+			config := configResp.Config
 			checkName := config.Name
 			if checkName == "" {
 				continue

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -42,18 +42,47 @@ func (d *dispatcher) getState(scrub bool) (types.StateResponse, error) {
 	}
 
 	for _, node := range d.store.nodes {
-		configs := makeConfigArray(node.digestToConfig)
-		if scrub {
-			scrubbedConf := make([]integration.Config, 0, len(configs))
-			for _, config := range configs {
-				scrubbedConf = append(scrubbedConf, integration.ScrubCheckConfig(config, log.NewWrapper(1)))
+		rawConfigs := makeConfigArray(node.digestToConfig)
+
+		// Build config responses with instance IDs computed from unscrubbed configs.
+		// IDs must be computed before scrubbing because ScrubYaml re-serializes
+		// YAML bytes which changes the digest used in check ID computation.
+		configsWithIDs := make([]types.ConfigWithInstanceIDs, 0, len(rawConfigs))
+		for _, config := range rawConfigs {
+			digest := config.FastDigest()
+			instanceIDs := make([]string, 0, len(config.Instances))
+			for _, inst := range config.Instances {
+				instanceIDs = append(instanceIDs, string(checkid.BuildID(config.Name, digest, inst, config.InitConfig)))
 			}
-			configs = scrubbedConf
+
+			if scrub {
+				config = integration.ScrubCheckConfig(config, log.NewWrapper(1))
+			}
+
+			configsWithIDs = append(configsWithIDs, types.ConfigWithInstanceIDs{
+				InstanceIDs: instanceIDs,
+				Config:      config,
+			})
 		}
+
+		// Copy runner stats for this node. Stats are populated by the periodic
+		// rebalance cycle when advanced dispatching is enabled. Without advanced
+		// dispatching or when the runner is unreachable, stats will be empty.
+		// Take node read lock to avoid concurrent map read/write with updateRunnersStats.
+		var stats types.CLCRunnersStats
+		node.RLock()
+		if len(node.clcRunnerStats) > 0 {
+			stats = make(types.CLCRunnersStats, len(node.clcRunnerStats))
+			for k, v := range node.clcRunnerStats {
+				stats[k] = v
+			}
+		}
+		node.RUnlock()
 
 		n := types.StateNodeResponse{
 			Name:    node.name,
-			Configs: configs,
+			Configs: configsWithIDs,
+			Stats:   stats,
 		}
 		response.Nodes = append(response.Nodes, n)
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -763,3 +763,105 @@ func TestUpdateRunnersStats(t *testing.T) {
 
 	requireNotLocked(t, dispatcher.store)
 }
+
+func TestGetStateIncludesStats(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	dispatcher := newDispatcher(fakeTagger)
+	dispatcher.store.active = true
+	// Nil out the client so updateRunnersStats() is a no-op;
+	// we set stats manually below.
+	dispatcher.clcRunnersClient = nil
+
+	config := integration.Config{
+		Name:         "my_check",
+		ClusterCheck: true,
+		Instances:    []integration.Data{integration.Data("{}")},
+		InitConfig:   integration.Data("{}"),
+	}
+	dispatcher.addConfig(config, "node1")
+
+	status := types.NodeStatus{LastChange: 10}
+	_ = dispatcher.processNodeStatus("node1", "10.0.0.1", status)
+
+	// Manually set runner stats on the node (simulating updateRunnersStats)
+	node1, found := dispatcher.store.getNodeStore("node1")
+	require.True(t, found)
+	node1.Lock()
+	node1.clcRunnerStats = types.CLCRunnersStats{
+		"my_check:abc123": {
+			AverageExecutionTime: 500,
+			MetricSamples:        42,
+			Events:               3,
+			ServiceChecks:        1,
+			LastExecFailed:       false,
+			TotalRuns:            100,
+			TotalErrors:          2,
+			TotalMetricSamples:   4200,
+			TotalEvents:          300,
+			TotalServiceChecks:   100,
+			LastSuccessDate:      1775563775,
+			LastExecutionDate:    1775563775974,
+		},
+	}
+	node1.Unlock()
+
+	state, err := dispatcher.getState(false)
+	assert.NoError(t, err)
+	assert.False(t, state.Warmup)
+	require.Len(t, state.Nodes, 1)
+
+	nodeResp := state.Nodes[0]
+	assert.Equal(t, "node1", nodeResp.Name)
+	require.Len(t, nodeResp.Configs, 1)
+
+	// Verify instance IDs are precomputed
+	configResp := nodeResp.Configs[0]
+	assert.Equal(t, "my_check", configResp.Config.Name)
+	require.Len(t, configResp.InstanceIDs, 1)
+
+	// Verify stats are included in the response
+	require.NotNil(t, nodeResp.Stats)
+	require.Len(t, nodeResp.Stats, 1)
+
+	s, found := nodeResp.Stats["my_check:abc123"]
+	require.True(t, found)
+	assert.Equal(t, 500, s.AverageExecutionTime)
+	assert.Equal(t, 42, s.MetricSamples)
+	assert.Equal(t, 3, s.Events)
+	assert.Equal(t, 1, s.ServiceChecks)
+	assert.False(t, s.LastExecFailed)
+	assert.Equal(t, uint64(100), s.TotalRuns)
+	assert.Equal(t, uint64(2), s.TotalErrors)
+	assert.Equal(t, uint64(4200), s.TotalMetricSamples)
+	assert.Equal(t, uint64(300), s.TotalEvents)
+	assert.Equal(t, uint64(100), s.TotalServiceChecks)
+	assert.Equal(t, int64(1775563775), s.LastSuccessDate)
+	assert.Equal(t, int64(1775563775974), s.LastExecutionDate)
+
+	requireNotLocked(t, dispatcher.store)
+}
+
+func TestGetStateNoStats(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	dispatcher := newDispatcher(fakeTagger)
+	dispatcher.store.active = true
+	dispatcher.clcRunnersClient = nil
+
+	config := generateIntegration("my_check")
+	dispatcher.addConfig(config, "node1")
+
+	status := types.NodeStatus{LastChange: 10}
+	_ = dispatcher.processNodeStatus("node1", "10.0.0.1", status)
+
+	// Don't set any runner stats — simulates stats not yet collected
+	state, err := dispatcher.getState(false)
+	assert.NoError(t, err)
+	require.Len(t, state.Nodes, 1)
+	assert.Nil(t, state.Nodes[0].Stats)
+
+	// Verify config is included (no instances in this test config, so no instance IDs)
+	require.Len(t, state.Nodes[0].Configs, 1)
+	assert.Equal(t, "my_check", state.Nodes[0].Configs[0].Config.Name)
+
+	requireNotLocked(t, dispatcher.store)
+}

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -77,8 +77,17 @@ type StateResponse struct {
 
 // StateNodeResponse is a chunk of StateResponse
 type StateNodeResponse struct {
-	Name    string               `json:"name"`
-	Configs []integration.Config `json:"configs"`
+	Name    string                  `json:"name"`
+	Configs []ConfigWithInstanceIDs `json:"configs"`
+	Stats   CLCRunnersStats         `json:"stats,omitempty"`
+}
+
+// ConfigWithInstanceIDs pairs a config with its precomputed instance IDs.
+// Instance IDs are computed from unscrubbed configs at dispatch time
+// so they match the runner's check IDs regardless of config scrubbing.
+type ConfigWithInstanceIDs struct {
+	InstanceIDs []string           `json:"instance_ids"`
+	Config      integration.Config `json:"config"`
 }
 
 // Stats holds statistics for the agent status command
@@ -107,12 +116,21 @@ type CLCRunnersStats map[string]CLCRunnerStats
 
 // CLCRunnerStats is used to unmarshall the stats of each CLC Runner
 type CLCRunnerStats struct {
-	AverageExecutionTime int  `json:"AverageExecutionTime"`
-	MetricSamples        int  `json:"MetricSamples"`
-	HistogramBuckets     int  `json:"HistogramBuckets"`
-	Events               int  `json:"Events"`
-	IsClusterCheck       bool `json:"IsClusterCheck"`
-	LastExecFailed       bool `json:"LastExecFailed"`
+	AverageExecutionTime int    `json:"AverageExecutionTime"`
+	MetricSamples        int    `json:"MetricSamples"`
+	HistogramBuckets     int    `json:"HistogramBuckets"`
+	Events               int    `json:"Events"`
+	ServiceChecks        int    `json:"ServiceChecks"`
+	IsClusterCheck       bool   `json:"IsClusterCheck"`
+	LastExecFailed       bool   `json:"LastExecFailed"`
+	LastError            string `json:"LastError"`
+	TotalRuns            uint64 `json:"TotalRuns"`
+	TotalErrors          uint64 `json:"TotalErrors"`
+	TotalMetricSamples   uint64 `json:"TotalMetricSamples"`
+	TotalEvents          uint64 `json:"TotalEvents"`
+	TotalServiceChecks   uint64 `json:"TotalServiceChecks"`
+	LastSuccessDate      int64  `json:"LastSuccessDate"`
+	LastExecutionDate    int64  `json:"LastExecutionDate"`
 }
 
 // Workers is used to unmarshal the workers info of each CLC Runner

--- a/pkg/flare/clusteragent/cluster_checks.go
+++ b/pkg/flare/clusteragent/cluster_checks.go
@@ -13,9 +13,11 @@ import (
 	"slices"
 	"sort"
 	"text/tabwriter"
+	"time"
 
 	"github.com/fatih/color"
 
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipchttp "github.com/DataDog/datadog-agent/comp/core/ipc/httphelpers"
@@ -72,7 +74,7 @@ func GetClusterChecks(w io.Writer, checkName string, c ipc.HTTPClient) error {
 	if len(cr.Dangling) > 0 {
 		fmt.Fprintf(w, "=== %s configurations ===\n", color.RedString("Unassigned"))
 		for _, c := range cr.Dangling {
-			flare.PrintClusterCheckConfig(w, c, checkName)
+			flare.PrintClusterCheckConfig(w, c, checkName, nil)
 		}
 		fmt.Fprintln(w, "")
 	}
@@ -92,18 +94,60 @@ func GetClusterChecks(w io.Writer, checkName string, c ipc.HTTPClient) error {
 	}
 	table.Flush()
 
-	// Print per-node configurations
+	// Print per-node configurations with execution status
 	for _, node := range cr.Nodes {
 		if len(node.Configs) == 0 {
 			continue
 		}
 		fmt.Fprintf(w, "\n===== Checks on %s =====\n", color.HiMagentaString(node.Name))
-		for _, c := range node.Configs {
-			flare.PrintClusterCheckConfig(w, c, checkName)
+		for _, configResp := range node.Configs {
+			flare.PrintClusterCheckConfig(w, configResp.Config, checkName, configResp.InstanceIDs)
+			if len(node.Stats) > 0 {
+				printCheckExecutionStatus(w, configResp.Config, node.Stats, checkName, configResp.InstanceIDs)
+			}
 		}
 	}
 
 	return nil
+}
+
+// printCheckExecutionStatus prints the execution status for each instance of a config,
+// matching the node agent `agent status collector` output format.
+func printCheckExecutionStatus(w io.Writer, c integration.Config, stats types.CLCRunnersStats, checkName string, instanceIDs []string) {
+	if checkName != "" && c.Name != checkName {
+		return
+	}
+	if len(stats) == 0 {
+		return
+	}
+
+	for _, id := range instanceIDs {
+		s, found := stats[id]
+		if !found {
+			continue
+		}
+
+		statusStr := color.GreenString("OK")
+		if s.LastExecFailed {
+			statusStr = color.RedString("ERROR")
+		}
+		fmt.Fprintf(w, "  Instance ID: %s [%s]\n", id, statusStr)
+		fmt.Fprintf(w, "  Total Runs: %d\n", s.TotalRuns)
+		fmt.Fprintf(w, "  Metric Samples: Last Run: %d, Total: %d\n", s.MetricSamples, s.TotalMetricSamples)
+		fmt.Fprintf(w, "  Events: Last Run: %d, Total: %d\n", s.Events, s.TotalEvents)
+		fmt.Fprintf(w, "  Service Checks: Last Run: %d, Total: %d\n", s.ServiceChecks, s.TotalServiceChecks)
+		fmt.Fprintf(w, "  Average Execution Time : %s\n", (time.Duration(s.AverageExecutionTime) * time.Millisecond).String())
+		if s.LastExecutionDate > 0 {
+			fmt.Fprintf(w, "  Last Execution Date : %s\n", time.UnixMilli(s.LastExecutionDate).UTC().Format("2006-01-02 15:04:05 MST"))
+		}
+		if s.LastSuccessDate > 0 {
+			fmt.Fprintf(w, "  Last Successful Execution Date : %s\n", time.Unix(s.LastSuccessDate, 0).UTC().Format("2006-01-02 15:04:05 MST"))
+		}
+		if s.LastError != "" {
+			fmt.Fprintf(w, "  %s: %s\n", color.RedString("Last Error"), s.LastError)
+		}
+		fmt.Fprintln(w, "")
+	}
 }
 
 // GetEndpointsChecks dumps the endpointschecks dispatching state to the writer
@@ -137,7 +181,7 @@ func GetEndpointsChecks(w io.Writer, checkName string, c ipc.HTTPClient) error {
 	// Print summary of pod-backed endpointschecks
 	fmt.Fprintf(w, "\n===== %d Pod-backed Endpoints-Checks scheduled =====\n", len(cr.Configs))
 	for _, c := range cr.Configs {
-		flare.PrintClusterCheckConfig(w, c, checkName)
+		flare.PrintClusterCheckConfig(w, c, checkName, nil)
 	}
 
 	return nil

--- a/pkg/flare/clusteragent/cluster_checks_test.go
+++ b/pkg/flare/clusteragent/cluster_checks_test.go
@@ -1,0 +1,196 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package clusteragent
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+)
+
+func TestPrintCheckExecutionStatus_ExactMatch(t *testing.T) {
+	var buf bytes.Buffer
+
+	config := integration.Config{
+		Name:       "my_check",
+		InitConfig: integration.Data("{}"),
+		Instances:  []integration.Data{integration.Data("{}")},
+	}
+
+	instanceIDs := []string{"my_check:abc123"}
+	stats := types.CLCRunnersStats{
+		"my_check:abc123": {
+			AverageExecutionTime: 100,
+			TotalRuns:            50,
+			MetricSamples:        10,
+			LastExecFailed:       false,
+		},
+	}
+
+	printCheckExecutionStatus(&buf, config, stats, "", instanceIDs)
+	output := buf.String()
+
+	assert.Contains(t, output, "[OK]")
+	assert.Contains(t, output, "Total Runs: 50")
+	assert.Contains(t, output, "Metric Samples: Last Run: 10")
+	assert.Contains(t, output, "100ms")
+}
+
+func TestPrintCheckExecutionStatus_MultipleInstances(t *testing.T) {
+	var buf bytes.Buffer
+
+	config := integration.Config{
+		Name:       "http_check",
+		InitConfig: integration.Data("{}"),
+		Instances: []integration.Data{
+			integration.Data(`{"name": "instance_a", "url": "http://a.com"}`),
+			integration.Data(`{"name": "instance_b", "url": "http://b.com"}`),
+		},
+	}
+
+	instanceIDs := []string{
+		"http_check:instance_a:abc123",
+		"http_check:instance_b:def456",
+	}
+	stats := types.CLCRunnersStats{
+		"http_check:instance_a:abc123": {
+			AverageExecutionTime: 100,
+			TotalRuns:            10,
+		},
+		"http_check:instance_b:def456": {
+			AverageExecutionTime: 200,
+			TotalRuns:            20,
+		},
+	}
+
+	printCheckExecutionStatus(&buf, config, stats, "", instanceIDs)
+	output := buf.String()
+
+	assert.Contains(t, output, "Total Runs: 10")
+	assert.Contains(t, output, "Total Runs: 20")
+
+	lines := strings.Split(output, "\n")
+	instanceCount := 0
+	for _, line := range lines {
+		if strings.Contains(line, "Instance ID:") {
+			instanceCount++
+		}
+	}
+	assert.Equal(t, 2, instanceCount)
+}
+
+func TestPrintCheckExecutionStatus_EmptyStats(t *testing.T) {
+	var buf bytes.Buffer
+
+	config := integration.Config{
+		Name:       "my_check",
+		InitConfig: integration.Data("{}"),
+		Instances:  []integration.Data{integration.Data("{}")},
+	}
+
+	printCheckExecutionStatus(&buf, config, types.CLCRunnersStats{}, "", []string{"my_check:abc123"})
+	assert.Empty(t, buf.String())
+}
+
+func TestPrintCheckExecutionStatus_NoMatch(t *testing.T) {
+	var buf bytes.Buffer
+
+	config := integration.Config{
+		Name:       "my_check",
+		InitConfig: integration.Data("{}"),
+		Instances:  []integration.Data{integration.Data("{}")},
+	}
+
+	stats := types.CLCRunnersStats{
+		"other_check:abc123": {
+			TotalRuns: 100,
+		},
+	}
+
+	printCheckExecutionStatus(&buf, config, stats, "", []string{"my_check:xyz789"})
+	assert.Empty(t, buf.String())
+}
+
+func TestPrintCheckExecutionStatus_FilterByCheckName(t *testing.T) {
+	var buf bytes.Buffer
+
+	config := integration.Config{
+		Name:       "my_check",
+		InitConfig: integration.Data("{}"),
+		Instances:  []integration.Data{integration.Data("{}")},
+	}
+
+	instanceIDs := []string{"my_check:abc123"}
+	stats := types.CLCRunnersStats{
+		"my_check:abc123": {
+			TotalRuns: 100,
+		},
+	}
+
+	// Filter for a different check name — should print nothing
+	printCheckExecutionStatus(&buf, config, stats, "other_check", instanceIDs)
+	assert.Empty(t, buf.String())
+
+	// Filter for matching check name — should print stats
+	buf.Reset()
+	printCheckExecutionStatus(&buf, config, stats, "my_check", instanceIDs)
+	assert.Contains(t, buf.String(), "Total Runs: 100")
+}
+
+func TestPrintCheckExecutionStatus_ErrorFields(t *testing.T) {
+	var buf bytes.Buffer
+
+	config := integration.Config{
+		Name:       "my_check",
+		InitConfig: integration.Data("{}"),
+		Instances:  []integration.Data{integration.Data("{}")},
+	}
+
+	instanceIDs := []string{"my_check:abc123"}
+	stats := types.CLCRunnersStats{
+		"my_check:abc123": {
+			LastExecFailed:    true,
+			LastError:         "timeout after 30s",
+			TotalRuns:         100,
+			TotalErrors:       5,
+			LastSuccessDate:   1775563775,
+			LastExecutionDate: 1775563800000,
+		},
+	}
+
+	printCheckExecutionStatus(&buf, config, stats, "", instanceIDs)
+	output := buf.String()
+
+	assert.Contains(t, output, "[ERROR]")
+	assert.Contains(t, output, "timeout after 30s")
+	assert.Contains(t, output, "Last Execution Date")
+	assert.Contains(t, output, "Last Successful Execution Date")
+}
+
+func TestPrintCheckExecutionStatus_NilInstanceIDs(t *testing.T) {
+	var buf bytes.Buffer
+
+	config := integration.Config{
+		Name:       "my_check",
+		InitConfig: integration.Data("{}"),
+		Instances:  []integration.Data{integration.Data("{}")},
+	}
+
+	stats := types.CLCRunnersStats{
+		"my_check:abc123": {
+			TotalRuns: 100,
+		},
+	}
+
+	// Nil instanceIDs — should print nothing (no IDs to match)
+	printCheckExecutionStatus(&buf, config, stats, "", nil)
+	assert.Empty(t, buf.String())
+}

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -115,7 +115,7 @@ func PrintConfigWithInstanceIDs(w io.Writer, c integration.Config, instanceIDs [
 }
 
 // PrintClusterCheckConfig prints a human-readable representation of a configuration with any secrets scrubbed.
-func PrintClusterCheckConfig(w io.Writer, c integration.Config, checkName string) {
+func PrintClusterCheckConfig(w io.Writer, c integration.Config, checkName string, instanceIDs []string) {
 	if checkName != "" && c.Name != checkName {
 		return
 	}
@@ -136,8 +136,14 @@ func PrintClusterCheckConfig(w io.Writer, c integration.Config, checkName string
 	} else {
 		fmt.Fprintf(w, "%s: %s\n", color.BlueString("Configuration source"), color.RedString("Unknown configuration source"))
 	}
-	for _, inst := range c.Instances {
-		ID := string(checkid.BuildID(c.Name, configDigest, inst, c.InitConfig))
+	usePrecomputedIDs := len(instanceIDs) == len(c.Instances)
+	for i, inst := range c.Instances {
+		var ID string
+		if usePrecomputedIDs {
+			ID = instanceIDs[i]
+		} else {
+			ID = string(checkid.BuildID(c.Name, configDigest, inst, c.InitConfig))
+		}
 		fmt.Fprintf(w, "%s: %s\n", color.BlueString("Config for instance ID"), color.CyanString(ID))
 		fmt.Fprintln(w, string(inst))
 		fmt.Fprintln(w, "~")

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -19,7 +19,7 @@ func Test_convertExpvarRunnerStats(t *testing.T) {
 	}{
 		{
 			name:      "no error present",
-			inputJSON: []byte(`{"Checks": {"foo": {"id1": {"AverageExecutionTime": 42, "MetricSamples": 100, "HistogramBuckets": 50, "Events": 200, "LastError": ""}}}}`),
+			inputJSON: []byte(`{"Checks": {"foo": {"id1": {"AverageExecutionTime": 42, "MetricSamples": 100, "HistogramBuckets": 50, "Events": 200, "LastError": "", "UpdateTimestamp": "2026-04-07T12:00:00Z"}}}}`),
 			want: CLCChecks{
 				Checks: map[string]map[string]CLCStats{
 					"foo": {
@@ -29,6 +29,7 @@ func Test_convertExpvarRunnerStats(t *testing.T) {
 							HistogramBuckets:     50,
 							Events:               200,
 							LastExecFailed:       false,
+							LastExecutionDate:    1775563200000,
 						},
 					},
 				},
@@ -37,7 +38,7 @@ func Test_convertExpvarRunnerStats(t *testing.T) {
 		},
 		{
 			name:      "error present",
-			inputJSON: []byte(`{"Checks": {"foo": {"id1": {"AverageExecutionTime": 42, "MetricSamples": 100, "HistogramBuckets": 50, "Events": 200, "LastError": "this is an error"}}}}`),
+			inputJSON: []byte(`{"Checks": {"foo": {"id1": {"AverageExecutionTime": 42, "MetricSamples": 100, "HistogramBuckets": 50, "Events": 200, "LastError": "this is an error", "UpdateTimestamp": "2026-04-07T12:00:00Z"}}}}`),
 			want: CLCChecks{
 				Checks: map[string]map[string]CLCStats{
 					"foo": {
@@ -47,6 +48,8 @@ func Test_convertExpvarRunnerStats(t *testing.T) {
 							HistogramBuckets:     50,
 							Events:               200,
 							LastExecFailed:       true,
+							LastError:            "this is an error",
+							LastExecutionDate:    1775563200000,
 						},
 					},
 				},
@@ -58,6 +61,32 @@ func Test_convertExpvarRunnerStats(t *testing.T) {
 			inputJSON: []byte(`{"Checks": bad-json{}}`),
 			want:      CLCChecks{},
 			wantErr:   true,
+		},
+		{
+			name:      "all execution status fields",
+			inputJSON: []byte(`{"Checks": {"bar": {"id2": {"AverageExecutionTime": 500, "MetricSamples": 10, "HistogramBuckets": 5, "Events": 3, "ServiceChecks": 7, "TotalRuns": 100, "TotalErrors": 2, "TotalMetricSamples": 1000, "TotalEvents": 300, "TotalServiceChecks": 700, "LastSuccessDate": 1775563775, "UpdateTimestamp": "2026-04-07T12:09:35.974Z", "LastError": ""}}}}`),
+			want: CLCChecks{
+				Checks: map[string]map[string]CLCStats{
+					"bar": {
+						"id2": {
+							AverageExecutionTime: 500,
+							MetricSamples:        10,
+							HistogramBuckets:     5,
+							Events:               3,
+							ServiceChecks:        7,
+							LastExecFailed:       false,
+							TotalRuns:            100,
+							TotalErrors:          2,
+							TotalMetricSamples:   1000,
+							TotalEvents:          300,
+							TotalServiceChecks:   700,
+							LastSuccessDate:      1775563775,
+							LastExecutionDate:    1775563775974,
+						},
+					},
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/status/types.go
+++ b/pkg/status/types.go
@@ -19,11 +19,20 @@ type CLCChecks struct {
 
 // CLCStats is used to unmarshall the stats needed from the runner expvar payload
 type CLCStats struct {
-	AverageExecutionTime int  `json:"AverageExecutionTime"`
-	MetricSamples        int  `json:"MetricSamples"`
-	HistogramBuckets     int  `json:"HistogramBuckets"`
-	Events               int  `json:"Events"`
-	LastExecFailed       bool `json:"LastExecFailed"`
+	AverageExecutionTime int    `json:"AverageExecutionTime"`
+	MetricSamples        int    `json:"MetricSamples"`
+	HistogramBuckets     int    `json:"HistogramBuckets"`
+	Events               int    `json:"Events"`
+	ServiceChecks        int    `json:"ServiceChecks"`
+	LastExecFailed       bool   `json:"LastExecFailed"`
+	LastError            string `json:"LastError"`
+	TotalRuns            uint64 `json:"TotalRuns"`
+	TotalErrors          uint64 `json:"TotalErrors"`
+	TotalMetricSamples   uint64 `json:"TotalMetricSamples"`
+	TotalEvents          uint64 `json:"TotalEvents"`
+	TotalServiceChecks   uint64 `json:"TotalServiceChecks"`
+	LastSuccessDate      int64  `json:"LastSuccessDate"`
+	LastExecutionDate    int64  `json:"LastExecutionDate"`
 }
 
 // Workers is used to unmarshall the workers info needed from the runner expvar payload
@@ -47,11 +56,16 @@ func (d *CLCStats) UnmarshalJSON(data []byte) error {
 	d.MetricSamples = int(stats.MetricSamples)
 	d.HistogramBuckets = int(stats.HistogramBuckets)
 	d.Events = int(stats.Events)
-	if stats.LastError != "" {
-		d.LastExecFailed = true
-	} else {
-		d.LastExecFailed = false
-	}
+	d.ServiceChecks = int(stats.ServiceChecks)
+	d.LastError = stats.LastError
+	d.LastExecFailed = stats.LastError != ""
+	d.TotalRuns = stats.TotalRuns
+	d.TotalErrors = stats.TotalErrors
+	d.TotalMetricSamples = stats.TotalMetricSamples
+	d.TotalEvents = stats.TotalEvents
+	d.TotalServiceChecks = stats.TotalServiceChecks
+	d.LastSuccessDate = stats.LastSuccessDate
+	d.LastExecutionDate = stats.UpdateTimestamp.UnixMilli()
 
 	return nil
 }

--- a/releasenotes-dca/notes/cluster-check-execution-status-cli-dc67172ae448ae58.yaml
+++ b/releasenotes-dca/notes/cluster-check-execution-status-cli-dc67172ae448ae58.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    The ``datadog-cluster-agent clusterchecks`` CLI command now displays
+    check execution status for checks running on Cluster Level Check (CLC)
+    runners, matching the node agent ``agent status collector`` output format.
+    This includes OK/ERROR status, total runs, metric samples, events,
+    service checks, average execution time, last execution date, last
+    successful execution date, and last error message.


### PR DESCRIPTION
### What does this PR do?
  Extends the datadog-cluster-agent clusterchecks CLI command to display check
  execution status for checks running on CLC runners, matching the node agent agent
  status collector output format.
Running the following command in cluster-agent 
```
datadog-cluster-agent clusterchecks --check kubernetes_state_core
```
Before:
```
  ===== Checks on datadog-cluster-checks-runner-77844b957d-8xvpj =====

  === kubernetes_state_core check ===
  Configuration provider: file
  Configuration source: file:/etc/datadog-agent/conf.d/kubernetes_state_core.d/kuber
  netes_state_core.yaml.default
  Config for instance ID: kubernetes_state_core:d417aee8e5fba450
  collectors:
    - pods
    - replicationcontrollers
    ...
  empty_default_hostname: true
  skip_leader_election: true
  tags:
    - ...
  ~
  ===
```

  After:
```
  ===== Checks on datadog-cluster-checks-runner-77844b957d-8xvpj =====

  === kubernetes_state_core check ===
  Configuration provider: file
  Configuration source: file:/etc/datadog-agent/conf.d/kubernetes_state_core.d/kuber
  netes_state_core.yaml.default
  Config for instance ID: kubernetes_state_core:d417aee8e5fba450
  collectors:
    - pods
    - replicationcontrollers
    ...
  empty_default_hostname: true
  skip_leader_election: true
  tags:
     - ...
  ~
  ===
    Instance ID: kubernetes_state_core:d417aee8e5fba450 [OK]
    Total Runs: 1240
    Metric Samples: Last Run: 197303, Total: 244458445
    Events: Last Run: 0, Total: 0
    Service Checks: Last Run: 406, Total: 503034
    Average Execution Time : 3.173s
    Last Execution Date : 2026-04-07 20:12:57 UTC
    Last Successful Execution Date : 2026-04-07 20:12:57 UTC
```
<img width="623" height="431" alt="Screenshot 2026-04-07 at 4 56 46 PM" src="https://github.com/user-attachments/assets/8a928379-e861-4ace-a00c-98d46e4a0241" />


### Motivation
When we debug cluster check failures currently must exec into each CLC runner pod individually to run agent status collector. This PR collector execution status centrally in the DCA CLI, giving us a single place to see check health across all CLC runners. This is part of plan of collecting clustercheck status in datadog_agent_integration metadata table. 

### Implementation detail:
  1. Keeps more fields during unmarshalling (pkg/status/types.go) — TotalRuns, TotalErrors, LastError, ServiceChecks, timestamps, and totals
  2. Mirrors them on the DCA side (types/types.go) and adds a Stats field to StateNodeResponse
  3. Exposes them in getState() (dispatcher_configs.go) — copies nodeStore.clcRunnerStats into the API response
  4. Displays them in the CLI (cluster_checks.go) — new printCheckExecutionStatus() matches node agent format
  5. Always creates the CLC runners client (dispatcher_main.go) — previously gated on advanced dispatching
  Note Stats are only available when advanced dispatching is enabled

### Describe how you validated your changes
unit test and cli command see above

### Additional Notes
