### PR TITLE
chore: update agent-health Jira project key from HEAL to AGTHEAL

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -35,7 +35,7 @@ github_labels = ["team/agent-configuration"]
 exclude_members = ["sgnn7"]
 
 [teams."Agent Health"]
-jira_project = "HEAL"
+jira_project = "AGTHEAL"
 jira_issue_type = "QA"
 jira_statuses = ["To Do", "In Progress", "Done"]
 github_team = "agent-health"

--- a/tasks/libs/pipeline/github_jira_map.yaml
+++ b/tasks/libs/pipeline/github_jira_map.yaml
@@ -52,6 +52,6 @@
 '@datadog/agent-processing-and-routing': APR
 '@datadog/agent-discovery': DSCVR
 '@datadog/synthetics-executing': SYNORG
-'@datadog/agent-health': HEAL
+'@datadog/agent-health': AGTHEAL
 '@datadog/profiling-full-host': 'PROF'
 '@datadog/q-branch': DEFAULT_JIRA_PROJECT


### PR DESCRIPTION
### What does this PR do?
Updates the Jira project key for the `agent-health` team from `HEAL` to `AGTHEAL` in two places:
- `.ddqa/config.toml`
- `tasks/libs/pipeline/github_jira_map.yaml`

### Motivation
The Jira project key for the Agent Health team has changed.

### Describe how you validated your changes
No functional change — only configuration strings updated.

### Additional Notes
N/A