### PR TITLE
[observer] Parametrize log optimizations

### DIFF
--- a/cmd/observer-testbench/README.md
+++ b/cmd/observer-testbench/README.md
@@ -276,6 +276,7 @@ When `--config` is provided it takes full precedence over `--enable`/`--disable`
 
 | Param | Default | Description |
 |-------|---------|-------------|
+| `disable_optimizations` | `false` | When `true`, skips deferred emit and cluster GC: emits on the first matching log per pattern and disables TTL/GC (`min_cluster_size_before_emit`, `cluster_time_to_live_sec`, and `garbage_collection_interval_sec` are forced to zero; other fields still apply). |
 | `min_cluster_size_before_emit` | 5 | Minimum matching logs on a pattern before emitting a metric |
 | `max_tokenized_string_length` | 12500 | Max input length before tokenization (0 = patterns package default) |
 | `max_num_tokens` | 250 | Max tokens per message (0 = patterns package default) |

--- a/cmd/observer-testbench/README.md
+++ b/cmd/observer-testbench/README.md
@@ -272,6 +272,18 @@ When `--config` is provided it takes full precedence over `--enable`/`--disable`
 | `window_seconds` | 120 | How long to keep anomalies before eviction |
 | `min_cluster_size` | 0 | Minimum cluster size to report (0 = report all) |
 
+#### `log_pattern_extractor`
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `min_cluster_size_before_emit` | 5 | Minimum matching logs on a pattern before emitting a metric |
+| `max_tokenized_string_length` | 12500 | Max input length before tokenization (0 = patterns package default) |
+| `max_num_tokens` | 250 | Max tokens per message (0 = patterns package default) |
+| `parse_hex_dump` | `true` | Recognize hex dumps in the tokenizer |
+| `min_token_match_ratio` | 0.5 | Minimum fraction of token positions that must match to merge lines (0 = default 0.5) |
+| `cluster_time_to_live_sec` | 14400 | Clusters with no matching log for this many seconds are removed during GC. `0` disables cluster garbage collection. |
+| `garbage_collection_interval_sec` | 3600 | Minimum seconds between GC passes when cluster TTL is enabled (nonzero `cluster_time_to_live_sec`) |
+
 #### `cross_signal`
 
 | Param | Default | Description |

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -27,6 +27,8 @@ const defaultGarbageCollectionInterval = 1 * time.Hour
 
 // LogPatternExtractorConfig holds hyperparameters for the log pattern extractor.
 type LogPatternExtractorConfig struct {
+	// This will disable all optimizations like MinClusterSizeBeforeEmit, ClusterTimeToLiveSec, etc.
+	DisableOptimizations bool `json:"disable_optimizations,omitempty"`
 	// MinClusterSizeBeforeEmit is the minimum number of logs matching a pattern
 	// before emitting metrics. Zero means the default from DefaultLogPatternExtractorConfig.
 	MinClusterSizeBeforeEmit int `json:"min_cluster_size_before_emit,omitempty"`
@@ -60,6 +62,14 @@ func DefaultLogPatternExtractorConfig() LogPatternExtractorConfig {
 		MaxTokenizedStringLength:     12500,
 		MaxNumTokens:                 250,
 		ParseHexDump:                 &parseHexDump,
+	}
+}
+
+func (c *LogPatternExtractorConfig) UpdateConfig() {
+	if c.DisableOptimizations {
+		c.MinClusterSizeBeforeEmit = 0
+		c.ClusterTimeToLiveSec = 0
+		c.GarbageCollectionIntervalSec = 0
 	}
 }
 
@@ -150,6 +160,7 @@ func NewLogPatternExtractor(cfg LogPatternExtractorConfig) *LogPatternExtractor 
 	if cfg.MinClusterSizeBeforeEmit <= 0 {
 		cfg.MinClusterSizeBeforeEmit = defaults.MinClusterSizeBeforeEmit
 	}
+	cfg.UpdateConfig()
 	registry := NewTagGroupByKeyRegistry()
 	tok := tokenizerFromConfig(cfg)
 	newSub := func() *patterns.PatternClusterer {

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -18,6 +18,13 @@ import (
 // name in the catalog, and in notify formatting for log-derived anomalies.
 const LogPatternExtractorName = "log_pattern_extractor"
 
+// TODO(agent-q): Add a test to ensure this is >= the time we evict metrics
+// defaultClusterTimeToLive is the time to live for a cluster.
+// If a cluster hasn't been seen since this time, it will be removed.
+const defaultClusterTimeToLive = 4 * time.Hour
+
+const defaultGarbageCollectionInterval = 1 * time.Hour
+
 // LogPatternExtractorConfig holds hyperparameters for the log pattern extractor.
 type LogPatternExtractorConfig struct {
 	// MinClusterSizeBeforeEmit is the minimum number of logs matching a pattern
@@ -34,12 +41,25 @@ type LogPatternExtractorConfig struct {
 	// that must match for two log lines to merge into one pattern. Range (0,1];
 	// zero means the default 0.5 (Drain-style).
 	MinTokenMatchRatio float64 `json:"min_token_match_ratio,omitempty"`
+	// ClusterTimeToLiveSec is how long (seconds) a cluster may go without a matching log before it is removed.
+	// Zero disables cluster garbage collection.
+	ClusterTimeToLiveSec int64 `json:"cluster_time_to_live_sec,omitempty"`
+	// GarbageCollectionIntervalSec is the minimum time between GC passes when ClusterTimeToLiveSec > 0.
+	GarbageCollectionIntervalSec int64 `json:"garbage_collection_interval_sec,omitempty"`
 }
 
 // DefaultLogPatternExtractorConfig returns defaults aligned with the patterns package.
 func DefaultLogPatternExtractorConfig() LogPatternExtractorConfig {
+	parseHexDump := true
+
 	return LogPatternExtractorConfig{
-		MinClusterSizeBeforeEmit: 5,
+		MinClusterSizeBeforeEmit:     5,
+		ClusterTimeToLiveSec:         int64(defaultClusterTimeToLive.Seconds()),
+		GarbageCollectionIntervalSec: int64(defaultGarbageCollectionInterval.Seconds()),
+		MinTokenMatchRatio:           0.5,
+		MaxTokenizedStringLength:     12500,
+		MaxNumTokens:                 250,
+		ParseHexDump:                 &parseHexDump,
 	}
 }
 
@@ -57,13 +77,6 @@ func tokenizerFromConfig(cfg LogPatternExtractorConfig) *patterns.Tokenizer {
 	return t
 }
 
-// TODO(agent-q): Add a test to ensure this is >= the time we evict metrics
-// defaultClusterTimeToLive is the time to live for a cluster.
-// If a cluster hasn't been seen since this time, it will be removed.
-const defaultClusterTimeToLive = 4 * time.Hour
-
-const defaultGarbageCollectionInterval = 1 * time.Hour
-
 // PatternKeyInfo contains what can identify a pattern.
 type PatternKeyInfo struct {
 	ClusterID int64
@@ -73,12 +86,10 @@ type PatternKeyInfo struct {
 // LogPatternExtractor is a LogMetricsExtractor that clusters log messages into
 // patterns and emits a count metric per pattern.
 type LogPatternExtractor struct {
-	taggedClusterer              *TaggedPatternClusterer
-	registry                     *TagGroupByKeyRegistry
-	ctx                          logPatternExtractorContext
-	NextGarbageCollectionTime    int64
-	ClusterTimeToLiveSec         int
-	GarbageCollectionIntervalSec int
+	taggedClusterer           *TaggedPatternClusterer
+	registry                  *TagGroupByKeyRegistry
+	ctx                       logPatternExtractorContext
+	NextGarbageCollectionTime int64
 	// config is the resolved hyperparameters (MinClusterSizeBeforeEmit is never zero after init).
 	config LogPatternExtractorConfig
 }
@@ -145,11 +156,9 @@ func NewLogPatternExtractor(cfg LogPatternExtractorConfig) *LogPatternExtractor 
 		return patterns.NewPatternClustererWithTokenizer(tok, cfg.MinTokenMatchRatio)
 	}
 	return &LogPatternExtractor{
-		taggedClusterer:              NewTaggedPatternClustererWithFactory(registry, newSub),
-		registry:                     registry,
-		config:                       cfg,
-		ClusterTimeToLiveSec:         int(defaultClusterTimeToLive.Seconds()),
-		GarbageCollectionIntervalSec: int(defaultGarbageCollectionInterval.Seconds()),
+		taggedClusterer: NewTaggedPatternClustererWithFactory(registry, newSub),
+		registry:        registry,
+		config:          cfg,
 	}
 }
 
@@ -260,12 +269,12 @@ type gcResult struct {
 // maybeGarbageCollect removes stale clusters from all sub-clusterers and
 // returns the context keys evicted so the engine can drop matching contextRefs.
 func (e *LogPatternExtractor) maybeGarbageCollect(currentTime int64) gcResult {
-	if currentTime < e.NextGarbageCollectionTime {
+	if e.config.ClusterTimeToLiveSec == 0 || currentTime < e.NextGarbageCollectionTime {
 		return gcResult{}
 	}
-	e.NextGarbageCollectionTime = currentTime + int64(e.GarbageCollectionIntervalSec)
+	e.NextGarbageCollectionTime = currentTime + e.config.GarbageCollectionIntervalSec
 
-	cutoff := currentTime - int64(e.ClusterTimeToLiveSec)
+	cutoff := currentTime - e.config.ClusterTimeToLiveSec
 	evicted := e.taggedClusterer.GarbageCollectBefore(cutoff)
 	if len(evicted) == 0 {
 		return gcResult{}

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -65,7 +65,7 @@ func DefaultLogPatternExtractorConfig() LogPatternExtractorConfig {
 	}
 }
 
-func (c *LogPatternExtractorConfig) UpdateConfig() {
+func (c *LogPatternExtractorConfig) RefreshConfig() {
 	if c.DisableOptimizations {
 		c.MinClusterSizeBeforeEmit = 0
 		c.ClusterTimeToLiveSec = 0
@@ -156,11 +156,21 @@ func (c *logPatternExtractorContext) removeTaggedCluster(taggedKey string) {
 // NewLogPatternExtractor creates a new LogPatternExtractor.
 // A zero-value cfg is accepted; zero fields fall back to DefaultLogPatternExtractorConfig values.
 func NewLogPatternExtractor(cfg LogPatternExtractorConfig) *LogPatternExtractor {
+	// Apply defaults first and then refresh config to finalize it
 	defaults := DefaultLogPatternExtractorConfig()
 	if cfg.MinClusterSizeBeforeEmit <= 0 {
 		cfg.MinClusterSizeBeforeEmit = defaults.MinClusterSizeBeforeEmit
 	}
-	cfg.UpdateConfig()
+	if !cfg.DisableOptimizations {
+		if cfg.ClusterTimeToLiveSec <= 0 {
+			cfg.ClusterTimeToLiveSec = defaults.ClusterTimeToLiveSec
+		}
+		if cfg.GarbageCollectionIntervalSec <= 0 {
+			cfg.GarbageCollectionIntervalSec = defaults.GarbageCollectionIntervalSec
+		}
+	}
+	cfg.RefreshConfig()
+
 	registry := NewTagGroupByKeyRegistry()
 	tok := tokenizerFromConfig(cfg)
 	newSub := func() *patterns.PatternClusterer {

--- a/comp/observer/impl/log_pattern_extractor_test.go
+++ b/comp/observer/impl/log_pattern_extractor_test.go
@@ -177,10 +177,10 @@ func TestLogPatternExtractor_DeferredEmitUntilMinPatterns(t *testing.T) {
 func TestLogPatternExtractor_GarbageCollectRemovesStaleClusterAndContext(t *testing.T) {
 	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
 	e.config.MinClusterSizeBeforeEmit = 1
-	e.ClusterTimeToLiveSec = 10
+	e.config.ClusterTimeToLiveSec = 10
 	// GC scheduling uses wall-clock seconds; 0 means the next ProcessLog can run
 	// maybeGarbageCollect without waiting an extra second (tests run in one Unix second).
-	e.GarbageCollectionIntervalSec = 0
+	e.config.GarbageCollectionIntervalSec = 0
 
 	tags := []string{"service:api"}
 	// Distinct messages so the second log does not refresh the first cluster's LastSeenUnix.
@@ -226,14 +226,61 @@ func TestLogPatternExtractor_GarbageCollectRemovesStaleClusterAndContext(t *test
 	require.Len(t, remaining, 1, "stale cluster should be removed from tagged clusterer")
 }
 
+func TestLogPatternExtractor_DisableOptimizationsSkipsGarbageCollection(t *testing.T) {
+	cfg := DefaultLogPatternExtractorConfig()
+	cfg.DisableOptimizations = true
+	e := NewLogPatternExtractor(cfg)
+	require.Zero(t, e.config.ClusterTimeToLiveSec, "disable optimizations must clear TTL")
+	require.Zero(t, e.config.GarbageCollectionIntervalSec, "disable optimizations must clear GC interval")
+
+	tags := []string{"service:api"}
+	// Structurally different lines so the pattern clusterer keeps two clusters (unlike
+	// two strings that differ only by a numeric token, which often merge into one template).
+	msg1 := []byte(`10.143.180.25 - - [27/Aug/2020:00:27:02 +0000] "POST /api/v1/series HTTP/1.1" 202 16`)
+	msg2 := []byte(`2020-08-27 02:32:42 ERROR (connector.go:34) - Failed to connected to redis`)
+
+	const tsMs1 = 1_000_000 // unix sec = 1000
+	res1 := e.ProcessLog(&mockLogView{
+		content:     msg1,
+		status:      "warn",
+		tags:        tags,
+		timestampMs: tsMs1,
+	})
+	require.Len(t, res1.Metrics, 1)
+	ctxKey1 := res1.Metrics[0].ContextKey
+	_, ok := e.GetContextByKey(ctxKey1)
+	require.True(t, ok)
+
+	// Same timeline as TestLogPatternExtractor_GarbageCollectRemovesStaleClusterAndContext, where GC
+	// would evict cluster A — but with DisableOptimizations, TTL is off so A stays.
+	const tsMs2 = 1_015_000 // unix sec = 1015
+	res2 := e.ProcessLog(&mockLogView{
+		content:     msg2,
+		status:      "warn",
+		tags:        tags,
+		timestampMs: tsMs2,
+	})
+	require.Len(t, res2.Metrics, 1)
+	require.Empty(t, res2.EvictedContextKeys, "GC must not run when optimizations are disabled")
+	ctxKey2 := res2.Metrics[0].ContextKey
+
+	_, ok = e.GetContextByKey(ctxKey1)
+	require.True(t, ok, "first cluster context must remain without GC")
+	_, ok = e.GetContextByKey(ctxKey2)
+	require.True(t, ok)
+
+	remaining := e.taggedClusterer.GetAllClusters()
+	require.Len(t, remaining, 2, "both clusters should still exist when GC is disabled")
+}
+
 func TestLogPatternExtractor_GCEvictedContextKeysTwoTagSetsOneCluster(t *testing.T) {
 	// Two different tag-sets that share the same split dimensions (same sub-clusterer)
 	// produce two context keys for the same cluster. GC should evict both when the cluster
 	// becomes stale. Non-split tags (e.g. "version:") differ so the context keys differ.
 	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
 	e.config.MinClusterSizeBeforeEmit = 1
-	e.ClusterTimeToLiveSec = 10
-	e.GarbageCollectionIntervalSec = 0
+	e.config.ClusterTimeToLiveSec = 10
+	e.config.GarbageCollectionIntervalSec = 0
 	// Pin NextGarbageCollectionTime far in the future so GC does not fire during
 	// the setup phase. GarbageCollectionIntervalSec=0 would otherwise trigger GC
 	// on every ProcessLog call, evicting the cluster before both tags are ingested.
@@ -268,8 +315,8 @@ func TestLogPatternExtractor_GCEvictedContextKeysTwoTagSetsOneCluster(t *testing
 func TestLogPatternExtractor_NoGCBeforeInterval(t *testing.T) {
 	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
 	e.config.MinClusterSizeBeforeEmit = 1
-	e.ClusterTimeToLiveSec = 10
-	e.GarbageCollectionIntervalSec = 3600 // far in the future
+	e.config.ClusterTimeToLiveSec = 10
+	e.config.GarbageCollectionIntervalSec = 3600 // far in the future
 
 	msg := []byte("WARN connection refused to db host *")
 	res1 := e.ProcessLog(&mockLogView{content: msg, status: "warn", tags: nil, timestampMs: 1_000_000})

--- a/comp/observer/impl/log_pattern_extractor_test.go
+++ b/comp/observer/impl/log_pattern_extractor_test.go
@@ -174,6 +174,13 @@ func TestLogPatternExtractor_DeferredEmitUntilMinPatterns(t *testing.T) {
 	require.Len(t, out.Metrics, 1)
 }
 
+func TestLogPatternExtractor_ZeroConfigAppliesGCDefaults(t *testing.T) {
+	e := NewLogPatternExtractor(LogPatternExtractorConfig{})
+	defaults := DefaultLogPatternExtractorConfig()
+	assert.Equal(t, defaults.ClusterTimeToLiveSec, e.config.ClusterTimeToLiveSec)
+	assert.Equal(t, defaults.GarbageCollectionIntervalSec, e.config.GarbageCollectionIntervalSec)
+}
+
 func TestLogPatternExtractor_GarbageCollectRemovesStaleClusterAndContext(t *testing.T) {
 	e := NewLogPatternExtractor(DefaultLogPatternExtractorConfig())
 	e.config.MinClusterSizeBeforeEmit = 1

--- a/comp/observer/impl/testbench_params.go
+++ b/comp/observer/impl/testbench_params.go
@@ -33,7 +33,9 @@ import (
 //	    "log_pattern_extractor": {
 //	      "min_cluster_size_before_emit": 5,
 //	      "max_tokenized_string_length": 8000,
-//	      "min_token_match_ratio": 0.5
+//	      "min_token_match_ratio": 0.5,
+//	      "cluster_time_to_live_sec": 14400,
+//	      "garbage_collection_interval_sec": 3600
 //	    },
 //	    "rrcf": { "enabled": false }
 //	  }

--- a/comp/observer/impl/testbench_params.go
+++ b/comp/observer/impl/testbench_params.go
@@ -31,6 +31,7 @@ import (
 //	      "min_cluster_size": 2
 //	    },
 //	    "log_pattern_extractor": {
+//	      "disable_optimizations": false,
 //	      "min_cluster_size_before_emit": 5,
 //	      "max_tokenized_string_length": 8000,
 //	      "min_token_match_ratio": 0.5,

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -749,6 +749,10 @@ def _sample_component_params(trial, component: str) -> dict:
             "max_num_tokens": trial.suggest_int("log_pattern_extractor.max_num_tokens", 32, 512),
             "parse_hex_dump": trial.suggest_categorical("log_pattern_extractor.parse_hex_dump", [True, False]),
             "min_token_match_ratio": trial.suggest_float("log_pattern_extractor.min_token_match_ratio", 0.2, 0.95),
+            "cluster_time_to_live_sec": trial.suggest_int("log_pattern_extractor.cluster_time_to_live_sec", 600, 86400),
+            "garbage_collection_interval_sec": trial.suggest_int(
+                "log_pattern_extractor.garbage_collection_interval_sec", 60, 7200
+            ),
         },
     }
     fn = space.get(component)

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -740,6 +740,9 @@ def _sample_component_params(trial, component: str) -> dict:
             "min_cluster_size": trial.suggest_int("time_cluster.min_cluster_size", 0, 8),
         },
         "log_pattern_extractor": lambda: {
+            "disable_optimizations": trial.suggest_categorical(
+                "log_pattern_extractor.disable_optimizations", [True, False]
+            ),
             "min_cluster_size_before_emit": trial.suggest_int(
                 "log_pattern_extractor.min_cluster_size_before_emit", 1, 30
             ),


### PR DESCRIPTION
### What does this PR do?

Log memory optimizations are now parametrized and could be turned off in evals to compare without optimizations baseline.

Adds:
- Parameters for garbage collection
- DisableOptimizations boolean
- A test to ensure we don't garbage collect when optimizations disabled

### Motivation

### Describe how you validated your changes

### Additional Notes
