### PR TITLE
[procmgr] Extract transport abstraction layer for cross-platform IPC

### DIFF
--- a/pkg/procmgr/rust/src/bins/dd-procmgr.rs
+++ b/pkg/procmgr/rust/src/bins/dd-procmgr.rs
@@ -119,7 +119,7 @@ async fn connect(socket_override: Option<&str>) -> Result<ProcessManagerClient<C
         None => socket_path(),
     };
     let path_clone = path.clone();
-    let channel = Endpoint::from_static(dd_procmgrd::grpc::UDS_DUMMY_ENDPOINT)
+    let channel = Endpoint::from_static(dd_procmgrd::transport::DUMMY_ENDPOINT)
         .connect_with_connector(service_fn(move |_| {
             let p = path_clone.clone();
             async move {

--- a/pkg/procmgr/rust/src/grpc/mod.rs
+++ b/pkg/procmgr/rust/src/grpc/mod.rs
@@ -6,10 +6,6 @@
 pub mod server;
 pub mod service;
 
-/// Placeholder URI for tonic Endpoint when connecting over UDS.
-/// The actual address is irrelevant because `connect_with_connector` bypasses it.
-pub const UDS_DUMMY_ENDPOINT: &str = "http://[::]:50051";
-
 #[cfg(not(bazel))]
 pub mod proto {
     tonic::include_proto!("datadog.procmgr");
@@ -124,7 +120,7 @@ mod tests {
             }
         });
 
-        let channel = Endpoint::from_static(super::UDS_DUMMY_ENDPOINT)
+        let channel = Endpoint::from_static(crate::transport::DUMMY_ENDPOINT)
             .connect_with_connector(service_fn(move |_| {
                 let path = sock_path.clone();
                 async move {

--- a/pkg/procmgr/rust/src/grpc/server.rs
+++ b/pkg/procmgr/rust/src/grpc/server.rs
@@ -7,21 +7,16 @@ use crate::command::Command;
 use crate::grpc::proto;
 use crate::grpc::service::ProcessManagerService;
 use crate::manager::ProcessManager;
+use crate::transport;
 use anyhow::{Context, Result};
-use log::{info, warn};
-use std::path::{Path, PathBuf};
+use log::info;
 use tokio::net::UnixListener;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::Server;
 
-const DEFAULT_SOCKET_PATH: &str = "/var/run/datadog-procmgrd/dd-procmgrd.sock";
-const SOCKET_PERMISSIONS: u32 = 0o660;
-
-pub fn socket_path() -> PathBuf {
-    std::env::var("DD_PM_SOCKET_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(DEFAULT_SOCKET_PATH))
+pub fn socket_path() -> std::path::PathBuf {
+    transport::ipc_path()
 }
 
 pub async fn run(
@@ -29,12 +24,12 @@ pub async fn run(
     cmd_tx: mpsc::Sender<Command>,
     shutdown: tokio::sync::oneshot::Receiver<()>,
 ) -> Result<()> {
-    let path = socket_path();
-    prepare_socket(&path)?;
+    let path = transport::ipc_path();
+    transport::prepare(&path)?;
 
     let uds = UnixListener::bind(&path)
         .with_context(|| format!("failed to bind Unix socket: {}", path.display()))?;
-    set_socket_permissions(&path);
+    transport::set_permissions(&path);
     info!("gRPC server listening on {}", path.display());
 
     let uds_stream = UnixListenerStream::new(uds);
@@ -58,102 +53,69 @@ pub async fn run(
         .context("gRPC server error")?;
 
     info!("gRPC server stopped");
-    cleanup_socket(&path);
+    transport::cleanup(&path);
     Ok(())
-}
-
-fn prepare_socket(path: &Path) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create socket directory: {}", parent.display()))?;
-    }
-    match std::fs::remove_file(path) {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => {
-            return Err(e)
-                .with_context(|| format!("failed to remove stale socket: {}", path.display()));
-        }
-    }
-    Ok(())
-}
-
-fn set_socket_permissions(path: &Path) {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        if let Err(e) =
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(SOCKET_PERMISSIONS))
-        {
-            warn!("failed to set socket permissions: {e}");
-        }
-    }
-}
-
-fn cleanup_socket(path: &Path) {
-    match std::fs::remove_file(path) {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => warn!("failed to clean up socket {}: {e}", path.display()),
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::os::unix::fs::PermissionsExt;
+    use crate::transport;
 
     #[test]
-    fn test_prepare_socket_creates_parent_dirs() {
+    fn test_prepare_creates_parent_dirs() {
         let dir = tempfile::tempdir().unwrap();
         let nested = dir.path().join("a").join("b").join("c").join("test.sock");
-        prepare_socket(&nested).unwrap();
+        transport::prepare(&nested).unwrap();
         assert!(nested.parent().unwrap().exists());
     }
 
     #[test]
-    fn test_prepare_socket_removes_stale_file() {
+    fn test_prepare_removes_stale_file() {
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("stale.sock");
         std::fs::write(&sock, b"leftover").unwrap();
         assert!(sock.exists());
-        prepare_socket(&sock).unwrap();
+        transport::prepare(&sock).unwrap();
         assert!(!sock.exists());
     }
 
     #[test]
-    fn test_prepare_socket_noop_on_fresh_path() {
+    fn test_prepare_noop_on_fresh_path() {
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("fresh.sock");
         assert!(!sock.exists());
-        prepare_socket(&sock).unwrap();
+        transport::prepare(&sock).unwrap();
         assert!(!sock.exists());
     }
 
     #[test]
-    fn test_set_socket_permissions() {
+    fn test_set_permissions() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("perm.sock");
         std::fs::write(&file, b"").unwrap();
-        set_socket_permissions(&file);
-        let mode = std::fs::metadata(&file).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, SOCKET_PERMISSIONS);
+        transport::set_permissions(&file);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&file).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o660);
+        }
     }
 
     #[test]
-    fn test_cleanup_socket_removes_file() {
+    fn test_cleanup_removes_file() {
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("cleanup.sock");
         std::fs::write(&sock, b"").unwrap();
         assert!(sock.exists());
-        cleanup_socket(&sock);
+        transport::cleanup(&sock);
         assert!(!sock.exists());
     }
 
     #[test]
-    fn test_cleanup_socket_noop_if_missing() {
+    fn test_cleanup_noop_if_missing() {
         let dir = tempfile::tempdir().unwrap();
         let sock = dir.path().join("nonexistent.sock");
-        cleanup_socket(&sock);
+        transport::cleanup(&sock);
     }
 }

--- a/pkg/procmgr/rust/src/lib.rs
+++ b/pkg/procmgr/rust/src/lib.rs
@@ -15,4 +15,5 @@ pub mod shutdown;
 pub mod state;
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers;
+pub mod transport;
 pub mod uuid_gen;

--- a/pkg/procmgr/rust/src/transport/mod.rs
+++ b/pkg/procmgr/rust/src/transport/mod.rs
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+#[cfg(unix)]
+mod uds;
+#[cfg(unix)]
+pub use self::uds::*;
+
+#[cfg(windows)]
+mod named_pipe;
+#[cfg(windows)]
+pub use self::named_pipe::*;

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_PIPE_PATH: &str = r"\\.\pipe\datadog-procmgrd";
+
+/// Placeholder URI for tonic Endpoint when connecting over Named Pipes.
+pub const DUMMY_ENDPOINT: &str = "http://[::]:50051";
+
+pub fn ipc_path() -> PathBuf {
+    std::env::var("DD_PM_PIPE_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_PIPE_PATH))
+}
+
+pub fn prepare(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+pub fn set_permissions(_path: &Path) {}
+
+pub fn cleanup(_path: &Path) {}

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -12,7 +12,7 @@ const DEFAULT_PIPE_PATH: &str = r"\\.\pipe\datadog-procmgrd";
 pub const DUMMY_ENDPOINT: &str = "http://[::]:50051";
 
 pub fn ipc_path() -> PathBuf {
-    std::env::var("DD_PM_PIPE_PATH")
+    std::env::var("DD_PM_SOCKET_PATH")
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from(DEFAULT_PIPE_PATH))
 }

--- a/pkg/procmgr/rust/src/transport/uds.rs
+++ b/pkg/procmgr/rust/src/transport/uds.rs
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use anyhow::{Context, Result};
+use log::warn;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_SOCKET_PATH: &str = "/var/run/datadog-procmgrd/dd-procmgrd.sock";
+const SOCKET_PERMISSIONS: u32 = 0o660;
+
+/// Placeholder URI for tonic Endpoint when connecting over UDS.
+/// The actual address is irrelevant because `connect_with_connector` bypasses it.
+pub const DUMMY_ENDPOINT: &str = "http://[::]:50051";
+
+pub fn ipc_path() -> PathBuf {
+    std::env::var("DD_PM_SOCKET_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_SOCKET_PATH))
+}
+
+pub fn prepare(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create socket directory: {}", parent.display()))?;
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("failed to remove stale socket: {}", path.display()));
+        }
+    }
+    Ok(())
+}
+
+pub fn set_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Err(e) =
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(SOCKET_PERMISSIONS))
+    {
+        warn!("failed to set socket permissions: {e}");
+    }
+}
+
+pub fn cleanup(path: &Path) {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => warn!("failed to clean up socket {}: {e}", path.display()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn test_prepare_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("a").join("b").join("c").join("test.sock");
+        prepare(&nested).unwrap();
+        assert!(nested.parent().unwrap().exists());
+    }
+
+    #[test]
+    fn test_prepare_removes_stale_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("stale.sock");
+        std::fs::write(&sock, b"leftover").unwrap();
+        assert!(sock.exists());
+        prepare(&sock).unwrap();
+        assert!(!sock.exists());
+    }
+
+    #[test]
+    fn test_prepare_noop_on_fresh_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("fresh.sock");
+        assert!(!sock.exists());
+        prepare(&sock).unwrap();
+        assert!(!sock.exists());
+    }
+
+    #[test]
+    fn test_set_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("perm.sock");
+        std::fs::write(&file, b"").unwrap();
+        set_permissions(&file);
+        let mode = std::fs::metadata(&file).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, SOCKET_PERMISSIONS);
+    }
+
+    #[test]
+    fn test_cleanup_removes_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("cleanup.sock");
+        std::fs::write(&sock, b"").unwrap();
+        assert!(sock.exists());
+        cleanup(&sock);
+        assert!(!sock.exists());
+    }
+
+    #[test]
+    fn test_cleanup_noop_if_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("nonexistent.sock");
+        cleanup(&sock);
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Introduces a `transport/` module that abstracts IPC transport details behind a platform-gated interface (`transport::ipc_path()`, `transport::prepare()`, `transport::set_permissions()`, `transport::cleanup()`, `transport::DUMMY_ENDPOINT`). On Unix, `transport/uds.rs` contains the UDS logic previously in `grpc/server.rs`. On Windows, `transport/named_pipe.rs` provides stubs targeting Windows Named Pipes.

Callers (`grpc/server.rs`, `grpc/mod.rs`, `bins/dd-procmgr.rs`) now delegate to `transport::` instead of inlining UDS-specific code.

### Motivation

Part of the procmgr Windows port. Unix uses UDS for daemon↔CLI communication and Windows will use Named Pipes. Extracting the transport layer now enables swapping the backend per platform without touching server or client logic.

### Describe how you validated your changes

- `cargo check` / `cargo clippy` / `cargo fmt --check` all clean
- All 238 tests pass (137 unit + 15 binary + 86 E2E)
- Transport tests duplicated in both `transport::uds::tests` and `grpc::server::tests` (server tests will be cleaned up later)

### Additional Notes