### PR TITLE
Add Datadog code coverage upload

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,6 +52,7 @@
 /renovate.json                          @DataDog/agent-devx
 /pyproject.toml                         @DataDog/agent-devx
 /repository.datadog.yml                 @DataDog/agent-devx
+/code-coverage.datadog.yml              @DataDog/agent-devx
 /generate_tools.go                      @DataDog/agent-devx
 /service.datadog.yaml                   @DataDog/agent-delivery @DataDog/agent-devx
 /static-analysis.datadog.yml            @DataDog/agent-devx

--- a/.gitlab/build/source_test/common.yml
+++ b/.gitlab/build/source_test/common.yml
@@ -7,6 +7,11 @@
   - CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $CODECOV token) || exit $?; export CODECOV_TOKEN
   - dda inv -- -e coverage.upload-to-codecov $COVERAGE_CACHE_FLAG || true
 
+.upload_coverage_datadog:
+  # Upload coverage files to Datadog Code Coverage. Never fail on coverage upload.
+  - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
+  - datadog-ci coverage upload --format=go-coverprofile coverage.out || true
+
 .unit_test_base:
   extends: .bazel:defs:cache:progressive
   variables:

--- a/.gitlab/build/source_test/common.yml
+++ b/.gitlab/build/source_test/common.yml
@@ -9,8 +9,9 @@
 
 .upload_coverage_datadog:
   # Upload coverage files to Datadog Code Coverage. Never fail on coverage upload.
+  - curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" -o /tmp/datadog-ci && chmod +x /tmp/datadog-ci || true
   - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
-  - datadog-ci coverage upload --format=go-coverprofile coverage.out || true
+  - /tmp/datadog-ci coverage upload --format=go-coverprofile coverage.out || true
 
 .unit_test_base:
   extends: .bazel:defs:cache:progressive

--- a/.gitlab/build/source_test/common.yml
+++ b/.gitlab/build/source_test/common.yml
@@ -9,9 +9,8 @@
 
 .upload_coverage_datadog:
   # Upload coverage files to Datadog Code Coverage. Never fail on coverage upload.
-  - curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" -o /tmp/datadog-ci && chmod +x /tmp/datadog-ci || true
   - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
-  - /tmp/datadog-ci coverage upload --format=go-coverprofile coverage.out || true
+  - datadog-ci coverage upload --format=go-coverprofile coverage.out || true
 
 .unit_test_base:
   extends: .bazel:defs:cache:progressive

--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -59,6 +59,7 @@ tests_linux-x64-py3:
   after_script:
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]
+    - !reference [.upload_coverage_datadog]
   variables:
     CONDA_ENV: ddpy3
 
@@ -70,6 +71,7 @@ tests_nodetreemodel:
   after_script:
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]
+    - !reference [.upload_coverage_datadog]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   rules:
     - !reference [.except_mergequeue]
@@ -123,6 +125,7 @@ tests_linux-arm64-py3:
   after_script:
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]
+    - !reference [.upload_coverage_datadog]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
   variables:
@@ -213,6 +216,7 @@ tests_gpu:
   after_script:
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]
+    - !reference [.upload_coverage_datadog]
   variables:
     FLAVORS: ''
     EXTRA_OPTS: '--targets=./pkg/gpu/integrationtests,./pkg/collector/corechecks/gpu/integrationtests'

--- a/.gitlab/build/source_test/macos.yml
+++ b/.gitlab/build/source_test/macos.yml
@@ -24,6 +24,7 @@ include:
     - !reference [.install_python_dependencies]
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]
+    - !reference [.upload_coverage_datadog]
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -119,10 +119,8 @@
     - |
       if [ -d "$E2E_COVERAGE_OUT_DIR" ]; then
         DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
-        for folder in "$E2E_COVERAGE_OUT_DIR"/*/; do
-          if [ -f "${folder}coverage.txt" ]; then
-            datadog-ci coverage upload --format=go-coverprofile "${folder}coverage.txt" || true
-          fi
+        for coverage in "$E2E_COVERAGE_OUT_DIR"/*/coverage.txt; do
+          datadog-ci coverage upload --format=go-coverprofile "$coverage" || true
         done
       fi
   artifacts:

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -115,6 +115,16 @@
         dda inv -- -e coverage.process-e2e-coverage-folders $E2E_COVERAGE_OUT_DIR
         dda inv -- -e dyntest.compute-and-upload-job-index --bucket-uri $S3_PERMANENT_ARTIFACTS_URI --coverage-folder $E2E_COVERAGE_OUT_DIR --commit-sha $CI_COMMIT_SHA --job-id $CI_JOB_ID
       fi
+    # Upload e2e coverage to Datadog Code Coverage (side-by-side with Codecov)
+    - |
+      if [ -d "$E2E_COVERAGE_OUT_DIR" ]; then
+        DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
+        for folder in "$E2E_COVERAGE_OUT_DIR"/*/; do
+          if [ -f "${folder}coverage.txt" ]; then
+            datadog-ci coverage upload --format=go-coverprofile "${folder}coverage.txt" || true
+          fi
+        done
+      fi
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/code-coverage.datadog.yml
+++ b/code-coverage.datadog.yml
@@ -1,0 +1,9 @@
+schema-version: v1
+ignore:
+  - "pkg/trace/testutil/"
+  - "pkg/trace/log/"
+  - "**/*.pb.go"
+  - "**/*.gen.go"
+  - "**/*_easyjson.go"
+  - "test/e2e-framework/"
+  - "test/new-e2e/"

--- a/tasks/winbuildscripts/Invoke-UnitTests.ps1
+++ b/tasks/winbuildscripts/Invoke-UnitTests.ps1
@@ -160,6 +160,18 @@ Invoke-BuildScript `
             # Non-fatal: print but do not fail the script
             Write-Host -ForegroundColor Red "coverage upload failed (non-fatal): $($_.Exception.Message)"
         }
+        # Upload coverage to Datadog Code Coverage (side-by-side with Codecov)
+        try {
+            $Env:DD_API_KEY = Get-VaultSecret -parameterName "$Env:API_KEY_ORG2" -ErrorAction Stop
+            & datadog-ci.exe coverage upload --format=go-coverprofile coverage.out
+            if ($LASTEXITCODE -ne 0) {
+                throw "Datadog coverage upload failed with exit code $LASTEXITCODE"
+            }
+        }
+        catch {
+            # Non-fatal: print but do not fail the script
+            Write-Host -ForegroundColor Red "Datadog coverage upload failed (non-fatal): $($_.Exception.Message)"
+        }
     }
     if ($UploadTestResults) {
         try {


### PR DESCRIPTION
## What does this PR do?

We're migrating Datadog repositories from Codecov to [Datadog Code Coverage](https://docs.datadoghq.com/code_analysis/code_coverage/) for tracking test coverage. This PR adds a Datadog coverage upload **alongside** the existing Codecov upload so we can run both systems in parallel and verify parity before switching over.

Replaces fork PR #47768.