### PR TITLE
feat(deps): Enable gomod manager in Renovate configuration

### DIFF
--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 jobs:
   mod_tidy_and_generate_licenses:
-    if: ${{ github.repository == 'DataDog/datadog-agent' && github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-go') }}
+    if: ${{ github.repository == 'DataDog/datadog-agent' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]') && contains(github.event.pull_request.labels.*.name, 'dependencies-go') }}
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/renovate.json
+++ b/renovate.json
@@ -67,7 +67,40 @@
       },
       {
         "matchManagers": ["gomod"],
+        "labels": ["dependencies", "dependencies-go", "changelog/no-changelog", "qa/no-code-change"]
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": [
+          "github.com/DataDog/datadog-agent/**",
+          "golang.org/x/**",
+          "go.opentelemetry.io/**",
+          "github.com/open-telemetry/opentelemetry-collector-contrib/**",
+          "github.com/spf13/cast",
+          "github.com/mailru/easyjson"
+        ],
         "enabled": false
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": ["github.com/twmb/franz-go{,/**}"],
+        "groupName": "franz-go"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": ["github.com/uptrace/bun{,/**}"],
+        "groupName": "bun"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": ["github.com/aws/aws-sdk-go-v2{,/**}"],
+        "groupName": "aws-sdk-go-v2"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchDepNames": ["k8s.io/**"],
+        "matchUpdateTypes": ["patch"],
+        "groupName": "k8s-io"
       },
       {
         "matchManagers": ["pyenv"],


### PR DESCRIPTION
### What does this PR do?

Activates the `gomod` manager in Renovate, replacing the previous Dependabot gomod configuration that was removed in #48314.

Changes to `renovate.json`:
- Removes the blanket `gomod` disable rule
- Adds `dependencies-go` label for gomod PRs
- Adds ignore rules for internal/managed dependencies
- Adds dependency groups matching the old Dependabot config

### Motivation

Re-enable automated Go dependency updates via Renovate after the temporary freeze from #48314. This consolidates all go.mod files under a single Renovate config (no per-directory split like the old Dependabot setup).

**Ignored dependencies:**
- `github.com/DataDog/datadog-agent/**` — internal modules
- `golang.org/x/**` — updated via dedicated workflow (#44953)
- `go.opentelemetry.io/**` / `opentelemetry-collector-contrib/**` — updated via `dda inv`
- `github.com/spf13/cast` — replaced in main go.mod
- `github.com/mailru/easyjson` — pinned intentionally
- `go` version updates — disabled

**Groups (same as old Dependabot):**
- `franz-go` — `github.com/twmb/franz-go` and sub-packages
- `bun` — `github.com/uptrace/bun` and sub-packages
- `aws-sdk-go-v2` — `github.com/aws/aws-sdk-go-v2` and sub-packages
- `k8s-io` — `k8s.io/*` (patch updates only)

### Describe how you validated your changes

Waiting for Renovate to pick up the config and update the Dependency Dashboard issue to verify the list of proposed updates is correct.

### Additional Notes

Part of the Dependabot → Renovate migration effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)