### PR TITLE
[procmgr] Delegate gRPC server to transport::serve()

### DIFF
--- a/pkg/procmgr/rust/src/grpc/server.rs
+++ b/pkg/procmgr/rust/src/grpc/server.rs
@@ -9,10 +9,7 @@ use crate::grpc::service::ProcessManagerService;
 use crate::manager::ProcessManager;
 use crate::transport;
 use anyhow::{Context, Result};
-use log::info;
-use tokio::net::UnixListener;
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::Server;
 
 pub fn socket_path() -> std::path::PathBuf {
@@ -24,16 +21,6 @@ pub async fn run(
     cmd_tx: mpsc::Sender<Command>,
     shutdown: tokio::sync::oneshot::Receiver<()>,
 ) -> Result<()> {
-    let path = transport::ipc_path();
-    transport::prepare(&path)?;
-
-    let uds = UnixListener::bind(&path)
-        .with_context(|| format!("failed to bind Unix socket: {}", path.display()))?;
-    transport::set_permissions(&path);
-    info!("gRPC server listening on {}", path.display());
-
-    let uds_stream = UnixListenerStream::new(uds);
-
     let svc = ProcessManagerService::new(mgr, cmd_tx);
     let pm_service = proto::process_manager_server::ProcessManagerServer::new(svc);
 
@@ -45,16 +32,10 @@ pub async fn run(
         .add_service(reflection)
         .add_service(pm_service);
 
-    router
-        .serve_with_incoming_shutdown(uds_stream, async {
-            let _ = shutdown.await;
-        })
-        .await
-        .context("gRPC server error")?;
-
-    info!("gRPC server stopped");
-    transport::cleanup(&path);
-    Ok(())
+    transport::serve(router, async {
+        let _ = shutdown.await;
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -4,6 +4,7 @@
 // Copyright 2026-present Datadog, Inc.
 
 use anyhow::Result;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 
 const DEFAULT_PIPE_PATH: &str = r"\\.\pipe\datadog-procmgrd";
@@ -22,5 +23,12 @@ pub fn prepare(_path: &Path) -> Result<()> {
 }
 
 pub fn set_permissions(_path: &Path) {}
+
+pub async fn serve<F>(_router: tonic::transport::server::Router, _shutdown: F) -> Result<()>
+where
+    F: Future<Output = ()>,
+{
+    anyhow::bail!("Named Pipe transport is not yet implemented on Windows")
+}
 
 pub fn cleanup(_path: &Path) {}

--- a/pkg/procmgr/rust/src/transport/uds.rs
+++ b/pkg/procmgr/rust/src/transport/uds.rs
@@ -4,8 +4,11 @@
 // Copyright 2026-present Datadog, Inc.
 
 use anyhow::{Context, Result};
-use log::warn;
+use log::{info, warn};
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use tokio::net::UnixListener;
+use tokio_stream::wrappers::UnixListenerStream;
 
 const DEFAULT_SOCKET_PATH: &str = "/var/run/datadog-procmgrd/dd-procmgrd.sock";
 const SOCKET_PERMISSIONS: u32 = 0o660;
@@ -43,6 +46,30 @@ pub fn set_permissions(path: &Path) {
     {
         warn!("failed to set socket permissions: {e}");
     }
+}
+
+pub async fn serve<F>(router: tonic::transport::server::Router, shutdown: F) -> Result<()>
+where
+    F: Future<Output = ()>,
+{
+    let path = ipc_path();
+    prepare(&path)?;
+
+    let uds = UnixListener::bind(&path)
+        .with_context(|| format!("failed to bind Unix socket: {}", path.display()))?;
+    set_permissions(&path);
+    info!("gRPC server listening on {}", path.display());
+
+    let uds_stream = UnixListenerStream::new(uds);
+
+    router
+        .serve_with_incoming_shutdown(uds_stream, shutdown)
+        .await
+        .context("gRPC server error")?;
+
+    info!("gRPC server stopped");
+    cleanup(&path);
+    Ok(())
 }
 
 pub fn cleanup(path: &Path) {


### PR DESCRIPTION
### What does this PR do?

Moves the UDS bind/listen/stream logic from `grpc/server.rs` into `transport::serve()`, making `server.rs` fully platform-agnostic. The server now only builds the tonic router and delegates the entire serving lifecycle (prepare, bind, permissions, serve, cleanup) to the transport layer.

### Motivation

Part of the procmgr Windows port. After we extracted the transport helpers, `server.rs` still contained UDS-specific `UnixListener::bind()` and `UnixListenerStream` calls. This step completes the abstraction so that swapping UDS for Named Pipes on Windows requires zero changes to server logic.

### Describe how you validated your changes

- `cargo check` / `cargo clippy` / `cargo fmt --check` all clean
- All 238 tests pass (137 unit + 15 binary + 86 E2E)

### Additional Notes