### PR TITLE
[ACIX-1397] Migrate Github App to dd-octo-sts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -320,7 +320,6 @@ variables:
   # Start vault variables
   AGENT_API_KEY_ORG2: agent-api-key-org-2 # agent-devx
   AGENT_APP_KEY_ORG2: agent-app-key-org-2 # agent-devx
-  AGENT_GITHUB_APP: agent-github-app # agent-devx
   AGENT_QA_E2E: agent-qa-e2e # agent-devx
   ATLASSIAN_WRITE: atlassian-write # agent-devx
   CODECOV: codecov # agent-devx
@@ -329,8 +328,6 @@ variables:
   E2E_AZURE: e2e-azure # agent-devx
   E2E_GCP: e2e-gcp # agent-devx
   INSTALL_SCRIPT_API_KEY_ORG2: install-script-api-key-org-2 # agent-devx
-  MACOS_GITHUB_APP_1: macos-github-app-one # agent-devx
-  MACOS_GITHUB_APP_2: macos-github-app-two # agent-devx
   MACOS_APPLE_APPLICATION_SIGNING: apple-application-signing # agent-delivery
   MACOS_APPLE_DEVELOPER_ACCOUNT: apple-developer-account # agent-delivery
   MACOS_APPLE_INSTALLER_SIGNING: apple-installer-signing # agent-delivery

--- a/.gitlab/.ci-linters.yml
+++ b/.gitlab/.ci-linters.yml
@@ -75,7 +75,6 @@ job-owners:
     - export_testing_public_key
     - generate-flakes-finder-pipeline
     - generate-fips-e2e-pipeline
-    - github_rate_limit_info
     - go_deps
     - go_e2e_deps
     - go_mod_tidy_check

--- a/.gitlab/.post/notify/notify.yml
+++ b/.gitlab/.post/notify/notify.yml
@@ -65,7 +65,7 @@ notify_gitlab_ci_changes:
           - .gitlab/**/*.yml
         compare_to: $COMPARE_TO_BRANCH
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
   script:
     - python3 -m dda self dep sync -f legacy-tasks
     - dda inv -- -e notify.gitlab-ci-diff --from-diff artifacts/diff.gitlab-ci.yml --pr-comment

--- a/.gitlab/.post/notify/notify.yml
+++ b/.gitlab/.post/notify/notify.yml
@@ -37,7 +37,6 @@ notify:
   timeout: 15 minutes # Added to prevent a stuck job blocking the resource_group defined above
   script:
     - !reference [.notify_setup]
-    - !reference [.setup_agent_github_app]
     - dda inv -- -e notify.check-consistent-failures -p $CI_PIPELINE_ID
 
 send_pipeline_stats:
@@ -64,7 +63,6 @@ notify_gitlab_ci_changes:
         compare_to: $COMPARE_TO_BRANCH
   script:
     - python3 -m dda self dep sync -f legacy-tasks
-    - !reference [.setup_agent_github_app]
     - dda inv -- -e notify.gitlab-ci-diff --from-diff artifacts/diff.gitlab-ci.yml --pr-comment
 
 close_failing_tests_stale_issues:

--- a/.gitlab/.post/notify/notify.yml
+++ b/.gitlab/.post/notify/notify.yml
@@ -51,12 +51,11 @@ send_pipeline_stats:
 
 notify_gitlab_ci_changes:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  extends: .notify-job
+  extends:
+    - .notify-job
+    - .dd_octo_sts
   needs: [compute_gitlab_ci_config]
   tags: ["arch:amd64", "specific:true"]
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
   rules:
     - !reference [.except_mergequeue]
     - changes:
@@ -65,7 +64,7 @@ notify_gitlab_ci_changes:
           - .gitlab/**/*.yml
         compare_to: $COMPARE_TO_BRANCH
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
+    - !reference [.setup_github_token_comment_pr]
   script:
     - python3 -m dda self dep sync -f legacy-tasks
     - dda inv -- -e notify.gitlab-ci-diff --from-diff artifacts/diff.gitlab-ci.yml --pr-comment

--- a/.gitlab/.post/notify/notify.yml
+++ b/.gitlab/.post/notify/notify.yml
@@ -54,6 +54,9 @@ notify_gitlab_ci_changes:
   extends: .notify-job
   needs: [compute_gitlab_ci_config]
   tags: ["arch:amd64", "specific:true"]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   rules:
     - !reference [.except_mergequeue]
     - changes:
@@ -61,6 +64,8 @@ notify_gitlab_ci_changes:
           - .gitlab-ci.yml
           - .gitlab/**/*.yml
         compare_to: $COMPARE_TO_BRANCH
+  before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
   script:
     - python3 -m dda self dep sync -f legacy-tasks
     - dda inv -- -e notify.gitlab-ci-diff --from-diff artifacts/diff.gitlab-ci.yml --pr-comment

--- a/.gitlab/.pre/ci_configuration.yml
+++ b/.gitlab/.pre/ci_configuration.yml
@@ -14,14 +14,12 @@ test_gitlab_compare_to:
   stage: .pre
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64"]
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
+  extends: .dd_octo_sts
   rules:
     - !reference [.except_mergequeue]
     - !reference [.on_gitlab_changes]
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.write)
+    - !reference [.setup_github_token_write]
   script:
     - dda self dep sync -f legacy-tasks
     - dda inv -- pipeline.compare-to-itself

--- a/.gitlab/.pre/ci_configuration.yml
+++ b/.gitlab/.pre/ci_configuration.yml
@@ -14,11 +14,15 @@ test_gitlab_compare_to:
   stage: .pre
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64"]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   rules:
     - !reference [.except_mergequeue]
     - !reference [.on_gitlab_changes]
+  before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.write)
   script:
-    - !reference [.setup_agent_github_app]
     - dda self dep sync -f legacy-tasks
     - dda inv -- pipeline.compare-to-itself
 

--- a/.gitlab/.pre/common/shared.yml
+++ b/.gitlab/.pre/common/shared.yml
@@ -1,4 +1,22 @@
 ---
+# DD Octo STS id_tokens template - extend this to get the DDOCTOSTS_ID_TOKEN
+# Usage: extends: .dd_octo_sts (or add to extends list)
+.dd_octo_sts:
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+
+# GitHub token setup scripts - use with !reference in before_script
+# Example: - !reference [.setup_github_token_comment_pr]
+.setup_github_token_comment_pr:
+  - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
+
+.setup_github_token_read:
+  - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.read)
+
+.setup_github_token_write:
+  - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.write)
+
 # Sets up a cache for gems used by Omnibus
 # Usage:
 # !reference [.cache_omnibus_ruby_deps, setup] somewhere ahead of invoking bundle

--- a/.gitlab/.pre/common/shared.yml
+++ b/.gitlab/.pre/common/shared.yml
@@ -17,6 +17,9 @@
 .setup_github_token_write:
   - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.write)
 
+.setup_github_ci_platform_machine_images_token:
+  - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/ci-platform-machine-images --policy self.datadog-agent.trigger-agent-bump)
+
 # Sets up a cache for gems used by Omnibus
 # Usage:
 # !reference [.cache_omnibus_ruby_deps, setup] somewhere ahead of invoking bundle

--- a/.gitlab/.pre/common/shared.yml
+++ b/.gitlab/.pre/common/shared.yml
@@ -19,12 +19,6 @@
     paths:
       - omnibus/vendor/bundle
 
-.setup_agent_github_app:
-  - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP key_b64) || exit $?; export GITHUB_KEY_B64
-  - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP app_id) || exit $?; export GITHUB_APP_ID
-  - GITHUB_INSTALLATION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP installation_id) || exit $?; export GITHUB_INSTALLATION_ID
-  - echo "Using agent GitHub App"
-
 ## Shared `dd-pkg` steps:
 # - Install `dd-pkg`, logging the version in use for the job
 .setup_dd_pkg:

--- a/.gitlab/.pre/deps_fetch/deps_fetch.yml
+++ b/.gitlab/.pre/deps_fetch/deps_fetch.yml
@@ -112,13 +112,12 @@ go_tools_deps_arm64:
         - modcache_tools_arm64.tar.zst
 
 go_e2e_deps:
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
-  extends: .cache
+  extends:
+    - .cache
+    - .dd_octo_sts
   tags: ["arch:amd64", "specific:true"]
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.read)
+    - !reference [.setup_github_token_read]
   script:
     - |
       if [ ! -f modcache_e2e.tar.zst ]; then

--- a/.gitlab/.pre/setup/setup.yml
+++ b/.gitlab/.pre/setup/setup.yml
@@ -23,26 +23,3 @@ setup_agent_version:
       dotenv: build.env
   variables:
     DISABLE_GIT_CACHE: true
-
-github_rate_limit_info:
-  stage: .pre
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64", "specific:true"]
-  rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
-  script:
-    - dda self dep sync -f legacy-tasks
-    # Send stats for app 1
-    - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 key_b64) || exit $?; export GITHUB_KEY_B64
-    - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 app_id) || exit $?; export GITHUB_APP_ID
-    - GITHUB_INSTALLATION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 installation_id) || exit $?; export GITHUB_INSTALLATION_ID
-    - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
-    - dda inv -- github.send-rate-limit-info-datadog --pipeline-id $CI_PIPELINE_ID --app-instance 1
-    # Send stats for app 2
-    - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_2 key_b64) || exit $?; export GITHUB_KEY_B64
-    - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_2 app_id) || exit $?; export GITHUB_APP_ID
-    - GITHUB_INSTALLATION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_2 installation_id) || exit $?; export GITHUB_INSTALLATION_ID
-    - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
-    - dda inv -- github.send-rate-limit-info-datadog --pipeline-id $CI_PIPELINE_ID --app-instance 2
-  allow_failure: true

--- a/.gitlab/build/pkg_metrics/pkg_metrics.yml
+++ b/.gitlab/build/pkg_metrics/pkg_metrics.yml
@@ -103,5 +103,4 @@ check_pkg_size:
     - agent_rpm-arm64-a7
     - iot_agent_rpm-arm64
   script:
-    - !reference [.setup_agent_github_app]
     - dda inv -- package.check-size

--- a/.gitlab/build/source_test/codeql_scan.yml
+++ b/.gitlab/build/source_test/codeql_scan.yml
@@ -5,9 +5,7 @@
 run_codeql_scan:
   image: registry.ddbuild.io/code-scanning:v89505840-d7f7832-datadog-agent
   tags: ["arch:amd64", "specific:true"]
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
+  extends: .dd_octo_sts
   stage: source_test
   rules:
   - !reference [.on_scheduled_main]

--- a/.gitlab/build/source_test/golang_deps_diff.yml
+++ b/.gitlab/build/source_test/golang_deps_diff.yml
@@ -23,14 +23,7 @@ golang_deps_diff:
   script:
     # Get API key to send metrics
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
-<<<<<<< HEAD
-    # Get GitHub app credentials to check PR draft status
-    - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP key_b64) || exit $?; export GITHUB_KEY_B64
-    - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP app_id) || exit $?; export GITHUB_APP_ID
     - dda inv -- -e github.is-pr-ready --git-ref "${CI_COMMIT_REF_NAME}" --target-branch main && REPORT_METRICS="--report-metrics" || REPORT_METRICS=""
-=======
-    - dda inv -- -e github.is-pr-ready --git-ref "${CI_COMMIT_REF_NAME}" && REPORT_METRICS="--report-metrics" || REPORT_METRICS=""
->>>>>>> 6d1ca6b9e5b (Remove everything related to Github App)
     - dda inv -- -e go-deps.diff --report-file=deps-report.md ${REPORT_METRICS} --git-ref "${CI_COMMIT_REF_NAME}"
   artifacts:
     paths:

--- a/.gitlab/build/source_test/golang_deps_diff.yml
+++ b/.gitlab/build/source_test/golang_deps_diff.yml
@@ -5,6 +5,9 @@ golang_deps_diff:
   stage: source_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   rules:
     - !reference [.on_dev_branches]
     - when: on_success
@@ -15,14 +18,19 @@ golang_deps_diff:
     KUBERNETES_MEMORY_REQUEST: "16Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"
   before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
     - !reference [.retrieve_linux_go_deps]
   script:
     # Get API key to send metrics
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
+<<<<<<< HEAD
     # Get GitHub app credentials to check PR draft status
     - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP key_b64) || exit $?; export GITHUB_KEY_B64
     - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP app_id) || exit $?; export GITHUB_APP_ID
     - dda inv -- -e github.is-pr-ready --git-ref "${CI_COMMIT_REF_NAME}" --target-branch main && REPORT_METRICS="--report-metrics" || REPORT_METRICS=""
+=======
+    - dda inv -- -e github.is-pr-ready --git-ref "${CI_COMMIT_REF_NAME}" && REPORT_METRICS="--report-metrics" || REPORT_METRICS=""
+>>>>>>> 6d1ca6b9e5b (Remove everything related to Github App)
     - dda inv -- -e go-deps.diff --report-file=deps-report.md ${REPORT_METRICS} --git-ref "${CI_COMMIT_REF_NAME}"
   artifacts:
     paths:
@@ -37,9 +45,12 @@ golang_deps_commenter:
     - !reference [.on_dev_branches]
     - when: on_success
   needs: ["golang_deps_diff"]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+  before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
   script:
-    - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP key_b64) || exit $?; export GITHUB_KEY_B64
-    - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP app_id) || exit $?; export GITHUB_APP_ID
     - if [ ! -s deps-report.md ]; then
         dda inv -- -e github.pr-commenter --title="Go Package Import Differences" --force-delete ;
       else
@@ -51,13 +62,14 @@ golang_deps_send_count_metrics:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
     - !reference [.retrieve_linux_go_deps]
   script:
     # Get API key to send metrics
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
-    # Get GitHub app credentials to check PR draft status
-    - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP key_b64) || exit $?; export GITHUB_KEY_B64
-    - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP app_id) || exit $?; export GITHUB_APP_ID
     - dda inv -- -e github.is-pr-ready --git-ref "${CI_COMMIT_REF_NAME}" --target-branch main && NO_SEND_SERIES="" || NO_SEND_SERIES="--no-send-series"
     - dda inv -- -e go-deps.send-count-metrics --git-sha "${CI_COMMIT_SHA}" --git-ref "${CI_COMMIT_REF_NAME}" ${NO_SEND_SERIES}

--- a/.gitlab/build/source_test/golang_deps_diff.yml
+++ b/.gitlab/build/source_test/golang_deps_diff.yml
@@ -18,7 +18,7 @@ golang_deps_diff:
     KUBERNETES_MEMORY_REQUEST: "16Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
     - !reference [.retrieve_linux_go_deps]
   script:
     # Get API key to send metrics
@@ -49,7 +49,7 @@ golang_deps_commenter:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
   script:
     - if [ ! -s deps-report.md ]; then
         dda inv -- -e github.pr-commenter --title="Go Package Import Differences" --force-delete ;
@@ -66,7 +66,7 @@ golang_deps_send_count_metrics:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
     - !reference [.retrieve_linux_go_deps]
   script:
     # Get API key to send metrics

--- a/.gitlab/build/source_test/golang_deps_diff.yml
+++ b/.gitlab/build/source_test/golang_deps_diff.yml
@@ -5,9 +5,7 @@ golang_deps_diff:
   stage: source_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
+  extends: .dd_octo_sts
   rules:
     - !reference [.on_dev_branches]
     - when: on_success
@@ -18,7 +16,7 @@ golang_deps_diff:
     KUBERNETES_MEMORY_REQUEST: "16Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
+    - !reference [.setup_github_token_comment_pr]
     - !reference [.retrieve_linux_go_deps]
   script:
     # Get API key to send metrics
@@ -38,11 +36,9 @@ golang_deps_commenter:
     - !reference [.on_dev_branches]
     - when: on_success
   needs: ["golang_deps_diff"]
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
+  extends: .dd_octo_sts
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
+    - !reference [.setup_github_token_comment_pr]
   script:
     - if [ ! -s deps-report.md ]; then
         dda inv -- -e github.pr-commenter --title="Go Package Import Differences" --force-delete ;
@@ -55,11 +51,9 @@ golang_deps_send_count_metrics:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
+  extends: .dd_octo_sts
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
+    - !reference [.setup_github_token_comment_pr]
     - !reference [.retrieve_linux_go_deps]
   script:
     # Get API key to send metrics

--- a/.gitlab/build/source_test/kmt_tasks.yml
+++ b/.gitlab/build/source_test/kmt_tasks.yml
@@ -4,6 +4,9 @@
 .test_kmt_local_setup:
   stage: source_test
   needs: []
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   rules:
     - !reference [.on_invoke_tasks_changes]
     - !reference [.except_mergequeue]
@@ -11,9 +14,10 @@
         paths:
           - .gitlab/build/source_test/kmt_tasks.yml
         compare_to: $COMPARE_TO_BRANCH
+  before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.read)
   script:
     # Avoid rate limits when running kmt.init (pulumi queries the Github API to get the releases of plugins)
-    - export GITHUB_TOKEN=$(dda inv github.get-token-from-app)
     - dda inv -- kmt.init --remote-setup-only --skip-ssh-setup --exclude-requirements $KMT_EXCLUDE_REQUIREMENTS --images ""
     - export PATH=$PATH:$HOME/.pulumi/bin  # Simulate a shell restart, required for the check
     - dda inv -- kmt.selfcheck --remote-setup-only --exclude-requirements $KMT_EXCLUDE_REQUIREMENTS --show-flare-for-failures
@@ -22,8 +26,6 @@ test_kmt_local_setup_linux:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64"]
   extends: .test_kmt_local_setup
-  before_script:
-    - !reference [.setup_agent_github_app]
   variables:
     # Some requirements cannot be tested in the CI yet:
     # - Docker,Compiler,UserInDockerGroup: no docker-in-docker support in these jobs yet
@@ -40,7 +42,6 @@ test_kmt_local_setup_macos:
   before_script:
     - !reference [.vault_login]
     - !reference [.aws_retry_config]
-    - !reference [.setup_agent_github_app]
     # Selecting the current Go version
     - |
       eval $(gimme $(cat .go-version))
@@ -59,3 +60,5 @@ test_kmt_local_setup_macos:
   id_tokens:
     CI_IDENTITIES_GITLAB_ID_TOKEN:
       aud: ci-identities
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts

--- a/.gitlab/build/source_test/kmt_tasks.yml
+++ b/.gitlab/build/source_test/kmt_tasks.yml
@@ -4,6 +4,7 @@
 .test_kmt_local_setup:
   stage: source_test
   needs: []
+  extends: .dd_octo_sts
   rules:
     - !reference [.on_invoke_tasks_changes]
     - !reference [.except_mergequeue]

--- a/.gitlab/build/source_test/kmt_tasks.yml
+++ b/.gitlab/build/source_test/kmt_tasks.yml
@@ -39,6 +39,7 @@ test_kmt_local_setup_macos:
   before_script:
     - !reference [.vault_login]
     - !reference [.aws_retry_config]
+    - !reference [.setup_github_token_read]
     # Selecting the current Go version
     - |
       eval $(gimme $(cat .go-version))

--- a/.gitlab/build/source_test/kmt_tasks.yml
+++ b/.gitlab/build/source_test/kmt_tasks.yml
@@ -4,9 +4,6 @@
 .test_kmt_local_setup:
   stage: source_test
   needs: []
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
   rules:
     - !reference [.on_invoke_tasks_changes]
     - !reference [.except_mergequeue]
@@ -15,7 +12,7 @@
           - .gitlab/build/source_test/kmt_tasks.yml
         compare_to: $COMPARE_TO_BRANCH
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.read)
+    - !reference [.setup_github_token_read]
   script:
     # Avoid rate limits when running kmt.init (pulumi queries the Github API to get the releases of plugins)
     - dda inv -- kmt.init --remote-setup-only --skip-ssh-setup --exclude-requirements $KMT_EXCLUDE_REQUIREMENTS --images ""

--- a/.gitlab/build/source_test/notify.yml
+++ b/.gitlab/build/source_test/notify.yml
@@ -2,13 +2,17 @@ unit_tests_notify:
   stage: source_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   rules:
     - !reference [.except_main_release_or_mq]
     - !reference [.except_disable_unit_tests]
     - when: always
+  before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
   script:
     - dda self dep sync -f legacy-tasks
-    - !reference [.setup_agent_github_app]
     - dda inv -- notify.unit-tests --pipeline-id $CI_PIPELINE_ID --pipeline-url $CI_PIPELINE_URL --branch-name $CI_COMMIT_REF_NAME
   needs:
     - tests_linux-x64-py3

--- a/.gitlab/build/source_test/notify.yml
+++ b/.gitlab/build/source_test/notify.yml
@@ -10,7 +10,7 @@ unit_tests_notify:
     - !reference [.except_disable_unit_tests]
     - when: always
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
   script:
     - dda self dep sync -f legacy-tasks
     - dda inv -- notify.unit-tests --pipeline-id $CI_PIPELINE_ID --pipeline-url $CI_PIPELINE_URL --branch-name $CI_COMMIT_REF_NAME

--- a/.gitlab/build/source_test/notify.yml
+++ b/.gitlab/build/source_test/notify.yml
@@ -2,15 +2,13 @@ unit_tests_notify:
   stage: source_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
+  extends: .dd_octo_sts
   rules:
     - !reference [.except_main_release_or_mq]
     - !reference [.except_disable_unit_tests]
     - when: always
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
+    - !reference [.setup_github_token_comment_pr]
   script:
     - dda self dep sync -f legacy-tasks
     - dda inv -- notify.unit-tests --pipeline-id $CI_PIPELINE_ID --pipeline-url $CI_PIPELINE_URL --branch-name $CI_COMMIT_REF_NAME

--- a/.gitlab/distribute/trigger_release/agent.yml
+++ b/.gitlab/distribute/trigger_release/agent.yml
@@ -66,7 +66,7 @@ generate_windows_gitlab_runner_bump_pr:
       when: never
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/ci-platform-machine-images --policy self.datadog-agent.trigger-agent-bump)
+    - !reference [.setup_github_ci_platform_machine_images_token]
   script:
     # We are using the agent platform auto PR github app to access the ci-platform-machine-images repository
     - dda self dep sync -f legacy-tasks

--- a/.gitlab/distribute/trigger_release/agent.yml
+++ b/.gitlab/distribute/trigger_release/agent.yml
@@ -55,26 +55,22 @@ trigger_manual_prod_release:
       when: never
     - !reference [.on_deploy_stable_or_beta_manual_auto_on_stable]
 
-.setup_github_app_agent_platform_auto_pr:
-  # GitHub App rate-limits are per-app. Since we are rarely calling the job, we are only using the instance 2
-  - |
-    GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_2 key_b64) || exit $?; export GITHUB_KEY_B64
-    GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_2 app_id) || exit $?; export GITHUB_APP_ID
-    GITHUB_INSTALLATION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_2 installation_id) || exit $?; export GITHUB_INSTALLATION_ID
-    echo "Using GitHub App instance 2"
-
 generate_windows_gitlab_runner_bump_pr:
   stage: trigger_release
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   needs: ["trigger_auto_staging_release"]
   tags: ["arch:arm64", "specific:true"]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   rules:
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
       when: never
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+  before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/ci-platform-machine-images --policy self.datadog-agent.trigger-agent-bump)
   script:
     # We are using the agent platform auto PR github app to access the ci-platform-machine-images repository
-    - !reference [.setup_github_app_agent_platform_auto_pr]
     - dda self dep sync -f legacy-tasks
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
     - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
@@ -86,14 +82,18 @@ generate_windows_gitlab_runner_bump_pr_manual:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   needs: ["trigger_auto_staging_release"]
   tags: ["arch:arm64", "specific:true"]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   rules:
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
       when: never
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
       when: manual
+  before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/ci-platform-machine-images --policy self.datadog-agent.trigger-agent-bump)
   script:
     # We are using the agent platform auto PR github app to access the ci-platform-machine-images repository
-    - !reference [.setup_github_app_agent_platform_auto_pr]
     - dda self dep sync -f legacy-tasks
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
     - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN

--- a/.gitlab/distribute/trigger_release/agent.yml
+++ b/.gitlab/distribute/trigger_release/agent.yml
@@ -60,9 +60,7 @@ generate_windows_gitlab_runner_bump_pr:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   needs: ["trigger_auto_staging_release"]
   tags: ["arch:arm64", "specific:true"]
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
+  extends: .dd_octo_sts
   rules:
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
       when: never
@@ -82,9 +80,7 @@ generate_windows_gitlab_runner_bump_pr_manual:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   needs: ["trigger_auto_staging_release"]
   tags: ["arch:arm64", "specific:true"]
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
+  extends: .dd_octo_sts
   rules:
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
       when: never

--- a/.gitlab/test/functional_test/files_inventory_check.yml
+++ b/.gitlab/test/functional_test/files_inventory_check.yml
@@ -16,7 +16,7 @@ files_inventory_check:
   needs:
     - agent_deb-x64-a7
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
   script:
     - dda inv -- files-inventory.check ${CI_COMMIT_BRANCH} ${OMNIBUS_PACKAGE_DIR}
   artifacts:

--- a/.gitlab/test/functional_test/files_inventory_check.yml
+++ b/.gitlab/test/functional_test/files_inventory_check.yml
@@ -5,6 +5,9 @@ files_inventory_check:
     - !reference [.on_dev_branches_with_artifact_changes]
     - !reference [.except_mergequeue]
     - when: on_success
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   variables:
@@ -12,8 +15,9 @@ files_inventory_check:
     OVERRIDE_GIT_STRATEGY: clone
   needs:
     - agent_deb-x64-a7
+  before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
   script:
-    - !reference [ .setup_agent_github_app ]
     - dda inv -- files-inventory.check ${CI_COMMIT_BRANCH} ${OMNIBUS_PACKAGE_DIR}
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/test/functional_test/files_inventory_check.yml
+++ b/.gitlab/test/functional_test/files_inventory_check.yml
@@ -5,9 +5,7 @@ files_inventory_check:
     - !reference [.on_dev_branches_with_artifact_changes]
     - !reference [.except_mergequeue]
     - when: on_success
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
+  extends: .dd_octo_sts
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   variables:
@@ -16,7 +14,7 @@ files_inventory_check:
   needs:
     - agent_deb-x64-a7
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
+    - !reference [.setup_github_token_comment_pr]
   script:
     - dda inv -- files-inventory.check ${CI_COMMIT_BRANCH} ${OMNIBUS_PACKAGE_DIR}
   artifacts:

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -13,9 +13,7 @@ static_quality_gates:
         compare_to: $COMPARE_TO_BRANCH
     - when: manual
       allow_failure: true
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
+  extends: .dd_octo_sts
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   tags: ["arch:amd64", "specific:true"]
   needs:
@@ -52,7 +50,7 @@ static_quality_gates:
     - job: windows_msi_and_bosh_zip_x64-a7
       optional: true
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
+    - !reference [.setup_github_token_comment_pr]
   script:
     - !reference [.login_to_docker_readonly_crane]
     # `datadog-ci` relies on `DATADOG_API_KEY` so we get that here.
@@ -93,15 +91,13 @@ manual_gate_threshold_update:
     - !reference [.on_dev_branches_with_artifact_changes_manual]
     - when: manual
       allow_failure: true
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
+  extends: .dd_octo_sts
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   tags: ["arch:amd64", "specific:true"]
   needs:
     - static_quality_gates
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.write)
+    - !reference [.setup_github_token_write]
   script:
     - !reference [.login_to_docker_readonly_crane]
     - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -52,7 +52,7 @@ static_quality_gates:
     - job: windows_msi_and_bosh_zip_x64-a7
       optional: true
   before_script:
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
   script:
     - !reference [.login_to_docker_readonly_crane]
     # `datadog-ci` relies on `DATADOG_API_KEY` so we get that here.

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -13,6 +13,9 @@ static_quality_gates:
         compare_to: $COMPARE_TO_BRANCH
     - when: manual
       allow_failure: true
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   tags: ["arch:amd64", "specific:true"]
   needs:
@@ -48,6 +51,8 @@ static_quality_gates:
     - iot_agent_suse-x64
     - job: windows_msi_and_bosh_zip_x64-a7
       optional: true
+  before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
   script:
     - !reference [.login_to_docker_readonly_crane]
     # `datadog-ci` relies on `DATADOG_API_KEY` so we get that here.
@@ -55,7 +60,6 @@ static_quality_gates:
     - export DD_API_KEY="$DATADOG_API_KEY"
     # DD_APP_KEY is required for querying metrics (e.g., fetching ancestor metrics for relative size calculation)
     - DD_APP_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_APP_KEY_ORG2" token)" || exit $?; export DD_APP_KEY
-    - !reference [ .setup_agent_github_app ]
     - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
     - dda inv -- quality-gates.parse-and-trigger-gates || exit $?
   retry:
@@ -89,12 +93,16 @@ manual_gate_threshold_update:
     - !reference [.on_dev_branches_with_artifact_changes_manual]
     - when: manual
       allow_failure: true
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   tags: ["arch:amd64", "specific:true"]
   needs:
     - static_quality_gates
+  before_script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.write)
   script:
     - !reference [.login_to_docker_readonly_crane]
-    - !reference [.setup_agent_github_app]
     - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
     - dda inv -- quality-gates.manual-threshold-update || exit $?

--- a/.gitlab/test/kernel_matrix_testing/common.yml
+++ b/.gitlab/test/kernel_matrix_testing/common.yml
@@ -323,7 +323,9 @@
     fi
 
 .notify_ebpf_complexity_changes:
-  extends: .notify-job
+  extends:
+    - .notify-job
+    - .dd_octo_sts
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   timeout: 15m
@@ -355,12 +357,9 @@
               - fedora_38
             TEST_SET: no_usm
     - job: compute_gitlab_ci_config
-  id_tokens:
-    DDOCTOSTS_ID_TOKEN:
-      aud: dd-octo-sts
   before_script:
     - python3 -m dda self dep sync -f legacy-tasks
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
+    - !reference [.setup_github_token_comment_pr]
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
   script:
     - dda inv -- -e ebpf.generate-complexity-summary-for-pr --gitlab-config-file artifacts/after.gitlab-ci.yml $EXTRA_ARGS

--- a/.gitlab/test/kernel_matrix_testing/common.yml
+++ b/.gitlab/test/kernel_matrix_testing/common.yml
@@ -355,6 +355,9 @@
               - fedora_38
             TEST_SET: no_usm
     - job: compute_gitlab_ci_config
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   before_script:
     - python3 -m dda self dep sync -f legacy-tasks
     - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)

--- a/.gitlab/test/kernel_matrix_testing/common.yml
+++ b/.gitlab/test/kernel_matrix_testing/common.yml
@@ -357,7 +357,7 @@
     - job: compute_gitlab_ci_config
   before_script:
     - python3 -m dda self dep sync -f legacy-tasks
-    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.comment-pr)
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
   script:
     - dda inv -- -e ebpf.generate-complexity-summary-for-pr --gitlab-config-file artifacts/after.gitlab-ci.yml $EXTRA_ARGS

--- a/.gitlab/test/kernel_matrix_testing/common.yml
+++ b/.gitlab/test/kernel_matrix_testing/common.yml
@@ -357,7 +357,7 @@
     - job: compute_gitlab_ci_config
   before_script:
     - python3 -m dda self dep sync -f legacy-tasks
-    - !reference [.setup_agent_github_app]
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pr-comment)
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
   script:
     - dda inv -- -e ebpf.generate-complexity-summary-for-pr --gitlab-config-file artifacts/after.gitlab-ci.yml $EXTRA_ARGS

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import time
 from collections import Counter
 
 from invoke.context import Context
@@ -18,7 +17,7 @@ from tasks.libs.ciproviders.github_actions_tools import (
     trigger_windows_bump_workflow,
 )
 from tasks.libs.common.color import Color, color_message
-from tasks.libs.common.datadog_api import create_gauge, send_event, send_metrics
+from tasks.libs.common.datadog_api import send_event
 from tasks.libs.owners.linter import codeowner_has_orphans, directory_has_packages_without_owner
 from tasks.libs.owners.parsing import read_owners
 from tasks.libs.pipeline.notifications import DEFAULT_SLACK_CHANNEL, GITHUB_SLACK_MAP

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -169,13 +169,6 @@ def send_rate_limit_info_datadog(_, pipeline_id, app_instance):
     send_metrics([metric])
 
 
-@task
-def get_token_from_app(_, app_id_env='GITHUB_APP_ID', pkey_env='GITHUB_KEY_B64'):
-    from .libs.ciproviders.github_api import GithubAPI
-
-    GithubAPI.get_token_from_app(app_id_env, pkey_env)
-
-
 def _get_teams(changed_files, owners_file='.github/CODEOWNERS', best_teams_only=True) -> list[str]:
     """Returns a list of teams that are responsible for changed files
 

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -149,26 +149,6 @@ def get_milestone_id(_, milestone):
     print(m.number)
 
 
-@task
-def send_rate_limit_info_datadog(_, pipeline_id, app_instance):
-    from tasks.libs.ciproviders.github_api import GithubAPI
-
-    gh = GithubAPI()
-    rate_limit_info = gh.get_rate_limit_info()
-    print(f"Remaining rate limit for app instance {app_instance}: {rate_limit_info[0]}/{rate_limit_info[1]}")
-    metric = create_gauge(
-        metric_name='github.rate_limit.remaining',
-        timestamp=int(time.time()),
-        value=rate_limit_info[0],
-        tags=[
-            'source:github',
-            'repository:datadog-agent',
-            f'app_instance:{app_instance}',
-        ],
-    )
-    send_metrics([metric])
-
-
 def _get_teams(changed_files, owners_file='.github/CODEOWNERS', best_teams_only=True) -> list[str]:
     """Returns a list of teams that are responsible for changed files
 

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import os
 import re
 from collections.abc import Iterable
@@ -20,7 +19,6 @@ try:
         Auth,
         Github,
         GithubException,
-        GithubIntegration,
         GithubObject,
         InputGitTreeElement,
         PullRequest,
@@ -534,23 +532,6 @@ class GithubAPI:
                 message="Github App Authentication is no longer supported in the CI, use dd-octo-sts instead",
                 code=1,
             )
-
-    @staticmethod
-    def get_token_from_app(app_id_env='GITHUB_APP_ID', pkey_env='GITHUB_KEY_B64'):
-        app_id = os.environ.get(app_id_env)
-        app_key_b64 = os.environ.get(pkey_env)
-        if app_id is None or app_key_b64 is None:
-            raise RuntimeError(f"Missing {app_id_env} or {pkey_env}")
-        app_key = base64.b64decode(app_key_b64).decode("ascii")
-
-        auth = Auth.AppAuth(app_id, app_key)
-        integration = GithubIntegration(auth=auth)
-        installations = integration.get_installations()
-        if installations.totalCount == 0:
-            raise RuntimeError("Failed to list app installations")
-        install_id = installations[0].id
-        auth_token = integration.get_access_token(install_id)
-        print(auth_token.token)
 
     def create_label(self, name, color, description="", exist_ok=False):
         """

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -529,25 +529,11 @@ class GithubAPI:
         if public_repo:
             return Auth.Login("user", "password")
 
-        if "GITHUB_APP_ID" not in os.environ or "GITHUB_KEY_B64" not in os.environ:
+        if "GITHUB_APP_ID" in os.environ or "GITHUB_KEY_B64" in os.environ:
             raise Exit(
-                message="For private repositories on CI, you need to set the GITHUB_APP_ID and GITHUB_KEY_B64 environment variables",
+                message="Github App Authentication is no longer supported in the CI, use dd-octo-sts instead",
                 code=1,
             )
-
-        appAuth = Auth.AppAuth(
-            os.environ['GITHUB_APP_ID'], base64.b64decode(os.environ['GITHUB_KEY_B64']).decode('ascii')
-        )
-        installation_id = os.environ.get('GITHUB_INSTALLATION_ID', None)
-        if installation_id is None:
-            # Even if we don't know the installation id, there's an API endpoint to
-            # retrieve it, given the other credentials (app id + key).
-            integration = GithubIntegration(auth=appAuth)
-            installations = integration.get_installations()
-            if installations.totalCount == 0:
-                raise Exit(message='No usable installation found', code=1)
-            installation_id = installations[0].id
-        return appAuth.get_installation_auth(int(installation_id))
 
     @staticmethod
     def get_token_from_app(app_id_env='GITHUB_APP_ID', pkey_env='GITHUB_KEY_B64'):

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -526,12 +526,11 @@ class GithubAPI:
             return Auth.Token(os.environ["GITHUB_TOKEN"])
         if public_repo:
             return Auth.Login("user", "password")
-
-        if "GITHUB_APP_ID" in os.environ or "GITHUB_KEY_B64" in os.environ:
-            raise Exit(
-                message="Github App Authentication is no longer supported in the CI, use dd-octo-sts instead",
-                code=1,
-            )
+        
+        raise Exit(
+            message="No authentication found, you must pass a GITHUB_TOKEN in the CI, Github App authentication is no longer supported in the CI, use dd-octo-sts instead",
+            code=1,
+        )
 
     def create_label(self, name, color, description="", exist_ok=False):
         """

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -389,12 +389,6 @@ class GithubAPI:
             if RELEASE_BRANCH_PATTERN.match(branch.name):
                 yield branch
 
-    def get_rate_limit_info(self):
-        """
-        Gets the current rate limit info.
-        """
-        return self._github.rate_limiting
-
     def publish_comment(self, pr, comment):
         """
         Publish a comment on a given PR.

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -526,7 +526,7 @@ class GithubAPI:
             return Auth.Token(os.environ["GITHUB_TOKEN"])
         if public_repo:
             return Auth.Login("user", "password")
-        
+
         raise Exit(
             message="No authentication found, you must pass a GITHUB_TOKEN in the CI, Github App authentication is no longer supported in the CI, use dd-octo-sts instead",
             code=1,

--- a/tasks/unit_tests/testdata/variables.yml
+++ b/tasks/unit_tests/testdata/variables.yml
@@ -126,23 +126,11 @@ variables:
   E2E_TESTS_AZURE_SUBSCRIPTION_ID: ci.datadog-agent.e2e_tests_azure_subscription_id  # agent-devx
   E2E_TESTS_GCP_CREDENTIALS: ci.datadog-agent.e2e_tests_gcp_credentials  # agent-devx
   E2E_PULUMI_CONFIG_PASSPHRASE: ci.datadog-agent.pulumi_password  # agent-devx
-  GITHUB_PR_COMMENTER_APP_KEY: pr-commenter.github_app_key  # agent-devx
-  GITHUB_PR_COMMENTER_INTEGRATION_ID: pr-commenter.github_integration_id  # agent-devx
-  GITHUB_PR_COMMENTER_INSTALLATION_ID: pr-commenter.github_installation_id  # agent-devx
   GITLAB_SCHEDULER_TOKEN: ci.datadog-agent.gitlab_pipelines_scheduler_token  # ci-cd
   GITLAB_READ_API_TOKEN: ci.datadog-agent.gitlab_read_api_token  # ci-cd
   GITLAB_FULL_API_TOKEN: ci.datadog-agent.gitlab_full_api_token  # ci-cd
   INSTALL_SCRIPT_API_KEY: ci.agent-linux-install-script.datadog_api_key_2  # agent-delivery
   JIRA_READ_API_TOKEN: ci.datadog-agent.jira_read_api_token  # agent-devx
-  AGENT_GITHUB_APP_ID: ci.datadog-agent.platform-github-app-id  # agent-devx
-  AGENT_GITHUB_INSTALLATION_ID: ci.datadog-agent.platform-github-app-installation-id  # agent-devx
-  AGENT_GITHUB_KEY: ci.datadog-agent.platform-github-app-key  # agent-devx
-  MACOS_GITHUB_APP_ID: ci.datadog-agent.macos_github_app_id  # agent-devx
-  MACOS_GITHUB_INSTALLATION_ID: ci.datadog-agent.macos_github_installation_id  # agent-devx
-  MACOS_GITHUB_KEY: ci.datadog-agent.macos_github_key_b64  # agent-devx
-  MACOS_GITHUB_APP_ID_2: ci.datadog-agent.macos_github_app_id_2  # agent-devx
-  MACOS_GITHUB_INSTALLATION_ID_2: ci.datadog-agent.macos_github_installation_id_2  # agent-devx
-  MACOS_GITHUB_KEY_2: ci.datadog-agent.macos_github_key_b64_2  # agent-devx
   RPM_GPG_KEY: ci.datadog-agent.rpm_signing_private_key_${RPM_GPG_KEY_ID}  # agent-delivery
   RPM_SIGNING_PASSPHRASE: ci.datadog-agent.rpm_signing_key_passphrase_${RPM_GPG_KEY_ID}  # agent-delivery
   SLACK_AGENT_CI_TOKEN: ci.datadog-agent.slack_agent_ci_token  # agent-devx
@@ -161,13 +149,10 @@ variables:
   # Start vault variables
   AGENT_API_KEY_ORG2: agent-api-key-org-2  # agent-devx
   AGENT_APP_KEY_ORG2: agent-app-key-org-2  # agent-devx
-  AGENT_GITHUB_APP: agent-github-app  # agent-devx
   AGENT_QA_E2E: agent-qa-e2e  # agent-devx
   ATLASSIAN_WRITE: atlassian-write  # agent-devx
   DOCKER_REGISTRY_RO: dockerhub-readonly  # agent-delivery
   INSTALL_SCRIPT_API_KEY_ORG2: install-script-api-key-org-2  # agent-devx
-  MACOS_GITHUB_APP_1: macos-github-app-one  # agent-devx
-  MACOS_GITHUB_APP_2: macos-github-app-two  # agent-devx
   SLACK_AGENT: slack-agent-ci  # agent-devx
   # End vault variables
 


### PR DESCRIPTION
### What does this PR do?

Remove all references to Github App in datadog-agent CI. We should no longer rely on Github App and move to dd-octo-sts instead

### Motivation

Better security

### Describe how you validated your changes

### Additional Notes
