### PR TITLE
[ACTP] Retry PAR enrollment on transient HTTP errors

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -290,8 +290,16 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 		enrollmentHostname = ""
 	}
 
-	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerNamePrefix, enrollmentHostname, apiKey, appKey)
-	if err != nil {
+	breaker := util.NewCircuitBreaker("enrollment", cfg.MinBackoff, cfg.MaxBackoff, cfg.WaitBeforeRetry, cfg.MaxAttempts)
+	var enrollmentResult *enrollment.Result
+	if err = breaker.DoWithCondition(ctx, func() error {
+		var innerErr error
+		enrollmentResult, innerErr = enrollment.SelfEnroll(ctx, ddSite, runnerNamePrefix, enrollmentHostname, apiKey, appKey)
+		if innerErr != nil && opms.IsRetryableHTTPError(innerErr) {
+			p.logger.Warnf("Enrollment failed with retryable error, will retry: %v", innerErr)
+		}
+		return innerErr
+	}, opms.IsRetryableHTTPError); err != nil {
 		return nil, fmt.Errorf("enrollment API call failed: %w", err)
 	}
 	p.logger.Info("Self-enrollment successful")

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -196,6 +196,7 @@ func (p *PrivateActionRunner) start(ctx context.Context) error {
 	p.logger.Info("Private action runner starting")
 	p.logger.Info("==> Version : " + parversion.RunnerVersion)
 	p.logger.Info("==> Site : " + cfg.DatadogSite)
+	p.logger.Info("==> API Host : " + cfg.DDApiHost)
 	p.logger.Info("==> URN : " + cfg.Urn)
 
 	keysManager := taskverifier.NewKeyManager(p.rcClient)

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -86,7 +86,7 @@ func FromDDConfig(config config.Component) (*Config, error) {
 		AllowIMDSEndpoint:         config.GetBool(setup.PARHttpAllowImdsEndpoint),
 		RShellAllowedPaths:        config.GetStringSlice(setup.PARRestrictedShellAllowedPaths),
 		DDHost:                    ddHost,
-		DDApiHost:                 ddHost,
+		DDApiHost:                 "api." + ddSite,
 		Modes:                     []modes.Mode{modes.ModePull},
 		OrgId:                     orgID,
 		PrivateKey:                privateKey,

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -224,8 +224,8 @@ func TestFromDDConfig(t *testing.T) {
 			assert.Equal(t, tt.expectedDDHost, cfg.DDHost, "DDHost mismatch")
 			assert.Equal(t, tt.expectedDDSite, cfg.DatadogSite, "DatadogSite mismatch")
 
-			// Verify DDApiHost is also set to the same value as DDHost
-			assert.Equal(t, tt.expectedDDHost, cfg.DDApiHost, "DDApiHost should match DDHost")
+			// Verify DDApiHost is derived from site, not from dd_url
+			assert.Equal(t, "api."+tt.expectedDDSite, cfg.DDApiHost, "DDApiHost should be api.<site>")
 		})
 	}
 }

--- a/pkg/privateactionrunner/opms/errors.go
+++ b/pkg/privateactionrunner/opms/errors.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package opms
+
+import "errors"
+
+// RetryableHTTPError indicates the enrollment HTTP request failed with a
+// transient error that is safe to retry (e.g. 429, 502, 503, 504, or a network
+// error). StatusCode is 0 for network-level failures.
+type RetryableHTTPError struct {
+	StatusCode int
+	cause      error
+}
+
+func (e *RetryableHTTPError) Error() string { return e.cause.Error() }
+func (e *RetryableHTTPError) Unwrap() error { return e.cause }
+
+// IsRetryableHTTPError reports whether err is (or wraps) a
+// RetryableHTTPError.
+func IsRetryableHTTPError(err error) bool {
+	var retryable *RetryableHTTPError
+	return errors.As(err, &retryable)
+}
+
+// isRetryableStatusCode returns true for HTTP status codes that represent
+// transient server-side or rate-limiting conditions worth retrying.
+// 500 Internal Server Error is intentionally excluded as it typically
+// indicates a server-side bug that retrying will not resolve.
+func isRetryableStatusCode(statusCode int) bool {
+	switch statusCode {
+	case 429, 502, 503, 504:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/privateactionrunner/opms/errors_test.go
+++ b/pkg/privateactionrunner/opms/errors_test.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package opms
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRetryableHTTPError(t *testing.T) {
+	cause := errors.New("underlying error")
+
+	t.Run("true for RetryableHTTPError", func(t *testing.T) {
+		err := &RetryableHTTPError{StatusCode: 503, cause: cause}
+		assert.True(t, IsRetryableHTTPError(err))
+	})
+
+	t.Run("true when wrapped with fmt.Errorf %w", func(t *testing.T) {
+		inner := &RetryableHTTPError{StatusCode: 429, cause: cause}
+		err := fmt.Errorf("enrollment failed: %w", inner)
+		assert.True(t, IsRetryableHTTPError(err))
+	})
+
+	t.Run("false for plain error", func(t *testing.T) {
+		assert.False(t, IsRetryableHTTPError(errors.New("plain error")))
+	})
+
+	t.Run("false for nil", func(t *testing.T) {
+		assert.False(t, IsRetryableHTTPError(nil))
+	})
+}
+
+func TestRetryableHTTPError_ErrorAndUnwrap(t *testing.T) {
+	cause := errors.New("root cause")
+	err := &RetryableHTTPError{StatusCode: 503, cause: cause}
+
+	assert.Equal(t, "root cause", err.Error())
+	assert.ErrorIs(t, err, cause)
+}
+
+func TestIsRetryableStatusCode(t *testing.T) {
+	retryable := []int{429, 502, 503, 504}
+	for _, code := range retryable {
+		assert.True(t, isRetryableStatusCode(code), "expected %d to be retryable", code)
+	}
+
+	nonRetryable := []int{200, 400, 401, 403, 404, 413, 500}
+	for _, code := range nonRetryable {
+		assert.False(t, isRetryableStatusCode(code), "expected %d to be non-retryable", code)
+	}
+}

--- a/pkg/privateactionrunner/opms/public_opms.go
+++ b/pkg/privateactionrunner/opms/public_opms.go
@@ -107,7 +107,7 @@ func (p *publicClient) EnrollWithApiKey(
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send runner creation request: %w", err)
+		return nil, &RetryableHTTPError{StatusCode: 0, cause: fmt.Errorf("failed to send runner creation request: %w", err)}
 	}
 	defer func() {
 		err = resp.Body.Close()
@@ -122,7 +122,11 @@ func (p *publicClient) EnrollWithApiKey(
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("runner creation failed with HTTP status code %d and response %s", resp.StatusCode, string(respBody))
+		httpErr := fmt.Errorf("runner creation failed with HTTP status code %d and response %s", resp.StatusCode, string(respBody))
+		if isRetryableStatusCode(resp.StatusCode) {
+			return nil, &RetryableHTTPError{StatusCode: resp.StatusCode, cause: httpErr}
+		}
+		return nil, httpErr
 	}
 
 	createRunnerResponse := new(par.CreateRunnerResponse)

--- a/pkg/privateactionrunner/util/circuit_breaker.go
+++ b/pkg/privateactionrunner/util/circuit_breaker.go
@@ -32,13 +32,24 @@ func NewCircuitBreaker(name string, minBackoff, maxBackoff, waitBeforeRetry time
 	}
 }
 
+// Do runs fn with exponential backoff, retrying on any error until fn succeeds
+// or ctx is cancelled.
 func (breaker *CircuitBreaker) Do(ctx context.Context, fn func() error) {
+	alwaysRetry := func(error) bool { return true }
+	_ = breaker.DoWithCondition(ctx, fn, alwaysRetry)
+}
+
+// DoWithCondition runs fn with exponential backoff, retrying only when
+// shouldRetry(err) returns true. It returns nil on success, the first
+// non-retryable error immediately, or ctx.Err() if the context is cancelled
+// while waiting to retry. Retries indefinitely on retryable errors.
+func (breaker *CircuitBreaker) DoWithCondition(ctx context.Context, fn func() error, shouldRetry func(error) bool) error {
 	var attempt int32 = 1
 
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return ctx.Err()
 		default:
 		}
 
@@ -50,17 +61,21 @@ func (breaker *CircuitBreaker) Do(ctx context.Context, fn func() error) {
 		}
 
 		err := fn()
-		if err != nil {
-			backoff := time.Duration(float64(breaker.minBackoff) * math.Pow(2, float64(attempt-1)))
-			if backoff > breaker.maxBackoff {
-				backoff = breaker.maxBackoff
-			}
-
-			sleepWithCtx(ctx, backoff)
-			attempt++
-			continue
+		if err == nil {
+			return nil
 		}
-		break
+
+		if !shouldRetry(err) {
+			return err
+		}
+
+		backoff := time.Duration(float64(breaker.minBackoff) * math.Pow(2, float64(attempt-1)))
+		if backoff > breaker.maxBackoff {
+			backoff = breaker.maxBackoff
+		}
+
+		sleepWithCtx(ctx, backoff)
+		attempt++
 	}
 }
 

--- a/pkg/privateactionrunner/util/circuit_breaker_test.go
+++ b/pkg/privateactionrunner/util/circuit_breaker_test.go
@@ -1,0 +1,136 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package util
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errRetryable = errors.New("retryable error")
+var errFatal = errors.New("fatal error")
+
+func alwaysRetry(err error) bool { return true }
+func neverRetry(err error) bool  { return false }
+func retryOnlyRetryable(err error) bool {
+	return errors.Is(err, errRetryable)
+}
+
+func newFastBreaker() *CircuitBreaker {
+	return NewCircuitBreaker("test", time.Millisecond, 5*time.Millisecond, 10*time.Millisecond, 3)
+}
+
+func TestDoWithCondition_SuccessOnFirstCall(t *testing.T) {
+	breaker := newFastBreaker()
+	calls := 0
+	err := breaker.DoWithCondition(context.Background(), func() error {
+		calls++
+		return nil
+	}, alwaysRetry)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestDoWithCondition_RetriesOnRetryableError(t *testing.T) {
+	breaker := newFastBreaker()
+	calls := 0
+	err := breaker.DoWithCondition(context.Background(), func() error {
+		calls++
+		if calls < 3 {
+			return errRetryable
+		}
+		return nil
+	}, retryOnlyRetryable)
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestDoWithCondition_StopsOnNonRetryableError(t *testing.T) {
+	breaker := newFastBreaker()
+	calls := 0
+	err := breaker.DoWithCondition(context.Background(), func() error {
+		calls++
+		return errFatal
+	}, neverRetry)
+	assert.ErrorIs(t, err, errFatal)
+	assert.Equal(t, 1, calls, "should not retry when shouldRetry returns false")
+}
+
+func TestDoWithCondition_StopsOnNonRetryableErrorAfterRetries(t *testing.T) {
+	breaker := newFastBreaker()
+	calls := 0
+	err := breaker.DoWithCondition(context.Background(), func() error {
+		calls++
+		if calls < 2 {
+			return errRetryable
+		}
+		return errFatal
+	}, retryOnlyRetryable)
+	assert.ErrorIs(t, err, errFatal)
+	assert.Equal(t, 2, calls)
+}
+
+func TestDoWithCondition_ReturnsCtxErrWhenCancelled(t *testing.T) {
+	breaker := newFastBreaker()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	calls := 0
+	err := breaker.DoWithCondition(ctx, func() error {
+		calls++
+		cancel() // cancel after first call
+		return errRetryable
+	}, alwaysRetry)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, calls)
+}
+
+func TestDoWithCondition_ReturnsCtxErrWhenAlreadyCancelled(t *testing.T) {
+	breaker := newFastBreaker()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	err := breaker.DoWithCondition(ctx, func() error {
+		calls++
+		return nil
+	}, alwaysRetry)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, calls, "should not call fn when context is already done")
+}
+
+func TestDo_RetriesUntilSuccess(t *testing.T) {
+	breaker := newFastBreaker()
+	calls := 0
+	breaker.Do(context.Background(), func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+	assert.Equal(t, 3, calls)
+}
+
+func TestDo_StopsOnContextCancel(t *testing.T) {
+	breaker := newFastBreaker()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	calls := 0
+	breaker.Do(ctx, func() error {
+		calls++
+		cancel()
+		return errors.New("always fails")
+	})
+
+	assert.Equal(t, 1, calls)
+}


### PR DESCRIPTION
### What does this PR do?

Two related improvements to the Private Action Runner:

1. **Enrollment retry on transient errors**: PAR now retries self-enrollment on network errors and HTTP 429/502/503/504 with exponential backoff, blocking startup until it succeeds or the context is cancelled. Previously a single transient failure would permanently prevent startup (especially bad on systemd where rapid failures exhaust `StartLimitBurst`).

2. **DDApiHost derived from site**: `DDApiHost` is now always `api.<site>` (consistent with how enrollment and connections already build their base URL) rather than being extracted from the global `dd_url` setting.

### Motivation

- A transient 503 during enrollment on systemd caused PAR to fail all 5 restart attempts in under 10 seconds, marking the service permanently failed with no recovery.
- `DDApiHost` was inconsistently derived — enrollment and connections constructed `https://api.<site>` inline while `DDApiHost` used a different derivation path. This unifies the source of truth.

### Describe how you validated your changes

- `CircuitBreaker.DoWithCondition`: unit tests covering success, retry until success, immediate stop on non-retryable error, context cancellation.
- `RetryableHTTPError` / `IsRetryableHTTPError`: unit tests covering direct, wrapped, plain, and nil errors.
- `isRetryableStatusCode`: all retryable (429, 502, 503, 504) and non-retryable (200, 400, 401, 403, 404, 413, 500) codes asserted.
- `DDApiHost` derivation tested via `TestFromDDConfig` for US, EU, Gov, and dd_url-override cases.
- `go build ./pkg/privateactionrunner/... ./comp/privateactionrunner/...` passes clean.

### Additional Notes

- `CircuitBreaker.Do` is refactored to delegate to the new `DoWithCondition` (no behaviour change for callers).
- HTTP 500 is intentionally non-retryable: it indicates a server bug that repeated requests are unlikely to resolve.
- `RetryableHTTPError` is named generically for potential reuse beyond enrollment.