### PR TITLE
fix(ci): Update Rust license path in cargo-bazel-tidy workflow

### DIFF
--- a/.github/workflows/cargo-bazel-tidy.yml
+++ b/.github/workflows/cargo-bazel-tidy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Generate Rust licenses
         run: |
           cargo install --git https://github.com/DataDog/rust-license-tool dd-rust-license-tool
-          cd pkg/discovery/module/rust && dd-rust-license-tool write
+          cd rust && dd-rust-license-tool --manifest-path ../Cargo.toml write
       - name: Create commit
         id: commit
         run: |


### PR DESCRIPTION
### What does this PR do?

Fixes the Rust license generation path in `.github/workflows/cargo-bazel-tidy.yml` from `pkg/discovery/module/rust` to `rust/`, matching the move done in #47516.

### Motivation

PR #47516 moved Rust license files to a top-level `rust/` directory but missed updating this workflow. As a result, `dd-rust-license-tool write` fails on all Renovate Cargo PRs with:

```
Package glob-match-0.2.1 is missing a repository
Error: Could not fix up package details.
```

The tool runs in the wrong directory and can't find `license-tool.toml` (which has the override for `glob-match`).

### Describe how you validated your changes

The updated command matches the invoke task on main (`tasks/licenses.py:generate_rust_licenses`). After this merges, re-triggering any Renovate Cargo PR will validate the fix.

### Additional Notes

All 10 open Renovate Cargo PRs are currently blocked by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)