### PR TITLE
[procmgr] Port grpc/mod.rs tests to cross-platform helpers

### DIFF
--- a/pkg/procmgr/rust/src/grpc/mod.rs
+++ b/pkg/procmgr/rust/src/grpc/mod.rs
@@ -21,7 +21,7 @@ pub mod proto {
         process_manager_proto::datadog::procmgr::FILE_DESCRIPTOR_SET;
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::proto;
     use super::proto::process_manager_client::ProcessManagerClient;
@@ -36,6 +36,8 @@ mod tests {
     use tokio_stream::wrappers::UnixListenerStream;
     use tonic::transport::{Channel, Endpoint};
     use tower::service_fn;
+
+    use crate::test_helpers;
 
     async fn start_test_server(
         defs: Vec<ProcessDefinition>,
@@ -324,6 +326,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_config_reflects_runtime_creates() {
+        let (cmd, args) = test_helpers::true_cmd();
         let (mut client, _shutdown) = start_test_server(vec![ProcessDefinition {
             name: "svc-a".to_string(),
             config: ProcessConfig {
@@ -344,7 +347,8 @@ mod tests {
         client
             .create(proto::CreateRequest {
                 name: "dynamic-svc".to_string(),
-                command: "/bin/echo".to_string(),
+                command: cmd.to_string(),
+                args,
                 ..Default::default()
             })
             .await
@@ -441,43 +445,48 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_status_mixed_states() {
+        let (sleep_cmd, sleep_args) = test_helpers::sleep_cmd(60);
+        let (fail_cmd, fail_args) = test_helpers::exit_cmd(1);
+        let (exit_cmd, exit_args) = test_helpers::exit_cmd(0);
+        let (true_cmd, true_args) = test_helpers::true_cmd();
         let defs = vec![
             ProcessDefinition {
                 name: "running-svc".to_string(),
                 config: ProcessConfig {
-                    command: "/bin/sleep".to_string(),
-                    args: vec!["60".to_string()],
+                    command: sleep_cmd.to_string(),
+                    args: sleep_args.clone(),
                     ..Default::default()
                 },
             },
             ProcessDefinition {
                 name: "failed-svc".to_string(),
                 config: ProcessConfig {
-                    command: "/bin/sh".to_string(),
-                    args: vec!["-c".to_string(), "exit 1".to_string()],
+                    command: fail_cmd.to_string(),
+                    args: fail_args,
                     ..Default::default()
                 },
             },
             ProcessDefinition {
                 name: "stopped-svc".to_string(),
                 config: ProcessConfig {
-                    command: "/bin/sleep".to_string(),
-                    args: vec!["60".to_string()],
+                    command: sleep_cmd.to_string(),
+                    args: sleep_args,
                     ..Default::default()
                 },
             },
             ProcessDefinition {
                 name: "exited-svc".to_string(),
                 config: ProcessConfig {
-                    command: "/bin/sh".to_string(),
-                    args: vec!["-c".to_string(), "exit 0".to_string()],
+                    command: exit_cmd.to_string(),
+                    args: exit_args,
                     ..Default::default()
                 },
             },
             ProcessDefinition {
                 name: "created-svc".to_string(),
                 config: ProcessConfig {
-                    command: "/bin/true".to_string(),
+                    command: true_cmd.to_string(),
+                    args: true_args,
                     ..Default::default()
                 },
             },
@@ -545,21 +554,18 @@ mod tests {
             .unwrap()
             .into_inner();
         if let Some(p) = list.processes.iter().find(|p| p.name == "running-svc") {
-            nix::sys::signal::kill(
-                nix::unistd::Pid::from_raw(p.pid as i32),
-                nix::sys::signal::Signal::SIGKILL,
-            )
-            .ok();
+            test_helpers::cleanup_process(p.pid);
         }
     }
 
     #[tokio::test]
     async fn test_list_shows_running_pid() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         let (mut client, _shutdown) = start_test_server(vec![ProcessDefinition {
             name: "live-proc".to_string(),
             config: ProcessConfig {
-                command: "/bin/sleep".to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args,
                 ..Default::default()
             },
         }])
@@ -586,22 +592,19 @@ mod tests {
             "running process should report a non-zero pid"
         );
 
-        nix::sys::signal::kill(
-            nix::unistd::Pid::from_raw(resp.processes[0].pid as i32),
-            nix::sys::signal::Signal::SIGKILL,
-        )
-        .ok();
+        test_helpers::cleanup_process(resp.processes[0].pid);
     }
 
     // -- Write RPC tests --
 
     #[tokio::test]
     async fn test_start_rpc_success() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         let (mut client, _shutdown) = start_test_server(vec![ProcessDefinition {
             name: "sleeper".to_string(),
             config: ProcessConfig {
-                command: "/bin/sleep".to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args,
                 ..Default::default()
             },
         }])
@@ -636,11 +639,7 @@ mod tests {
         assert_eq!(resp.processes[0].pid, start_resp.pid);
 
         // Clean up
-        nix::sys::signal::kill(
-            nix::unistd::Pid::from_raw(start_resp.pid as i32),
-            nix::sys::signal::Signal::SIGKILL,
-        )
-        .ok();
+        test_helpers::cleanup_process(start_resp.pid);
     }
 
     #[tokio::test]
@@ -658,11 +657,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_start_rpc_already_running() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         let (mut client, _shutdown) = start_test_server(vec![ProcessDefinition {
             name: "running".to_string(),
             config: ProcessConfig {
-                command: "/bin/sleep".to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args,
                 ..Default::default()
             },
         }])
@@ -683,27 +683,22 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
 
-        nix::sys::signal::kill(
-            nix::unistd::Pid::from_raw({
-                let resp = client
-                    .list(proto::ListRequest {})
-                    .await
-                    .unwrap()
-                    .into_inner();
-                resp.processes[0].pid as i32
-            }),
-            nix::sys::signal::Signal::SIGKILL,
-        )
-        .ok();
+        let resp = client
+            .list(proto::ListRequest {})
+            .await
+            .unwrap()
+            .into_inner();
+        test_helpers::cleanup_process(resp.processes[0].pid);
     }
 
     #[tokio::test]
     async fn test_stop_rpc_success() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         let (mut client, _shutdown) = start_test_server(vec![ProcessDefinition {
             name: "to-stop".to_string(),
             config: ProcessConfig {
-                command: "/bin/sleep".to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args,
                 ..Default::default()
             },
         }])
@@ -786,11 +781,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_start_then_stop_round_trip() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         let (mut client, _shutdown) = start_test_server(vec![ProcessDefinition {
             name: "lifecycle".to_string(),
             config: ProcessConfig {
-                command: "/bin/sleep".to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args,
                 ..Default::default()
             },
         }])
@@ -834,13 +830,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_then_start() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         let (mut client, _shutdown) = start_test_server(vec![]).await;
 
         client
             .create(proto::CreateRequest {
                 name: "new-svc".to_string(),
-                command: "/bin/sleep".to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args,
                 auto_start: Some(false),
                 ..Default::default()
             })
@@ -870,22 +867,19 @@ mod tests {
         assert_eq!(resp.processes[0].state, proto::ProcessState::Running as i32);
         assert!(resp.processes[0].pid > 0);
 
-        nix::sys::signal::kill(
-            nix::unistd::Pid::from_raw(resp.processes[0].pid as i32),
-            nix::sys::signal::Signal::SIGKILL,
-        )
-        .ok();
+        test_helpers::cleanup_process(resp.processes[0].pid);
     }
 
     #[tokio::test]
     async fn test_create_auto_start() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         let (mut client, _shutdown) = start_test_server(vec![]).await;
 
         client
             .create(proto::CreateRequest {
                 name: "auto-svc".to_string(),
-                command: "/bin/sleep".to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args,
                 auto_start: Some(true),
                 ..Default::default()
             })
@@ -906,11 +900,7 @@ mod tests {
             "auto-started process should have a PID"
         );
 
-        nix::sys::signal::kill(
-            nix::unistd::Pid::from_raw(resp.processes[0].pid as i32),
-            nix::sys::signal::Signal::SIGKILL,
-        )
-        .ok();
+        test_helpers::cleanup_process(resp.processes[0].pid);
     }
 
     #[tokio::test]
@@ -1008,12 +998,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_defaults_applied() {
+        let (cmd, args) = test_helpers::true_cmd();
         let (mut client, _shutdown) = start_test_server(vec![]).await;
 
         client
             .create(proto::CreateRequest {
                 name: "defaults-svc".to_string(),
-                command: "/bin/echo".to_string(),
+                command: cmd.to_string(),
+                args: args.clone(),
                 ..Default::default()
             })
             .await
@@ -1028,12 +1020,12 @@ mod tests {
             .into_inner();
 
         let detail = resp.detail.unwrap();
-        assert_eq!(detail.command, "/bin/echo");
+        assert_eq!(detail.command, cmd);
         assert!(detail.auto_start, "auto_start should default to true");
         assert_eq!(detail.stdout, "inherit");
         assert_eq!(detail.stderr, "inherit");
         assert_eq!(detail.restart_policy, "never");
-        assert!(detail.args.is_empty());
+        assert_eq!(detail.args, args);
         assert!(detail.env.is_empty());
     }
 
@@ -1114,11 +1106,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_start_stop_by_uuid_prefix() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
         let defs = vec![ProcessDefinition {
             name: "svc-b".to_string(),
             config: ProcessConfig {
-                command: "/bin/sleep".to_string(),
-                args: vec!["60".to_string()],
+                command: cmd.to_string(),
+                args,
                 ..Default::default()
             },
         }];


### PR DESCRIPTION
### What does this PR do?

Ports the `grpc/mod.rs` integration tests for cross-platform compatibility:
- cfg-gates the test module with `#[cfg(all(test, unix))]` since `start_test_server` relies on UDS (`UnixListener`, `UnixListenerStream`, `UnixStream`)
- Replaces hardcoded Unix commands (`/bin/sleep`, `/bin/sh -c "exit N"`, `/bin/true`) with `test_helpers` helpers in all tests that actually spawn processes
- Replaces 6 `nix::sys::signal::kill` cleanup calls with `test_helpers::cleanup_process`
- Tests using commands as pure config data (never spawned) are left unchanged

### Motivation

Part of the procmgr Windows port. These tests won't compile on Windows due to UDS imports. The UDS test infrastructure will be replaced with Named Pipes later; for now, cfg-gating keeps CI green on both platforms.

### Describe how you validated your changes

- `cargo clippy` / `cargo fmt --check` clean
- 232 tests pass (131 unit + 15 binary + 86 E2E)

### Additional Notes