### PR TITLE
[ACIX-1397] Create dd-octo-sts policies to migrate out of Github App on datadog-aagent

### DIFF
--- a/.github/chainguard/self.gitlab.comment-pr.sts.yaml
+++ b/.github/chainguard/self.gitlab.comment-pr.sts.yaml
@@ -1,0 +1,15 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/datadog-agent:.*"
+
+claim_pattern:
+  project_path: "DataDog/datadog-agent"
+  project_id: "4670"
+  ref_type: "branch"
+  ref: ".+"
+
+# GitLab CI jobs that post or update GitHub issue comments on PRs (e.g. notify.gitlab-ci-diff --pr-comment).
+# Permissions mirror self.add-dependabot-pr-to-mq.comment-pr.sts.yaml (issue comments on PRs).
+permissions:
+  contents: read
+  pull_requests: write

--- a/.github/chainguard/self.gitlab.write.sts.yaml
+++ b/.github/chainguard/self.gitlab.write.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/datadog-agent:.*"
+
+claim_pattern:
+  project_path: "DataDog/datadog-agent"
+  project_id: "4670"
+  ref: ".+"
+  
+permissions:
+  contents: write


### PR DESCRIPTION


### What does this PR do?

Create dd-octo-sts policies that will be used to move out of Github App

### Motivation

### Describe how you validated your changes

### Additional Notes
