### PR TITLE
Read datadog.yaml config variable when creating cmd

### DIFF
--- a/pkg/fleet/installer/commands/BUILD.bazel
+++ b/pkg/fleet/installer/commands/BUILD.bazel
@@ -53,5 +53,10 @@ go_test(
         "//pkg/fleet/installer/repository",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//assert",
-    ],
+    ] + select({
+        "@rules_go//go/platform:windows": [
+            "//pkg/fleet/installer/paths",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/fleet/installer/commands/BUILD.bazel
+++ b/pkg/fleet/installer/commands/BUILD.bazel
@@ -49,13 +49,9 @@ go_test(
     deps = [
         "//pkg/fleet/installer/env",
         "//pkg/fleet/installer/exec",
+        "//pkg/fleet/installer/paths",
         "//pkg/fleet/installer/repository",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//assert",
-    ] + select({
-        "@rules_go//go/platform:windows": [
-            "//pkg/fleet/installer/paths",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
 )

--- a/pkg/fleet/installer/commands/BUILD.bazel
+++ b/pkg/fleet/installer/commands/BUILD.bazel
@@ -53,10 +53,5 @@ go_test(
         "//pkg/fleet/installer/repository",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//assert",
-    ] + select({
-        "@rules_go//go/platform:windows": [
-            "//pkg/fleet/installer/paths",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
 )

--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -44,6 +44,9 @@ const (
 	AnnotationHumanReadableErrors = "human-readable-errors"
 )
 
+// agentConfigDir is the directory containing datadog.yaml. Overridable in tests.
+var agentConfigDir = paths.AgentConfigDir
+
 type cmdOption func(*cmdConfig)
 type cmdConfig struct{ quiet bool }
 
@@ -211,7 +214,7 @@ func newTelemetry(env *env.Env) *telemetry.Telemetry {
 // applyDatadogYAMLRegistryConfig reads installer.registry from datadog.yaml and
 // applies any values not already set by environment variables.
 func applyDatadogYAMLRegistryConfig(e *env.Env) {
-	configPath := filepath.Join(paths.AgentConfigDir, "datadog.yaml")
+	configPath := filepath.Join(agentConfigDir, "datadog.yaml")
 	rawConfig, err := os.ReadFile(configPath)
 	if err != nil {
 		return

--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -80,6 +80,7 @@ func newCmd(operation string, opts ...cmdOption) *cmd {
 		o(cfg)
 	}
 	env := env.FromEnv()
+	applyDatadogYAMLRegistryConfig(env)
 	if !env.IsFromDaemon && !cfg.quiet {
 		setupStdoutLogger(env)
 	}
@@ -161,6 +162,17 @@ type telemetryConfigFields struct {
 	Site   string `yaml:"site"`
 }
 
+type installerRegistryYAMLConfig struct {
+	Installer struct {
+		Registry struct {
+			URL      string `yaml:"url"`
+			Auth     string `yaml:"auth"`
+			Username string `yaml:"username"`
+			Password string `yaml:"password"`
+		} `yaml:"registry"`
+	} `yaml:"installer"`
+}
+
 // telemetryConfig is a best effort to get the API key / site from `datadog.yaml`.
 func telemetryConfig() telemetryConfigFields {
 	configPath := filepath.Join(paths.AgentConfigDir, "datadog.yaml")
@@ -194,6 +206,37 @@ func newTelemetry(env *env.Env) *telemetry.Telemetry {
 
 	t := telemetry.NewTelemetry(env.HTTPClient(), apiKey, site, "datadog-installer") // No sampling rules for commands
 	return t
+}
+
+// applyDatadogYAMLRegistryConfig reads installer.registry from datadog.yaml and
+// applies any values not already set by environment variables.
+func applyDatadogYAMLRegistryConfig(e *env.Env) {
+	configPath := filepath.Join(paths.AgentConfigDir, "datadog.yaml")
+	rawConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		return
+	}
+	var config installerRegistryYAMLConfig
+	if err = yaml.Unmarshal(rawConfig, &config); err != nil {
+		return
+	}
+	r := config.Installer.Registry
+	if e.RegistryOverride == "" {
+		if agentURL := os.Getenv("DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE"); agentURL != "" {
+			e.RegistryOverride = agentURL
+		} else if r.URL != "" {
+			e.RegistryOverride = r.URL
+		}
+	}
+	if e.RegistryAuthOverride == "" && r.Auth != "" {
+		e.RegistryAuthOverride = r.Auth
+	}
+	if e.RegistryUsername == "" && r.Username != "" {
+		e.RegistryUsername = r.Username
+	}
+	if e.RegistryPassword == "" && r.Password != "" {
+		e.RegistryPassword = r.Password
+	}
 }
 
 // RootCommands returns the root commands

--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -213,7 +213,7 @@ func newTelemetry(env *env.Env) *telemetry.Telemetry {
 
 // applyDatadogYAMLRegistryConfig reads installer.registry from datadog.yaml and
 // applies any values not already set by environment variables.
-func applyDatadogYAMLRegistryConfig(e *env.Env) {
+func applyDatadogYAMLRegistryConfig(env *env.Env) {
 	configPath := filepath.Join(agentConfigDir, "datadog.yaml")
 	rawConfig, err := os.ReadFile(configPath)
 	if err != nil {
@@ -224,21 +224,17 @@ func applyDatadogYAMLRegistryConfig(e *env.Env) {
 		return
 	}
 	r := config.Installer.Registry
-	if e.RegistryOverride == "" {
-		if agentURL := os.Getenv("DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE"); agentURL != "" {
-			e.RegistryOverride = agentURL
-		} else if r.URL != "" {
-			e.RegistryOverride = r.URL
-		}
+	if env.HasDefaultRegistryOverride() && r.Auth != "" {
+		env.RegistryOverride = r.URL
 	}
-	if e.RegistryAuthOverride == "" && r.Auth != "" {
-		e.RegistryAuthOverride = r.Auth
+	if env.HasDefaultRegistryAuthOverride() && r.Auth != "" {
+		env.RegistryAuthOverride = r.Auth
 	}
-	if e.RegistryUsername == "" && r.Username != "" {
-		e.RegistryUsername = r.Username
+	if env.HasDefaultRegistryUsername() && r.Username != "" {
+		env.RegistryUsername = r.Username
 	}
-	if e.RegistryPassword == "" && r.Password != "" {
-		e.RegistryPassword = r.Password
+	if env.HasDefaultRegistryPassword() && r.Password != "" {
+		env.RegistryPassword = r.Password
 	}
 }
 

--- a/pkg/fleet/installer/commands/command_test.go
+++ b/pkg/fleet/installer/commands/command_test.go
@@ -7,7 +7,10 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -15,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/exec"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 )
 
@@ -121,6 +125,153 @@ func TestConfigAndPackageStates(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, res)
+}
+
+// testEnvAccessor allows tests to read any field of env.Env by name.
+type testEnvAccessor struct{ e *env.Env }
+
+func (a testEnvAccessor) GetEnv(field string) string {
+	v := reflect.ValueOf(a.e).Elem()
+	f := v.FieldByName(field)
+	if !f.IsValid() {
+		return fmt.Sprintf("<unknown field %q>", field)
+	}
+	return fmt.Sprintf("%v", f.Interface())
+}
+
+type testCmd struct {
+	*cmd
+	Test testEnvAccessor
+}
+
+// newTestingCmd creates a cmd via newCmd and exposes its env through Test.GetEnv.
+func newTestingCmd() *testCmd {
+	c := newCmd("unit_test", withQuiet())
+	return &testCmd{cmd: c, Test: testEnvAccessor{e: c.env}}
+}
+
+func TestNewCmd(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string            // written to temp dir as datadog.yaml; empty means no file
+		envVars map[string]string // set via t.Setenv before creating the cmd
+		checks  map[string]string // env.Env field name -> expected value
+	}{
+		{
+			name: "no config no env vars",
+			checks: map[string]string{
+				"RegistryAuthOverride": "",
+				"RegistryOverride":     "",
+				"RegistryUsername":     "",
+				"RegistryPassword":     "",
+			},
+		},
+		{
+			name: "env vars only",
+			envVars: map[string]string{
+				"DD_INSTALLER_REGISTRY_AUTH":     "gcr",
+				"DD_INSTALLER_REGISTRY_URL":      "env-registry.example.com",
+				"DD_INSTALLER_REGISTRY_USERNAME": "env-user",
+				"DD_INSTALLER_REGISTRY_PASSWORD": "env-pass",
+			},
+			checks: map[string]string{
+				"RegistryAuthOverride": "gcr",
+				"RegistryOverride":     "env-registry.example.com",
+				"RegistryUsername":     "env-user",
+				"RegistryPassword":     "env-pass",
+			},
+		},
+		{
+			name: "datadog.yaml only",
+			yaml: `
+installer:
+  registry:
+    url:      yaml-registry.example.com
+    auth:     gcr
+    username: yaml-user
+    password: yaml-pass
+`,
+			checks: map[string]string{
+				"RegistryAuthOverride": "gcr",
+				"RegistryOverride":     "yaml-registry.example.com",
+				"RegistryUsername":     "yaml-user",
+				"RegistryPassword":     "yaml-pass",
+			},
+		},
+		{
+			name: "env vars take precedence over datadog.yaml",
+			yaml: `
+installer:
+  registry:
+    url:      yaml-registry.example.com
+    auth:     yaml-auth
+    username: yaml-user
+    password: yaml-pass
+`,
+			envVars: map[string]string{
+				"DD_INSTALLER_REGISTRY_AUTH": "env-auth",
+				"DD_INSTALLER_REGISTRY_URL":  "env-registry.example.com",
+			},
+			checks: map[string]string{
+				"RegistryAuthOverride": "env-auth",
+				"RegistryOverride":     "env-registry.example.com",
+				// remaining fields not set by env var are filled from YAML
+				"RegistryUsername": "yaml-user",
+				"RegistryPassword": "yaml-pass",
+			},
+		},
+		{
+			name: "DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE takes precedence over yaml url",
+			yaml: `
+installer:
+  registry:
+    url: yaml-registry.example.com
+`,
+			envVars: map[string]string{
+				"DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE": "pkg-registry.example.com",
+			},
+			checks: map[string]string{
+				"RegistryOverride": "pkg-registry.example.com",
+			},
+		},
+		{
+			name: "partial yaml fills only provided fields",
+			yaml: `
+installer:
+  registry:
+    auth: gcr
+`,
+			checks: map[string]string{
+				"RegistryAuthOverride": "gcr",
+				"RegistryOverride":     "",
+				"RegistryUsername":     "",
+				"RegistryPassword":     "",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			agentConfigDir = dir
+			t.Cleanup(func() { agentConfigDir = paths.AgentConfigDir })
+
+			if tc.yaml != "" {
+				err := os.WriteFile(filepath.Join(dir, "datadog.yaml"), []byte(tc.yaml), 0644)
+				assert.NoError(t, err)
+			}
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+
+			cmd := newTestingCmd()
+			defer cmd.stop(nil)
+
+			for field, want := range tc.checks {
+				assert.Equal(t, want, cmd.Test.GetEnv(field), "field %s", field)
+			}
+		})
+	}
 }
 
 func TestSetupCommandHasHumanReadableAnnotation(t *testing.T) {

--- a/pkg/fleet/installer/commands/command_test.go
+++ b/pkg/fleet/installer/commands/command_test.go
@@ -221,20 +221,6 @@ installer:
 			},
 		},
 		{
-			name: "DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE takes precedence over yaml url",
-			yaml: `
-installer:
-  registry:
-    url: yaml-registry.example.com
-`,
-			envVars: map[string]string{
-				"DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE": "pkg-registry.example.com",
-			},
-			checks: map[string]string{
-				"RegistryOverride": "pkg-registry.example.com",
-			},
-		},
-		{
 			name: "partial yaml fills only provided fields",
 			yaml: `
 installer:

--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -221,6 +221,22 @@ type Env struct {
 	IsFromDaemon bool
 }
 
+func (e *Env) HasDefaultRegistryOverride() bool {
+	return e.RegistryOverride == defaultEnv.RegistryOverride
+}
+
+func (e *Env) HasDefaultRegistryAuthOverride() bool {
+	return e.RegistryAuthOverride == defaultEnv.RegistryAuthOverride
+}
+
+func (e *Env) HasDefaultRegistryUsername() bool {
+	return e.RegistryUsername == defaultEnv.RegistryUsername
+}
+
+func (e *Env) HasDefaultRegistryPassword() bool {
+	return e.RegistryPassword == defaultEnv.RegistryPassword
+}
+
 // HTTPClient returns an HTTP client with the proxy settings from the environment.
 func (e *Env) HTTPClient() *http.Client {
 	proxyConfig := &httpproxy.Config{


### PR DESCRIPTION
### What does this PR do?

This PR read the datadog.yaml installer configuration during the creation of the installer commands to override environment variable if set in the configuration.

### Motivation

Installing ddot extension with DD_INSTALLER_REGISTRY_URL (for instance) env variable didn't have the same effect than the ddot extension install with installer.registry.url setup in datadog.yaml which shouldn't be the case.

### Describe how you validated your changes

Added a unit test to check if env variable are correctly set if datadog.yaml configure the installer
