### PR TITLE
[ AGNTLOG-598 ] [logs-agent] Syslog v1: Message model, Origin, and Framer infrastructure

### DIFF
--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -318,8 +318,11 @@ func (d *decoderImpl) Stop() {
 
 func (d *decoderImpl) run() {
 	defer func() {
-		// flush any remaining output in component order, and then close the
-		// output channel
+		// Flush any remaining output in component order, and then close the
+		// output channel. The framer flush gives the FrameMatcher a chance to
+		// emit buffered data that was waiting for a delimiter that never
+		// arrived (e.g. non-transparent syslog without a trailing LF).
+		d.framer.Flush()
 		d.lineParser.flush()
 		d.lineHandler.flush()
 		close(d.outputChan)

--- a/pkg/logs/internal/framer/docker_stream.go
+++ b/pkg/logs/internal/framer/docker_stream.go
@@ -21,6 +21,10 @@ type dockerStreamMatcher struct {
 	contentLenLimit int
 }
 
+// FlushFrame implements FrameMatcher. Partial docker stream data is not
+// emitted at end-of-stream.
+func (s *dockerStreamMatcher) FlushFrame([]byte) ([]byte, int) { return nil, 0 }
+
 // FindFrame implements FrameMatcher#FindFrame.
 func (s *dockerStreamMatcher) FindFrame(buf []byte, seen int) ([]byte, int, bool) {
 	for i := seen; i < len(buf); i++ {

--- a/pkg/logs/internal/framer/framer.go
+++ b/pkg/logs/internal/framer/framer.go
@@ -43,6 +43,13 @@ const (
 	// headers are included in the log frame.  The size in those headers is not
 	// consulted.  The result does not include the trailing newlines.
 	DockerStream
+
+	// UTF8NewlineDatagram splits on newlines like UTF8Newline, but also
+	// flushes any remaining data at the end of each Process() call. This is
+	// appropriate for datagram transports (UDP, unixgram) where each
+	// Process() call represents a complete, discrete message — there is no
+	// subsequent data that could complete a partial frame.
+	UTF8NewlineDatagram
 )
 
 // Framer gets chunks of bytes (via Process(..)) and uses an
@@ -69,6 +76,16 @@ type Framer struct {
 	// Over this size, the framer will break the bytes into individual frames
 	// of this size with no delimiting.
 	contentLenLimit int
+
+	// flushAfterProcess, when true, emits any unframed remainder at the end
+	// of each Process() call. Used for datagram transports where each call
+	// is a complete, discrete message.
+	flushAfterProcess bool
+
+	// lastInput holds the most recent message passed to Process(), used by
+	// Flush() to inherit metadata (Origin, tags, etc.) when emitting a
+	// buffered remainder at end-of-stream.
+	lastInput *message.Message
 }
 
 // NewFramer initializes a Framer.
@@ -110,17 +127,20 @@ func NewFramer(
 		matcher = &dockerStreamMatcher{contentLenLimit}
 	case NoFraming:
 		matcher = &noFramingMatcher{}
+	case UTF8NewlineDatagram:
+		matcher = &oneByteNewLineMatcher{contentLenLimit}
 	default:
 		panic(fmt.Sprintf("unknown framing %d", framing))
 	}
 
 	return &Framer{
-		frames:          atomic.NewInt64(0),
-		outputFn:        outputFn,
-		matcher:         matcher,
-		buffer:          bytes.Buffer{},
-		bytesFramed:     0,
-		contentLenLimit: contentLenLimit,
+		frames:            atomic.NewInt64(0),
+		outputFn:          outputFn,
+		matcher:           matcher,
+		buffer:            bytes.Buffer{},
+		bytesFramed:       0,
+		contentLenLimit:   contentLenLimit,
+		flushAfterProcess: framing == UTF8NewlineDatagram,
 	}
 }
 
@@ -133,6 +153,8 @@ func (fr *Framer) GetFrameCount() int64 {
 // Process handles an incoming chunk of data.  It will call outputFn for any recognized frames.  Partial
 // frames are maintained between calls to Process.  The passed buffer is not used after return.
 func (fr *Framer) Process(input *message.Message) {
+	fr.lastInput = input
+
 	// we can only process unstructured message in the framer
 	if input.State != message.StateUnstructured {
 		fr.outputFn(input, len(input.GetContent()))
@@ -170,39 +192,19 @@ func (fr *Framer) Process(input *message.Message) {
 				content, rawDataLen = buf[:contentLenLimit], contentLenLimit
 				isTruncated = true
 			} else {
-				// matcher didn't find a frame, so leave the remainder in
-				// buffer
 				break
 			}
 		}
 
-		// copy the data so that we can reuse fr.buffer (`content` is a slice
-		// of `fr.buffer`)
-		owned := make([]byte, len(content))
-		copy(owned, content)
-
-		// Copy ParsingExtra and override frame-specific fields
-		parsingExtra := input.ParsingExtra
-		parsingExtra.IsTruncated = isTruncated
-
-		c := &message.Message{
-			MessageContent: message.MessageContent{
-				State: message.StateUnstructured,
-			},
-			MessageMetadata: message.MessageMetadata{
-				Origin:             input.Origin,
-				Status:             input.Status,
-				IngestionTimestamp: input.IngestionTimestamp,
-				ParsingExtra:       parsingExtra,
-				ServerlessExtra:    input.ServerlessExtra,
-			},
-		}
-		c.SetContent(owned)
-
-		fr.outputFn(c, rawDataLen)
-		fr.frames.Inc()
+		fr.emitFrame(input, content, rawDataLen, isTruncated)
 		framed += rawDataLen
 		seen = framed
+	}
+
+	if fr.flushAfterProcess && framed < end {
+		buf := fr.buffer.Bytes()[framed:]
+		fr.emitFrame(input, buf, len(buf), false)
+		framed = end
 	}
 
 	fr.bytesFramed = framed
@@ -231,6 +233,53 @@ func (fr *Framer) normalizeBuffer() {
 		fr.buffer.Truncate(len(unframed))
 		fr.bytesFramed = 0
 	}
+}
+
+// Flush emits any unframed remainder left in the buffer by delegating to the
+// matcher's FlushFrame. Called by the decoder at end-of-stream (e.g. when a
+// TCP connection closes). The matcher decides whether the remainder is a valid
+// frame worth emitting.
+func (fr *Framer) Flush() {
+	framed := fr.bytesFramed
+	end := fr.buffer.Len()
+	if framed >= end || fr.lastInput == nil {
+		return
+	}
+	buf := fr.buffer.Bytes()[framed:]
+	content, rawDataLen := fr.matcher.FlushFrame(buf)
+	if content == nil {
+		return
+	}
+	fr.emitFrame(fr.lastInput, content, rawDataLen, false)
+	fr.bytesFramed += rawDataLen
+	fr.normalizeBuffer()
+}
+
+// emitFrame copies content out of the framer buffer and sends it as a new
+// unstructured message, inheriting metadata from the original input message.
+func (fr *Framer) emitFrame(input *message.Message, content []byte, rawDataLen int, isTruncated bool) {
+	owned := make([]byte, len(content))
+	copy(owned, content)
+
+	parsingExtra := input.ParsingExtra
+	parsingExtra.IsTruncated = isTruncated
+
+	c := &message.Message{
+		MessageContent: message.MessageContent{
+			State: message.StateUnstructured,
+		},
+		MessageMetadata: message.MessageMetadata{
+			Origin:             input.Origin,
+			Status:             input.Status,
+			IngestionTimestamp: input.IngestionTimestamp,
+			ParsingExtra:       parsingExtra,
+			ServerlessExtra:    input.ServerlessExtra,
+		},
+	}
+	c.SetContent(owned)
+
+	fr.outputFn(c, rawDataLen)
+	fr.frames.Inc()
 }
 
 // reset resets the framer to begin framing a new stream, for testing.

--- a/pkg/logs/internal/framer/framer_test.go
+++ b/pkg/logs/internal/framer/framer_test.go
@@ -643,6 +643,137 @@ func TestFramerInputNotDockerHeader(t *testing.T) {
 	assert.Equal(t, len(expected2)+1, output.rawDataLen)
 }
 
+func TestUTF8NewlineDatagramFraming(t *testing.T) {
+	test := func(chunks [][]byte, lines []string, rawLens []int) func(*testing.T) {
+		return func(t *testing.T) {
+			gotContent := []string{}
+			gotLens := []int{}
+			outputFn := func(msg *message.Message, rawDataLen int) {
+				gotContent = append(gotContent, string(msg.GetContent()))
+				gotLens = append(gotLens, rawDataLen)
+			}
+			fr := NewFramer(outputFn, UTF8NewlineDatagram, contentLenLimit)
+			for _, chunk := range chunks {
+				logMessage := message.NewMessage(chunk, nil, "", 0)
+				fr.Process(logMessage)
+			}
+			require.Equal(t, lines, gotContent)
+			require.Equal(t, rawLens, gotLens)
+			require.Equal(t, int64(len(lines)), fr.GetFrameCount())
+		}
+	}
+
+	t.Run("no trailing newline", test(
+		[][]byte{[]byte("hello")},
+		[]string{"hello"},
+		[]int{5},
+	))
+
+	t.Run("with trailing newline", test(
+		[][]byte{[]byte("hello\n")},
+		[]string{"hello"},
+		[]int{6},
+	))
+
+	t.Run("multiple lines with trailing newline", test(
+		[][]byte{[]byte("line1\nline2\n")},
+		[]string{"line1", "line2"},
+		[]int{6, 6},
+	))
+
+	t.Run("multiple lines without trailing newline", test(
+		[][]byte{[]byte("line1\nline2")},
+		[]string{"line1", "line2"},
+		[]int{6, 5},
+	))
+
+	t.Run("empty datagram", test(
+		[][]byte{[]byte("")},
+		[]string{},
+		[]int{},
+	))
+
+	t.Run("just a newline", test(
+		[][]byte{[]byte("\n")},
+		[]string{""},
+		[]int{1},
+	))
+
+	t.Run("two datagrams in sequence", test(
+		[][]byte{[]byte("first"), []byte("second")},
+		[]string{"first", "second"},
+		[]int{5, 6},
+	))
+
+	t.Run("datagram with mixed newline-terminated and not", test(
+		[][]byte{[]byte("a\nb\nc")},
+		[]string{"a", "b", "c"},
+		[]int{2, 2, 1},
+	))
+
+	t.Run("no cross-datagram buffering", func(t *testing.T) {
+		gotContent := []string{}
+		gotLens := []int{}
+		outputFn := func(msg *message.Message, rawDataLen int) {
+			gotContent = append(gotContent, string(msg.GetContent()))
+			gotLens = append(gotLens, rawDataLen)
+		}
+		fr := NewFramer(outputFn, UTF8NewlineDatagram, contentLenLimit)
+
+		msg1 := message.NewMessage([]byte("partial"), nil, "", 0)
+		fr.Process(msg1)
+		require.Equal(t, []string{"partial"}, gotContent,
+			"first datagram should flush immediately, not buffer")
+
+		msg2 := message.NewMessage([]byte("next"), nil, "", 0)
+		fr.Process(msg2)
+		require.Equal(t, []string{"partial", "next"}, gotContent,
+			"second datagram should be independent, not concatenated with first")
+	})
+}
+
+func TestFlush(t *testing.T) {
+	t.Run("UTF8Newline/partial line not emitted", func(t *testing.T) {
+		gotContent := []string{}
+		outputFn := func(msg *message.Message, _ int) {
+			gotContent = append(gotContent, string(msg.GetContent()))
+		}
+		fr := NewFramer(outputFn, UTF8Newline, contentLenLimit)
+
+		msg := message.NewMessage([]byte("no newline here"), nil, "", 0)
+		fr.Process(msg)
+		require.Empty(t, gotContent)
+
+		fr.Flush()
+		require.Empty(t, gotContent, "UTF8Newline should not flush partial lines")
+	})
+
+	t.Run("NoFraming/always drained so Flush is no-op", func(t *testing.T) {
+		gotContent := []string{}
+		outputFn := func(msg *message.Message, _ int) {
+			gotContent = append(gotContent, string(msg.GetContent()))
+		}
+		fr := NewFramer(outputFn, NoFraming, contentLenLimit)
+
+		msg := message.NewMessage([]byte("already framed"), nil, "", 0)
+		fr.Process(msg)
+		require.Equal(t, []string{"already framed"}, gotContent)
+
+		fr.Flush()
+		require.Len(t, gotContent, 1, "NoFraming buffer is always empty after Process")
+	})
+
+	t.Run("Flush before any Process is no-op", func(t *testing.T) {
+		gotContent := []string{}
+		outputFn := func(msg *message.Message, _ int) {
+			gotContent = append(gotContent, string(msg.GetContent()))
+		}
+		fr := NewFramer(outputFn, UTF8Newline, contentLenLimit)
+		fr.Flush()
+		require.Empty(t, gotContent, "Flush with no prior Process should be safe no-op")
+	})
+}
+
 func TestStructuredContent(t *testing.T) {
 	// structured log messages must not be processed by the framer
 	outputFn, outputChan := framerOutput()

--- a/pkg/logs/internal/framer/matcher.go
+++ b/pkg/logs/internal/framer/matcher.go
@@ -15,4 +15,9 @@ type FrameMatcher interface {
 	// The `seen` argument is the length of `buf` last time this function was called,
 	// and can be used to avoid repeating work when looking for a frame terminator.
 	FindFrame(buf []byte, seen int) (content []byte, rawDataLen int, wasTruncated bool)
+
+	// FlushFrame is called at end-of-stream with any unframed remainder in buf.
+	// If the remainder represents a valid frame that should be emitted, return
+	// the content and raw byte length. Return nil, 0 to discard the remainder.
+	FlushFrame(buf []byte) (content []byte, rawDataLen int)
 }

--- a/pkg/logs/internal/framer/no_framing.go
+++ b/pkg/logs/internal/framer/no_framing.go
@@ -8,6 +8,10 @@ package framer
 // noFramingMatcher considers the given bytes as already framed.
 type noFramingMatcher struct{}
 
+// FlushFrame implements FrameMatcher. No-framing already emits everything
+// in FindFrame, so there is no remainder to flush.
+func (m *noFramingMatcher) FlushFrame([]byte) ([]byte, int) { return nil, 0 }
+
 // FindFrame considers the given bytes buffer as one full frame.
 func (m *noFramingMatcher) FindFrame(buf []byte, _ int) ([]byte, int, bool) {
 	return buf, len(buf), false

--- a/pkg/logs/internal/framer/onebyte.go
+++ b/pkg/logs/internal/framer/onebyte.go
@@ -17,6 +17,10 @@ type oneByteNewLineMatcher struct {
 	contentLenLimit int
 }
 
+// FlushFrame implements FrameMatcher. Partial newline-delimited lines are
+// not emitted at end-of-stream.
+func (ob *oneByteNewLineMatcher) FlushFrame([]byte) ([]byte, int) { return nil, 0 }
+
 // FindFrame implements FrameMatcher#FindFrame.
 func (ob *oneByteNewLineMatcher) FindFrame(buf []byte, seen int) ([]byte, int, bool) {
 	nl := bytes.IndexByte(buf[seen:], '\n')

--- a/pkg/logs/internal/framer/twobyte.go
+++ b/pkg/logs/internal/framer/twobyte.go
@@ -29,6 +29,10 @@ type twoByteNewLineMatcher struct {
 	newline []byte
 }
 
+// FlushFrame implements FrameMatcher. Partial newline-delimited lines are
+// not emitted at end-of-stream.
+func (tb *twoByteNewLineMatcher) FlushFrame([]byte) ([]byte, int) { return nil, 0 }
+
 // FindFrame implements FrameMatcher#FindFrame.
 func (tb *twoByteNewLineMatcher) FindFrame(buf []byte, seen int) ([]byte, int, bool) {
 	var nl int

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -9,6 +9,8 @@ package message
 import (
 	"encoding/json"
 	"errors"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
@@ -142,6 +144,58 @@ const (
 	StateEncoded
 )
 
+// HasContent reports whether the message carries meaningful data.
+// For structured messages, content lives in metadata fields (e.g. "siem",
+// "journald"), so the message has content even when the "message" key is empty.
+// For unstructured messages, content is present only when the raw bytes are
+// non-empty.
+func (m *MessageContent) HasContent() bool {
+	if m.State == StateStructured {
+		return m.structuredContent != nil
+	}
+	return len(m.content) > 0
+}
+
+// GetStructuredAttribute retrieves a dot-delimited attribute from structured
+// content. For example, "siem.device_vendor" walks Data["siem"] ->
+// map["device_vendor"]. Returns the string value and true if found.
+// Non-string leaf types (int, float64, bool) are converted via strconv.
+func (m *MessageContent) GetStructuredAttribute(path string) (string, bool) {
+	if m.State != StateStructured {
+		return "", false
+	}
+	bsc, ok := m.structuredContent.(*BasicStructuredContent)
+	if !ok || bsc == nil {
+		return "", false
+	}
+
+	parts := strings.Split(path, ".")
+	var current interface{} = bsc.Data
+	for _, key := range parts {
+		obj, ok := current.(map[string]interface{})
+		if !ok {
+			return "", false
+		}
+		current, ok = obj[key]
+		if !ok {
+			return "", false
+		}
+	}
+
+	switch v := current.(type) {
+	case string:
+		return v, true
+	case int:
+		return strconv.Itoa(v), true
+	case float64:
+		return strconv.FormatFloat(v, 'g', -1, 64), true
+	case bool:
+		return strconv.FormatBool(v), true
+	default:
+		return "", false
+	}
+}
+
 // GetContent returns the bytes array containing only the message content
 // E.g. from a structured log:
 //
@@ -207,6 +261,14 @@ type ParsingExtra struct {
 	IsMultiLine bool
 	IsMRFAllow  bool
 	Tags        []string
+	// SourceOverride, if non-empty, is applied to the message origin's source
+	// by the tailer after origin creation. Used by parsers (e.g. syslog) that
+	// run before the origin exists.
+	SourceOverride string
+	// ServiceOverride, if non-empty, is applied to the message origin's service
+	// by the tailer after origin creation. Used by parsers (e.g. syslog) that
+	// run before the origin exists.
+	ServiceOverride string
 }
 
 // ServerlessExtra ships extra information from logs processing in serverless envs.

--- a/pkg/logs/message/message_test.go
+++ b/pkg/logs/message/message_test.go
@@ -25,6 +25,126 @@ func TestMessage(t *testing.T) {
 	assert.Equal(t, StatusInfo, message.GetStatus())
 }
 
+func TestHasContent(t *testing.T) {
+	t.Run("unstructured with content", func(t *testing.T) {
+		msg := NewMessage([]byte("hello"), nil, "", 0)
+		assert.True(t, msg.HasContent())
+	})
+
+	t.Run("unstructured empty", func(t *testing.T) {
+		msg := NewMessage([]byte{}, nil, "", 0)
+		assert.False(t, msg.HasContent())
+	})
+
+	t.Run("structured with message", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{"message": "hello"}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		assert.True(t, msg.HasContent())
+	})
+
+	t.Run("structured with empty message", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{"message": "", "siem": map[string]interface{}{"format": "CEF"}}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		assert.True(t, msg.HasContent())
+	})
+
+	t.Run("structured nil content", func(t *testing.T) {
+		msg := &Message{MessageContent: MessageContent{State: StateStructured, structuredContent: nil}}
+		assert.False(t, msg.HasContent())
+	})
+
+	t.Run("rendered with content", func(t *testing.T) {
+		msg := NewMessage([]byte("hello"), nil, "", 0)
+		msg.SetRendered([]byte(`{"message":"hello"}`))
+		assert.True(t, msg.HasContent())
+	})
+
+	t.Run("rendered empty", func(t *testing.T) {
+		msg := NewMessage(nil, nil, "", 0)
+		msg.SetRendered([]byte{})
+		assert.False(t, msg.HasContent())
+	})
+}
+
+func TestGetStructuredAttribute(t *testing.T) {
+	t.Run("top-level string", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{"message": "hello"}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		val, ok := msg.GetStructuredAttribute("message")
+		assert.True(t, ok)
+		assert.Equal(t, "hello", val)
+	})
+
+	t.Run("nested dot path", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{
+			"siem": map[string]interface{}{
+				"device_vendor": "Security",
+			},
+		}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		val, ok := msg.GetStructuredAttribute("siem.device_vendor")
+		assert.True(t, ok)
+		assert.Equal(t, "Security", val)
+	})
+
+	t.Run("deeply nested", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{
+			"a": map[string]interface{}{
+				"b": map[string]interface{}{
+					"c": "deep",
+				},
+			},
+		}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		val, ok := msg.GetStructuredAttribute("a.b.c")
+		assert.True(t, ok)
+		assert.Equal(t, "deep", val)
+	})
+
+	t.Run("numeric leaf", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{
+			"count": float64(42),
+		}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		val, ok := msg.GetStructuredAttribute("count")
+		assert.True(t, ok)
+		assert.Equal(t, "42", val)
+	})
+
+	t.Run("missing key returns false", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{"message": "hello"}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		_, ok := msg.GetStructuredAttribute("nonexistent")
+		assert.False(t, ok)
+	})
+
+	t.Run("missing nested key returns false", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{
+			"siem": map[string]interface{}{},
+		}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		_, ok := msg.GetStructuredAttribute("siem.device_vendor")
+		assert.False(t, ok)
+	})
+
+	t.Run("unstructured message returns false", func(t *testing.T) {
+		msg := NewMessage([]byte("hello"), nil, "", 0)
+		_, ok := msg.GetStructuredAttribute("message")
+		assert.False(t, ok)
+	})
+
+	t.Run("map leaf returns false", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{
+			"siem": map[string]interface{}{
+				"nested": map[string]interface{}{"a": "b"},
+			},
+		}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		_, ok := msg.GetStructuredAttribute("siem.nested")
+		assert.False(t, ok)
+	})
+}
+
 func TestNewPayload(t *testing.T) {
 	messages := []*Message{
 		NewMessage([]byte("hello"), nil, "", 0),

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -20,11 +20,12 @@ type Origin struct {
 	// FilePath is the concrete path to the file that the message originated from.
 	// This is only populated for file and journald sources. It is used by the
 	// auditor to store the file path when fingerprinting is enabled.
-	FilePath    string
-	Fingerprint *types.Fingerprint
-	service     string
-	source      string
-	tags        []string
+	FilePath     string
+	Fingerprint  *types.Fingerprint
+	service      string
+	source       string
+	mappedSource string
+	tags         []string
 }
 
 // NewOrigin returns a new Origin
@@ -120,11 +121,23 @@ func (o *Origin) SetSource(source string) {
 	o.source = source
 }
 
-// Source returns the source of the configuration if set or the source of the message,
-// if none are defined, returns an empty string by default.
+// SetMappedSource sets a high-priority source override, typically from a
+// remap_attribute_to_source processing rule. It takes precedence over both
+// the config source and the parser-derived source.
+func (o *Origin) SetMappedSource(source string) {
+	o.mappedSource = source
+}
+
+// Source returns the source with the following priority:
+//  1. mappedSource (set by remap_attribute_to_source processing rule)
+//  2. LogSource.Config.Source (user-configured source)
+//  3. o.source (parser-derived, e.g. syslog AppName)
 func (o *Origin) Source() string {
 	if o == nil || o.LogSource == nil {
 		return ""
+	}
+	if o.mappedSource != "" {
+		return o.mappedSource
 	}
 	if o.LogSource.Config.Source != "" {
 		return o.LogSource.Config.Source

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -100,6 +100,40 @@ func TestDefaultSourceValueIsSourceFromConfig(t *testing.T) {
 	assert.Equal(t, "bar", origin.Source())
 }
 
+func TestMappedSourceTakesPriority(t *testing.T) {
+	t.Run("mapped overrides config source", func(t *testing.T) {
+		cfg := &config.LogsConfig{Source: "config_source"}
+		source := sources.NewLogSource("", cfg)
+		origin := NewOrigin(source)
+		origin.SetMappedSource("mapped_source")
+		assert.Equal(t, "mapped_source", origin.Source())
+	})
+
+	t.Run("mapped overrides parser source", func(t *testing.T) {
+		cfg := &config.LogsConfig{}
+		source := sources.NewLogSource("", cfg)
+		origin := NewOrigin(source)
+		origin.SetSource("parser_source")
+		origin.SetMappedSource("mapped_source")
+		assert.Equal(t, "mapped_source", origin.Source())
+	})
+
+	t.Run("config source used when no mapped source", func(t *testing.T) {
+		cfg := &config.LogsConfig{Source: "config_source"}
+		source := sources.NewLogSource("", cfg)
+		origin := NewOrigin(source)
+		assert.Equal(t, "config_source", origin.Source())
+	})
+
+	t.Run("parser source used as final fallback", func(t *testing.T) {
+		cfg := &config.LogsConfig{}
+		source := sources.NewLogSource("", cfg)
+		origin := NewOrigin(source)
+		origin.SetSource("parser_source")
+		assert.Equal(t, "parser_source", origin.Source())
+	})
+}
+
 func TestDefaultServiceValueIsServiceFromConfig(t *testing.T) {
 	var cfg *config.LogsConfig
 	var source *sources.LogSource

--- a/pkg/logs/tailers/container/tailer.go
+++ b/pkg/logs/tailers/container/tailer.go
@@ -416,7 +416,7 @@ func (d *dockerMessageForwarder) forward() {
 		d.tailer.done <- struct{}{}
 	}()
 	for output := range d.tailer.decoder.OutputChan() {
-		if len(output.GetContent()) > 0 {
+		if output.HasContent() {
 			msg := buildMessage(d.tailer, output)
 			d.tailer.outputChan <- msg
 		}
@@ -456,7 +456,7 @@ func (k *kubeletMessageForwarder) forward() {
 		k.tailer.done <- struct{}{}
 	}()
 	for output := range k.tailer.decoder.OutputChan() {
-		if len(output.GetContent()) > 0 {
+		if output.HasContent() {
 			// Because the kubelet API does not support sub-second granularity we run the risk of logging duplicates
 			// we check the timestamp to drop logs that have already been processed
 			logTime, _ := time.Parse(time.RFC3339Nano, output.ParsingExtra.Timestamp)

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -206,6 +206,12 @@ func (t *Tailer) forwardMessages() {
 	}()
 
 	for decodedMessage := range t.decoder.OutputChan() {
+		// This tailer produces StateStructured messages where "message" is
+		// populated from the journal MESSAGE field. Currently, entries without
+		// a MESSAGE field result in an empty "message" and are silently dropped
+		// here -- the structured metadata (unit name, priority, etc.) is
+		// discarded along with it. If that becomes a real concern, replace this
+		// check with decodedMessage.HasContent() (see stream_tailer.go).
 		if len(decodedMessage.GetContent()) > 0 {
 			// Preserve the original message structure and ParsingExtra information (including IsTruncated)
 			// The decodedMessage already has the proper origin with tags set

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -151,6 +151,12 @@ func (t *Tailer) forwardMessages() {
 	}()
 
 	for decodedMessage := range t.decoder.OutputChan() {
+		// This tailer produces StateStructured messages where "message" is
+		// populated from the rendered Windows Event text. Currently, events
+		// with empty rendered text are silently dropped here -- the structured
+		// metadata (Event XML attributes, channel, provider, etc.) is discarded
+		// along with it. If that becomes a real concern, replace this check
+		// with decodedMessage.HasContent() (see stream_tailer.go).
 		if len(decodedMessage.GetContent()) > 0 {
 			// Leverage the existing message instead of creating a new one
 			// This preserves all bookmark information and is more efficient


### PR DESCRIPTION
## Summary

**Part 1 of 6** in the syslog ingestion stack (`syslog-v1` → `syslog-v6`). Each PR targets `main`; use per-commit view for incremental diffs.

Foundation plumbing that downstream branches depend on:

- **Message model**: `HasContent()` for structured-message-aware content checks, `GetStructuredAttribute()` for dot-path attribute lookups, `ParsingExtra.SourceOverride`/`ServiceOverride` fields
- **Origin**: `SetMappedSource()` with priority (mapped > config > parser), `mappedSource` field
- **Framer**: `FlushFrame` added to `FrameMatcher` interface with no-op implementations on all existing matchers, `Flush()` method, `emitFrame()` extraction, `UTF8NewlineDatagram` framing mode
- **Decoder**: `framer.Flush()` call at end-of-stream
- **Container tailer**: `HasContent()` replaces `len(GetContent()) > 0`
- **Journald/WindowsEvent tailers**: documentation comments

## Test plan

- [x] `inv test --targets=./pkg/logs/message` — HasContent, GetStructuredAttribute, MappedSource tests pass
- [x] `inv test --targets=./pkg/logs/internal/framer` — UTF8NewlineDatagram, Flush tests pass
- [x] All existing framer/message tests remain green