### PR TITLE
[ AGNTLOG-599 ] [logs-agent] Syslog v2: Core syslog parser (RFC 3164/5424)

### DIFF
--- a/pkg/logs/internal/parsers/syslog/parser.go
+++ b/pkg/logs/internal/parsers/syslog/parser.go
@@ -51,8 +51,6 @@ func (p *parser) Parse(msg *message.Message) (*message.Message, error) {
 		msgBody = string(content)
 	}
 
-	// TODO: replace BasicStructuredContent with a custom StructuredContent to
-	// avoid per-message map allocations (2 maps + interface{} boxing).
 	sc := &message.BasicStructuredContent{
 		Data: map[string]interface{}{
 			"message": msgBody,

--- a/pkg/logs/internal/parsers/syslog/parser.go
+++ b/pkg/logs/internal/parsers/syslog/parser.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package syslog
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// parser implements parsers.Parser for syslog-formatted input.
+// It converts each newline-framed line into a StateStructured message,
+// preserving all syslog metadata in a BasicStructuredContent.
+//
+// PRI detection is automatic: if a line starts with '<', it is parsed as a
+// network-format syslog message (RFC 5424 or BSD with PRI). Otherwise it is
+// parsed as a plain BSD line without PRI (e.g., traditional /var/log/syslog).
+type parser struct{}
+
+// NewParser returns a parsers.Parser for syslog-formatted input.
+// PRI headers are auto-detected per line; no configuration is needed.
+func NewParser() parsers.Parser {
+	return &parser{}
+}
+
+// Parse implements parsers.Parser. It parses the unstructured line content
+// and returns a new StateStructured message with syslog metadata.
+//
+// Unlike most parsers, Parse always returns a valid *message.Message even when
+// err != nil. On error, the structured message contains the raw content as its
+// "message" field and best-effort syslog metadata. Callers MUST NOT discard
+// the result on error — the message is intentionally usable.
+func (p *parser) Parse(msg *message.Message) (*message.Message, error) {
+	var parsed SyslogMessage
+	var err error
+
+	content := msg.GetContent()
+	if len(content) > 0 && content[0] == '<' {
+		parsed, err = Parse(content)
+	} else {
+		parsed, err = ParseBSDLine(content)
+	}
+
+	// On error, guarantee the original content is preserved even if parsed.Msg
+	// is nil (e.g. empty input). On success, use the parsed Msg body.
+	msgBody := string(parsed.Msg)
+	if err != nil && len(parsed.Msg) == 0 && len(content) > 0 {
+		msgBody = string(content)
+	}
+
+	// TODO: replace BasicStructuredContent with a custom StructuredContent to
+	// avoid per-message map allocations (2 maps + interface{} boxing).
+	sc := &message.BasicStructuredContent{
+		Data: map[string]interface{}{
+			"message": msgBody,
+			"syslog":  BuildSyslogFields(&parsed),
+		},
+	}
+
+	structured := message.NewStructuredMessage(
+		sc,
+		msg.Origin,
+		SeverityToStatus(parsed.Pri),
+		msg.IngestionTimestamp,
+	)
+	structured.RawDataLen = msg.RawDataLen
+	structured.ParsingExtra = msg.ParsingExtra
+	structured.ParsingExtra.Timestamp = parsed.Timestamp
+
+	if parsed.AppName != "" && parsed.AppName != nilvalue {
+		structured.ParsingExtra.SourceOverride = parsed.AppName
+		structured.ParsingExtra.ServiceOverride = parsed.AppName
+	}
+
+	return structured, err
+}
+
+// SupportsPartialLine implements parsers.Parser. Syslog lines are always
+// complete (one message per line), so partial line support is not needed.
+func (p *parser) SupportsPartialLine() bool {
+	return false
+}

--- a/pkg/logs/internal/parsers/syslog/parser.go
+++ b/pkg/logs/internal/parsers/syslog/parser.go
@@ -43,10 +43,11 @@ func (p *parser) Parse(msg *message.Message) (*message.Message, error) {
 		parsed, err = ParseBSDLine(content)
 	}
 
-	// On error, guarantee the original content is preserved even if parsed.Msg
-	// is nil (e.g. empty input). On success, use the parsed Msg body.
+	// On error, always preserve the full original content so malformed lines
+	// are reconstructable from output. parsed.Msg may be a truncated fragment
+	// (e.g. line[pos:] after a PRI header) which would silently drop the prefix.
 	msgBody := string(parsed.Msg)
-	if err != nil && len(parsed.Msg) == 0 && len(content) > 0 {
+	if err != nil {
 		msgBody = string(content)
 	}
 

--- a/pkg/logs/internal/parsers/syslog/parser_test.go
+++ b/pkg/logs/internal/parsers/syslog/parser_test.go
@@ -1,0 +1,211 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package syslog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+)
+
+func newTestMessage(content []byte) *message.Message {
+	source := sources.NewLogSource("test", &config.LogsConfig{})
+	origin := message.NewOrigin(source)
+	msg := message.NewMessage(content, origin, "", time.Now().UnixNano())
+	msg.RawDataLen = len(content)
+	return msg
+}
+
+func TestSyslogParser_NetworkFormat_RFC5424(t *testing.T) {
+	parser := NewParser()
+
+	input := newTestMessage([]byte(`<165>1 2003-10-11T22:14:15.003Z mymachine evntslog - ID47 [exampleSDID@32473 iut="3"] An application event log entry`))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	// StateStructured
+	assert.Equal(t, message.StateStructured, result.State)
+
+	// Content is the MSG body
+	assert.Equal(t, "An application event log entry", string(result.GetContent()))
+
+	// Status from severity
+	assert.Equal(t, message.StatusNotice, result.Status)
+
+	// Appname stored as source/service override in ParsingExtra
+	assert.Equal(t, "evntslog", result.ParsingExtra.SourceOverride)
+	assert.Equal(t, "evntslog", result.ParsingExtra.ServiceOverride)
+
+	// RawDataLen preserved
+	assert.Equal(t, len(input.GetContent()), result.RawDataLen)
+
+	// Timestamp extracted
+	assert.Equal(t, "2003-10-11T22:14:15.003Z", result.ParsingExtra.Timestamp)
+}
+
+func TestSyslogParser_NetworkFormat_BSD(t *testing.T) {
+	parser := NewParser()
+
+	input := newTestMessage([]byte(`<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8`))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, message.StateStructured, result.State)
+	assert.Equal(t, message.StatusCritical, result.Status)
+
+	// Appname stored as source/service override in ParsingExtra
+	assert.Equal(t, "su", result.ParsingExtra.SourceOverride)
+	assert.Equal(t, "su", result.ParsingExtra.ServiceOverride)
+}
+
+func TestSyslogParser_BSDLineFormat(t *testing.T) {
+	parser := NewParser()
+
+	// BSD line without PRI: "Oct 11 22:14:15 mymachine su: message"
+	input := newTestMessage([]byte(`Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8`))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, message.StateStructured, result.State)
+
+	// No PRI -> StatusInfo
+	assert.Equal(t, message.StatusInfo, result.Status)
+
+	// Appname stored as source/service override in ParsingExtra
+	assert.Equal(t, "su", result.ParsingExtra.SourceOverride)
+	assert.Equal(t, "su", result.ParsingExtra.ServiceOverride)
+}
+
+func TestSyslogParser_AppNameNILVALUE(t *testing.T) {
+	parser := NewParser()
+
+	input := newTestMessage([]byte(`<14>1 2003-10-11T22:14:15.003Z mymachine - - - - test message`))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+	assert.Equal(t, message.StateStructured, result.State)
+
+	// NILVALUE appname should not set override
+	assert.Equal(t, "", result.ParsingExtra.SourceOverride)
+	assert.Equal(t, "", result.ParsingExtra.ServiceOverride)
+}
+
+func TestSyslogParser_Malformed(t *testing.T) {
+	parser := NewParser()
+
+	input := newTestMessage([]byte(`<14>`))
+	result, err := parser.Parse(input)
+
+	// Should return error but still produce a message with raw content preserved
+	assert.Error(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, message.StateStructured, result.State)
+	assert.Equal(t, "<14>", string(result.GetContent()))
+}
+
+func TestSyslogParser_SupportsPartialLine(t *testing.T) {
+	parser := NewParser()
+	assert.False(t, parser.SupportsPartialLine())
+}
+
+func TestSyslogParser_AutoDetect_MixedFormats(t *testing.T) {
+	// A single parser instance should auto-detect PRI vs non-PRI per line.
+	parser := NewParser()
+
+	// Line with PRI (network format)
+	priInput := newTestMessage([]byte(`<14>1 2003-10-11T22:14:15.003Z myhost myapp - - - PRI message`))
+	priResult, err := parser.Parse(priInput)
+	require.NoError(t, err)
+	assert.Equal(t, message.StateStructured, priResult.State)
+	assert.Equal(t, "PRI message", string(priResult.GetContent()))
+	assert.Equal(t, message.StatusInfo, priResult.Status) // 14%8=6 -> info
+
+	// Line without PRI (BSD on-disk format)
+	bsdInput := newTestMessage([]byte(`Oct 11 22:14:15 myhost su: BSD message`))
+	bsdResult, err := parser.Parse(bsdInput)
+	require.NoError(t, err)
+	assert.Equal(t, message.StateStructured, bsdResult.State)
+	assert.Equal(t, "BSD message", string(bsdResult.GetContent()))
+	assert.Equal(t, message.StatusInfo, bsdResult.Status) // no PRI -> -1 -> info
+
+	// Another PRI line to confirm no state lock-in
+	pri2Input := newTestMessage([]byte(`<11>1 2003-10-11T22:14:16.003Z myhost otherapp - - - Second PRI`))
+	pri2Result, err := parser.Parse(pri2Input)
+	require.NoError(t, err)
+	assert.Equal(t, "Second PRI", string(pri2Result.GetContent()))
+	assert.Equal(t, message.StatusError, pri2Result.Status) // 11%8=3 -> error
+}
+
+func TestSyslogParser_NonSyslogText(t *testing.T) {
+	parser := NewParser()
+
+	lines := []string{
+		"this is not syslog at all",
+		"ERROR 2025-01-15 connection refused",
+		"12345 plain numeric line",
+		`{"json":"log","level":"warn"}`,
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			input := newTestMessage([]byte(line))
+			result, err := parser.Parse(input)
+
+			// Parser returns an error but still produces a usable message.
+			assert.Error(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, message.StateStructured, result.State)
+
+			// Status falls back to info (Pri=-1 → no severity).
+			assert.Equal(t, message.StatusInfo, result.Status)
+
+			// The entire input is preserved as the structured message body.
+			assert.Equal(t, line, string(result.GetContent()))
+
+			rendered, rerr := result.Render()
+			require.NoError(t, rerr)
+			assert.Contains(t, string(rendered), `"message"`)
+			assert.Contains(t, string(rendered), `"syslog"`)
+
+			// Syslog metadata is sparse — no source/service override.
+			assert.Empty(t, result.ParsingExtra.SourceOverride)
+			assert.Empty(t, result.ParsingExtra.ServiceOverride)
+		})
+	}
+}
+
+func TestSyslogParser_RenderedContent_RFC5424(t *testing.T) {
+	parser := NewParser()
+
+	input := newTestMessage([]byte(`<165>1 2003-10-11T22:14:15.003Z mymachine evntslog - ID47 [exampleSDID@32473 iut="3"] An application event log entry`))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	// Render should produce valid JSON with message and syslog fields
+	rendered, err := result.Render()
+	require.NoError(t, err)
+	assert.Contains(t, string(rendered), `"message"`)
+	assert.Contains(t, string(rendered), `"syslog"`)
+	assert.Contains(t, string(rendered), `"An application event log entry"`)
+}
+
+func TestSyslogParser_IngestionTimestampPreserved(t *testing.T) {
+	parser := NewParser()
+	ts := int64(1234567890)
+
+	source := sources.NewLogSource("test", &config.LogsConfig{})
+	origin := message.NewOrigin(source)
+	msg := message.NewMessage([]byte(`<14>1 2003-10-11T22:14:15.003Z myhost myapp - - - test`), origin, "", ts)
+
+	result, err := parser.Parse(msg)
+	require.NoError(t, err)
+	assert.Equal(t, ts, result.IngestionTimestamp)
+}

--- a/pkg/logs/internal/parsers/syslog/syslog.go
+++ b/pkg/logs/internal/parsers/syslog/syslog.go
@@ -74,9 +74,9 @@ const nilvalue = "-"
 
 // RFC 5424 §6.3: PRINTUSASCII range and max name length for SD-ID / PARAM-NAME.
 const (
-	printUSASCIIMin = 33 // '!' — lower bound of PRINTUSASCII (%d33-126)
+	printUSASCIIMin = 33  // '!' — lower bound of PRINTUSASCII (%d33-126)
 	printUSASCIIMax = 126 // '~' — upper bound of PRINTUSASCII
-	maxSDNameLen    = 32 // max length for SD-ID and PARAM-NAME
+	maxSDNameLen    = 32  // max length for SD-ID and PARAM-NAME
 )
 
 // SyslogMessage is a parsed syslog message (RFC 5424 or RFC 3164/BSD).

--- a/pkg/logs/internal/parsers/syslog/syslog.go
+++ b/pkg/logs/internal/parsers/syslog/syslog.go
@@ -1,0 +1,772 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package syslog parses RFC 5424 and RFC 3164 (BSD) syslog messages.
+//
+// Two public entry points:
+//
+//   - Parse(line) for network input (with PRI, auto-detects RFC 5424 vs BSD)
+//   - ParseBSDLine(line) for on-disk log files (no PRI, e.g. /var/log/syslog)
+//
+// Best-effort: on malformed input the parser extracts as many fields as
+// possible and returns a partial SyslogMessage (Partial=true) alongside the error.
+// Fatal errors (empty input, no PRI) return Pri=-1 and the raw content in Msg.
+//
+// The parser is allocation-light: it returns SyslogMessage by value (no heap
+// escape) and string fields are standard Go strings (independent copies of the
+// input). The Msg field ([]byte) aliases the input buffer for zero-copy
+// performance; callers that need to retain Msg after reusing the input buffer
+// must copy it. All other (string) fields are safe to hold indefinitely.
+package syslog
+
+import (
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// Pre-allocated sentinel errors — avoids fmt.Errorf allocations on error paths.
+var (
+	errEmpty          = errors.New("empty message")
+	errNoPRIClose     = errors.New("invalid PRI: no '>' found")
+	errMissingSD      = errors.New("missing STRUCTURED-DATA")
+	errHeaderTooShort = errors.New("header too short: need 5 SPs after VERSION")
+
+	errPRIFormat   = errors.New("invalid PRI: must be <1-3 digits>")
+	errPRINonDigit = errors.New("invalid PRI: non-digit in PRIVAL")
+	errPRIRange    = errors.New("invalid PRI: PRIVAL > 191")
+
+	errVersionEmpty = errors.New("invalid VERSION: empty")
+	errVersionStart = errors.New("invalid VERSION: must start with nonzero digit")
+	errVersionLen   = errors.New("invalid VERSION: max 3 digits")
+	errVersionDigit = errors.New("invalid VERSION: non-digit")
+
+	errTruncatedAfterPRI = errors.New("truncated message: nothing after PRI")
+	errNoSPAfterVersion  = errors.New("header too short: no SP after VERSION")
+
+	errSDEmpty        = errors.New("structured data: empty")
+	errSDExpected     = errors.New("structured data: expected '-' or '['")
+	errSDElemOpen     = errors.New("SD-ELEMENT: expected '['")
+	errSDIDInvalid    = errors.New("SD-ELEMENT: invalid character in SD-ID")
+	errSDIDTooLong    = errors.New("SD-ELEMENT: SD-ID too long")
+	errSDIDRequired   = errors.New("SD-ELEMENT: SD-ID required after '['")
+	errSDElemExpect   = errors.New("SD-ELEMENT: expected SP or ']'")
+	errSDElemUnclosed = errors.New("SD-ELEMENT: unclosed '['")
+
+	errSDParamEmpty    = errors.New("SD-PARAM: empty")
+	errSDParamNameBad  = errors.New("SD-PARAM: invalid in PARAM-NAME")
+	errSDParamNameLong = errors.New("SD-PARAM: PARAM-NAME too long")
+	errSDParamNoEq     = errors.New("SD-PARAM: expected '=' after PARAM-NAME")
+	errSDParamNoQuote  = errors.New("SD-PARAM: expected '\"' after '='")
+	errSDParamTrailBS  = errors.New("SD-PARAM: backslash at end of value")
+	errSDParamUnclosed = errors.New("SD-PARAM: unclosed '\"'")
+
+	// BSD-specific errors
+	errBSDTimestamp  = errors.New("BSD: invalid timestamp format")
+	errBSDMonth      = errors.New("BSD: unrecognized month abbreviation")
+	errBSDHostname   = errors.New("BSD: missing hostname")
+	errUnknownFormat = errors.New("unknown format: expected digit (RFC 5424) or letter (BSD) after PRI")
+)
+
+const nilvalue = "-"
+
+// SyslogMessage is a parsed syslog message (RFC 5424 or RFC 3164/BSD).
+//
+// String fields are independent copies of the input. The Msg field aliases
+// the input buffer; callers must copy it before reusing the input.
+type SyslogMessage struct {
+	Pri       int    // PRIVAL 0-191 (Facility*8 + Severity); -1 if absent (file input)
+	Version   string // VERSION (e.g. "1") for RFC 5424; "" for BSD
+	Timestamp string // TIMESTAMP or "-"
+	Hostname  string // HOSTNAME or "-"
+	AppName   string // APP-NAME or "-"
+	ProcID    string // PROCID or "-"
+	MsgID     string // MSGID or "-"
+
+	// StructuredData is the parsed STRUCTURED-DATA as a nested map.
+	// Outer key is the SD-ID, inner map is PARAM-NAME to PARAM-VALUE.
+	// nil for BSD messages and NILVALUE ("-").
+	StructuredData map[string]map[string]string
+
+	// Msg is the message body (MSG for RFC 5424, CONTENT for BSD)
+	// after stripping optional UTF-8 BOM (RFC 5424 only).
+	Msg []byte
+
+	// Partial is true when the parser recovered from malformed input.
+	// Some fields may be populated while others remain at defaults.
+	Partial bool
+}
+
+// toHeaderString converts a header field byte slice to a string.
+// Returns the nilvalue constant for "-" to avoid allocation.
+func toHeaderString(b []byte) string {
+	if len(b) == 1 && b[0] == '-' {
+		return nilvalue
+	}
+	return string(b)
+}
+
+// Parse parses a single syslog message from network input (TCP or UDP).
+// The message MUST have a PRI header (<digits>). After parsing PRI, the
+// format is auto-detected:
+//
+//   - Digit after '>' → RFC 5424
+//   - Letter after '>' → BSD (RFC 3164)
+//
+// Returns SyslogMessage by value for zero heap allocation on the happy path.
+// On malformed input, returns a partial SyslogMessage (Partial=true) with as many
+// fields populated as possible, alongside a non-nil error.
+func Parse(line []byte) (SyslogMessage, error) {
+	if len(line) == 0 {
+		return SyslogMessage{Pri: -1}, errEmpty
+	}
+
+	// --- Extract PRI (find '>') ---
+	// PRI is at most 5 chars: '<' + 3 digits + '>'. Cap scan at 5.
+	gtPos := -1
+	limit := len(line)
+	if limit > 5 {
+		limit = 5
+	}
+	for i := 0; i < limit; i++ {
+		if line[i] == '>' {
+			gtPos = i
+			break
+		}
+	}
+	if gtPos < 0 {
+		return SyslogMessage{Pri: -1, Msg: line, Partial: true}, errNoPRIClose
+	}
+
+	// --- Validate PRI ---
+	if gtPos < 2 || line[0] != '<' {
+		return SyslogMessage{Pri: -1, Msg: line, Partial: true}, errPRIFormat
+	}
+	pri := 0
+	for i := 1; i < gtPos; i++ {
+		d := line[i]
+		if d < '0' || d > '9' {
+			return SyslogMessage{Pri: -1, Msg: line, Partial: true}, errPRINonDigit
+		}
+		pri = pri*10 + int(d-'0')
+	}
+
+	// Best-effort: accept PRI > 191 but remember the error.
+	var priErr error
+	if pri > 191 {
+		priErr = errPRIRange
+	}
+
+	// --- Dispatch based on byte after '>' ---
+	pos := gtPos + 1
+	if pos >= len(line) {
+		return SyslogMessage{Pri: pri, Msg: line, Partial: true}, errTruncatedAfterPRI
+	}
+
+	var msg SyslogMessage
+	var err error
+
+	b := line[pos]
+	switch {
+	case b >= '0' && b <= '9':
+		msg, err = parseRFC5424(line, pri, pos)
+	case (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z'):
+		msg, err = parseBSD(line, pri, pos)
+	default:
+		return SyslogMessage{Pri: pri, Msg: line, Partial: true}, errUnknownFormat
+	}
+
+	// Apply PRI range warning — join with any downstream error so neither is lost.
+	if priErr != nil {
+		msg.Partial = true
+		err = errors.Join(priErr, err)
+	}
+
+	return msg, err
+}
+
+// ParseBSDLine parses a single BSD syslog line from an on-disk log file
+// (e.g. /var/log/syslog). The message has no PRI header; Pri is set to -1.
+//
+// Returns SyslogMessage by value. On malformed input, returns a partial SyslogMessage
+// (Partial=true) alongside a non-nil error.
+func ParseBSDLine(line []byte) (SyslogMessage, error) {
+	if len(line) == 0 {
+		return SyslogMessage{Pri: -1}, errEmpty
+	}
+	return parseBSD(line, -1, 0)
+}
+
+// ---------------------------------------------------------------------------
+// RFC 5424 parsing
+// ---------------------------------------------------------------------------
+
+// parseRFC5424 parses an RFC 5424 message starting at line[pos] (the VERSION
+// field). PRI has already been extracted.
+//
+// Best-effort: on incomplete headers or malformed SD, populates as many fields
+// as possible, sets Partial=true, and returns the error.
+func parseRFC5424(line []byte, pri int, pos int) (SyslogMessage, error) {
+	// --- VERSION: from pos to first SP ---
+	sp := pos
+	for sp < len(line) && line[sp] != ' ' {
+		sp++
+	}
+	if sp >= len(line) {
+		return SyslogMessage{Pri: pri, Msg: line[pos:], Partial: true}, errNoSPAfterVersion
+	}
+	verRaw := line[pos:sp]
+
+	// Validate VERSION: NONZERO-DIGIT 0*2DIGIT
+	if len(verRaw) == 0 {
+		return SyslogMessage{Pri: pri, Msg: line[pos:], Partial: true}, errVersionEmpty
+	}
+	if verRaw[0] < '1' || verRaw[0] > '9' {
+		return SyslogMessage{Pri: pri, Msg: line[pos:], Partial: true}, errVersionStart
+	}
+	if len(verRaw) > 3 {
+		return SyslogMessage{Pri: pri, Msg: line[pos:], Partial: true}, errVersionLen
+	}
+	for i := 1; i < len(verRaw); i++ {
+		if verRaw[i] < '0' || verRaw[i] > '9' {
+			return SyslogMessage{Pri: pri, Msg: line[pos:], Partial: true}, errVersionDigit
+		}
+	}
+
+	// --- Find SPs after VERSION to delimit header fields ---
+	// Fields: TIMESTAMP SP HOSTNAME SP APP-NAME SP PROCID SP MSGID SP ...
+	//
+	// NOTE: This uses a simple space-counting heuristic. It works because
+	// RFC 5424 HEADER fields are single tokens (no embedded spaces), but it
+	// will mis-parse non-conformant TIMESTAMP values that contain extra spaces.
+	// This is an intentional performance trade-off vs. regex or field-by-field parsing.
+	var spPos [5]int
+	found := 0
+	for i := sp + 1; i < len(line); i++ {
+		if line[i] == ' ' {
+			spPos[found] = i
+			found++
+			if found == 5 {
+				break
+			}
+		}
+	}
+
+	// Build message with defaults for all fields.
+	msg := SyslogMessage{
+		Pri:       pri,
+		Version:   toHeaderString(verRaw),
+		Timestamp: nilvalue,
+		Hostname:  nilvalue,
+		AppName:   nilvalue,
+		ProcID:    nilvalue,
+		MsgID:     nilvalue,
+	}
+
+	// --- Best-effort: extract available header fields in order ---
+
+	if found < 1 {
+		// Only VERSION; remainder is MSG.
+		if sp+1 < len(line) {
+			msg.Msg = line[sp+1:]
+		}
+		msg.Partial = true
+		return msg, errHeaderTooShort
+	}
+	msg.Timestamp = toHeaderString(line[sp+1 : spPos[0]])
+
+	if found < 2 {
+		if spPos[0]+1 < len(line) {
+			msg.Msg = line[spPos[0]+1:]
+		}
+		msg.Partial = true
+		return msg, errHeaderTooShort
+	}
+	msg.Hostname = toHeaderString(line[spPos[0]+1 : spPos[1]])
+
+	if found < 3 {
+		if spPos[1]+1 < len(line) {
+			msg.Msg = line[spPos[1]+1:]
+		}
+		msg.Partial = true
+		return msg, errHeaderTooShort
+	}
+	msg.AppName = toHeaderString(line[spPos[1]+1 : spPos[2]])
+
+	if found < 4 {
+		if spPos[2]+1 < len(line) {
+			msg.Msg = line[spPos[2]+1:]
+		}
+		msg.Partial = true
+		return msg, errHeaderTooShort
+	}
+	msg.ProcID = toHeaderString(line[spPos[2]+1 : spPos[3]])
+
+	if found < 5 {
+		if spPos[3]+1 < len(line) {
+			msg.Msg = line[spPos[3]+1:]
+		}
+		msg.Partial = true
+		return msg, errHeaderTooShort
+	}
+	msg.MsgID = toHeaderString(line[spPos[3]+1 : spPos[4]])
+
+	// --- Parse STRUCTURED-DATA ---
+	rest := line[spPos[4]+1:]
+	if len(rest) == 0 {
+		msg.Partial = true
+		return msg, errMissingSD
+	}
+
+	sd, sdLen, sdErr := parseStructuredData(rest)
+	if sdErr != nil {
+		msg.StructuredData = sd // preserve any successfully-parsed SD elements
+		msg.Msg = rest[sdLen:]  // remainder after last successful parse
+		msg.Partial = true
+		return msg, sdErr
+	}
+	msg.StructuredData = sd
+
+	// --- Optional [SP MSG] ---
+	if sdLen < len(rest) && rest[sdLen] == ' ' {
+		rawMsg := rest[sdLen+1:]
+		msg.Msg = stripBOM(rawMsg)
+	}
+
+	return msg, nil
+}
+
+// ---------------------------------------------------------------------------
+// BSD (RFC 3164) parsing
+// ---------------------------------------------------------------------------
+
+// parseBSD parses a BSD syslog message starting at line[pos]. PRI has already
+// been extracted (pri=-1 for file input where PRI is absent).
+//
+// Best-effort: extracts TIMESTAMP, HOSTNAME, TAG (APP-NAME + PROCID), and
+// CONTENT (MSG) in order. On failure at any step, remaining fields get
+// defaults and unparsed data goes into Msg.
+func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
+	msg := SyslogMessage{
+		Pri:       pri,
+		Timestamp: nilvalue,
+		Hostname:  nilvalue,
+		AppName:   nilvalue,
+		ProcID:    nilvalue,
+		MsgID:     nilvalue,
+	}
+
+	// --- TIMESTAMP: exactly 15 bytes ---
+	// Format: Mmm dd hh:mm:ss  (or Mmm  d hh:mm:ss for single-digit day)
+	if pos+15 > len(line) {
+		if pos < len(line) {
+			msg.Msg = line[pos:]
+		}
+		msg.Partial = true
+		return msg, errBSDTimestamp
+	}
+
+	tsRaw := line[pos : pos+15]
+	if !isValidBSDTimestamp(tsRaw) {
+		// Invalid month — stuff everything into MSG.
+		msg.Msg = line[pos:]
+		msg.Partial = true
+		return msg, errBSDMonth
+	}
+	msg.Timestamp = string(tsRaw)
+	pos += 15
+
+	// --- SP + HOSTNAME ---
+	if pos >= len(line) || line[pos] != ' ' {
+		msg.Partial = true
+		return msg, errBSDHostname
+	}
+	pos++ // skip SP
+
+	hostEnd := pos
+	for hostEnd < len(line) && line[hostEnd] != ' ' {
+		hostEnd++
+	}
+	if hostEnd == pos {
+		msg.Partial = true
+		return msg, errBSDHostname
+	}
+	msg.Hostname = string(line[pos:hostEnd])
+
+	if hostEnd >= len(line) {
+		return msg, nil
+	}
+	pos = hostEnd + 1 // skip SP after hostname
+
+	if pos >= len(line) {
+		return msg, nil
+	}
+
+	// --- TAG + CONTENT ---
+	rest := line[pos:]
+	parseBSDTag(&msg, rest)
+	return msg, nil
+}
+
+// parseBSDTag extracts APP-NAME, PROCID, and MSG from the TAG+CONTENT portion
+// of a BSD syslog message. It modifies msg in place.
+//
+// TAG patterns:
+//
+//	appname[pid]: content   → AppName=appname, ProcID=pid, Msg=content
+//	appname: content        → AppName=appname, ProcID="-", Msg=content
+//	appname content         → AppName=appname, ProcID="-", Msg=content
+//	-- MARK --              → AppName="-", Msg="-- MARK --" (non-alpha start)
+//
+// NOTE: RFC 3164 limits TAG to 32 alphanumeric characters, but real-world
+// emitters regularly exceed this. We intentionally accept unbounded TAG lengths
+// for compatibility with common syslog implementations (rsyslog, syslog-ng).
+func parseBSDTag(msg *SyslogMessage, rest []byte) {
+	if len(rest) == 0 {
+		return
+	}
+
+	// TAG must start with an alphanumeric character. If not, the entire
+	// rest is CONTENT (e.g. "-- MARK --").
+	first := rest[0]
+	if !isAlphaNumeric(first) {
+		msg.Msg = rest
+		return
+	}
+
+	// Scan for the first TAG delimiter: '[', ':', or ' '.
+	delimIdx := -1
+	delimChar := byte(0)
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == '[' || rest[i] == ':' || rest[i] == ' ' {
+			delimIdx = i
+			delimChar = rest[i]
+			break
+		}
+	}
+
+	if delimIdx < 0 {
+		// No delimiter — entire rest is APP-NAME with no MSG.
+		msg.AppName = string(rest)
+		return
+	}
+
+	switch delimChar {
+	case '[':
+		// appname[pid]: content
+		msg.AppName = string(rest[:delimIdx])
+
+		// Find closing ']'.
+		closePos := delimIdx + 1
+		for closePos < len(rest) && rest[closePos] != ']' {
+			closePos++
+		}
+		if closePos >= len(rest) {
+			// Unclosed bracket — best effort: rest after APP-NAME is MSG.
+			msg.Msg = rest[delimIdx:]
+			msg.Partial = true
+			return
+		}
+
+		msg.ProcID = string(rest[delimIdx+1 : closePos])
+
+		// Consume optional ':' and SP after ']'.
+		contentStart := closePos + 1
+		if contentStart < len(rest) && rest[contentStart] == ':' {
+			contentStart++
+		}
+		if contentStart < len(rest) && rest[contentStart] == ' ' {
+			contentStart++
+		}
+		if contentStart < len(rest) {
+			msg.Msg = rest[contentStart:]
+		}
+
+	case ':':
+		// appname: content
+		msg.AppName = string(rest[:delimIdx])
+
+		contentStart := delimIdx + 1
+		if contentStart < len(rest) && rest[contentStart] == ' ' {
+			contentStart++
+		}
+		if contentStart < len(rest) {
+			msg.Msg = rest[contentStart:]
+		}
+
+	case ' ':
+		// appname content (no colon or bracket delimiter)
+		msg.AppName = string(rest[:delimIdx])
+
+		contentStart := delimIdx + 1
+		if contentStart < len(rest) {
+			msg.Msg = rest[contentStart:]
+		}
+	}
+}
+
+// isValidBSDTimestamp checks the 15-byte BSD timestamp "Mmm dd hh:mm:ss" for
+// structural validity: valid month abbreviation plus spaces at [3] and [6],
+// colons at [9] and [12]. This prevents false-positive matches on lines that
+// coincidentally start with a month abbreviation (e.g. "December sales...").
+func isValidBSDTimestamp(b []byte) bool {
+	if len(b) < 15 {
+		return false
+	}
+	if b[3] != ' ' || b[6] != ' ' || b[9] != ':' || b[12] != ':' {
+		return false
+	}
+	switch b[0] {
+	case 'J':
+		return (b[1] == 'a' && b[2] == 'n') || // Jan
+			(b[1] == 'u' && (b[2] == 'n' || b[2] == 'l')) // Jun, Jul
+	case 'F':
+		return b[1] == 'e' && b[2] == 'b' // Feb
+	case 'M':
+		return b[1] == 'a' && (b[2] == 'r' || b[2] == 'y') // Mar, May
+	case 'A':
+		return (b[1] == 'p' && b[2] == 'r') || // Apr
+			(b[1] == 'u' && b[2] == 'g') // Aug
+	case 'S':
+		return b[1] == 'e' && b[2] == 'p' // Sep
+	case 'O':
+		return b[1] == 'c' && b[2] == 't' // Oct
+	case 'N':
+		return b[1] == 'o' && b[2] == 'v' // Nov
+	case 'D':
+		return b[1] == 'e' && b[2] == 'c' // Dec
+	}
+	return false
+}
+
+// isAlphaNumeric returns true for ASCII letters and digits.
+func isAlphaNumeric(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+// ---------------------------------------------------------------------------
+// STRUCTURED-DATA parsing (RFC 5424)
+// ---------------------------------------------------------------------------
+
+// parseStructuredData parses STRUCTURED-DATA at the start of b.
+// Returns the parsed SD elements as a map (SD-ID -> params), the byte length
+// consumed (needed to locate the MSG field), and any error.
+// NILVALUE ("-") returns (nil, 1, nil).
+func parseStructuredData(b []byte) (map[string]map[string]string, int, error) {
+	if len(b) == 0 {
+		return nil, 0, errSDEmpty
+	}
+	if b[0] == '-' {
+		return nil, 1, nil
+	}
+	if b[0] != '[' {
+		return nil, 0, errSDExpected
+	}
+	result := make(map[string]map[string]string)
+	i := 0
+	for i < len(b) && b[i] == '[' {
+		sdID, params, end, err := parseSDElement(b, i)
+		if err != nil {
+			if len(result) > 0 {
+				return result, i, err
+			}
+			return nil, 0, err
+		}
+		result[sdID] = params
+		i = end
+	}
+	return result, i, nil
+}
+
+// parseSDElement parses a single [ SD-ID *(SP SD-PARAM) ] starting at b[pos].
+// Returns the SD-ID, the params map, and the index one past the closing ']'.
+func parseSDElement(b []byte, pos int) (string, map[string]string, int, error) {
+	if pos >= len(b) || b[pos] != '[' {
+		return "", nil, 0, errSDElemOpen
+	}
+	i := pos + 1
+
+	// SD-ID: 1*32 PRINTUSASCII except '=', SP, ']', '"'
+	idStart := i
+	for i < len(b) {
+		c := b[i]
+		if c == ' ' || c == ']' {
+			break
+		}
+		if c == '=' || c == '"' || c < 33 || c > 126 {
+			return "", nil, 0, errSDIDInvalid
+		}
+		i++
+		if i-idStart > 32 {
+			return "", nil, 0, errSDIDTooLong
+		}
+	}
+	if i == idStart {
+		return "", nil, 0, errSDIDRequired
+	}
+	sdID := string(b[idStart:i])
+	params := make(map[string]string)
+
+	// *(SP SD-PARAM) then ']'
+	for i < len(b) {
+		if b[i] == ']' {
+			return sdID, params, i + 1, nil
+		}
+		if b[i] != ' ' {
+			return "", nil, 0, errSDElemExpect
+		}
+		i++ // skip SP
+		name, value, end, err := parseSDParam(b, i)
+		if err != nil {
+			return "", nil, 0, err
+		}
+		params[name] = value
+		i = end
+	}
+	return "", nil, 0, errSDElemUnclosed
+}
+
+// parseSDParam parses PARAM-NAME "=" '"' PARAM-VALUE '"' starting at b[pos].
+// Returns PARAM-NAME, the unescaped PARAM-VALUE, and the index one past the
+// closing '"'.
+func parseSDParam(b []byte, pos int) (string, string, int, error) {
+	if pos >= len(b) {
+		return "", "", 0, errSDParamEmpty
+	}
+	i := pos
+
+	// PARAM-NAME: 1*32 PRINTUSASCII except '=', SP, ']', '"'
+	for i < len(b) && b[i] != '=' {
+		c := b[i]
+		if c == ' ' || c == ']' || c == '"' || c < 33 || c > 126 {
+			return "", "", 0, errSDParamNameBad
+		}
+		i++
+		if i-pos > 32 {
+			return "", "", 0, errSDParamNameLong
+		}
+	}
+	if i == pos || i >= len(b) {
+		return "", "", 0, errSDParamNoEq
+	}
+	name := string(b[pos:i])
+	i++ // skip '='
+	if i >= len(b) || b[i] != '"' {
+		return "", "", 0, errSDParamNoQuote
+	}
+	i++ // skip opening '"'
+
+	// Scan PARAM-VALUE: find closing '"', handle escapes.
+	// Track whether any escapes are present to avoid allocation when possible.
+	valStart := i
+	hasEscape := false
+	for i < len(b) {
+		c := b[i]
+		if c == '\\' {
+			if i+1 >= len(b) {
+				return "", "", 0, errSDParamTrailBS
+			}
+			hasEscape = true
+			i += 2 // skip backslash + next byte
+			continue
+		}
+		if c == '"' {
+			var value string
+			if hasEscape {
+				value = unescapeSDValue(b[valStart:i])
+			} else {
+				value = string(b[valStart:i])
+			}
+			return name, value, i + 1, nil
+		}
+		i++
+	}
+	return "", "", 0, errSDParamUnclosed
+}
+
+// unescapeSDValue removes RFC 5424 §6.3.3 escapes from a PARAM-VALUE.
+// Valid escapes: \" -> ", \\ -> \, \] -> ]. Invalid escapes are treated
+// as literal (the backslash is removed).
+func unescapeSDValue(b []byte) string {
+	buf := make([]byte, 0, len(b))
+	for i := 0; i < len(b); i++ {
+		if b[i] == '\\' && i+1 < len(b) {
+			i++ // skip backslash, take next byte literally
+			buf = append(buf, b[i])
+		} else {
+			buf = append(buf, b[i])
+		}
+	}
+	return string(buf)
+}
+
+// stripBOM removes the UTF-8 BOM (%xEF.BB.BF) if present.
+func stripBOM(b []byte) []byte {
+	if len(b) >= 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF {
+		return b[3:]
+	}
+	return b
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers for structured message construction
+// ---------------------------------------------------------------------------
+
+// SeverityToStatus maps a syslog PRI value to an agent log status.
+// Syslog severity is Pri % 8 per RFC 5424. The agent defines matching
+// status constants in pkg/logs/message/status.go.
+func SeverityToStatus(pri int) string {
+	if pri < 0 {
+		return message.StatusInfo
+	}
+	switch pri % 8 {
+	case 0:
+		return message.StatusEmergency
+	case 1:
+		return message.StatusAlert
+	case 2:
+		return message.StatusCritical
+	case 3:
+		return message.StatusError
+	case 4:
+		return message.StatusWarning
+	case 5:
+		return message.StatusNotice
+	case 6:
+		return message.StatusInfo
+	case 7:
+		return message.StatusDebug
+	}
+	return message.StatusInfo // unreachable: pri%8 covers 0-7
+}
+
+// BuildSyslogFields returns the syslog metadata map for a parsed message.
+// Used by both the TCP tailer's builder and the file parser to construct
+// the "syslog" sub-map in the structured content.
+//
+// Fields that are absent or empty are omitted:
+//   - Pri < 0: severity and facility are omitted
+//   - Version == "": version is omitted (BSD messages)
+//   - StructuredData == nil: structured_data is omitted (BSD messages)
+func BuildSyslogFields(parsed *SyslogMessage) map[string]interface{} {
+	fields := map[string]interface{}{
+		"timestamp": parsed.Timestamp,
+		"hostname":  parsed.Hostname,
+		"appname":   parsed.AppName,
+		"procid":    parsed.ProcID,
+		"msgid":     parsed.MsgID,
+	}
+	if parsed.Pri >= 0 {
+		fields["severity"] = parsed.Pri % 8
+		fields["facility"] = parsed.Pri / 8
+	}
+	if parsed.Version != "" {
+		fields["version"] = parsed.Version
+	}
+	if parsed.StructuredData != nil {
+		fields["structured_data"] = parsed.StructuredData
+	}
+	return fields
+}

--- a/pkg/logs/internal/parsers/syslog/syslog.go
+++ b/pkg/logs/internal/parsers/syslog/syslog.go
@@ -72,6 +72,13 @@ var (
 
 const nilvalue = "-"
 
+// RFC 5424 §6.3: PRINTUSASCII range and max name length for SD-ID / PARAM-NAME.
+const (
+	printUSASCIIMin = 33 // '!' — lower bound of PRINTUSASCII (%d33-126)
+	printUSASCIIMax = 126 // '~' — upper bound of PRINTUSASCII
+	maxSDNameLen    = 32 // max length for SD-ID and PARAM-NAME
+)
+
 // SyslogMessage is a parsed syslog message (RFC 5424 or RFC 3164/BSD).
 //
 // String fields are independent copies of the input. The Msg field aliases
@@ -595,11 +602,11 @@ func parseSDElement(b []byte, pos int) (string, map[string]string, int, error) {
 		if c == ' ' || c == ']' {
 			break
 		}
-		if c == '=' || c == '"' || c < 33 || c > 126 {
+		if c == '=' || c == '"' || c < printUSASCIIMin || c > printUSASCIIMax {
 			return "", nil, 0, errSDIDInvalid
 		}
 		i++
-		if i-idStart > 32 {
+		if i-idStart > maxSDNameLen {
 			return "", nil, 0, errSDIDTooLong
 		}
 	}
@@ -640,11 +647,11 @@ func parseSDParam(b []byte, pos int) (string, string, int, error) {
 	// PARAM-NAME: 1*32 PRINTUSASCII except '=', SP, ']', '"'
 	for i < len(b) && b[i] != '=' {
 		c := b[i]
-		if c == ' ' || c == ']' || c == '"' || c < 33 || c > 126 {
+		if c == ' ' || c == ']' || c == '"' || c < printUSASCIIMin || c > printUSASCIIMax {
 			return "", "", 0, errSDParamNameBad
 		}
 		i++
-		if i-pos > 32 {
+		if i-pos > maxSDNameLen {
 			return "", "", 0, errSDParamNameLong
 		}
 	}

--- a/pkg/logs/internal/parsers/syslog/syslog_fuzz_test.go
+++ b/pkg/logs/internal/parsers/syslog/syslog_fuzz_test.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package syslog
+
+import (
+	"testing"
+)
+
+func FuzzParse(f *testing.F) {
+	// RFC 5424 seeds
+	f.Add([]byte(`<165>1 2003-10-11T22:14:15.003Z mymachine evntslog - ID47 [exampleSDID@32473 iut="3"] msg`))
+	f.Add([]byte(`<14>1 - - - - - - test`))
+	f.Add([]byte(`<75>1 1969-12-03T23:58:58Z - - - - -`))
+	f.Add([]byte(`<13>1 2019-02-13T19:48:34+00:00 host root 8449 - [meta sequenceId="1"][origin ip="10.0.0.1"] msg`))
+
+	// BSD seeds
+	f.Add([]byte(`<13>Feb 13 20:07:26 74794bfb6795 root[8539]: i am foobar`))
+	f.Add([]byte(`<190>Dec 28 16:49:07 myhost nginx: 127.0.0.1 - - request`))
+	f.Add([]byte(`<46>Jan  5 15:33:03 myhost rsyslogd: start`))
+	f.Add([]byte(`<4>Jan 26 05:59:54 ubnt kernel: [WAN_LOCAL-default-D]IN=eth0`))
+
+	// Edge cases
+	f.Add([]byte(`<14>`))
+	f.Add([]byte(`<>`))
+	f.Add([]byte(`<999>1 - - - - - - test`))
+	f.Add([]byte(`<0>1 - - - - - - test`))
+	f.Add([]byte(``))
+	f.Add([]byte(`not syslog`))
+	f.Add([]byte("\x00\x01\x02"))
+	f.Add([]byte("\xff\xfe\xfd"))
+	f.Add([]byte(`<14>1 ts host app pid mid [sd key="val\"ue"] msg`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		msg, err := Parse(data)
+
+		if err == nil {
+			if msg.Pri < 0 || msg.Pri > 191 {
+				if !msg.Partial {
+					t.Errorf("Pri %d out of range without Partial flag", msg.Pri)
+				}
+			}
+		} else {
+			if msg.Pri >= 0 {
+				// PRI was successfully parsed but a later stage failed.
+				if msg.Pri > 191 && !msg.Partial {
+					t.Errorf("Pri %d out of range without Partial flag", msg.Pri)
+				}
+			}
+			// Pri == -1 means PRI was never parsed — always valid on error.
+		}
+	})
+}
+
+func FuzzParseBSDLine(f *testing.F) {
+	f.Add([]byte(`Dec 28 16:49:07 myhost nginx: 127.0.0.1 - - request`))
+	f.Add([]byte(`Jan  5 15:33:03 myhost rsyslogd: start`))
+	f.Add([]byte(`not syslog at all`))
+	f.Add([]byte(`12345 numeric prefix`))
+	f.Add([]byte(``))
+	f.Add([]byte("\x00\x01\x02"))
+	f.Add([]byte(`Feb 13 20:07:26 host root[8539]: msg`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		msg, _ := ParseBSDLine(data)
+
+		if msg.Pri != -1 {
+			t.Errorf("ParseBSDLine should always return Pri=-1, got %d", msg.Pri)
+		}
+	})
+}

--- a/pkg/logs/internal/parsers/syslog/syslog_test.go
+++ b/pkg/logs/internal/parsers/syslog/syslog_test.go
@@ -1,0 +1,762 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package syslog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+func TestSeverityToStatus(t *testing.T) {
+	tests := []struct {
+		pri    int
+		status string
+	}{
+		{0, message.StatusEmergency}, // severity 0
+		{1, message.StatusAlert},     // severity 1
+		{2, message.StatusCritical},  // severity 2
+		{3, message.StatusError},     // severity 3
+		{4, message.StatusWarning},   // severity 4
+		{5, message.StatusNotice},    // severity 5
+		{6, message.StatusInfo},      // severity 6
+		{7, message.StatusDebug},     // severity 7
+		{8, message.StatusEmergency}, // facility 1, severity 0
+		{14, message.StatusInfo},     // facility 1, severity 6
+		{165, message.StatusNotice},  // facility 20, severity 5
+		{-1, message.StatusInfo},     // absent PRI
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.status, SeverityToStatus(tt.pri), "pri=%d", tt.pri)
+	}
+}
+
+func TestBuildSyslogFields_RFC5424(t *testing.T) {
+	parsed := &SyslogMessage{
+		Pri:       165,
+		Version:   "1",
+		Timestamp: "2003-10-11T22:14:15.003Z",
+		Hostname:  "mymachine",
+		AppName:   "evntslog",
+		ProcID:    "-",
+		MsgID:     "ID47",
+		StructuredData: map[string]map[string]string{
+			"exampleSDID@32473": {"iut": "3"},
+		},
+		Msg: []byte("An application event log entry"),
+	}
+
+	fields := BuildSyslogFields(parsed)
+
+	assert.Equal(t, "2003-10-11T22:14:15.003Z", fields["timestamp"])
+	assert.Equal(t, "mymachine", fields["hostname"])
+	assert.Equal(t, "evntslog", fields["appname"])
+	assert.Equal(t, "-", fields["procid"])
+	assert.Equal(t, "ID47", fields["msgid"])
+	assert.Equal(t, 5, fields["severity"])  // 165 % 8
+	assert.Equal(t, 20, fields["facility"]) // 165 / 8
+	assert.Equal(t, "1", fields["version"])
+	assert.Equal(t, map[string]map[string]string{
+		"exampleSDID@32473": {"iut": "3"},
+	}, fields["structured_data"])
+}
+
+func TestBuildSyslogFields_BSD(t *testing.T) {
+	parsed := &SyslogMessage{
+		Pri:       38,
+		Timestamp: "Oct 11 22:14:15",
+		Hostname:  "mymachine",
+		AppName:   "su",
+		ProcID:    "-",
+		MsgID:     "-",
+	}
+
+	fields := BuildSyslogFields(parsed)
+
+	// BSD: no version, no structured_data
+	_, hasVersion := fields["version"]
+	assert.False(t, hasVersion, "BSD messages should not have version")
+	_, hasSD := fields["structured_data"]
+	assert.False(t, hasSD, "BSD messages should not have structured_data")
+
+	// severity = 38 % 8 = 6, facility = 38 / 8 = 4
+	assert.Equal(t, 6, fields["severity"])
+	assert.Equal(t, 4, fields["facility"])
+}
+
+func TestBuildSyslogFields_NoPri(t *testing.T) {
+	parsed := &SyslogMessage{
+		Pri: -1,
+	}
+
+	fields := BuildSyslogFields(parsed)
+
+	_, hasSev := fields["severity"]
+	assert.False(t, hasSev, "Pri=-1 should omit severity")
+	_, hasFac := fields["facility"]
+	assert.False(t, hasFac, "Pri=-1 should omit facility")
+}
+
+// ---------------------------------------------------------------------------
+// parseStructuredData unit tests
+// ---------------------------------------------------------------------------
+
+func TestParseStructuredData_SingleElement(t *testing.T) {
+	input := []byte(`[exampleSDID@32473 iut="3" eventSource="Application"]`)
+	sd, n, err := parseStructuredData(input)
+	assert.NoError(t, err)
+	assert.Equal(t, len(input), n)
+	assert.Equal(t, map[string]map[string]string{
+		"exampleSDID@32473": {
+			"iut":         "3",
+			"eventSource": "Application",
+		},
+	}, sd)
+}
+
+func TestParseStructuredData_MultipleElements(t *testing.T) {
+	input := []byte(`[id1 a="1"][id2 b="2" c="3"]`)
+	sd, n, err := parseStructuredData(input)
+	assert.NoError(t, err)
+	assert.Equal(t, len(input), n)
+	assert.Equal(t, map[string]map[string]string{
+		"id1": {"a": "1"},
+		"id2": {"b": "2", "c": "3"},
+	}, sd)
+}
+
+func TestParseStructuredData_NILVALUE(t *testing.T) {
+	input := []byte(`-`)
+	sd, n, err := parseStructuredData(input)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.Nil(t, sd)
+}
+
+func TestParseStructuredData_ElementNoParams(t *testing.T) {
+	input := []byte(`[myID]`)
+	sd, n, err := parseStructuredData(input)
+	assert.NoError(t, err)
+	assert.Equal(t, len(input), n)
+	assert.Equal(t, map[string]map[string]string{
+		"myID": {},
+	}, sd)
+}
+
+func TestParseStructuredData_EscapedQuote(t *testing.T) {
+	input := []byte(`[id1 key="val\"ue"]`)
+	sd, _, err := parseStructuredData(input)
+	assert.NoError(t, err)
+	assert.Equal(t, `val"ue`, sd["id1"]["key"])
+}
+
+func TestParseStructuredData_EscapedBackslash(t *testing.T) {
+	input := []byte(`[id1 key="val\\ue"]`)
+	sd, _, err := parseStructuredData(input)
+	assert.NoError(t, err)
+	assert.Equal(t, `val\ue`, sd["id1"]["key"])
+}
+
+func TestParseStructuredData_EscapedBracket(t *testing.T) {
+	input := []byte(`[id1 key="val\]ue"]`)
+	sd, _, err := parseStructuredData(input)
+	assert.NoError(t, err)
+	assert.Equal(t, `val]ue`, sd["id1"]["key"])
+}
+
+func TestParseStructuredData_NoEscapeFastPath(t *testing.T) {
+	input := []byte(`[id1 key="simple"]`)
+	sd, _, err := parseStructuredData(input)
+	assert.NoError(t, err)
+	assert.Equal(t, "simple", sd["id1"]["key"])
+}
+
+func TestParseStructuredData_Empty(t *testing.T) {
+	_, _, err := parseStructuredData([]byte{})
+	assert.Error(t, err)
+}
+
+func TestParseStructuredData_InvalidStart(t *testing.T) {
+	_, _, err := parseStructuredData([]byte(`x`))
+	assert.Error(t, err)
+}
+
+func TestParseStructuredData_MultipleEscapes(t *testing.T) {
+	input := []byte(`[id1 key="a\"b\\c\]d"]`)
+	sd, _, err := parseStructuredData(input)
+	assert.NoError(t, err)
+	assert.Equal(t, `a"b\c]d`, sd["id1"]["key"])
+}
+
+// ---------------------------------------------------------------------------
+// Parse() direct unit tests — RFC 5424
+// ---------------------------------------------------------------------------
+
+func TestParse_RFC5424_BasicNoSD(t *testing.T) {
+	msg, err := Parse([]byte(`<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - 'su root' failed for lonvick on /dev/pts/8`))
+	assert.NoError(t, err)
+	assert.False(t, msg.Partial)
+	assert.Equal(t, 34, msg.Pri)
+	assert.Equal(t, "1", msg.Version)
+	assert.Equal(t, "2003-10-11T22:14:15.003Z", msg.Timestamp)
+	assert.Equal(t, "mymachine.example.com", msg.Hostname)
+	assert.Equal(t, "su", msg.AppName)
+	assert.Equal(t, "-", msg.ProcID)
+	assert.Equal(t, "ID47", msg.MsgID)
+	assert.Nil(t, msg.StructuredData)
+	assert.Equal(t, "'su root' failed for lonvick on /dev/pts/8", string(msg.Msg))
+}
+
+func TestParse_RFC5424_WithSD(t *testing.T) {
+	msg, err := Parse([]byte(`<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] An application event log entry...`))
+	assert.NoError(t, err)
+	assert.False(t, msg.Partial)
+	assert.Equal(t, 165, msg.Pri)
+	assert.Equal(t, "1", msg.Version)
+	assert.Equal(t, "2003-10-11T22:14:15.003Z", msg.Timestamp)
+	assert.Equal(t, "mymachine.example.com", msg.Hostname)
+	assert.Equal(t, "evntslog", msg.AppName)
+	assert.Equal(t, "-", msg.ProcID)
+	assert.Equal(t, "ID47", msg.MsgID)
+	assert.Equal(t, map[string]map[string]string{
+		"exampleSDID@32473": {
+			"iut":         "3",
+			"eventSource": "Application",
+			"eventID":     "1011",
+		},
+	}, msg.StructuredData)
+	assert.Equal(t, "An application event log entry...", string(msg.Msg))
+}
+
+func TestParse_RFC5424_EmptyParamValue(t *testing.T) {
+	msg, err := Parse([]byte(`<165>1 2003-10-11T22:14:15.003Z mymachine evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="" eventID="1011"] msg`))
+	assert.NoError(t, err)
+	assert.Equal(t, "", msg.StructuredData["exampleSDID@32473"]["eventSource"])
+	assert.Equal(t, "3", msg.StructuredData["exampleSDID@32473"]["iut"])
+	assert.Equal(t, "1011", msg.StructuredData["exampleSDID@32473"]["eventID"])
+}
+
+func TestParse_RFC5424_MultipleSD(t *testing.T) {
+	msg, err := Parse([]byte(`<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - [meta sequenceId="1" sysUpTime="37" language="EN"][origin ip="192.168.0.1" software="test"] i am foobar`))
+	assert.NoError(t, err)
+	assert.Equal(t, 13, msg.Pri)
+	assert.Equal(t, "1", msg.Version)
+	assert.Equal(t, "2019-02-13T19:48:34+00:00", msg.Timestamp)
+	assert.Equal(t, "74794bfb6795", msg.Hostname)
+	assert.Equal(t, "root", msg.AppName)
+	assert.Equal(t, "8449", msg.ProcID)
+	assert.Equal(t, map[string]map[string]string{
+		"meta":   {"sequenceId": "1", "sysUpTime": "37", "language": "EN"},
+		"origin": {"ip": "192.168.0.1", "software": "test"},
+	}, msg.StructuredData)
+	assert.Equal(t, "i am foobar", string(msg.Msg))
+}
+
+func TestParse_RFC5424_NILVALUETimestamp(t *testing.T) {
+	msg, err := Parse([]byte(`<14>1 - 10.0.4.87 Serial-Debugger - - - Serializer started!`))
+	assert.NoError(t, err)
+	assert.Equal(t, 14, msg.Pri)
+	assert.Equal(t, "1", msg.Version)
+	assert.Equal(t, "-", msg.Timestamp)
+	assert.Equal(t, "10.0.4.87", msg.Hostname)
+	assert.Equal(t, "Serial-Debugger", msg.AppName)
+	assert.Equal(t, "-", msg.ProcID)
+	assert.Equal(t, "-", msg.MsgID)
+	assert.Nil(t, msg.StructuredData)
+	assert.Equal(t, "Serializer started!", string(msg.Msg))
+}
+
+func TestParse_RFC5424_IPv4Hostname(t *testing.T) {
+	msg, err := Parse([]byte(`<34>1 2003-10-11T22:14:15.003Z 42.52.1.1 su - ID47 - bananas and peas`))
+	assert.NoError(t, err)
+	assert.Equal(t, "42.52.1.1", msg.Hostname)
+	assert.Equal(t, "su", msg.AppName)
+	assert.Equal(t, "ID47", msg.MsgID)
+	assert.Equal(t, "bananas and peas", string(msg.Msg))
+}
+
+func TestParse_RFC5424_IPv6Hostname(t *testing.T) {
+	msg, err := Parse([]byte(`<34>1 2003-10-11T22:14:15.003Z ::FFFF:129.144.52.38 su - ID47 - bananas and peas`))
+	assert.NoError(t, err)
+	assert.Equal(t, "::FFFF:129.144.52.38", msg.Hostname)
+	assert.Equal(t, "su", msg.AppName)
+	assert.Equal(t, "bananas and peas", string(msg.Msg))
+}
+
+func TestParse_RFC5424_ColonInAppname(t *testing.T) {
+	msg, err := Parse([]byte(`<28>1 2020-05-22T14:59:09.250-03:00 OX-XXX-MX204 OX-XXX-CONTEUDO:rpd 6589 - - bgp_listen_accept: Connection attempt from unconfigured neighbor`))
+	assert.NoError(t, err)
+	assert.Equal(t, 28, msg.Pri)
+	assert.Equal(t, "OX-XXX-MX204", msg.Hostname)
+	assert.Equal(t, "OX-XXX-CONTEUDO:rpd", msg.AppName)
+	assert.Equal(t, "6589", msg.ProcID)
+	assert.Equal(t, "bgp_listen_accept: Connection attempt from unconfigured neighbor", string(msg.Msg))
+}
+
+func TestParse_RFC5424_ColonInMsgID(t *testing.T) {
+	msg, err := Parse([]byte(`<131>1 2025-05-09T09:56:18.906539+02:00 Host-Name.network.example appname 1234 01230456:1: [F5@1234 hostname="Host-Name.network.example" errdefs_msgno="01230456:1:"] RST sent from 192.0.2.1:443`))
+	assert.NoError(t, err)
+	assert.Equal(t, 131, msg.Pri)
+	assert.Equal(t, "Host-Name.network.example", msg.Hostname)
+	assert.Equal(t, "appname", msg.AppName)
+	assert.Equal(t, "1234", msg.ProcID)
+	assert.Equal(t, "01230456:1:", msg.MsgID)
+	assert.Equal(t, map[string]map[string]string{
+		"F5@1234": {
+			"hostname":      "Host-Name.network.example",
+			"errdefs_msgno": "01230456:1:",
+		},
+	}, msg.StructuredData)
+	assert.Equal(t, "RST sent from 192.0.2.1:443", string(msg.Msg))
+}
+
+func TestParse_RFC5424_EmptyMsg(t *testing.T) {
+	msg, err := Parse([]byte(`<75>1 1969-12-03T23:58:58Z - - - - -`))
+	assert.NoError(t, err)
+	assert.Equal(t, 75, msg.Pri)
+	assert.Equal(t, "1", msg.Version)
+	assert.Equal(t, "1969-12-03T23:58:58Z", msg.Timestamp)
+	assert.Equal(t, "-", msg.Hostname)
+	assert.Equal(t, "-", msg.AppName)
+	assert.Equal(t, "-", msg.ProcID)
+	assert.Equal(t, "-", msg.MsgID)
+	assert.Nil(t, msg.StructuredData)
+	assert.Empty(t, msg.Msg)
+}
+
+func TestParse_RFC5424_EmptySDElement(t *testing.T) {
+	msg, err := Parse([]byte(`<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - [empty] qwerty`))
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]map[string]string{
+		"empty": {},
+	}, msg.StructuredData)
+	assert.Equal(t, "qwerty", string(msg.Msg))
+}
+
+func TestParse_RFC5424_EmptyAndNonEmptySDElements(t *testing.T) {
+	msg, err := Parse([]byte(`<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - [non_empty x="1"][empty] qwerty`))
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]map[string]string{
+		"non_empty": {"x": "1"},
+		"empty":     {},
+	}, msg.StructuredData)
+	assert.Equal(t, "qwerty", string(msg.Msg))
+}
+
+func TestParse_RFC5424_IncorrectSDElement(t *testing.T) {
+	// SD element with a bare param name (no ="value") is malformed.
+	msg, err := Parse([]byte(`<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - [incorrect x] qwerty`))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+	assert.Equal(t, "74794bfb6795", msg.Hostname)
+	assert.Equal(t, "root", msg.AppName)
+	assert.Equal(t, "8449", msg.ProcID)
+}
+
+func TestParse_RFC5424_BOMStripping(t *testing.T) {
+	// UTF-8 BOM (0xEF 0xBB 0xBF) before the message body should be stripped.
+	input := append(
+		[]byte(`<34>1 2003-10-11T22:14:15.003Z myhost su - ID47 - `),
+		0xEF, 0xBB, 0xBF,
+	)
+	input = append(input, []byte("test message")...)
+	msg, err := Parse(input)
+	assert.NoError(t, err)
+	assert.Equal(t, "test message", string(msg.Msg))
+}
+
+func TestParse_RFC5424_NegativeTimezoneOffset(t *testing.T) {
+	msg, err := Parse([]byte(`<28>1 2020-05-22T14:59:09.250-03:00 myhost myapp 6589 - - some message`))
+	assert.NoError(t, err)
+	assert.Equal(t, "2020-05-22T14:59:09.250-03:00", msg.Timestamp)
+	assert.Equal(t, "myhost", msg.Hostname)
+	assert.Equal(t, "myapp", msg.AppName)
+}
+
+// ---------------------------------------------------------------------------
+// Parse() direct unit tests — BSD / RFC 3164
+// ---------------------------------------------------------------------------
+
+func TestParse_BSD_WithPID(t *testing.T) {
+	msg, err := Parse([]byte(`<13>Feb 13 20:07:26 74794bfb6795 root[8539]: i am foobar`))
+	assert.NoError(t, err)
+	assert.Equal(t, 13, msg.Pri)
+	assert.Equal(t, "Feb 13 20:07:26", msg.Timestamp)
+	assert.Equal(t, "74794bfb6795", msg.Hostname)
+	assert.Equal(t, "root", msg.AppName)
+	assert.Equal(t, "8539", msg.ProcID)
+	assert.Equal(t, "i am foobar", string(msg.Msg))
+}
+
+func TestParse_BSD_AppnameColonMsg(t *testing.T) {
+	msg, err := Parse([]byte(`<190>Dec 28 16:49:07 plertrood-thinkpad-x220 nginx: 127.0.0.1 - - request`))
+	assert.NoError(t, err)
+	assert.Equal(t, 190, msg.Pri)
+	assert.Equal(t, "Dec 28 16:49:07", msg.Timestamp)
+	assert.Equal(t, "plertrood-thinkpad-x220", msg.Hostname)
+	assert.Equal(t, "nginx", msg.AppName)
+	assert.Equal(t, "-", msg.ProcID)
+	assert.Equal(t, "127.0.0.1 - - request", string(msg.Msg))
+}
+
+func TestParse_BSD_SingleDigitDay(t *testing.T) {
+	msg, err := Parse([]byte(`<46>Jan  5 15:33:03 plertrood-ThinkPad-X220 rsyslogd: start`))
+	assert.NoError(t, err)
+	assert.Equal(t, 46, msg.Pri)
+	assert.Equal(t, "Jan  5 15:33:03", msg.Timestamp)
+	assert.Equal(t, "plertrood-ThinkPad-X220", msg.Hostname)
+	assert.Equal(t, "rsyslogd", msg.AppName)
+	assert.Equal(t, "start", string(msg.Msg))
+}
+
+func TestParse_BSD_NoTag(t *testing.T) {
+	// Double space after hostname: the parser consumes one SP after the
+	// hostname, leaving the second SP as the first byte of rest. That byte
+	// is non-alphanumeric, so parseBSDTag treats the whole rest as MSG.
+	msg, err := Parse([]byte(`<46>Jan  5 15:33:03 plertrood-ThinkPad-X220  [some content] start`))
+	assert.NoError(t, err)
+	assert.Equal(t, "plertrood-ThinkPad-X220", msg.Hostname)
+	assert.Equal(t, "-", msg.AppName)
+	assert.Equal(t, " [some content] start", string(msg.Msg))
+}
+
+func TestParse_BSD_BracketContentInMsg(t *testing.T) {
+	// iptables-style content: brackets in MSG that are NOT structured data.
+	msg, err := Parse([]byte(`<4>Jan 26 05:59:54 ubnt kernel: [WAN_LOCAL-default-D]IN=eth0 OUT= SRC=135.148.25.121`))
+	assert.NoError(t, err)
+	assert.Equal(t, 4, msg.Pri)
+	assert.Equal(t, "ubnt", msg.Hostname)
+	assert.Equal(t, "kernel", msg.AppName)
+	assert.Equal(t, "[WAN_LOCAL-default-D]IN=eth0 OUT= SRC=135.148.25.121", string(msg.Msg))
+}
+
+func TestParse_BSD_ImmediateColonNoSpace(t *testing.T) {
+	// TAG with colon immediately followed by content (no space after colon).
+	msg, err := Parse([]byte(`<13>Feb 13 20:07:26 74794bfb6795 root[8539]:syslog message`))
+	assert.NoError(t, err)
+	assert.Equal(t, "root", msg.AppName)
+	assert.Equal(t, "8539", msg.ProcID)
+	assert.Equal(t, "syslog message", string(msg.Msg))
+}
+
+func TestParseBSDLine_NoPRI(t *testing.T) {
+	msg, err := ParseBSDLine([]byte(`Dec 28 16:49:07 plertrood-thinkpad-x220 nginx: 127.0.0.1 - - request`))
+	assert.NoError(t, err)
+	assert.Equal(t, -1, msg.Pri)
+	assert.Equal(t, "Dec 28 16:49:07", msg.Timestamp)
+	assert.Equal(t, "plertrood-thinkpad-x220", msg.Hostname)
+	assert.Equal(t, "nginx", msg.AppName)
+	assert.Equal(t, "127.0.0.1 - - request", string(msg.Msg))
+}
+
+// ---------------------------------------------------------------------------
+// Parse() edge cases
+// ---------------------------------------------------------------------------
+
+func TestParse_EmptyInput(t *testing.T) {
+	_, err := Parse([]byte{})
+	assert.Error(t, err)
+}
+
+func TestParse_InvalidMessage(t *testing.T) {
+	msg, err := Parse([]byte("complete and utter gobbledegook"))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+	assert.Equal(t, -1, msg.Pri)
+	assert.Equal(t, "complete and utter gobbledegook", string(msg.Msg))
+}
+
+func TestParse_PRIOnly(t *testing.T) {
+	msg, err := Parse([]byte(`<14>`))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+	assert.Equal(t, 14, msg.Pri)
+	assert.Equal(t, "<14>", string(msg.Msg))
+}
+
+func TestParse_PRIOutOfRange(t *testing.T) {
+	// PRI > 191 is out of spec but the parser accepts it best-effort.
+	msg, err := Parse([]byte(`<192>1 2003-10-11T22:14:15.003Z myhost myapp - - - test`))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+	assert.Equal(t, 192, msg.Pri)
+	assert.Equal(t, "myhost", msg.Hostname)
+}
+
+func TestParse_AllNILVALUEFields(t *testing.T) {
+	msg, err := Parse([]byte(`<14>1 - - - - - - test`))
+	assert.NoError(t, err)
+	assert.Equal(t, "1", msg.Version)
+	assert.Equal(t, "-", msg.Timestamp)
+	assert.Equal(t, "-", msg.Hostname)
+	assert.Equal(t, "-", msg.AppName)
+	assert.Equal(t, "-", msg.ProcID)
+	assert.Equal(t, "-", msg.MsgID)
+	assert.Nil(t, msg.StructuredData)
+	assert.Equal(t, "test", string(msg.Msg))
+}
+
+func TestParseBSDLine_EmptyInput(t *testing.T) {
+	_, err := ParseBSDLine([]byte{})
+	assert.Error(t, err)
+}
+
+func TestParseBSDLine_NonSyslogContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"plain text", "not syslog at all"},
+		{"numeric prefix", "12345 some data"},
+		{"json line", `{"level":"warn","msg":"oops"}`},
+		{"error log", "ERROR 2025-01-15 connection refused"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := ParseBSDLine([]byte(tt.input))
+			assert.Error(t, err)
+			assert.True(t, msg.Partial)
+			assert.Equal(t, -1, msg.Pri)
+			assert.Equal(t, tt.input, string(msg.Msg))
+		})
+	}
+}
+
+func TestParse_BSD_HighPRI(t *testing.T) {
+	// PRI=190 → facility=LOG_LOCAL7 (23), severity=SEV_INFO (6). Valid range.
+	msg, err := Parse([]byte(`<190>Feb 13 21:31:56 74794bfb6795 liblogging-stdlog: start`))
+	assert.NoError(t, err)
+	assert.Equal(t, 190, msg.Pri)
+	assert.Equal(t, "74794bfb6795", msg.Hostname)
+	assert.Equal(t, "liblogging-stdlog", msg.AppName)
+	assert.Equal(t, "start", string(msg.Msg))
+}
+
+// ---------------------------------------------------------------------------
+// Additional coverage: error paths, edge cases
+// ---------------------------------------------------------------------------
+
+func TestParse_PRIOutOfRange_BSD(t *testing.T) {
+	// PRI > 191 combined with BSD body: both priErr and parse result preserved.
+	msg, err := Parse([]byte(`<200>Feb 13 20:07:26 myhost sshd[123]: login`))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+	assert.Equal(t, 200, msg.Pri)
+	assert.Equal(t, "myhost", msg.Hostname)
+	assert.Equal(t, "sshd", msg.AppName)
+	assert.Contains(t, err.Error(), "PRI")
+}
+
+func TestParse_TruncatedHostname_BSD(t *testing.T) {
+	// Timestamp present but line ends before hostname can be fully parsed.
+	msg, err := Parse([]byte(`<13>Feb 13 20:07:26 `))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+	assert.Equal(t, 13, msg.Pri)
+}
+
+func TestParse_EmptySDParamName(t *testing.T) {
+	// SD with an empty param name: [id@1 ="val"]
+	msg, err := Parse([]byte(`<14>1 - - - - - [id@1 ="val"] test`))
+	// The parser should handle this gracefully (best-effort or error).
+	if err != nil {
+		assert.True(t, msg.Partial)
+	}
+	assert.Equal(t, 14, msg.Pri)
+}
+
+func TestParse_MultipleSD_ErrorInSecond(t *testing.T) {
+	// First SD is valid, second is malformed (missing closing bracket).
+	msg, err := Parse([]byte(`<14>1 - - - - - [ok@1 a="b"][bad@2 c="d" test`))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+	assert.Equal(t, 14, msg.Pri)
+	// First SD element should be preserved (best-effort partial return).
+	require.NotNil(t, msg.StructuredData, "partial SD should be returned on error")
+	params, ok := msg.StructuredData["ok@1"]
+	assert.True(t, ok, "first SD element should be preserved")
+	assert.Equal(t, "b", params["a"])
+}
+
+func TestParse_RFC5424_VersionErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"version starts with 0", "<14>0 - - - - - - test"},
+		{"version too long", "<14>1234 - - - - - - test"},
+		{"version non-digit", "<14>1a - - - - - - test"},
+		{"no space after version", "<14>1"},
+		{"empty version", "<14> - - - - - - test"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := Parse([]byte(tt.input))
+			assert.Error(t, err)
+			assert.True(t, msg.Partial)
+			assert.Equal(t, 14, msg.Pri, "PRI should be preserved on version errors")
+		})
+	}
+}
+
+func TestParseBSDLine_EmptyInput_Pri(t *testing.T) {
+	msg, err := ParseBSDLine([]byte{})
+	assert.Error(t, err)
+	assert.Equal(t, -1, msg.Pri, "empty input should yield Pri=-1")
+}
+
+func TestParse_Empty_Pri(t *testing.T) {
+	msg, err := Parse([]byte{})
+	assert.Error(t, err)
+	assert.Equal(t, -1, msg.Pri, "empty input should yield Pri=-1")
+}
+
+func TestParse_NoPRI_Pri(t *testing.T) {
+	msg, err := Parse([]byte("no angle bracket at all"))
+	assert.Error(t, err)
+	assert.Equal(t, -1, msg.Pri, "missing PRI should yield Pri=-1")
+	assert.True(t, msg.Partial)
+}
+
+func TestSeverityToStatus_NegativePri(t *testing.T) {
+	assert.Equal(t, message.StatusInfo, SeverityToStatus(-1))
+	assert.Equal(t, message.StatusInfo, SeverityToStatus(-999))
+}
+
+func TestParse_SDName_ControlCharsRejected(t *testing.T) {
+	// PRINTUSASCII is %d33-126; control chars and DEL must be rejected.
+	// Control char in SD-ID:
+	msg, err := Parse([]byte("<14>1 - - - - - [\x01bad@1 a=\"b\"] test"))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+
+	// DEL (127) in PARAM-NAME:
+	msg, err = Parse([]byte("<14>1 - - - - - [ok@1 \x7Fname=\"b\"] test"))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+
+	// High byte (128+) in SD-ID:
+	msg, err = Parse([]byte("<14>1 - - - - - [\x80bad@1 a=\"b\"] test"))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+}
+
+func TestParse_BOM_InMSG_RFC5424(t *testing.T) {
+	// RFC 5424 §6.4: MSG may start with a BOM; the parser strips it.
+	msg, err := Parse([]byte("<14>1 - - - - - - \xEF\xBB\xBFhello"))
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", string(msg.Msg))
+}
+
+func TestParse_BOM_InMSG_BSD(t *testing.T) {
+	// BSD MSG does not have BOM stripping — BOM is preserved verbatim.
+	// This documents the intentional asymmetry with RFC 5424.
+	msg, err := Parse([]byte("<13>Feb 13 20:07:26 myhost sshd[123]: \xEF\xBB\xBFlogin"))
+	assert.NoError(t, err)
+	assert.Equal(t, "myhost", msg.Hostname)
+	assert.Equal(t, "\xEF\xBB\xBFlogin", string(msg.Msg))
+}
+
+func TestParse_BOM_BeforePRI(t *testing.T) {
+	// BOM before PRI is not handled — Parse() sees 0xEF as the first byte,
+	// not '<'. This documents the known limitation.
+	input := append([]byte{0xEF, 0xBB, 0xBF}, []byte(`<13>Feb 13 20:07:26 myhost sshd: login`)...)
+	_, err := Parse(input)
+	assert.Error(t, err, "BOM before PRI is not supported")
+}
+
+func TestParse_DuplicateSDParamName(t *testing.T) {
+	// Duplicate param names within the same SD-ELEMENT: last write wins.
+	msg, err := Parse([]byte(`<14>1 - - - - - [id@1 key="first" key="second"] test`))
+	assert.NoError(t, err)
+	require.NotNil(t, msg.StructuredData)
+	params := msg.StructuredData["id@1"]
+	assert.Equal(t, "second", params["key"], "last-write-wins for duplicate param names")
+}
+
+func TestParse_VersionZero(t *testing.T) {
+	// VERSION starting with '0' should route to parseRFC5424 and return
+	// errVersionStart (not errUnknownFormat).
+	msg, err := Parse([]byte(`<14>0 - - - - - - test`))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+	assert.Equal(t, 14, msg.Pri, "PRI should be preserved")
+	assert.Contains(t, err.Error(), "VERSION", "error should mention VERSION, not unknown format")
+}
+
+func TestParse_FalsePositiveBSD(t *testing.T) {
+	// A line starting with a month name but without valid BSD timestamp
+	// structure should not be parsed as BSD syslog.
+	msg, err := Parse([]byte(`<14>December sales report for Q4`))
+	assert.Error(t, err)
+	assert.True(t, msg.Partial)
+	assert.Equal(t, 14, msg.Pri)
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+func BenchmarkParse_RFC5424_NoSD(b *testing.B) {
+	input := []byte(`<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 - An application event log entry`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Parse(input) //nolint:errcheck
+	}
+}
+
+func BenchmarkParse_RFC5424_WithSD(b *testing.B) {
+	input := []byte(`<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] An application event log entry`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Parse(input) //nolint:errcheck
+	}
+}
+
+func BenchmarkParse_BSD(b *testing.B) {
+	input := []byte(`<13>Feb 13 20:07:26 74794bfb6795 root[8539]: i am foobar`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Parse(input) //nolint:errcheck
+	}
+}
+
+func BenchmarkParseBSDLine(b *testing.B) {
+	input := []byte(`Dec 28 16:49:07 plertrood-thinkpad-x220 nginx: 127.0.0.1 - - request`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParseBSDLine(input) //nolint:errcheck
+	}
+}
+
+func BenchmarkBuildSyslogFields(b *testing.B) {
+	parsed := &SyslogMessage{
+		Pri:       165,
+		Version:   "1",
+		Timestamp: "2003-10-11T22:14:15.003Z",
+		Hostname:  "mymachine",
+		AppName:   "evntslog",
+		ProcID:    "-",
+		MsgID:     "ID47",
+		StructuredData: map[string]map[string]string{
+			"exampleSDID@32473": {"iut": "3"},
+		},
+		Msg: []byte("An application event log entry"),
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		BuildSyslogFields(parsed)
+	}
+}


### PR DESCRIPTION
## Summary

**Part 2 of 6** in the syslog ingestion stack (`syslog-v1` → `syslog-v6`). Each PR targets `main`; use per-commit view for incremental diffs.

Core RFC 3164/5424 parsing library plus the `parsers.Parser` interface implementation. No CEF/LEEF yet.

- **syslog.go**: Full RFC 5424 parser (PRI, VERSION, TIMESTAMP, HOSTNAME, APP-NAME, PROCID, MSGID, STRUCTURED-DATA, MSG), RFC 3164/BSD parser with and without PRI header, auto-detection, severity/facility decoding, timestamp normalization
- **parser.go**: `parsers.Parser` interface producing `StateStructured` messages with syslog metadata in `BasicStructuredContent`, `SourceOverride`/`ServiceOverride` from AppName
- Comprehensive test coverage for both RFC formats, edge cases, malformed input, and mixed-format auto-detection

## Test plan

- [x] `inv test --targets=./pkg/logs/internal/parsers/syslog` — 56 tests pass
- [x] RFC 5424 and RFC 3164 parsing verified
- [x] Auto-detection between formats verified
- [x] Malformed input handling verified