### PR TITLE
[ AGNTLOG-600 ] [logs-agent] Syslog v3: CEF/LEEF structured message parser

### DIFF
--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -103,6 +103,12 @@ type LogsConfig struct {
 	// ProcessRawMessage is used to process the raw message instead of only the content part of the message.
 	ProcessRawMessage *bool `mapstructure:"process_raw_message" json:"process_raw_message" yaml:"process_raw_message"`
 
+	// SIEMParsing enables CEF/LEEF header detection and extraction within syslog
+	// message bodies. When true (the default), syslog messages whose body starts
+	// with "CEF:" or "LEEF:" are parsed into structured SIEM fields. Set to false
+	// to skip this detection and treat the message body as plain text.
+	SIEMParsing *bool `mapstructure:"siem_parsing" json:"siem_parsing" yaml:"siem_parsing"`
+
 	AutoMultiLine               *bool   `mapstructure:"auto_multi_line_detection" json:"auto_multi_line_detection" yaml:"auto_multi_line_detection"`
 	AutoMultiLineSampleSize     int     `mapstructure:"auto_multi_line_sample_size" json:"auto_multi_line_sample_size" yaml:"auto_multi_line_sample_size"`
 	AutoMultiLineMatchThreshold float64 `mapstructure:"auto_multi_line_match_threshold" json:"auto_multi_line_match_threshold" yaml:"auto_multi_line_match_threshold"`

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -115,6 +115,9 @@ type LogsConfig struct {
 	// AutoMultiLineOptions provides detailed configuration for auto multi-line detection specific to this source.
 	// It maps to the 'auto_multi_line' key in the YAML configuration.
 	AutoMultiLineOptions *SourceAutoMultiLineOptions `mapstructure:"auto_multi_line" json:"auto_multi_line" yaml:"auto_multi_line"`
+	// ExperimentalAdaptiveSampling provides per-source overrides for the experimental adaptive sampler.
+	// It maps to the 'experimental_adaptive_sampling' key in the YAML configuration.
+	ExperimentalAdaptiveSampling *SourceAdaptiveSamplingOptions `mapstructure:"experimental_adaptive_sampling" json:"experimental_adaptive_sampling" yaml:"experimental_adaptive_sampling"`
 	// CustomSamples holds the raw string content of the 'auto_multi_line_detection_custom_samples' YAML block.
 	// Downstream code will be responsible for parsing this string.
 	AutoMultiLineSamples []*AutoMultilineSample   `mapstructure:"auto_multi_line_detection_custom_samples" json:"auto_multi_line_detection_custom_samples" yaml:"auto_multi_line_detection_custom_samples"`
@@ -153,6 +156,13 @@ type SourceAutoMultiLineOptions struct {
 
 	// TagAggregatedJSON allows to enable or disable the tagging of aggregated JSON logs for this source.
 	TagAggregatedJSON *bool `mapstructure:"tag_aggregated_json" json:"tag_aggregated_json" yaml:"tag_aggregated_json"`
+}
+
+// SourceAdaptiveSamplingOptions defines per-source overrides for the experimental adaptive sampler.
+// Additional per-source filters can be added here later.
+type SourceAdaptiveSamplingOptions struct {
+	// Enabled overrides the global adaptive sampling toggle for this source when set.
+	Enabled *bool `mapstructure:"enabled" json:"enabled" yaml:"enabled"`
 }
 
 // AutoMultilineSample defines a sample used to create auto multiline detection

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -104,9 +104,10 @@ type LogsConfig struct {
 	ProcessRawMessage *bool `mapstructure:"process_raw_message" json:"process_raw_message" yaml:"process_raw_message"`
 
 	// SIEMParsing enables CEF/LEEF header detection and extraction within syslog
-	// message bodies. When true (the default), syslog messages whose body starts
-	// with "CEF:" or "LEEF:" are parsed into structured SIEM fields. Set to false
-	// to skip this detection and treat the message body as plain text.
+	// message bodies. When true (the default once syslog ingestion is wired up),
+	// syslog messages whose body starts with "CEF:" or "LEEF:" are parsed into
+	// structured SIEM fields. Set to false to skip this detection and treat the
+	// message body as plain text. See IsSIEMParsingEnabled() for nil handling.
 	SIEMParsing *bool `mapstructure:"siem_parsing" json:"siem_parsing" yaml:"siem_parsing"`
 
 	AutoMultiLine               *bool   `mapstructure:"auto_multi_line_detection" json:"auto_multi_line_detection" yaml:"auto_multi_line_detection"`

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -115,9 +115,6 @@ type LogsConfig struct {
 	// AutoMultiLineOptions provides detailed configuration for auto multi-line detection specific to this source.
 	// It maps to the 'auto_multi_line' key in the YAML configuration.
 	AutoMultiLineOptions *SourceAutoMultiLineOptions `mapstructure:"auto_multi_line" json:"auto_multi_line" yaml:"auto_multi_line"`
-	// ExperimentalAdaptiveSampling provides per-source overrides for the experimental adaptive sampler.
-	// It maps to the 'experimental_adaptive_sampling' key in the YAML configuration.
-	ExperimentalAdaptiveSampling *SourceAdaptiveSamplingOptions `mapstructure:"experimental_adaptive_sampling" json:"experimental_adaptive_sampling" yaml:"experimental_adaptive_sampling"`
 	// CustomSamples holds the raw string content of the 'auto_multi_line_detection_custom_samples' YAML block.
 	// Downstream code will be responsible for parsing this string.
 	AutoMultiLineSamples []*AutoMultilineSample   `mapstructure:"auto_multi_line_detection_custom_samples" json:"auto_multi_line_detection_custom_samples" yaml:"auto_multi_line_detection_custom_samples"`
@@ -156,13 +153,6 @@ type SourceAutoMultiLineOptions struct {
 
 	// TagAggregatedJSON allows to enable or disable the tagging of aggregated JSON logs for this source.
 	TagAggregatedJSON *bool `mapstructure:"tag_aggregated_json" json:"tag_aggregated_json" yaml:"tag_aggregated_json"`
-}
-
-// SourceAdaptiveSamplingOptions defines per-source overrides for the experimental adaptive sampler.
-// Additional per-source filters can be added here later.
-type SourceAdaptiveSamplingOptions struct {
-	// Enabled overrides the global adaptive sampling toggle for this source when set.
-	Enabled *bool `mapstructure:"enabled" json:"enabled" yaml:"enabled"`
 }
 
 // AutoMultilineSample defines a sample used to create auto multiline detection
@@ -612,6 +602,15 @@ func (c *LogsConfig) ShouldProcessRawMessage() bool {
 		return *c.ProcessRawMessage
 	}
 	return true // default behaviour when nothing's been configured
+}
+
+// IsSIEMParsingEnabled returns whether CEF/LEEF header detection is enabled
+// for this source. When SIEMParsing is nil (unconfigured), it defaults to true.
+func (c *LogsConfig) IsSIEMParsingEnabled() bool {
+	if c.SIEMParsing != nil {
+		return *c.SIEMParsing
+	}
+	return true
 }
 
 // ContainsWildcard returns true if the path contains any wildcard character

--- a/pkg/logs/internal/parsers/syslog/cef_leef.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef.go
@@ -1,0 +1,387 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package syslog
+
+import (
+	"bytes"
+	"strings"
+)
+
+// SIEMHeader holds the normalized header fields common to both CEF and LEEF.
+type SIEMHeader struct {
+	Format        string // "CEF" or "LEEF"
+	Version       string // e.g. "0", "1" for CEF; "1.0", "2.0" for LEEF
+	DeviceVendor  string
+	DeviceProduct string
+	DeviceVersion string
+	EventID       string // Signature ID (CEF) or Event ID (LEEF)
+	Name          string // CEF only; empty for LEEF
+	Severity      string // CEF header severity; empty for LEEF
+}
+
+var (
+	prefixCEF  = []byte("CEF:")
+	prefixLEEF = []byte("LEEF:")
+)
+
+// ParseCEFLEEF detects whether msg starts with a CEF or LEEF header and, if
+// so, parses the pipe-delimited header fields and the extension key-value
+// pairs. Returns ok=false if the message is not CEF/LEEF or is malformed.
+func ParseCEFLEEF(msg []byte) (header SIEMHeader, extension map[string]string, rawExtension []byte, ok bool) {
+	switch {
+	case bytes.HasPrefix(msg, prefixCEF):
+		return parseCEF(msg)
+	case bytes.HasPrefix(msg, prefixLEEF):
+		return parseLEEF(msg)
+	default:
+		return SIEMHeader{}, nil, nil, false
+	}
+}
+
+// parseCEF parses: CEF:Version|Vendor|Product|DevVersion|SigID|Name|Severity|Extension
+// Requires exactly 7 pipe-delimited fields after the "CEF:" prefix.
+func parseCEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
+	rest := msg[len(prefixCEF):]
+
+	fields, ext, ok := splitHeaderPipes(rest, 7)
+	if !ok {
+		return SIEMHeader{}, nil, nil, false
+	}
+
+	header := SIEMHeader{
+		Format:        "CEF",
+		Version:       unescapeCEFHeader(fields[0]),
+		DeviceVendor:  unescapeCEFHeader(fields[1]),
+		DeviceProduct: unescapeCEFHeader(fields[2]),
+		DeviceVersion: unescapeCEFHeader(fields[3]),
+		EventID:       unescapeCEFHeader(fields[4]),
+		Name:          unescapeCEFHeader(fields[5]),
+		Severity:      unescapeCEFHeader(fields[6]),
+	}
+
+	extension := parseCEFExtension(ext)
+	return header, extension, ext, true
+}
+
+// parseLEEF parses LEEF 1.0 and 2.0 messages.
+//
+// LEEF 1.0: LEEF:1.0|Vendor|Product|Version|EventID|<tab-delimited extension>
+// LEEF 2.0: LEEF:2.0|Vendor|Product|Version|EventID|Delimiter|<extension>
+func parseLEEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
+	rest := msg[len(prefixLEEF):]
+
+	pipeIdx := bytes.IndexByte(rest, '|')
+	if pipeIdx < 0 {
+		return SIEMHeader{}, nil, nil, false
+	}
+	version := string(rest[:pipeIdx])
+
+	var delimiter byte = '\t' // LEEF 1.0 default
+	var fields []string
+	var ext []byte
+	var ok bool
+
+	switch {
+	case strings.HasPrefix(version, "2."):
+		// LEEF 2.0: 6 pipe-delimited fields (version + vendor + product + devVersion + eventID + delimiter)
+		fields, ext, ok = splitHeaderPipes(rest, 6)
+		if !ok {
+			return SIEMHeader{}, nil, nil, false
+		}
+		if d, valid := parseLEEFDelimiter(fields[5]); valid {
+			delimiter = d
+		}
+	default:
+		// LEEF 1.0 (or unknown): 5 pipe-delimited fields
+		fields, ext, ok = splitHeaderPipes(rest, 5)
+		if !ok {
+			return SIEMHeader{}, nil, nil, false
+		}
+	}
+
+	header := SIEMHeader{
+		Format:        "LEEF",
+		Version:       fields[0],
+		DeviceVendor:  fields[1],
+		DeviceProduct: fields[2],
+		DeviceVersion: fields[3],
+		EventID:       fields[4],
+	}
+
+	extension := parseLEEFExtension(ext, delimiter)
+	return header, extension, ext, true
+}
+
+// splitHeaderPipes splits b into exactly n pipe-delimited header fields.
+// The content after the last pipe is returned as the extension.
+// Escaped pipes (\|) inside field values are handled correctly.
+func splitHeaderPipes(b []byte, n int) (fields []string, extension []byte, ok bool) {
+	fields = make([]string, 0, n)
+	start := 0
+	for i := 0; i < len(b); i++ {
+		if b[i] == '\\' {
+			i++ // skip escaped character
+			continue
+		}
+		if b[i] == '|' {
+			fields = append(fields, string(b[start:i]))
+			start = i + 1
+			if len(fields) == n {
+				return fields, b[start:], true
+			}
+		}
+	}
+	return nil, nil, false
+}
+
+// parseCEFExtension parses CEF extension key-value pairs where spaces
+// separate pairs but values may also contain spaces.
+//
+// Key boundaries are identified by the pattern <SP><keyChars>= where
+// keyChars is [a-zA-Z0-9_]+. The value runs from the = until the space
+// before the next key boundary (or end of input for the last pair).
+func parseCEFExtension(ext []byte) map[string]string {
+	if len(ext) == 0 {
+		return nil
+	}
+
+	s := string(ext)
+
+	// Phase 1: find all key-boundary positions.
+	// A key boundary is at index i where s[i-1]==' ' (or i==0) and
+	// s[i..j-1] matches [a-zA-Z0-9_]+ followed by '='.
+	type keySpan struct {
+		keyStart int // index of first key char
+		eqPos    int // index of '='
+	}
+	var boundaries []keySpan
+
+	i := 0
+	for i < len(s) {
+		// A key can start at position 0, or after a space.
+		if i > 0 && s[i-1] != ' ' {
+			i++
+			continue
+		}
+		// Scan forward for [a-zA-Z0-9_]+ followed by '='
+		j := i
+		for j < len(s) && isKeyChar(s[j]) {
+			j++
+		}
+		if j > i && j < len(s) && s[j] == '=' {
+			// Check that the '=' is not escaped
+			if j > 0 && s[j-1] == '\\' {
+				i = j + 1
+				continue
+			}
+			boundaries = append(boundaries, keySpan{keyStart: i, eqPos: j})
+			i = j + 1
+		} else {
+			i++
+		}
+	}
+
+	if len(boundaries) == 0 {
+		return nil
+	}
+
+	// Phase 2: extract key-value pairs using the boundaries.
+	result := make(map[string]string, len(boundaries))
+	for idx, b := range boundaries {
+		key := s[b.keyStart:b.eqPos]
+		var value string
+		valStart := b.eqPos + 1
+		if idx+1 < len(boundaries) {
+			// Value runs up to the space before the next key boundary.
+			// The space immediately before the next key is the delimiter.
+			valEnd := boundaries[idx+1].keyStart - 1
+			if valEnd < valStart {
+				valEnd = valStart
+			}
+			value = s[valStart:valEnd]
+		} else {
+			// Last pair: value runs to end, with trailing spaces stripped.
+			value = strings.TrimRight(s[valStart:], " ")
+		}
+		result[key] = unescapeCEFValue(value)
+	}
+	return result
+}
+
+// parseLEEFExtension parses LEEF extension key-value pairs separated by
+// the given delimiter. Within each pair, the first '=' splits key from value.
+func parseLEEFExtension(ext []byte, delimiter byte) map[string]string {
+	if len(ext) == 0 {
+		return nil
+	}
+
+	s := string(ext)
+	result := make(map[string]string)
+
+	for _, token := range splitOnByte(s, delimiter) {
+		if len(token) == 0 {
+			continue
+		}
+		eqIdx := strings.IndexByte(token, '=')
+		if eqIdx < 0 {
+			continue
+		}
+		key := token[:eqIdx]
+		value := token[eqIdx+1:]
+		if key != "" {
+			result[key] = value
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// splitOnByte splits s on every occurrence of sep, returning all substrings
+// including empty ones. Unlike strings.Split, this avoids allocating when
+// the separator is a single byte.
+func splitOnByte(s string, sep byte) []string {
+	n := strings.Count(s, string(sep)) + 1
+	parts := make([]string, 0, n)
+	for {
+		idx := strings.IndexByte(s, sep)
+		if idx < 0 {
+			parts = append(parts, s)
+			break
+		}
+		parts = append(parts, s[:idx])
+		s = s[idx+1:]
+	}
+	return parts
+}
+
+// parseLEEFDelimiter parses the LEEF 2.0 delimiter field.
+// Accepts a single literal character or hex notation (0xHH or xHH).
+func parseLEEFDelimiter(field string) (byte, bool) {
+	if len(field) == 0 {
+		return 0, false
+	}
+
+	// Hex notation: "0x..." or "x..."
+	var hexStr string
+	switch {
+	case strings.HasPrefix(field, "0x") || strings.HasPrefix(field, "0X"):
+		hexStr = field[2:]
+	case (field[0] == 'x' || field[0] == 'X') && len(field) > 1:
+		hexStr = field[1:]
+	}
+
+	if hexStr != "" {
+		var val byte
+		for _, c := range []byte(hexStr) {
+			var nibble byte
+			switch {
+			case c >= '0' && c <= '9':
+				nibble = c - '0'
+			case c >= 'a' && c <= 'f':
+				nibble = c - 'a' + 10
+			case c >= 'A' && c <= 'F':
+				nibble = c - 'A' + 10
+			default:
+				return 0, false
+			}
+			val = val<<4 | nibble
+		}
+		return val, true
+	}
+
+	// Single literal character
+	if len(field) == 1 {
+		return field[0], true
+	}
+	return 0, false
+}
+
+// unescapeCEFHeader unescapes \\  and \| in CEF header field values.
+func unescapeCEFHeader(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var buf strings.Builder
+	buf.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			next := s[i+1]
+			switch next {
+			case '\\', '|':
+				buf.WriteByte(next)
+				i++
+				continue
+			}
+		}
+		buf.WriteByte(s[i])
+	}
+	return buf.String()
+}
+
+// unescapeCEFValue unescapes \\, \=, \n, and \r in CEF extension values.
+func unescapeCEFValue(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var buf strings.Builder
+	buf.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			next := s[i+1]
+			switch next {
+			case '\\':
+				buf.WriteByte('\\')
+				i++
+				continue
+			case '=':
+				buf.WriteByte('=')
+				i++
+				continue
+			case 'n':
+				buf.WriteByte('\n')
+				i++
+				continue
+			case 'r':
+				buf.WriteByte('\r')
+				i++
+				continue
+			}
+		}
+		buf.WriteByte(s[i])
+	}
+	return buf.String()
+}
+
+// isKeyChar returns true for characters valid in a CEF extension key: [a-zA-Z0-9_].
+func isKeyChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
+
+// BuildSIEMFields converts a SIEMHeader and parsed extension into the map
+// stored under the "siem" key in BasicStructuredContent.
+func BuildSIEMFields(header SIEMHeader, extension map[string]string) map[string]interface{} {
+	fields := map[string]interface{}{
+		"format":         header.Format,
+		"version":        header.Version,
+		"device_vendor":  header.DeviceVendor,
+		"device_product": header.DeviceProduct,
+		"device_version": header.DeviceVersion,
+		"event_id":       header.EventID,
+	}
+	if header.Name != "" {
+		fields["name"] = header.Name
+	}
+	if header.Severity != "" {
+		fields["severity"] = header.Severity
+	}
+	if len(extension) > 0 {
+		fields["extension"] = extension
+	}
+	return fields
+}

--- a/pkg/logs/internal/parsers/syslog/cef_leef.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef.go
@@ -7,6 +7,7 @@ package syslog
 
 import (
 	"bytes"
+	"strconv"
 	"strings"
 )
 
@@ -17,9 +18,9 @@ type SIEMHeader struct {
 	DeviceVendor  string
 	DeviceProduct string
 	DeviceVersion string
-	EventID       string // Signature ID (CEF) or Event ID (LEEF)
-	Name          string // CEF only; empty for LEEF
-	Severity      string // CEF header severity; empty for LEEF
+	EventID       string      // Signature ID (CEF) or Event ID (LEEF)
+	Name          string      // CEF only; empty for LEEF
+	Severity      interface{} // CEF header severity: int (0-10) or string label; nil for LEEF
 }
 
 var (
@@ -59,7 +60,7 @@ func parseCEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 		DeviceVersion: unescapeCEFHeader(fields[3]),
 		EventID:       unescapeCEFHeader(fields[4]),
 		Name:          unescapeCEFHeader(fields[5]),
-		Severity:      unescapeCEFHeader(fields[6]),
+		Severity:      parseCEFSeverity(fields[6]),
 	}
 
 	extension := parseCEFExtension(ext)
@@ -172,11 +173,6 @@ func parseCEFExtension(ext []byte) map[string]string {
 			j++
 		}
 		if j > i && j < len(s) && s[j] == '=' {
-			// Check that the '=' is not escaped
-			if j > 0 && s[j-1] == '\\' {
-				i = j + 1
-				continue
-			}
 			boundaries = append(boundaries, keySpan{keyStart: i, eqPos: j})
 			i = j + 1
 		} else {
@@ -196,12 +192,11 @@ func parseCEFExtension(ext []byte) map[string]string {
 		valStart := b.eqPos + 1
 		if idx+1 < len(boundaries) {
 			// Value runs up to the space before the next key boundary.
-			// The space immediately before the next key is the delimiter.
 			valEnd := boundaries[idx+1].keyStart - 1
 			if valEnd < valStart {
 				valEnd = valStart
 			}
-			value = s[valStart:valEnd]
+			value = strings.TrimRight(s[valStart:valEnd], " ")
 		} else {
 			// Last pair: value runs to end, with trailing spaces stripped.
 			value = strings.TrimRight(s[valStart:], " ")
@@ -243,8 +238,8 @@ func parseLEEFExtension(ext []byte, delimiter byte) map[string]string {
 }
 
 // splitOnByte splits s on every occurrence of sep, returning all substrings
-// including empty ones. Unlike strings.Split, this avoids allocating when
-// the separator is a single byte.
+// including empty ones. Uses IndexByte for the inner loop rather than the
+// multi-byte path in strings.Split.
 func splitOnByte(s string, sep byte) []string {
 	n := strings.Count(s, string(sep)) + 1
 	parts := make([]string, 0, n)
@@ -300,6 +295,20 @@ func parseLEEFDelimiter(field string) (byte, bool) {
 		return field[0], true
 	}
 	return 0, false
+}
+
+// parseCEFSeverity parses the CEF severity field per the ArcSight spec.
+// Valid integer values are 0-10; string labels (e.g. "Low", "High") are
+// preserved as-is. Returns nil for empty input.
+func parseCEFSeverity(raw string) interface{} {
+	raw = unescapeCEFHeader(raw)
+	if raw == "" {
+		return nil
+	}
+	if n, err := strconv.Atoi(raw); err == nil && n >= 0 && n <= 10 {
+		return n
+	}
+	return raw
 }
 
 // unescapeCEFHeader unescapes \\  and \| in CEF header field values.
@@ -365,6 +374,12 @@ func isKeyChar(c byte) bool {
 
 // BuildSIEMFields converts a SIEMHeader and parsed extension into the map
 // stored under the "siem" key in BasicStructuredContent.
+//
+// Mandatory header fields (device_vendor, device_product, device_version,
+// event_id) are always emitted, even when the source header contains empty
+// values (e.g. "||"). This mirrors the CEF/LEEF spec requirement that all
+// header positions are present and lets downstream consumers distinguish
+// "field was empty in the original message" from "field was not parsed".
 func BuildSIEMFields(header SIEMHeader, extension map[string]string) map[string]interface{} {
 	fields := map[string]interface{}{
 		"format":         header.Format,
@@ -377,7 +392,7 @@ func BuildSIEMFields(header SIEMHeader, extension map[string]string) map[string]
 	if header.Name != "" {
 		fields["name"] = header.Name
 	}
-	if header.Severity != "" {
+	if header.Severity != nil {
 		fields["severity"] = header.Severity
 	}
 	if len(extension) > 0 {

--- a/pkg/logs/internal/parsers/syslog/cef_leef.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef.go
@@ -281,6 +281,9 @@ func parseLEEFDelimiter(field string) (byte, bool) {
 	}
 
 	if hexStr != "" {
+		if len(hexStr) == 0 || len(hexStr) > 2 {
+			return 0, false
+		}
 		var val byte
 		for _, c := range []byte(hexStr) {
 			var nibble byte

--- a/pkg/logs/internal/parsers/syslog/cef_leef.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef.go
@@ -7,7 +7,6 @@ package syslog
 
 import (
 	"bytes"
-	"strconv"
 	"strings"
 )
 
@@ -18,9 +17,9 @@ type SIEMHeader struct {
 	DeviceVendor  string
 	DeviceProduct string
 	DeviceVersion string
-	EventID       string      // Signature ID (CEF) or Event ID (LEEF)
-	Name          string      // CEF only; empty for LEEF
-	Severity      interface{} // CEF header severity: int (0-10) or string label; nil for LEEF
+	EventID       string // Signature ID (CEF) or Event ID (LEEF)
+	Name          string // CEF only; empty for LEEF
+	Severity      string // CEF header severity (raw string, e.g. "10" or "High"); empty for LEEF
 }
 
 var (
@@ -60,7 +59,7 @@ func parseCEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 		DeviceVersion: unescapeCEFHeader(fields[3]),
 		EventID:       unescapeCEFHeader(fields[4]),
 		Name:          unescapeCEFHeader(fields[5]),
-		Severity:      parseCEFSeverity(fields[6]),
+		Severity:      unescapeCEFHeader(fields[6]),
 	}
 
 	extension := parseCEFExtension(ext)
@@ -74,6 +73,9 @@ func parseCEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 func parseLEEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 	rest := msg[len(prefixLEEF):]
 
+	// Fast scan for the first pipe to extract the version token. This does
+	// not honor escaped pipes (\|), which is acceptable because LEEF version
+	// strings never contain pipe characters.
 	pipeIdx := bytes.IndexByte(rest, '|')
 	if pipeIdx < 0 {
 		return SIEMHeader{}, nil, nil, false
@@ -85,9 +87,10 @@ func parseLEEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 	var ext []byte
 	var ok bool
 
+	isV2 := version == "2" || strings.HasPrefix(version, "2.")
 	switch {
-	case strings.HasPrefix(version, "2."):
-		// LEEF 2.0: 6 pipe-delimited fields (version + vendor + product + devVersion + eventID + delimiter)
+	case isV2:
+		// LEEF 2.x: 6 pipe-delimited fields (version + vendor + product + devVersion + eventID + delimiter)
 		fields, ext, ok = splitHeaderPipes(rest, 6)
 		if !ok {
 			return SIEMHeader{}, nil, nil, false
@@ -96,7 +99,8 @@ func parseLEEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 			delimiter = d
 		}
 	default:
-		// LEEF 1.0 (or unknown): 5 pipe-delimited fields
+		// LEEF 1.x: 5 pipe-delimited fields. Unrecognized versions (e.g. "2a")
+		// are routed here rather than silently assumed to be v2.
 		fields, ext, ok = splitHeaderPipes(rest, 5)
 		if !ok {
 			return SIEMHeader{}, nil, nil, false
@@ -106,10 +110,10 @@ func parseLEEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 	header := SIEMHeader{
 		Format:        "LEEF",
 		Version:       fields[0],
-		DeviceVendor:  fields[1],
-		DeviceProduct: fields[2],
-		DeviceVersion: fields[3],
-		EventID:       fields[4],
+		DeviceVendor:  unescapeCEFHeader(fields[1]),
+		DeviceProduct: unescapeCEFHeader(fields[2]),
+		DeviceVersion: unescapeCEFHeader(fields[3]),
+		EventID:       unescapeCEFHeader(fields[4]),
 	}
 
 	extension := parseLEEFExtension(ext, delimiter)
@@ -238,8 +242,7 @@ func parseLEEFExtension(ext []byte, delimiter byte) map[string]string {
 }
 
 // splitOnByte splits s on every occurrence of sep, returning all substrings
-// including empty ones. Uses IndexByte for the inner loop rather than the
-// multi-byte path in strings.Split.
+// including empty ones. Preallocates the result slice based on separator count.
 func splitOnByte(s string, sep byte) []string {
 	n := strings.Count(s, string(sep)) + 1
 	parts := make([]string, 0, n)
@@ -295,20 +298,6 @@ func parseLEEFDelimiter(field string) (byte, bool) {
 		return field[0], true
 	}
 	return 0, false
-}
-
-// parseCEFSeverity parses the CEF severity field per the ArcSight spec.
-// Valid integer values are 0-10; string labels (e.g. "Low", "High") are
-// preserved as-is. Returns nil for empty input.
-func parseCEFSeverity(raw string) interface{} {
-	raw = unescapeCEFHeader(raw)
-	if raw == "" {
-		return nil
-	}
-	if n, err := strconv.Atoi(raw); err == nil && n >= 0 && n <= 10 {
-		return n
-	}
-	return raw
 }
 
 // unescapeCEFHeader unescapes \\  and \| in CEF header field values.
@@ -392,7 +381,7 @@ func BuildSIEMFields(header SIEMHeader, extension map[string]string) map[string]
 	if header.Name != "" {
 		fields["name"] = header.Name
 	}
-	if header.Severity != nil {
+	if header.Severity != "" {
 		fields["severity"] = header.Severity
 	}
 	if len(extension) > 0 {

--- a/pkg/logs/internal/parsers/syslog/cef_leef.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef.go
@@ -98,6 +98,8 @@ func parseLEEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 		if d, valid := parseLEEFDelimiter(fields[5]); valid {
 			delimiter = d
 		}
+		// Invalid or empty delimiter field falls back to tab. This handles
+		// malformed v2 messages gracefully rather than rejecting them outright.
 	default:
 		// LEEF 1.x: 5 pipe-delimited fields. Unrecognized versions (e.g. "2a")
 		// are routed here rather than silently assumed to be v2.
@@ -109,7 +111,7 @@ func parseLEEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 
 	header := SIEMHeader{
 		Format:        "LEEF",
-		Version:       fields[0],
+		Version:       unescapeCEFHeader(fields[0]),
 		DeviceVendor:  unescapeCEFHeader(fields[1]),
 		DeviceProduct: unescapeCEFHeader(fields[2]),
 		DeviceVersion: unescapeCEFHeader(fields[3]),
@@ -212,6 +214,8 @@ func parseCEFExtension(ext []byte) map[string]string {
 
 // parseLEEFExtension parses LEEF extension key-value pairs separated by
 // the given delimiter. Within each pair, the first '=' splits key from value.
+// LEEF values are returned verbatim; the spec is non-prescriptive about
+// in-value escaping, unlike CEF which defines \=, \\, \n, and \r sequences.
 func parseLEEFExtension(ext []byte, delimiter byte) map[string]string {
 	if len(ext) == 0 {
 		return nil

--- a/pkg/logs/internal/parsers/syslog/cef_leef.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef.go
@@ -46,7 +46,7 @@ func ParseCEFLEEF(msg []byte) (header SIEMHeader, extension map[string]string, r
 func parseCEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 	rest := msg[len(prefixCEF):]
 
-	fields, ext, ok := splitHeaderPipes(rest, 7)
+	fields, ext, ok := splitHeaderPipes(rest, 7, true)
 	if !ok {
 		return SIEMHeader{}, nil, nil, false
 	}
@@ -91,7 +91,7 @@ func parseLEEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 	switch {
 	case isV2:
 		// LEEF 2.x: 6 pipe-delimited fields (version + vendor + product + devVersion + eventID + delimiter)
-		fields, ext, ok = splitHeaderPipes(rest, 6)
+		fields, ext, ok = splitHeaderPipes(rest, 6, false)
 		if !ok {
 			return SIEMHeader{}, nil, nil, false
 		}
@@ -103,7 +103,7 @@ func parseLEEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 	default:
 		// LEEF 1.x: 5 pipe-delimited fields. Unrecognized versions (e.g. "2a")
 		// are routed here rather than silently assumed to be v2.
-		fields, ext, ok = splitHeaderPipes(rest, 5)
+		fields, ext, ok = splitHeaderPipes(rest, 5, false)
 		if !ok {
 			return SIEMHeader{}, nil, nil, false
 		}
@@ -111,11 +111,11 @@ func parseLEEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 
 	header := SIEMHeader{
 		Format:        "LEEF",
-		Version:       unescapeCEFHeader(fields[0]),
-		DeviceVendor:  unescapeCEFHeader(fields[1]),
-		DeviceProduct: unescapeCEFHeader(fields[2]),
-		DeviceVersion: unescapeCEFHeader(fields[3]),
-		EventID:       unescapeCEFHeader(fields[4]),
+		Version:       fields[0],
+		DeviceVendor:  fields[1],
+		DeviceProduct: fields[2],
+		DeviceVersion: fields[3],
+		EventID:       fields[4],
 	}
 
 	extension := parseLEEFExtension(ext, delimiter)
@@ -124,12 +124,14 @@ func parseLEEF(msg []byte) (SIEMHeader, map[string]string, []byte, bool) {
 
 // splitHeaderPipes splits b into exactly n pipe-delimited header fields.
 // The content after the last pipe is returned as the extension.
-// Escaped pipes (\|) inside field values are handled correctly.
-func splitHeaderPipes(b []byte, n int) (fields []string, extension []byte, ok bool) {
+// When escapeAware is true (CEF), \| is treated as an escaped pipe inside
+// a field value. When false (LEEF), every pipe is a literal separator —
+// the LEEF spec does not define header-level escape sequences.
+func splitHeaderPipes(b []byte, n int, escapeAware bool) (fields []string, extension []byte, ok bool) {
 	fields = make([]string, 0, n)
 	start := 0
 	for i := 0; i < len(b); i++ {
-		if b[i] == '\\' {
+		if escapeAware && b[i] == '\\' {
 			i++ // skip escaped character
 			continue
 		}

--- a/pkg/logs/internal/parsers/syslog/cef_leef_test.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef_test.go
@@ -1,0 +1,446 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package syslog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// CEF header parsing
+// ---------------------------------------------------------------------------
+
+func TestParseCEFLEEF_CEF_Basic(t *testing.T) {
+	msg := []byte("CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232")
+	header, ext, rawExt, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+
+	assert.Equal(t, "CEF", header.Format)
+	assert.Equal(t, "0", header.Version)
+	assert.Equal(t, "Security", header.DeviceVendor)
+	assert.Equal(t, "threatmanager", header.DeviceProduct)
+	assert.Equal(t, "1.0", header.DeviceVersion)
+	assert.Equal(t, "100", header.EventID)
+	assert.Equal(t, "worm successfully stopped", header.Name)
+	assert.Equal(t, "10", header.Severity)
+
+	assert.Equal(t, "src=10.0.0.1 dst=2.1.2.2 spt=1232", string(rawExt))
+	assert.Equal(t, "10.0.0.1", ext["src"])
+	assert.Equal(t, "2.1.2.2", ext["dst"])
+	assert.Equal(t, "1232", ext["spt"])
+}
+
+func TestParseCEFLEEF_CEF_Version1(t *testing.T) {
+	msg := []byte("CEF:1|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1")
+	header, _, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "1", header.Version)
+}
+
+func TestParseCEFLEEF_CEF_EscapedPipeInHeader(t *testing.T) {
+	msg := []byte(`CEF:0|Vendor\|Inc|Product|1.0|100|Name|5|src=1.2.3.4`)
+	header, _, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "Vendor|Inc", header.DeviceVendor)
+}
+
+func TestParseCEFLEEF_CEF_EscapedBackslashInHeader(t *testing.T) {
+	msg := []byte(`CEF:0|Vendor\\Corp|Product|1.0|100|Name|5|src=1.2.3.4`)
+	header, _, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, `Vendor\Corp`, header.DeviceVendor)
+}
+
+func TestParseCEFLEEF_CEF_EmptyExtension(t *testing.T) {
+	msg := []byte("CEF:0|Vendor|Product|1.0|100|Name|5|")
+	header, ext, rawExt, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "CEF", header.Format)
+	assert.Equal(t, "", string(rawExt))
+	assert.Nil(t, ext)
+}
+
+func TestParseCEFLEEF_CEF_NoExtension(t *testing.T) {
+	// Missing final pipe means only 6 fields found, not 7.
+	msg := []byte("CEF:0|Vendor|Product|1.0|100|Name|5")
+	_, _, _, ok := ParseCEFLEEF(msg)
+	assert.False(t, ok)
+}
+
+func TestParseCEFLEEF_CEF_TooFewPipes(t *testing.T) {
+	msg := []byte("CEF:0|Vendor|Product|1.0|100")
+	_, _, _, ok := ParseCEFLEEF(msg)
+	assert.False(t, ok)
+}
+
+func TestParseCEFLEEF_CEF_EmptyMsg(t *testing.T) {
+	msg := []byte("CEF:")
+	_, _, _, ok := ParseCEFLEEF(msg)
+	assert.False(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// LEEF header parsing
+// ---------------------------------------------------------------------------
+
+func TestParseCEFLEEF_LEEF10_Basic(t *testing.T) {
+	msg := []byte("LEEF:1.0|Microsoft|MSExchange|2013 SP1|15345|src=10.0.1.7\tdst=10.0.0.5\tsev=5")
+	header, ext, rawExt, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+
+	assert.Equal(t, "LEEF", header.Format)
+	assert.Equal(t, "1.0", header.Version)
+	assert.Equal(t, "Microsoft", header.DeviceVendor)
+	assert.Equal(t, "MSExchange", header.DeviceProduct)
+	assert.Equal(t, "2013 SP1", header.DeviceVersion)
+	assert.Equal(t, "15345", header.EventID)
+	assert.Empty(t, header.Name)
+	assert.Empty(t, header.Severity)
+
+	assert.Equal(t, "src=10.0.1.7\tdst=10.0.0.5\tsev=5", string(rawExt))
+	assert.Equal(t, "10.0.1.7", ext["src"])
+	assert.Equal(t, "10.0.0.5", ext["dst"])
+	assert.Equal(t, "5", ext["sev"])
+}
+
+func TestParseCEFLEEF_LEEF20_TabDelimiter(t *testing.T) {
+	msg := []byte("LEEF:2.0|NXLog|MyApp|5.5|91|0x09|key1=val1\tkey2=val2")
+	header, ext, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+
+	assert.Equal(t, "LEEF", header.Format)
+	assert.Equal(t, "2.0", header.Version)
+	assert.Equal(t, "NXLog", header.DeviceVendor)
+	assert.Equal(t, "91", header.EventID)
+	assert.Equal(t, "val1", ext["key1"])
+	assert.Equal(t, "val2", ext["key2"])
+}
+
+func TestParseCEFLEEF_LEEF20_CaretDelimiter(t *testing.T) {
+	msg := []byte("LEEF:2.0|Lancope|StealthWatch|1.0|41|^|src=10.0.1.8^dst=10.0.0.5^sev=5")
+	header, ext, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+
+	assert.Equal(t, "LEEF", header.Format)
+	assert.Equal(t, "1.0", header.DeviceVersion)
+	assert.Equal(t, "10.0.1.8", ext["src"])
+	assert.Equal(t, "10.0.0.5", ext["dst"])
+	assert.Equal(t, "5", ext["sev"])
+	_ = header
+}
+
+func TestParseCEFLEEF_LEEF20_HexDelimiter(t *testing.T) {
+	msg := []byte("LEEF:2.0|Vendor|Product|1.0|100|0x5E|key1=a^key2=b")
+	_, ext, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "a", ext["key1"])
+	assert.Equal(t, "b", ext["key2"])
+}
+
+func TestParseCEFLEEF_LEEF20_LowercaseHex(t *testing.T) {
+	msg := []byte("LEEF:2.0|Vendor|Product|1.0|100|x7c|key1=a|key2=b")
+	_, ext, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "a", ext["key1"])
+	assert.Equal(t, "b", ext["key2"])
+}
+
+func TestParseCEFLEEF_LEEF_EmptyExtension(t *testing.T) {
+	msg := []byte("LEEF:1.0|Vendor|Product|1.0|100|")
+	header, ext, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "LEEF", header.Format)
+	assert.Nil(t, ext)
+}
+
+func TestParseCEFLEEF_LEEF_TooFewPipes(t *testing.T) {
+	msg := []byte("LEEF:1.0|Vendor|Product|1.0")
+	_, _, _, ok := ParseCEFLEEF(msg)
+	assert.False(t, ok)
+}
+
+func TestParseCEFLEEF_LEEF20_TooFewPipes(t *testing.T) {
+	msg := []byte("LEEF:2.0|Vendor|Product|1.0|100")
+	_, _, _, ok := ParseCEFLEEF(msg)
+	assert.False(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// Non-CEF/LEEF messages
+// ---------------------------------------------------------------------------
+
+func TestParseCEFLEEF_NotCEFOrLEEF(t *testing.T) {
+	cases := [][]byte{
+		[]byte("just a regular message"),
+		[]byte(""),
+		[]byte("CEF"),
+		[]byte("LEEF"),
+		[]byte("CEF 0"),
+		[]byte("LEEF 1.0"),
+		nil,
+	}
+	for _, msg := range cases {
+		_, _, _, ok := ParseCEFLEEF(msg)
+		assert.False(t, ok, "should not match: %q", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CEF extension parsing
+// ---------------------------------------------------------------------------
+
+func TestParseCEFExtension_SimpleKV(t *testing.T) {
+	ext := []byte("src=10.0.0.1 dst=2.1.2.2 spt=1232")
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "10.0.0.1", result["src"])
+	assert.Equal(t, "2.1.2.2", result["dst"])
+	assert.Equal(t, "1232", result["spt"])
+}
+
+func TestParseCEFExtension_ValueWithSpaces(t *testing.T) {
+	ext := []byte("filePath=/user/username/dir/my file name.txt dst=10.0.0.1")
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "/user/username/dir/my file name.txt", result["filePath"])
+	assert.Equal(t, "10.0.0.1", result["dst"])
+}
+
+func TestParseCEFExtension_EscapedEquals(t *testing.T) {
+	ext := []byte(`src=10.0.0.1 act=blocked a \= dst=1.1.1.1`)
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "10.0.0.1", result["src"])
+	assert.Equal(t, "blocked a =", result["act"])
+	assert.Equal(t, "1.1.1.1", result["dst"])
+}
+
+func TestParseCEFExtension_EscapedBackslash(t *testing.T) {
+	ext := []byte(`src=10.0.0.1 act=blocked a \\ dst=1.1.1.1`)
+	result := parseCEFExtension(ext)
+	assert.Equal(t, `blocked a \`, result["act"])
+	assert.Equal(t, "1.1.1.1", result["dst"])
+}
+
+func TestParseCEFExtension_EscapedNewline(t *testing.T) {
+	ext := []byte(`msg=Detected a threat.\nNo action needed`)
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "Detected a threat.\nNo action needed", result["msg"])
+}
+
+func TestParseCEFExtension_EscapedCR(t *testing.T) {
+	ext := []byte(`msg=line1\rline2`)
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "line1\rline2", result["msg"])
+}
+
+func TestParseCEFExtension_EmptyValue(t *testing.T) {
+	ext := []byte("key= dst=10.0.0.1")
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "", result["key"])
+	assert.Equal(t, "10.0.0.1", result["dst"])
+}
+
+func TestParseCEFExtension_SinglePair(t *testing.T) {
+	ext := []byte("src=10.0.0.1")
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "10.0.0.1", result["src"])
+	assert.Equal(t, 1, len(result))
+}
+
+func TestParseCEFExtension_DuplicateKeys(t *testing.T) {
+	ext := []byte("src=first src=second")
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "second", result["src"])
+}
+
+func TestParseCEFExtension_Empty(t *testing.T) {
+	assert.Nil(t, parseCEFExtension([]byte("")))
+	assert.Nil(t, parseCEFExtension(nil))
+}
+
+func TestParseCEFExtension_OnlyWhitespace(t *testing.T) {
+	assert.Nil(t, parseCEFExtension([]byte("   ")))
+}
+
+func TestParseCEFExtension_KeyWithUnderscore(t *testing.T) {
+	ext := []byte("custom_field=hello world dst=10.0.0.1")
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "hello world", result["custom_field"])
+	assert.Equal(t, "10.0.0.1", result["dst"])
+}
+
+func TestParseCEFExtension_PipeInValue(t *testing.T) {
+	// Per spec, pipes in extension values do NOT need escaping.
+	ext := []byte("act=blocked a | dst=1.1.1.1")
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "blocked a |", result["act"])
+	assert.Equal(t, "1.1.1.1", result["dst"])
+}
+
+func TestParseCEFExtension_TrailingSpacesLastValue(t *testing.T) {
+	ext := []byte("src=10.0.0.1   ")
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "10.0.0.1", result["src"])
+}
+
+// ---------------------------------------------------------------------------
+// LEEF extension parsing
+// ---------------------------------------------------------------------------
+
+func TestParseLEEFExtension_TabDelimited(t *testing.T) {
+	ext := []byte("src=10.0.0.1\tdst=10.0.0.2\tsev=5")
+	result := parseLEEFExtension(ext, '\t')
+	assert.Equal(t, "10.0.0.1", result["src"])
+	assert.Equal(t, "10.0.0.2", result["dst"])
+	assert.Equal(t, "5", result["sev"])
+}
+
+func TestParseLEEFExtension_CustomDelimiter(t *testing.T) {
+	ext := []byte("src=10.0.0.1^dst=10.0.0.2^sev=5")
+	result := parseLEEFExtension(ext, '^')
+	assert.Equal(t, "10.0.0.1", result["src"])
+	assert.Equal(t, "10.0.0.2", result["dst"])
+	assert.Equal(t, "5", result["sev"])
+}
+
+func TestParseLEEFExtension_ValueWithEquals(t *testing.T) {
+	ext := []byte("key1=a=b\tkey2=c")
+	result := parseLEEFExtension(ext, '\t')
+	assert.Equal(t, "a=b", result["key1"])
+	assert.Equal(t, "c", result["key2"])
+}
+
+func TestParseLEEFExtension_EmptyValue(t *testing.T) {
+	ext := []byte("key1=\tkey2=val")
+	result := parseLEEFExtension(ext, '\t')
+	assert.Equal(t, "", result["key1"])
+	assert.Equal(t, "val", result["key2"])
+}
+
+func TestParseLEEFExtension_DuplicateKeys(t *testing.T) {
+	ext := []byte("key=first\tkey=second")
+	result := parseLEEFExtension(ext, '\t')
+	assert.Equal(t, "second", result["key"])
+}
+
+func TestParseLEEFExtension_Empty(t *testing.T) {
+	assert.Nil(t, parseLEEFExtension([]byte(""), '\t'))
+	assert.Nil(t, parseLEEFExtension(nil, '\t'))
+}
+
+func TestParseLEEFExtension_NoEquals(t *testing.T) {
+	// Malformed token without '=' is skipped.
+	ext := []byte("noequals\tkey=val")
+	result := parseLEEFExtension(ext, '\t')
+	assert.Equal(t, "val", result["key"])
+	assert.Equal(t, 1, len(result))
+}
+
+// ---------------------------------------------------------------------------
+// parseLEEFDelimiter
+// ---------------------------------------------------------------------------
+
+func TestParseLEEFDelimiter(t *testing.T) {
+	tests := []struct {
+		input string
+		want  byte
+		ok    bool
+	}{
+		{"^", '^', true},
+		{"|", '|', true},
+		{"0x09", '\t', true},
+		{"0x5E", '^', true},
+		{"x7c", '|', true},
+		{"0X09", '\t', true},
+		{"X5E", '^', true},
+		{"", 0, false},
+		{"ab", 0, false},   // two literal chars, not hex
+		{"0xZZ", 0, false}, // invalid hex
+		{"0x", 0, false},   // hex prefix with no digits
+	}
+	for _, tc := range tests {
+		got, ok := parseLEEFDelimiter(tc.input)
+		assert.Equal(t, tc.ok, ok, "input=%q", tc.input)
+		if ok {
+			assert.Equal(t, tc.want, got, "input=%q", tc.input)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// unescapeCEFHeader
+// ---------------------------------------------------------------------------
+
+func TestUnescapeCEFHeader(t *testing.T) {
+	assert.Equal(t, `Vendor|Inc`, unescapeCEFHeader(`Vendor\|Inc`))
+	assert.Equal(t, `Vendor\Corp`, unescapeCEFHeader(`Vendor\\Corp`))
+	assert.Equal(t, `No escapes`, unescapeCEFHeader(`No escapes`))
+	assert.Equal(t, `Trailing\`, unescapeCEFHeader(`Trailing\`))
+	assert.Equal(t, `A|B\C`, unescapeCEFHeader(`A\|B\\C`))
+}
+
+// ---------------------------------------------------------------------------
+// unescapeCEFValue
+// ---------------------------------------------------------------------------
+
+func TestUnescapeCEFValue(t *testing.T) {
+	assert.Equal(t, `hello=world`, unescapeCEFValue(`hello\=world`))
+	assert.Equal(t, `back\slash`, unescapeCEFValue(`back\\slash`))
+	assert.Equal(t, "line1\nline2", unescapeCEFValue(`line1\nline2`))
+	assert.Equal(t, "line1\rline2", unescapeCEFValue(`line1\rline2`))
+	assert.Equal(t, `no escapes`, unescapeCEFValue(`no escapes`))
+	assert.Equal(t, `trailing\`, unescapeCEFValue(`trailing\`))
+}
+
+// ---------------------------------------------------------------------------
+// BuildSIEMFields
+// ---------------------------------------------------------------------------
+
+func TestBuildSIEMFields_CEF(t *testing.T) {
+	header := SIEMHeader{
+		Format:        "CEF",
+		Version:       "0",
+		DeviceVendor:  "Security",
+		DeviceProduct: "Firewall",
+		DeviceVersion: "1.0",
+		EventID:       "100",
+		Name:          "Attack",
+		Severity:      "10",
+	}
+	ext := map[string]string{"src": "1.2.3.4"}
+	fields := BuildSIEMFields(header, ext)
+
+	assert.Equal(t, "CEF", fields["format"])
+	assert.Equal(t, "0", fields["version"])
+	assert.Equal(t, "Security", fields["device_vendor"])
+	assert.Equal(t, "Firewall", fields["device_product"])
+	assert.Equal(t, "1.0", fields["device_version"])
+	assert.Equal(t, "100", fields["event_id"])
+	assert.Equal(t, "Attack", fields["name"])
+	assert.Equal(t, "10", fields["severity"])
+	assert.Equal(t, map[string]string{"src": "1.2.3.4"}, fields["extension"])
+}
+
+func TestBuildSIEMFields_LEEF(t *testing.T) {
+	header := SIEMHeader{
+		Format:        "LEEF",
+		Version:       "1.0",
+		DeviceVendor:  "Microsoft",
+		DeviceProduct: "MSExchange",
+		DeviceVersion: "2013 SP1",
+		EventID:       "15345",
+	}
+	fields := BuildSIEMFields(header, nil)
+
+	assert.Equal(t, "LEEF", fields["format"])
+	_, hasName := fields["name"]
+	assert.False(t, hasName)
+	_, hasSev := fields["severity"]
+	assert.False(t, hasSev)
+	_, hasExt := fields["extension"]
+	assert.False(t, hasExt)
+}

--- a/pkg/logs/internal/parsers/syslog/cef_leef_test.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef_test.go
@@ -6,7 +6,7 @@
 package syslog
 
 import (
-	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,12 +29,19 @@ func TestParseCEFLEEF_CEF_Basic(t *testing.T) {
 	assert.Equal(t, "1.0", header.DeviceVersion)
 	assert.Equal(t, "100", header.EventID)
 	assert.Equal(t, "worm successfully stopped", header.Name)
-	assert.Equal(t, 10, header.Severity)
+	assert.Equal(t, "10", header.Severity)
 
 	assert.Equal(t, "src=10.0.0.1 dst=2.1.2.2 spt=1232", string(rawExt))
 	assert.Equal(t, "10.0.0.1", ext["src"])
 	assert.Equal(t, "2.1.2.2", ext["dst"])
 	assert.Equal(t, "1232", ext["spt"])
+}
+
+func TestParseCEFLEEF_CEF_StringSeverity(t *testing.T) {
+	msg := []byte("CEF:0|Vendor|Product|1.0|100|Name|High|src=1.2.3.4")
+	header, _, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "High", header.Severity)
 }
 
 func TestParseCEFLEEF_CEF_Version1(t *testing.T) {
@@ -153,6 +160,21 @@ func TestParseCEFLEEF_LEEF20_LowercaseHex(t *testing.T) {
 	assert.Equal(t, "b", ext["key2"])
 }
 
+func TestParseCEFLEEF_LEEF_EscapedPipeInHeader(t *testing.T) {
+	msg := []byte("LEEF:1.0|Vendor\\|Inc|Product|1.0|100|src=10.0.0.1")
+	header, ext, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "Vendor|Inc", header.DeviceVendor)
+	assert.Equal(t, "10.0.0.1", ext["src"])
+}
+
+func TestParseCEFLEEF_LEEF_EscapedBackslashInHeader(t *testing.T) {
+	msg := []byte("LEEF:1.0|Vendor\\\\Corp|Product|1.0|100|src=10.0.0.1")
+	header, _, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "Vendor\\Corp", header.DeviceVendor)
+}
+
 func TestParseCEFLEEF_LEEF_EmptyExtension(t *testing.T) {
 	msg := []byte("LEEF:1.0|Vendor|Product|1.0|100|")
 	header, ext, _, ok := ParseCEFLEEF(msg)
@@ -177,12 +199,22 @@ func TestParseCEFLEEF_LEEF20_TooFewPipes(t *testing.T) {
 }
 
 func TestParseCEFLEEF_LEEF_VersionNoDot(t *testing.T) {
-	// LEEF:2 (no dot) falls through to LEEF-1 (5-pipe) behavior.
-	// This documents the current behavior: version "2" is not treated as 2.x.
-	msg := []byte("LEEF:2|Vendor|Product|1.0|100|src=10.0.0.1\tdst=10.0.0.2")
+	// Bare "2" is treated as LEEF-2 (6-pipe + custom delimiter).
+	msg := []byte("LEEF:2|Vendor|Product|1.0|100|^|src=10.0.0.1^dst=10.0.0.2")
 	header, ext, _, ok := ParseCEFLEEF(msg)
 	require.True(t, ok)
 	assert.Equal(t, "2", header.Version)
+	assert.Equal(t, "Vendor", header.DeviceVendor)
+	assert.Equal(t, "10.0.0.1", ext["src"])
+	assert.Equal(t, "10.0.0.2", ext["dst"])
+}
+
+func TestParseCEFLEEF_LEEF_VersionJunk(t *testing.T) {
+	// "2a" is not recognized as v2; routed to LEEF-1 (5-pipe).
+	msg := []byte("LEEF:2a|Vendor|Product|1.0|100|src=10.0.0.1\tdst=10.0.0.2")
+	header, ext, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "2a", header.Version)
 	assert.Equal(t, "10.0.0.1", ext["src"])
 	assert.Equal(t, "10.0.0.2", ext["dst"])
 }
@@ -420,33 +452,6 @@ func TestUnescapeCEFValue(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// parseCEFSeverity
-// ---------------------------------------------------------------------------
-
-func TestParseCEFSeverity_NumericInRange(t *testing.T) {
-	for i := 0; i <= 10; i++ {
-		result := parseCEFSeverity(strconv.Itoa(i))
-		assert.Equal(t, i, result)
-	}
-}
-
-func TestParseCEFSeverity_NumericOutOfRange(t *testing.T) {
-	assert.Equal(t, "11", parseCEFSeverity("11"))
-	assert.Equal(t, "-1", parseCEFSeverity("-1"))
-	assert.Equal(t, "999", parseCEFSeverity("999"))
-}
-
-func TestParseCEFSeverity_StringLabel(t *testing.T) {
-	assert.Equal(t, "Low", parseCEFSeverity("Low"))
-	assert.Equal(t, "High", parseCEFSeverity("High"))
-	assert.Equal(t, "Unknown", parseCEFSeverity("Unknown"))
-}
-
-func TestParseCEFSeverity_Empty(t *testing.T) {
-	assert.Nil(t, parseCEFSeverity(""))
-}
-
-// ---------------------------------------------------------------------------
 // BuildSIEMFields
 // ---------------------------------------------------------------------------
 
@@ -459,7 +464,7 @@ func TestBuildSIEMFields_CEF(t *testing.T) {
 		DeviceVersion: "1.0",
 		EventID:       "100",
 		Name:          "Attack",
-		Severity:      10,
+		Severity:      "10",
 	}
 	ext := map[string]string{"src": "1.2.3.4"}
 	fields := BuildSIEMFields(header, ext)
@@ -471,7 +476,7 @@ func TestBuildSIEMFields_CEF(t *testing.T) {
 	assert.Equal(t, "1.0", fields["device_version"])
 	assert.Equal(t, "100", fields["event_id"])
 	assert.Equal(t, "Attack", fields["name"])
-	assert.Equal(t, 10, fields["severity"])
+	assert.Equal(t, "10", fields["severity"])
 	assert.Equal(t, map[string]string{"src": "1.2.3.4"}, fields["extension"])
 }
 
@@ -510,6 +515,25 @@ func BenchmarkParseCEFLEEF_CEF(b *testing.B) {
 
 func BenchmarkParseCEFLEEF_LEEF(b *testing.B) {
 	input := []byte("LEEF:1.0|Microsoft|MSExchange|2013 SP1|15345|src=10.0.1.7\tdst=10.0.0.5\tsev=5")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParseCEFLEEF(input)
+	}
+}
+
+func BenchmarkParseCEFLEEF_Malformed(b *testing.B) {
+	input := []byte("CEF:0|only|three|pipes")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParseCEFLEEF(input)
+	}
+}
+
+func BenchmarkParseCEFLEEF_LargeExtension(b *testing.B) {
+	ext := strings.Repeat("key0=value0 ", 64)
+	input := []byte("CEF:0|V|P|1.0|100|N|5|" + ext)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/logs/internal/parsers/syslog/cef_leef_test.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef_test.go
@@ -6,6 +6,7 @@
 package syslog
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,7 @@ func TestParseCEFLEEF_CEF_Basic(t *testing.T) {
 	assert.Equal(t, "1.0", header.DeviceVersion)
 	assert.Equal(t, "100", header.EventID)
 	assert.Equal(t, "worm successfully stopped", header.Name)
-	assert.Equal(t, "10", header.Severity)
+	assert.Equal(t, 10, header.Severity)
 
 	assert.Equal(t, "src=10.0.0.1 dst=2.1.2.2 spt=1232", string(rawExt))
 	assert.Equal(t, "10.0.0.1", ext["src"])
@@ -132,7 +133,8 @@ func TestParseCEFLEEF_LEEF20_CaretDelimiter(t *testing.T) {
 	assert.Equal(t, "10.0.1.8", ext["src"])
 	assert.Equal(t, "10.0.0.5", ext["dst"])
 	assert.Equal(t, "5", ext["sev"])
-	_ = header
+	assert.Equal(t, "Lancope", header.DeviceVendor)
+	assert.Equal(t, "41", header.EventID)
 }
 
 func TestParseCEFLEEF_LEEF20_HexDelimiter(t *testing.T) {
@@ -156,6 +158,9 @@ func TestParseCEFLEEF_LEEF_EmptyExtension(t *testing.T) {
 	header, ext, _, ok := ParseCEFLEEF(msg)
 	require.True(t, ok)
 	assert.Equal(t, "LEEF", header.Format)
+	assert.Equal(t, "Vendor", header.DeviceVendor)
+	assert.Equal(t, "Product", header.DeviceProduct)
+	assert.Equal(t, "100", header.EventID)
 	assert.Nil(t, ext)
 }
 
@@ -169,6 +174,17 @@ func TestParseCEFLEEF_LEEF20_TooFewPipes(t *testing.T) {
 	msg := []byte("LEEF:2.0|Vendor|Product|1.0|100")
 	_, _, _, ok := ParseCEFLEEF(msg)
 	assert.False(t, ok)
+}
+
+func TestParseCEFLEEF_LEEF_VersionNoDot(t *testing.T) {
+	// LEEF:2 (no dot) falls through to LEEF-1 (5-pipe) behavior.
+	// This documents the current behavior: version "2" is not treated as 2.x.
+	msg := []byte("LEEF:2|Vendor|Product|1.0|100|src=10.0.0.1\tdst=10.0.0.2")
+	header, ext, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "2", header.Version)
+	assert.Equal(t, "10.0.0.1", ext["src"])
+	assert.Equal(t, "10.0.0.2", ext["dst"])
 }
 
 // ---------------------------------------------------------------------------
@@ -287,6 +303,13 @@ func TestParseCEFExtension_TrailingSpacesLastValue(t *testing.T) {
 	assert.Equal(t, "10.0.0.1", result["src"])
 }
 
+func TestParseCEFExtension_MultipleSpacesBetweenPairs(t *testing.T) {
+	ext := []byte("a=1  b=2")
+	result := parseCEFExtension(ext)
+	assert.Equal(t, "1", result["a"])
+	assert.Equal(t, "2", result["b"])
+}
+
 // ---------------------------------------------------------------------------
 // LEEF extension parsing
 // ---------------------------------------------------------------------------
@@ -397,6 +420,33 @@ func TestUnescapeCEFValue(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// parseCEFSeverity
+// ---------------------------------------------------------------------------
+
+func TestParseCEFSeverity_NumericInRange(t *testing.T) {
+	for i := 0; i <= 10; i++ {
+		result := parseCEFSeverity(strconv.Itoa(i))
+		assert.Equal(t, i, result)
+	}
+}
+
+func TestParseCEFSeverity_NumericOutOfRange(t *testing.T) {
+	assert.Equal(t, "11", parseCEFSeverity("11"))
+	assert.Equal(t, "-1", parseCEFSeverity("-1"))
+	assert.Equal(t, "999", parseCEFSeverity("999"))
+}
+
+func TestParseCEFSeverity_StringLabel(t *testing.T) {
+	assert.Equal(t, "Low", parseCEFSeverity("Low"))
+	assert.Equal(t, "High", parseCEFSeverity("High"))
+	assert.Equal(t, "Unknown", parseCEFSeverity("Unknown"))
+}
+
+func TestParseCEFSeverity_Empty(t *testing.T) {
+	assert.Nil(t, parseCEFSeverity(""))
+}
+
+// ---------------------------------------------------------------------------
 // BuildSIEMFields
 // ---------------------------------------------------------------------------
 
@@ -409,7 +459,7 @@ func TestBuildSIEMFields_CEF(t *testing.T) {
 		DeviceVersion: "1.0",
 		EventID:       "100",
 		Name:          "Attack",
-		Severity:      "10",
+		Severity:      10,
 	}
 	ext := map[string]string{"src": "1.2.3.4"}
 	fields := BuildSIEMFields(header, ext)
@@ -421,7 +471,7 @@ func TestBuildSIEMFields_CEF(t *testing.T) {
 	assert.Equal(t, "1.0", fields["device_version"])
 	assert.Equal(t, "100", fields["event_id"])
 	assert.Equal(t, "Attack", fields["name"])
-	assert.Equal(t, "10", fields["severity"])
+	assert.Equal(t, 10, fields["severity"])
 	assert.Equal(t, map[string]string{"src": "1.2.3.4"}, fields["extension"])
 }
 
@@ -443,4 +493,26 @@ func TestBuildSIEMFields_LEEF(t *testing.T) {
 	assert.False(t, hasSev)
 	_, hasExt := fields["extension"]
 	assert.False(t, hasExt)
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+func BenchmarkParseCEFLEEF_CEF(b *testing.B) {
+	input := []byte("CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParseCEFLEEF(input)
+	}
+}
+
+func BenchmarkParseCEFLEEF_LEEF(b *testing.B) {
+	input := []byte("LEEF:1.0|Microsoft|MSExchange|2013 SP1|15345|src=10.0.1.7\tdst=10.0.0.5\tsev=5")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParseCEFLEEF(input)
+	}
 }

--- a/pkg/logs/internal/parsers/syslog/cef_leef_test.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef_test.go
@@ -433,9 +433,12 @@ func TestParseLEEFDelimiter(t *testing.T) {
 		{"0X09", '\t', true},
 		{"X5E", '^', true},
 		{"", 0, false},
-		{"ab", 0, false},   // two literal chars, not hex
-		{"0xZZ", 0, false}, // invalid hex
-		{"0x", 0, false},   // hex prefix with no digits
+		{"ab", 0, false},    // two literal chars, not hex
+		{"0xZZ", 0, false},  // invalid hex
+		{"0x", 0, false},    // hex prefix with no digits
+		{"0x109", 0, false}, // more than 2 hex digits
+		{"x5EF", 0, false},  // more than 2 hex digits (x prefix)
+		{"0x9", '\t', true}, // single hex digit is valid
 	}
 	for _, tc := range tests {
 		got, ok := parseLEEFDelimiter(tc.input)

--- a/pkg/logs/internal/parsers/syslog/cef_leef_test.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef_test.go
@@ -161,19 +161,37 @@ func TestParseCEFLEEF_LEEF20_LowercaseHex(t *testing.T) {
 	assert.Equal(t, "b", ext["key2"])
 }
 
-func TestParseCEFLEEF_LEEF_EscapedPipeInHeader(t *testing.T) {
-	msg := []byte("LEEF:1.0|Vendor\\|Inc|Product|1.0|100|src=10.0.0.1")
+func TestParseCEFLEEF_LEEF20_BackslashDelimiter(t *testing.T) {
+	// Backslash as the literal LEEF 2.0 delimiter. Previously this failed
+	// because splitHeaderPipes treated \ as an escape and swallowed the
+	// subsequent pipe, preventing the splitter from finding all 6 fields.
+	msg := []byte("LEEF:2.0|Vendor|Product|1.0|100|\\|key1=val1\\key2=val2")
 	header, ext, _, ok := ParseCEFLEEF(msg)
 	require.True(t, ok)
-	assert.Equal(t, "Vendor|Inc", header.DeviceVendor)
-	assert.Equal(t, "10.0.0.1", ext["src"])
+	assert.Equal(t, "LEEF", header.Format)
+	assert.Equal(t, "Vendor", header.DeviceVendor)
+	assert.Equal(t, "val1", ext["key1"])
+	assert.Equal(t, "val2", ext["key2"])
 }
 
-func TestParseCEFLEEF_LEEF_EscapedBackslashInHeader(t *testing.T) {
+func TestParseCEFLEEF_LEEF_PipeInHeaderIsLiteral(t *testing.T) {
+	// LEEF does not define header-level escape sequences. A \| in a LEEF
+	// header is a literal backslash ending one field and a pipe starting
+	// the next, which shifts all subsequent fields.
+	msg := []byte("LEEF:1.0|Vendor\\|Inc|Product|1.0|100|src=10.0.0.1")
+	header, _, _, ok := ParseCEFLEEF(msg)
+	require.True(t, ok)
+	assert.Equal(t, "Vendor\\", header.DeviceVendor)
+	assert.Equal(t, "Inc", header.DeviceProduct)
+}
+
+func TestParseCEFLEEF_LEEF_BackslashInHeaderIsLiteral(t *testing.T) {
+	// Double backslash in LEEF is two literal backslash characters, not
+	// an escape sequence. The field value retains both backslashes.
 	msg := []byte("LEEF:1.0|Vendor\\\\Corp|Product|1.0|100|src=10.0.0.1")
 	header, _, _, ok := ParseCEFLEEF(msg)
 	require.True(t, ok)
-	assert.Equal(t, "Vendor\\Corp", header.DeviceVendor)
+	assert.Equal(t, "Vendor\\\\Corp", header.DeviceVendor)
 }
 
 func TestParseCEFLEEF_LEEF_EmptyExtension(t *testing.T) {

--- a/pkg/logs/internal/parsers/syslog/cef_leef_test.go
+++ b/pkg/logs/internal/parsers/syslog/cef_leef_test.go
@@ -6,6 +6,7 @@
 package syslog
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -205,6 +206,7 @@ func TestParseCEFLEEF_LEEF_VersionNoDot(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "2", header.Version)
 	assert.Equal(t, "Vendor", header.DeviceVendor)
+	assert.Equal(t, "1.0", header.DeviceVersion)
 	assert.Equal(t, "10.0.0.1", ext["src"])
 	assert.Equal(t, "10.0.0.2", ext["dst"])
 }
@@ -532,7 +534,14 @@ func BenchmarkParseCEFLEEF_Malformed(b *testing.B) {
 }
 
 func BenchmarkParseCEFLEEF_LargeExtension(b *testing.B) {
-	ext := strings.Repeat("key0=value0 ", 64)
+	var sb strings.Builder
+	for i := 0; i < 64; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "key%d=value%d", i, i)
+	}
+	ext := sb.String()
 	input := []byte("CEF:0|V|P|1.0|100|N|5|" + ext)
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/logs/internal/parsers/syslog/parser.go
+++ b/pkg/logs/internal/parsers/syslog/parser.go
@@ -65,9 +65,10 @@ func (p *parser) Parse(msg *message.Message) (*message.Message, error) {
 	}
 
 	// Detect and parse CEF/LEEF headers embedded in the syslog message body.
-	// All meaningful data is extracted into the "siem" key; the raw CEF/LEEF
-	// string has no body separate from its structured fields, so clear "message".
-	if p.siemParsing {
+	// Only attempt on the success path — when syslog parsing errored, msgBody
+	// holds the full raw content for lossless reconstruction and must not be
+	// replaced by a partial CEF/LEEF parse of a fragment.
+	if p.siemParsing && err == nil {
 		if header, ext, _, ok := ParseCEFLEEF(parsed.Msg); ok {
 			sc.Data["siem"] = BuildSIEMFields(header, ext)
 			sc.Data["message"] = ""

--- a/pkg/logs/internal/parsers/syslog/parser.go
+++ b/pkg/logs/internal/parsers/syslog/parser.go
@@ -38,6 +38,11 @@ func NewParser(siemParsing bool) parsers.Parser {
 // err != nil. On error, the structured message contains the raw content as its
 // "message" field and best-effort syslog metadata. Callers MUST NOT discard
 // the result on error — the message is intentionally usable.
+//
+// TODO(syslog-v7): On parse failure, return the original message unmodified
+// instead of wrapping partial metadata in a StateStructured message. This
+// avoids misleading syslog fields and prevents CEF/LEEF extraction on
+// potentially truncated fragments.
 func (p *parser) Parse(msg *message.Message) (*message.Message, error) {
 	var parsed SyslogMessage
 	var err error

--- a/pkg/logs/internal/parsers/syslog/parser.go
+++ b/pkg/logs/internal/parsers/syslog/parser.go
@@ -17,12 +17,18 @@ import (
 // PRI detection is automatic: if a line starts with '<', it is parsed as a
 // network-format syslog message (RFC 5424 or BSD with PRI). Otherwise it is
 // parsed as a plain BSD line without PRI (e.g., traditional /var/log/syslog).
-type parser struct{}
+type parser struct {
+	siemParsing bool
+}
 
 // NewParser returns a parsers.Parser for syslog-formatted input.
-// PRI headers are auto-detected per line; no configuration is needed.
-func NewParser() parsers.Parser {
-	return &parser{}
+// PRI headers are auto-detected per line.
+//
+// When siemParsing is true, CEF/LEEF headers in the message body are detected
+// and extracted into structured SIEM fields. When false, message bodies are
+// left as plain text regardless of content.
+func NewParser(siemParsing bool) parsers.Parser {
+	return &parser{siemParsing: siemParsing}
 }
 
 // Parse implements parsers.Parser. It parses the unstructured line content
@@ -56,6 +62,16 @@ func (p *parser) Parse(msg *message.Message) (*message.Message, error) {
 			"message": msgBody,
 			"syslog":  BuildSyslogFields(&parsed),
 		},
+	}
+
+	// Detect and parse CEF/LEEF headers embedded in the syslog message body.
+	// All meaningful data is extracted into the "siem" key; the raw CEF/LEEF
+	// string has no body separate from its structured fields, so clear "message".
+	if p.siemParsing {
+		if header, ext, _, ok := ParseCEFLEEF(parsed.Msg); ok {
+			sc.Data["siem"] = BuildSIEMFields(header, ext)
+			sc.Data["message"] = ""
+		}
 	}
 
 	structured := message.NewStructuredMessage(

--- a/pkg/logs/internal/parsers/syslog/parser_test.go
+++ b/pkg/logs/internal/parsers/syslog/parser_test.go
@@ -252,7 +252,7 @@ func TestSyslogParser_CEF_RFC5424(t *testing.T) {
 	assert.Equal(t, "1.0", siem["device_version"])
 	assert.Equal(t, "100", siem["event_id"])
 	assert.Equal(t, "worm successfully stopped", siem["name"])
-	assert.Equal(t, float64(10), siem["severity"])
+	assert.Equal(t, "10", siem["severity"])
 
 	ext, ok := siem["extension"].(map[string]interface{})
 	require.True(t, ok, "extension missing")

--- a/pkg/logs/internal/parsers/syslog/parser_test.go
+++ b/pkg/logs/internal/parsers/syslog/parser_test.go
@@ -252,7 +252,7 @@ func TestSyslogParser_CEF_RFC5424(t *testing.T) {
 	assert.Equal(t, "1.0", siem["device_version"])
 	assert.Equal(t, "100", siem["event_id"])
 	assert.Equal(t, "worm successfully stopped", siem["name"])
-	assert.Equal(t, "10", siem["severity"])
+	assert.Equal(t, float64(10), siem["severity"])
 
 	ext, ok := siem["extension"].(map[string]interface{})
 	require.True(t, ok, "extension missing")

--- a/pkg/logs/internal/parsers/syslog/parser_test.go
+++ b/pkg/logs/internal/parsers/syslog/parser_test.go
@@ -6,6 +6,7 @@
 package syslog
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -26,7 +27,7 @@ func newTestMessage(content []byte) *message.Message {
 }
 
 func TestSyslogParser_NetworkFormat_RFC5424(t *testing.T) {
-	parser := NewParser()
+	parser := NewParser(true)
 
 	input := newTestMessage([]byte(`<165>1 2003-10-11T22:14:15.003Z mymachine evntslog - ID47 [exampleSDID@32473 iut="3"] An application event log entry`))
 	result, err := parser.Parse(input)
@@ -53,7 +54,7 @@ func TestSyslogParser_NetworkFormat_RFC5424(t *testing.T) {
 }
 
 func TestSyslogParser_NetworkFormat_BSD(t *testing.T) {
-	parser := NewParser()
+	parser := NewParser(true)
 
 	input := newTestMessage([]byte(`<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8`))
 	result, err := parser.Parse(input)
@@ -68,7 +69,7 @@ func TestSyslogParser_NetworkFormat_BSD(t *testing.T) {
 }
 
 func TestSyslogParser_BSDLineFormat(t *testing.T) {
-	parser := NewParser()
+	parser := NewParser(true)
 
 	// BSD line without PRI: "Oct 11 22:14:15 mymachine su: message"
 	input := newTestMessage([]byte(`Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8`))
@@ -86,7 +87,7 @@ func TestSyslogParser_BSDLineFormat(t *testing.T) {
 }
 
 func TestSyslogParser_AppNameNILVALUE(t *testing.T) {
-	parser := NewParser()
+	parser := NewParser(true)
 
 	input := newTestMessage([]byte(`<14>1 2003-10-11T22:14:15.003Z mymachine - - - - test message`))
 	result, err := parser.Parse(input)
@@ -99,7 +100,7 @@ func TestSyslogParser_AppNameNILVALUE(t *testing.T) {
 }
 
 func TestSyslogParser_Malformed(t *testing.T) {
-	parser := NewParser()
+	parser := NewParser(true)
 
 	input := newTestMessage([]byte(`<14>`))
 	result, err := parser.Parse(input)
@@ -112,13 +113,13 @@ func TestSyslogParser_Malformed(t *testing.T) {
 }
 
 func TestSyslogParser_SupportsPartialLine(t *testing.T) {
-	parser := NewParser()
+	parser := NewParser(true)
 	assert.False(t, parser.SupportsPartialLine())
 }
 
 func TestSyslogParser_AutoDetect_MixedFormats(t *testing.T) {
 	// A single parser instance should auto-detect PRI vs non-PRI per line.
-	parser := NewParser()
+	parser := NewParser(true)
 
 	// Line with PRI (network format)
 	priInput := newTestMessage([]byte(`<14>1 2003-10-11T22:14:15.003Z myhost myapp - - - PRI message`))
@@ -145,7 +146,7 @@ func TestSyslogParser_AutoDetect_MixedFormats(t *testing.T) {
 }
 
 func TestSyslogParser_NonSyslogText(t *testing.T) {
-	parser := NewParser()
+	parser := NewParser(true)
 
 	lines := []string{
 		"this is not syslog at all",
@@ -183,7 +184,7 @@ func TestSyslogParser_NonSyslogText(t *testing.T) {
 }
 
 func TestSyslogParser_RenderedContent_RFC5424(t *testing.T) {
-	parser := NewParser()
+	parser := NewParser(true)
 
 	input := newTestMessage([]byte(`<165>1 2003-10-11T22:14:15.003Z mymachine evntslog - ID47 [exampleSDID@32473 iut="3"] An application event log entry`))
 	result, err := parser.Parse(input)
@@ -198,7 +199,7 @@ func TestSyslogParser_RenderedContent_RFC5424(t *testing.T) {
 }
 
 func TestSyslogParser_IngestionTimestampPreserved(t *testing.T) {
-	parser := NewParser()
+	parser := NewParser(true)
 	ts := int64(1234567890)
 
 	source := sources.NewLogSource("test", &config.LogsConfig{})
@@ -208,4 +209,222 @@ func TestSyslogParser_IngestionTimestampPreserved(t *testing.T) {
 	result, err := parser.Parse(msg)
 	require.NoError(t, err)
 	assert.Equal(t, ts, result.IngestionTimestamp)
+}
+
+// ---------------------------------------------------------------------------
+// CEF/LEEF integration tests (full syslog envelope + CEF/LEEF body)
+// ---------------------------------------------------------------------------
+
+func TestSyslogParser_CEF_RFC5424(t *testing.T) {
+	parser := NewParser(true)
+
+	input := newTestMessage([]byte(
+		`<14>1 2026-03-30T12:00:00Z firewall01 CEF - - - CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2 spt=1232`,
+	))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, message.StateStructured, result.State)
+
+	// CEF/LEEF messages have an empty message body; all data is in "siem"
+	assert.Equal(t, "", string(result.GetContent()))
+
+	// Render and verify JSON structure
+	rendered, err := result.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(rendered, &data))
+
+	// Syslog envelope fields should be present
+	syslog, ok := data["syslog"].(map[string]interface{})
+	require.True(t, ok, "syslog key missing")
+	assert.Equal(t, "firewall01", syslog["hostname"])
+	assert.Equal(t, "CEF", syslog["appname"])
+
+	// SIEM fields should be present
+	siem, ok := data["siem"].(map[string]interface{})
+	require.True(t, ok, "siem key missing from rendered output")
+	assert.Equal(t, "CEF", siem["format"])
+	assert.Equal(t, "0", siem["version"])
+	assert.Equal(t, "Security", siem["device_vendor"])
+	assert.Equal(t, "threatmanager", siem["device_product"])
+	assert.Equal(t, "1.0", siem["device_version"])
+	assert.Equal(t, "100", siem["event_id"])
+	assert.Equal(t, "worm successfully stopped", siem["name"])
+	assert.Equal(t, "10", siem["severity"])
+
+	ext, ok := siem["extension"].(map[string]interface{})
+	require.True(t, ok, "extension missing")
+	assert.Equal(t, "10.0.0.1", ext["src"])
+	assert.Equal(t, "2.1.2.2", ext["dst"])
+	assert.Equal(t, "1232", ext["spt"])
+}
+
+func TestSyslogParser_CEF_BSD(t *testing.T) {
+	parser := NewParser(true)
+
+	input := newTestMessage([]byte(
+		`<34>Oct 11 22:14:15 myhost CEF: CEF:0|Vendor|Product|1.0|200|Attack|8|src=1.2.3.4`,
+	))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", string(result.GetContent()))
+
+	rendered, err := result.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(rendered, &data))
+
+	siem, ok := data["siem"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "CEF", siem["format"])
+	assert.Equal(t, "Vendor", siem["device_vendor"])
+}
+
+func TestSyslogParser_LEEF10_RFC5424(t *testing.T) {
+	parser := NewParser(true)
+
+	input := newTestMessage([]byte(
+		"<13>1 2026-03-30T12:00:00Z server01 LEEF - - - LEEF:1.0|Microsoft|MSExchange|2013 SP1|15345|src=10.0.1.7\tdst=10.0.0.5\tsev=5",
+	))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, message.StateStructured, result.State)
+
+	rendered, err := result.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(rendered, &data))
+
+	siem, ok := data["siem"].(map[string]interface{})
+	require.True(t, ok, "siem key missing from rendered output")
+	assert.Equal(t, "LEEF", siem["format"])
+	assert.Equal(t, "1.0", siem["version"])
+	assert.Equal(t, "Microsoft", siem["device_vendor"])
+	assert.Equal(t, "MSExchange", siem["device_product"])
+	assert.Equal(t, "2013 SP1", siem["device_version"])
+	assert.Equal(t, "15345", siem["event_id"])
+
+	_, hasName := siem["name"]
+	assert.False(t, hasName)
+	_, hasSev := siem["severity"]
+	assert.False(t, hasSev)
+
+	ext, ok := siem["extension"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "10.0.1.7", ext["src"])
+	assert.Equal(t, "10.0.0.5", ext["dst"])
+	assert.Equal(t, "5", ext["sev"])
+}
+
+func TestSyslogParser_LEEF20_CustomDelimiter(t *testing.T) {
+	parser := NewParser(true)
+
+	input := newTestMessage([]byte(
+		`<113>1 2026-03-30T12:00:00Z hostname4 LEEF - - - LEEF:2.0|Lancope|StealthWatch|1.0|41|^|src=10.0.1.8^dst=10.0.0.5^sev=5`,
+	))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	rendered, err := result.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(rendered, &data))
+
+	siem, ok := data["siem"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "LEEF", siem["format"])
+	assert.Equal(t, "2.0", siem["version"])
+	assert.Equal(t, "41", siem["event_id"])
+
+	ext, ok := siem["extension"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "10.0.1.8", ext["src"])
+	assert.Equal(t, "10.0.0.5", ext["dst"])
+}
+
+func TestSyslogParser_NonCEFLEEF_Unchanged(t *testing.T) {
+	parser := NewParser(true)
+
+	input := newTestMessage([]byte(
+		`<165>1 2003-10-11T22:14:15.003Z mymachine evntslog - ID47 - Just a regular message`,
+	))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	rendered, err := result.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(rendered, &data))
+
+	_, hasSiem := data["siem"]
+	assert.False(t, hasSiem, "siem key should not be present for non-CEF/LEEF messages")
+	assert.Equal(t, "Just a regular message", data["message"])
+}
+
+func TestSyslogParser_CEF_EscapedPipesInHeader(t *testing.T) {
+	parser := NewParser(true)
+
+	input := newTestMessage([]byte(
+		`<14>1 2026-03-30T12:00:00Z host app - - - CEF:0|Vendor\|Inc|Product|1.0|100|Name|5|src=1.2.3.4`,
+	))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	rendered, err := result.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(rendered, &data))
+
+	siem := data["siem"].(map[string]interface{})
+	assert.Equal(t, "Vendor|Inc", siem["device_vendor"])
+}
+
+func TestSyslogParser_CEF_ExtensionWithSpacesInValue(t *testing.T) {
+	parser := NewParser(true)
+
+	input := newTestMessage([]byte(
+		`<14>1 2026-03-30T12:00:00Z host app - - - CEF:0|V|P|1.0|100|N|5|filePath=/user/dir/my file.txt dst=10.0.0.1`,
+	))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	rendered, err := result.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(rendered, &data))
+
+	ext := data["siem"].(map[string]interface{})["extension"].(map[string]interface{})
+	assert.Equal(t, "/user/dir/my file.txt", ext["filePath"])
+	assert.Equal(t, "10.0.0.1", ext["dst"])
+}
+
+func TestSyslogParser_SIEMParsingDisabled(t *testing.T) {
+	parser := NewParser(false)
+
+	input := newTestMessage([]byte(
+		`<14>1 2026-03-30T12:00:00Z host app - - - CEF:0|Security|FW|1.0|100|Blocked|5|src=10.0.0.1 dst=10.0.0.2`,
+	))
+	result, err := parser.Parse(input)
+	require.NoError(t, err)
+
+	rendered, err := result.Render()
+	require.NoError(t, err)
+
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(rendered, &data))
+
+	// With SIEM parsing disabled, the message body should be preserved as-is
+	// and no "siem" key should be present.
+	assert.Contains(t, data["message"], "CEF:0|Security|FW|")
+	assert.NotContains(t, data, "siem")
 }

--- a/pkg/logs/internal/parsers/syslog/parser_test.go
+++ b/pkg/logs/internal/parsers/syslog/parser_test.go
@@ -428,3 +428,17 @@ func TestSyslogParser_SIEMParsingDisabled(t *testing.T) {
 	assert.Contains(t, data["message"], "CEF:0|Security|FW|")
 	assert.NotContains(t, data, "siem")
 }
+
+func TestSyslogParser_MalformedSyslogDoesNotExtractSIEM(t *testing.T) {
+	parser := NewParser(true)
+	// Malformed PRI (non-digit) followed by valid CEF — syslog parse fails,
+	// so the err == nil gate must prevent CEF extraction.
+	input := newTestMessage([]byte(`<abc>CEF:0|V|P|1.0|100|N|5|src=1.2.3.4`))
+	result, err := parser.Parse(input)
+	require.Error(t, err)
+
+	rendered, rerr := result.Render()
+	require.NoError(t, rerr)
+	assert.Contains(t, string(rendered), `"message"`)
+	assert.NotContains(t, string(rendered), `"siem"`)
+}

--- a/pkg/logs/internal/parsers/syslog/syslog_fuzz_test.go
+++ b/pkg/logs/internal/parsers/syslog/syslog_fuzz_test.go
@@ -28,6 +28,10 @@ func FuzzParse(f *testing.F) {
 	f.Add([]byte(`<999>1 - - - - - - test`))
 	f.Add([]byte(`<0>1 - - - - - - test`))
 	f.Add([]byte(``))
+
+	// CEF/LEEF envelope seeds
+	f.Add([]byte(`<14>1 2026-03-30T12:00:00Z host app - - - CEF:0|Security|FW|1.0|100|Attack|10|src=10.0.0.1`))
+	f.Add([]byte(`<14>1 2026-03-30T12:00:00Z host app - - - LEEF:1.0|Vendor|Product|1.0|100|src=10.0.0.1`))
 	f.Add([]byte(`not syslog`))
 	f.Add([]byte("\x00\x01\x02"))
 	f.Add([]byte("\xff\xfe\xfd"))
@@ -68,6 +72,33 @@ func FuzzParseBSDLine(f *testing.F) {
 
 		if msg.Pri != -1 {
 			t.Errorf("ParseBSDLine should always return Pri=-1, got %d", msg.Pri)
+		}
+	})
+}
+
+func FuzzParseCEFLEEF(f *testing.F) {
+	f.Add([]byte("CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2"))
+	f.Add([]byte("LEEF:1.0|Microsoft|MSExchange|2013 SP1|15345|src=10.0.1.7\tdst=10.0.0.5"))
+	f.Add([]byte("LEEF:2.0|Vendor|Product|1.0|100|^|src=10.0.1.8^dst=10.0.0.5"))
+	f.Add([]byte(`CEF:0|Vendor\|Inc|Product|1.0|100|Name|5|act=blocked a \= dst=1.1.1.1`))
+	f.Add([]byte("not CEF or LEEF"))
+	f.Add([]byte("CEF:"))
+	f.Add([]byte("LEEF:"))
+	f.Add([]byte(""))
+	f.Add([]byte("\x00\x01\x02"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		header, ext, _, ok := ParseCEFLEEF(data)
+		if !ok {
+			return
+		}
+		if header.Format != "CEF" && header.Format != "LEEF" {
+			t.Errorf("unexpected format %q", header.Format)
+		}
+		// Walk extension map to ensure no nil keys or panics.
+		for k, v := range ext {
+			_ = k
+			_ = v
 		}
 	})
 }

--- a/pkg/logs/internal/parsers/syslog/syslog_fuzz_test.go
+++ b/pkg/logs/internal/parsers/syslog/syslog_fuzz_test.go
@@ -6,6 +6,7 @@
 package syslog
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -77,14 +78,15 @@ func FuzzParseBSDLine(f *testing.F) {
 }
 
 func FuzzParseCEFLEEF(f *testing.F) {
+	// Escape-heavy inputs exercise the splitter and unescaper.
 	f.Add([]byte("CEF:0|Security|threatmanager|1.0|100|worm successfully stopped|10|src=10.0.0.1 dst=2.1.2.2"))
+	f.Add([]byte(`CEF:0|Ven\|dor|Prod\\uct|1.0|100|Na\|me|High|act=blocked a \= b dst=1.1.1.1`))
 	f.Add([]byte("LEEF:1.0|Microsoft|MSExchange|2013 SP1|15345|src=10.0.1.7\tdst=10.0.0.5"))
 	f.Add([]byte("LEEF:2.0|Vendor|Product|1.0|100|^|src=10.0.1.8^dst=10.0.0.5"))
-	f.Add([]byte(`CEF:0|Vendor\|Inc|Product|1.0|100|Name|5|act=blocked a \= dst=1.1.1.1`))
-	f.Add([]byte("not CEF or LEEF"))
+	f.Add([]byte("LEEF:2|Vendor|Product|1.0|100|^|src=a^dst=b"))
 	f.Add([]byte("CEF:"))
 	f.Add([]byte("LEEF:"))
-	f.Add([]byte(""))
+	f.Add([]byte("CEF:0|A|B|C|D|E|F|" + strings.Repeat("k0=v0 ", 64)))
 	f.Add([]byte("\x00\x01\x02"))
 
 	f.Fuzz(func(t *testing.T, data []byte) {
@@ -95,10 +97,23 @@ func FuzzParseCEFLEEF(f *testing.F) {
 		if header.Format != "CEF" && header.Format != "LEEF" {
 			t.Errorf("unexpected format %q", header.Format)
 		}
-		// Walk extension map to ensure no nil keys or panics.
-		for k, v := range ext {
-			_ = k
-			_ = v
+		// Extension size must be bounded linearly by input size.
+		if len(ext) > len(data) {
+			t.Errorf("extension has %d keys for %d-byte input", len(ext), len(data))
 		}
+		// For CEF, every extension key must consist of valid key characters.
+		if header.Format == "CEF" {
+			for k := range ext {
+				for i := 0; i < len(k); i++ {
+					if !isKeyChar(k[i]) {
+						t.Errorf("invalid key char %q in key %q", k[i], k)
+					}
+				}
+			}
+		}
+		// Idempotence: re-parsing should not panic.
+		// (We can't check bit-identical headers because unescaping is lossy
+		// with respect to the raw bytes, but the round-trip must not crash.)
+		ParseCEFLEEF(data)
 	})
 }

--- a/pkg/logs/internal/parsers/syslog/syslog_fuzz_test.go
+++ b/pkg/logs/internal/parsers/syslog/syslog_fuzz_test.go
@@ -97,8 +97,8 @@ func FuzzParseCEFLEEF(f *testing.F) {
 		if header.Format != "CEF" && header.Format != "LEEF" {
 			t.Errorf("unexpected format %q", header.Format)
 		}
-		// Extension size must be bounded linearly by input size.
-		if len(ext) > len(data) {
+		// Every key=value pair costs at least 2 bytes (key + '=').
+		if len(ext)*2 > len(data) {
 			t.Errorf("extension has %d keys for %d-byte input", len(ext), len(data))
 		}
 		// For CEF, every extension key must consist of valid key characters.
@@ -111,9 +111,14 @@ func FuzzParseCEFLEEF(f *testing.F) {
 				}
 			}
 		}
-		// Idempotence: re-parsing should not panic.
-		// (We can't check bit-identical headers because unescaping is lossy
-		// with respect to the raw bytes, but the round-trip must not crash.)
-		ParseCEFLEEF(data)
+		// Determinism: re-parsing identical input must produce the same header.
+		// SIEMHeader is all-string fields, so == works directly.
+		h2, _, _, ok2 := ParseCEFLEEF(data)
+		if !ok2 {
+			t.Fatal("re-parse returned ok=false for previously ok input")
+		}
+		if h2 != header {
+			t.Errorf("non-deterministic header: first=%+v second=%+v", header, h2)
+		}
 	})
 }


### PR DESCRIPTION
## Summary

**Part 3 of 6** in the syslog ingestion stack (`syslog-v1` → `syslog-v6`). Each PR targets `main`; use per-commit view for incremental diffs.

Extends the core syslog parser with CEF and LEEF structured message support:

- **cef_leef.go**: ArcSight CEF parser with pipe-delimited header fields and key=value extension pairs with backslash escaping; IBM LEEF parser with tab or custom-delimiter separated key=value pairs; auto-detection from message body prefix (`CEF:`/`LEEF:`); populates `siem` sub-object in structured content
- Wire CEF/LEEF detection into parser.go message body processing
- Full test coverage for CEF/LEEF parsing, escaped pipes, spaces in values, custom delimiters, and integration with syslog envelope

## Test plan

- [x] `inv test --targets=./pkg/logs/internal/parsers/syslog` — 106 tests pass
- [x] CEF parsing with header fields and extensions verified
- [x] LEEF 1.0/2.0 with custom delimiters verified
- [x] Integration with syslog envelope (both RFC 5424 and BSD) verified