### PR TITLE
[ AGNTLOG-602 ] Syslog v5: remap_source processing rules and message metadata

### DIFF
--- a/comp/logs-library/processor/processor.go
+++ b/comp/logs-library/processor/processor.go
@@ -280,7 +280,16 @@ func (p *Processor) applyRedactingRules(msg *message.Message) bool {
 				msg.RecordProcessingRule(rule.Type, rule.Name)
 				return false
 			}
-
+		case config.RemapSource:
+			for _, match := range rule.Matching {
+				if val, ok := msg.GetStructuredAttribute(match.Attribute); ok && val == match.Value {
+					if msg.Origin != nil {
+						msg.Origin.SetMappedSource(match.NewSource)
+					}
+					msg.RecordProcessingRule(rule.Type, rule.Name)
+					break
+				}
+			}
 		}
 	}
 

--- a/comp/logs-library/processor/processor_test.go
+++ b/comp/logs-library/processor/processor_test.go
@@ -439,3 +439,192 @@ func TestExcludeTruncated(t *testing.T) {
 	assert.False(shouldProcess2)
 	assert.Equal(int64(1), msg2.Origin.LogSource.ProcessingInfo.GetCount(ruleType+":"+ruleName))
 }
+
+func TestRemapSource(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("matching mapping remaps source", func(_ *testing.T) {
+		source := sources.NewLogSource("", &config.LogsConfig{
+			Source: "syslog_fallback",
+			ProcessingRules: []*config.ProcessingRule{{
+				Type: config.RemapSource,
+				Name: "siem_remap",
+				Matching: []*config.SourceMatchEntry{
+					{Attribute: "siem.device_vendor", Value: "Security", NewSource: "arcsight"},
+					{Attribute: "siem.device_product", Value: "palo alto", NewSource: "pan"},
+				},
+			}},
+		})
+		sc := &message.BasicStructuredContent{Data: map[string]interface{}{
+			"message": "test",
+			"siem": map[string]interface{}{
+				"device_vendor": "Security",
+			},
+		}}
+		msg := message.NewStructuredMessage(sc, message.NewOrigin(source), "", 0)
+
+		p := &Processor{}
+		shouldProcess := p.applyRedactingRules(msg)
+		assert.True(shouldProcess)
+		assert.Equal("arcsight", msg.Origin.Source())
+	})
+
+	t.Run("second mapping matches", func(_ *testing.T) {
+		source := sources.NewLogSource("", &config.LogsConfig{
+			Source: "syslog_fallback",
+			ProcessingRules: []*config.ProcessingRule{{
+				Type: config.RemapSource,
+				Name: "siem_remap",
+				Matching: []*config.SourceMatchEntry{
+					{Attribute: "siem.device_vendor", Value: "Security", NewSource: "arcsight"},
+					{Attribute: "siem.device_product", Value: "palo alto", NewSource: "pan"},
+				},
+			}},
+		})
+		sc := &message.BasicStructuredContent{Data: map[string]interface{}{
+			"message": "test",
+			"siem": map[string]interface{}{
+				"device_product": "palo alto",
+			},
+		}}
+		msg := message.NewStructuredMessage(sc, message.NewOrigin(source), "", 0)
+
+		p := &Processor{}
+		shouldProcess := p.applyRedactingRules(msg)
+		assert.True(shouldProcess)
+		assert.Equal("pan", msg.Origin.Source())
+	})
+
+	t.Run("no match falls back to config source", func(_ *testing.T) {
+		source := sources.NewLogSource("", &config.LogsConfig{
+			Source: "syslog_fallback",
+			ProcessingRules: []*config.ProcessingRule{{
+				Type: config.RemapSource,
+				Name: "siem_remap",
+				Matching: []*config.SourceMatchEntry{
+					{Attribute: "siem.device_vendor", Value: "Security", NewSource: "arcsight"},
+				},
+			}},
+		})
+		sc := &message.BasicStructuredContent{Data: map[string]interface{}{
+			"message": "test",
+			"siem": map[string]interface{}{
+				"device_vendor": "UnknownVendor",
+			},
+		}}
+		msg := message.NewStructuredMessage(sc, message.NewOrigin(source), "", 0)
+
+		p := &Processor{}
+		shouldProcess := p.applyRedactingRules(msg)
+		assert.True(shouldProcess)
+		assert.Equal("syslog_fallback", msg.Origin.Source())
+	})
+
+	t.Run("unstructured message is a no-op", func(_ *testing.T) {
+		source := sources.NewLogSource("", &config.LogsConfig{
+			Source: "syslog_fallback",
+			ProcessingRules: []*config.ProcessingRule{{
+				Type: config.RemapSource,
+				Name: "siem_remap",
+				Matching: []*config.SourceMatchEntry{
+					{Attribute: "siem.device_vendor", Value: "Security", NewSource: "arcsight"},
+				},
+			}},
+		})
+		msg := newMessage([]byte("plain text"), source, "")
+
+		p := &Processor{}
+		shouldProcess := p.applyRedactingRules(msg)
+		assert.True(shouldProcess)
+		assert.Equal("syslog_fallback", msg.Origin.Source())
+	})
+
+	t.Run("first match wins", func(_ *testing.T) {
+		source := sources.NewLogSource("", &config.LogsConfig{
+			Source: "syslog_fallback",
+			ProcessingRules: []*config.ProcessingRule{{
+				Type: config.RemapSource,
+				Name: "siem_remap",
+				Matching: []*config.SourceMatchEntry{
+					{Attribute: "siem.format", Value: "CEF", NewSource: "cef_source"},
+					{Attribute: "siem.device_vendor", Value: "Security", NewSource: "arcsight"},
+				},
+			}},
+		})
+		sc := &message.BasicStructuredContent{Data: map[string]interface{}{
+			"message": "test",
+			"siem": map[string]interface{}{
+				"format":        "CEF",
+				"device_vendor": "Security",
+			},
+		}}
+		msg := message.NewStructuredMessage(sc, message.NewOrigin(source), "", 0)
+
+		p := &Processor{}
+		shouldProcess := p.applyRedactingRules(msg)
+		assert.True(shouldProcess)
+		assert.Equal("cef_source", msg.Origin.Source())
+	})
+}
+
+func TestRemapSource_EscapedDotPath(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("escaped dot matches dotted SD-ID key", func(_ *testing.T) {
+		source := sources.NewLogSource("", &config.LogsConfig{
+			Source: "fallback",
+			ProcessingRules: []*config.ProcessingRule{{
+				Type: config.RemapSource,
+				Name: "sd_remap",
+				Matching: []*config.SourceMatchEntry{
+					{Attribute: `syslog.structured_data.my\.org@99999.status`, Value: "ok", NewSource: "matched_sd"},
+				},
+			}},
+		})
+		sc := &message.BasicStructuredContent{Data: map[string]interface{}{
+			"message": "test",
+			"syslog": map[string]interface{}{
+				"structured_data": map[string]interface{}{
+					"my.org@99999": map[string]interface{}{
+						"status": "ok",
+					},
+				},
+			},
+		}}
+		msg := message.NewStructuredMessage(sc, message.NewOrigin(source), "", 0)
+
+		p := &Processor{}
+		shouldProcess := p.applyRedactingRules(msg)
+		assert.True(shouldProcess)
+		assert.Equal("matched_sd", msg.Origin.Source())
+	})
+
+	t.Run("unescaped dot in dotted key does not match", func(_ *testing.T) {
+		source := sources.NewLogSource("", &config.LogsConfig{
+			Source: "fallback",
+			ProcessingRules: []*config.ProcessingRule{{
+				Type: config.RemapSource,
+				Name: "sd_remap",
+				Matching: []*config.SourceMatchEntry{
+					{Attribute: "syslog.structured_data.my.org@99999.status", Value: "ok", NewSource: "should_not_match"},
+				},
+			}},
+		})
+		sc := &message.BasicStructuredContent{Data: map[string]interface{}{
+			"message": "test",
+			"syslog": map[string]interface{}{
+				"structured_data": map[string]interface{}{
+					"my.org@99999": map[string]interface{}{
+						"status": "ok",
+					},
+				},
+			},
+		}}
+		msg := message.NewStructuredMessage(sc, message.NewOrigin(source), "", 0)
+
+		p := &Processor{}
+		shouldProcess := p.applyRedactingRules(msg)
+		assert.True(shouldProcess)
+		assert.Equal("fallback", msg.Origin.Source())
+	})
+}

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
@@ -169,7 +168,7 @@ func (m *MessageContent) GetStructuredAttribute(path string) (string, bool) {
 		return "", false
 	}
 
-	parts := strings.Split(path, ".")
+	parts := splitEscapedPath(path)
 	var current interface{} = bsc.Data
 	for _, key := range parts {
 		obj, ok := current.(map[string]interface{})
@@ -194,6 +193,36 @@ func (m *MessageContent) GetStructuredAttribute(path string) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+// splitEscapedPath splits a dot-delimited attribute path while respecting
+// backslash escapes: \. represents a literal dot, \\ represents a literal
+// backslash. Segments are unescaped after splitting.
+func splitEscapedPath(s string) []string {
+	var parts []string
+	var seg []byte
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case '.':
+				seg = append(seg, '.')
+			case '\\':
+				seg = append(seg, '\\')
+			default:
+				seg = append(seg, '\\', s[i+1])
+			}
+			i++
+			continue
+		}
+		if s[i] == '.' {
+			parts = append(parts, string(seg))
+			seg = seg[:0]
+			continue
+		}
+		seg = append(seg, s[i])
+	}
+	parts = append(parts, string(seg))
+	return parts
 }
 
 // GetContent returns the bytes array containing only the message content

--- a/pkg/logs/message/message_test.go
+++ b/pkg/logs/message/message_test.go
@@ -249,3 +249,71 @@ func TestPayloadAllowsMessageContentGC(t *testing.T) {
 	assert.Equal(t, 1, len(payload.MessageMetas))
 	assert.Equal(t, int64(2), payload.MessageMetas[0].IngestionTimestamp)
 }
+
+func TestSplitEscapedPath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"syslog.hostname", []string{"syslog", "hostname"}},
+		{`syslog.structured_data.my\.org@99999.status`, []string{"syslog", "structured_data", "my.org@99999", "status"}},
+		{`a\\b.c`, []string{`a\b`, "c"}},
+		{`trailing\`, []string{`trailing\`}},
+		{`a\\.b`, []string{`a\`, "b"}},
+		{`no_dots`, []string{"no_dots"}},
+		{"", []string{""}},
+		{`\.`, []string{"."}},
+		{`\\`, []string{`\`}},
+		{`a.b.c.d`, []string{"a", "b", "c", "d"}},
+		{`a\.b\.c.d`, []string{"a.b.c", "d"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := splitEscapedPath(tc.input)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGetStructuredAttribute_EscapedDotInKey(t *testing.T) {
+	t.Run("dotted map key reachable with escape", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{
+			"syslog": map[string]interface{}{
+				"structured_data": map[string]interface{}{
+					"my.org@99999": map[string]interface{}{
+						"status": "ok",
+					},
+				},
+			},
+		}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		val, ok := msg.GetStructuredAttribute(`syslog.structured_data.my\.org@99999.status`)
+		assert.True(t, ok)
+		assert.Equal(t, "ok", val)
+	})
+
+	t.Run("unescaped dot in dotted key fails", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{
+			"syslog": map[string]interface{}{
+				"structured_data": map[string]interface{}{
+					"my.org@99999": map[string]interface{}{
+						"status": "ok",
+					},
+				},
+			},
+		}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		_, ok := msg.GetStructuredAttribute("syslog.structured_data.my.org@99999.status")
+		assert.False(t, ok)
+	})
+
+	t.Run("escaped backslash in path", func(t *testing.T) {
+		sc := &BasicStructuredContent{Data: map[string]interface{}{
+			`back\slash`: "found",
+		}}
+		msg := NewStructuredMessage(sc, nil, "", 0)
+		val, ok := msg.GetStructuredAttribute(`back\\slash`)
+		assert.True(t, ok)
+		assert.Equal(t, "found", val)
+	})
+}

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -122,14 +122,14 @@ func (o *Origin) SetSource(source string) {
 }
 
 // SetMappedSource sets a high-priority source override, typically from a
-// remap_attribute_to_source processing rule. It takes precedence over both
-// the config source and the parser-derived source.
+// remap_source processing rule. It takes precedence over both the config
+// source and the parser-derived source.
 func (o *Origin) SetMappedSource(source string) {
 	o.mappedSource = source
 }
 
 // Source returns the source with the following priority:
-//  1. mappedSource (set by remap_attribute_to_source processing rule)
+//  1. mappedSource (set by remap_source processing rule)
 //  2. LogSource.Config.Source (user-configured source)
 //  3. o.source (parser-derived, e.g. syslog AppName)
 func (o *Origin) Source() string {


### PR DESCRIPTION
### What does this PR do?

**Part 5** of the syslog ingestion stack. This PR adds support for dynamically remapping a log's source based on parsed syslog attributes, and extends the message type to carry structured metadata through the pipeline.

Configuration defining a remapping rule has already been defined in https://github.com/DataDog/datadog-agent/pull/49028 — this PR connects that configuration with actual functionality.

Specifically:

- **Processor**: Adds a `remap_source` processing rule to `applyRedactingRules`. When a syslog message carries structured content (e.g. parsed vendor fields), the processor can look up a dot-delimited attribute path and reassign the log's `ddsource` accordingly. The path walker supports escaped dots (`\.` for literal dots in key names) and escaped backslashes.
- **Message**: Extends `message.Message` with `ParsingExtra` to propagate `SourceOverride` and `ServiceOverride` from the parser through the rest of the pipeline without losing the original origin.

### Motivation

The syslog pipeline needs to dynamically reclassify logs by vendor (e.g. Cisco ASA, Palo Alto) based on attributes discovered during parsing. Rather than requiring users to manually configure a source for each vendor, `remap_source` rules let a single syslog listener automatically route logs to the correct integration pipeline. The message metadata extensions ensure that parser-discovered overrides survive through the processor and encoder stages.

### Describe how you validated your changes

- `inv test --only-modified-packages` — 70 tests pass across `comp/logs-library/processor` and `pkg/logs/message`
- `inv linter.go --only-modified-packages` — 0 issues

### Additional Notes

This is the first of three PRs split from the original syslog-v5 changeset. The next two PRs add the TCP stream tailer (v5.1, #50519) and the UDP datagram tailer (v5.2, #50520).

Stacked on `main`. Each PR in the stack targets `main`; use per-commit view for incremental diffs.