### PR TITLE
[CWS] Register missing sbom.generate_policies config key

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -96,6 +96,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.workloads_cache_size", 10)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.enrichment_ticker", "1m")
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.host.enabled", false)
+	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.generate_policies", false)
 
 	// CWS - Event sampling (per-type)
 	cfg.BindEnvAndSetDefault("runtime_security_config.event_sampling.open.enabled", false)


### PR DESCRIPTION
### What does this PR do?

Registers the `runtime_security_config.sbom.generate_policies` config key via `BindEnvAndSetDefault` in the system-probe CWS config setup.

### Motivation

The config key was being read in `pkg/security/config/config.go` but never registered in `pkg/config/setup/system_probe_cws.go`, causing a warning log at startup:

```
config key "runtime_security_config.sbom.generate_policies" is unknown
```

### Describe how you validated your changes

Verified the warning log is gone when running system-probe.

### Additional Notes

