### PR TITLE
NDMC-285: Retry column OIDs that were unvisited in snmp check

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
@@ -66,6 +66,7 @@ func fetchColumnOidsWithBatching(sess session.Session, oids []string, batchSizeO
 func fetchColumnOids(sess session.Session, oids []string, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
 	returnValues := make(valuestore.ColumnResultValuesType, len(oids))
 	alreadyProcessedOids := make(map[string]bool)
+	retriedOids := make(map[string]bool)
 	curOids := make(map[string]string, len(oids))
 	for _, oid := range oids {
 		curOids[oid] = oid
@@ -96,8 +97,19 @@ func fetchColumnOids(sess session.Session, oids []string, bulkMaxRepetitions uin
 		if err != nil {
 			return nil, err
 		}
-		newValues, nextOids := valuestore.ResultToColumnValues(columnOids, results)
+		newValues, nextOids := valuestore.ResultToColumnValues(columnOids, curOids, results)
 		updateColumnResultValues(returnValues, newValues)
+
+		// Retry each cursor at most once in case the device truncated the
+		// response. If the retry is also truncated, the OID is dropped.
+		// Reducing oid_batch_size is the fix for that case, or adding more retries.
+		for k, v := range curOids {
+			if nextOids[k] == v && !retriedOids[v] {
+				retriedOids[v] = true
+				delete(alreadyProcessedOids, v)
+			}
+		}
+
 		curOids = nextOids
 	}
 	return returnValues, nil

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
@@ -1002,6 +1002,78 @@ func Test_fetchColumnOids_alreadyProcessed(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(logs, "[DEBUG] fetchColumnOids: fetch column: OID already processed: 1.1.2.5"), logs)
 }
 
+func Test_fetchColumnOids_truncatedResponse_retriesAdvancedCursor(t *testing.T) {
+	sess := session.CreateMockSession()
+
+	bulkPacket1 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.1.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 11,
+			},
+			{
+				Name:  "1.1.2.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 21,
+			},
+		},
+	}
+	bulkPacket2 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.1.2",
+				Type:  gosnmp.TimeTicks,
+				Value: 12,
+			},
+		},
+	}
+	bulkPacket3 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.3.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 31,
+			},
+			{
+				Name:  "1.1.2.2",
+				Type:  gosnmp.TimeTicks,
+				Value: 22,
+			},
+		},
+	}
+	bulkPacket4 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.3.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 31,
+			},
+		},
+	}
+
+	sess.On("GetBulk", []string{"1.1.1", "1.1.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket1, nil)
+	sess.On("GetBulk", []string{"1.1.1.1", "1.1.2.1"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket2, nil)
+	sess.On("GetBulk", []string{"1.1.1.2", "1.1.2.1"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket3, nil)
+	sess.On("GetBulk", []string{"1.1.2.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket4, nil)
+
+	oids := []string{"1.1.1", "1.1.2"}
+	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 100)
+
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
+	assert.Nil(t, err)
+	assert.Equal(t, valuestore.ColumnResultValuesType{
+		"1.1.1": {
+			"1": valuestore.ResultValue{Value: float64(11)},
+			"2": valuestore.ResultValue{Value: float64(12)},
+		},
+		"1.1.2": {
+			"1": valuestore.ResultValue{Value: float64(21)},
+			"2": valuestore.ResultValue{Value: float64(22)},
+		},
+	}, columnValues)
+}
+
 func Test_batchSizeOptimizers(t *testing.T) {
 	now := time.Now()
 

--- a/pkg/collector/corechecks/snmp/internal/valuestore/gosnmp_value.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/gosnmp_value.go
@@ -54,11 +54,15 @@ func ResultToScalarValues(result *gosnmp.SnmpPacket) ScalarResultValuesType {
 // ResultToColumnValues builds column values
 // - ColumnResultValuesType: column values
 // - nextOidsMap: represent the oids that can be used to retrieve following rows/values
-func ResultToColumnValues(columnOids []string, snmpPacket *gosnmp.SnmpPacket) (ColumnResultValuesType, map[string]string) {
+func ResultToColumnValues(columnOids []string, curOidsMap map[string]string, snmpPacket *gosnmp.SnmpPacket) (ColumnResultValuesType, map[string]string) {
 	returnValues := make(ColumnResultValuesType, len(columnOids))
 	nextOidsMap := make(map[string]string, len(columnOids))
 	maxRowsPerCol := int(math.Ceil(float64(len(snmpPacket.Variables)) / float64(len(columnOids))))
+	visitedOids := make(map[string]bool, len(columnOids))
 	for i, pduVariable := range snmpPacket.Variables {
+		columnOid := columnOids[i%len(columnOids)]
+		visitedOids[columnOid] = true
+
 		if shouldSkip(pduVariable.Type) {
 			continue
 		}
@@ -70,7 +74,6 @@ func ResultToColumnValues(columnOids []string, snmpPacket *gosnmp.SnmpPacket) (C
 		}
 		// the snmpPacket might contain multiple row values for a single column
 		// and the columnOid can be derived from the index of the PDU variable.
-		columnOid := columnOids[i%len(columnOids)]
 		if _, ok := returnValues[columnOid]; !ok {
 			returnValues[columnOid] = make(map[string]ResultValue, maxRowsPerCol)
 		}
@@ -84,6 +87,13 @@ func ResultToColumnValues(columnOids []string, snmpPacket *gosnmp.SnmpPacket) (C
 			// If oid is not prefixed by columnOid, it means it's not part of the column
 			// and we can stop requesting the next row of this column. This is expected.
 			delete(nextOidsMap, columnOid)
+		}
+	}
+
+	// Carry forward unvisited OIDs at their current cursor for retry.
+	for _, columnOid := range columnOids {
+		if !visitedOids[columnOid] {
+			nextOidsMap[columnOid] = curOidsMap[columnOid]
 		}
 	}
 	return returnValues, nextOidsMap

--- a/pkg/collector/corechecks/snmp/internal/valuestore/gosnmp_value_test.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/gosnmp_value_test.go
@@ -15,6 +15,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 )
 
+func currOidsForColumns(columnOids []string) map[string]string {
+	currOids := make(map[string]string, len(columnOids))
+	for _, columnOid := range columnOids {
+		currOids[columnOid] = columnOid
+	}
+	return currOids
+}
+
 func Test_getValueFromPDU(t *testing.T) {
 	tests := []struct {
 		caseName          string
@@ -403,11 +411,119 @@ func Test_resultToColumnValues(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			values, nextOidsMap := ResultToColumnValues(tt.columnOids, tt.snmpPacket)
+			values, nextOidsMap := ResultToColumnValues(tt.columnOids, currOidsForColumns(tt.columnOids), tt.snmpPacket)
 			assert.Equal(t, tt.expectedValues, values)
 			assert.Equal(t, tt.expectedNextOidsMap, nextOidsMap)
 		})
 	}
+}
+
+// Test_resultToColumnValues_truncatedResponse verifies that when a GetBulk
+// response contains fewer varbinds than requested OIDs, the unvisited OIDs
+// are carried forward in nextOidsMap for retry.
+func Test_resultToColumnValues_truncatedResponse(t *testing.T) {
+	// Simulate requesting 5 column OIDs but the device truncates the response
+	// to only 2 varbinds (e.g. due to UDP PDU size limits after wrap-around).
+	// OIDs are sorted, as they would be in fetchColumnOids.
+	columnOids := []string{
+		"1.0.8802.1.1.2.1.3.7", // LLDP (unsupported — causes wrap-around)
+		"1.0.8802.1.1.2.1.4.1", // LLDP (unsupported — causes wrap-around)
+		"1.3.6.1.2.1.2.2.1.2",  // ifDescr (supported)
+		"1.3.6.1.2.1.2.2.1.14", // ifInErrors (supported)
+		"1.3.6.1.2.1.15.3.1.1", // BGP peer table (supported)
+	}
+
+	// The device wraps around unsupported LLDP OIDs to sysDescr, producing
+	// large values that fill the UDP PDU. Only 2 varbinds fit before truncation.
+	truncatedPacket := &gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				// Wrap-around: LLDP OID not supported, device returns sysDescr
+				Name:  "1.3.6.1.2.1.1.1.0",
+				Type:  gosnmp.OctetString,
+				Value: []byte("Cisco IOS Software, long description that fills PDU..."),
+			},
+			{
+				// Wrap-around: second LLDP OID also wraps to sysDescr
+				Name:  "1.3.6.1.2.1.1.1.0",
+				Type:  gosnmp.OctetString,
+				Value: []byte("Cisco IOS Software, long description that fills PDU..."),
+			},
+			// Truncated here — ifDescr, ifInErrors, and BGP OIDs get NO varbinds
+		},
+	}
+
+	_, nextOids := ResultToColumnValues(columnOids, currOidsForColumns(columnOids), truncatedPacket)
+
+	// LLDP wrap-around responses don't match column prefix, so they should not be in nextOids
+	assert.NotContains(t, nextOids, "1.0.8802.1.1.2.1.3.7", "LLDP wrap-around should be removed from nextOids")
+	assert.NotContains(t, nextOids, "1.0.8802.1.1.2.1.4.1", "LLDP wrap-around should be removed from nextOids")
+
+	// These supported OIDs received no varbinds due to PDU truncation.
+	// They MUST be carried forward in nextOids so they are retried.
+	assert.Contains(t, nextOids, "1.3.6.1.2.1.2.2.1.2", "ifDescr should be retried after truncation")
+	assert.Contains(t, nextOids, "1.3.6.1.2.1.2.2.1.14", "ifInErrors should be retried after truncation")
+	assert.Contains(t, nextOids, "1.3.6.1.2.1.15.3.1.1", "BGP should be retried after truncation")
+}
+
+func Test_resultToColumnValues_emptyResponse(t *testing.T) {
+	columnOids := []string{"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.15.3.1.1"}
+	emptyPacket := &gosnmp.SnmpPacket{Variables: []gosnmp.SnmpPDU{}}
+
+	_, nextOids := ResultToColumnValues(columnOids, currOidsForColumns(columnOids), emptyPacket)
+
+	// All OIDs should be carried forward for retry since none were visited
+	assert.Equal(t, map[string]string{
+		"1.3.6.1.2.1.2.2.1.2":  "1.3.6.1.2.1.2.2.1.2",
+		"1.3.6.1.2.1.2.2.1.14": "1.3.6.1.2.1.2.2.1.14",
+		"1.3.6.1.2.1.15.3.1.1": "1.3.6.1.2.1.15.3.1.1",
+	}, nextOids)
+}
+
+func Test_resultToColumnValues_allSkippableResponse(t *testing.T) {
+	columnOids := []string{"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.15.3.1.1"}
+	skippablePacket := &gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{Name: "1.3.6.1.2.1.2.2.1.2.1", Type: gosnmp.EndOfMibView},
+			{Name: "1.3.6.1.2.1.2.2.1.14.1", Type: gosnmp.EndOfMibView},
+			{Name: "1.3.6.1.2.1.15.3.1.1.1", Type: gosnmp.EndOfMibView},
+		},
+	}
+
+	_, nextOids := ResultToColumnValues(columnOids, currOidsForColumns(columnOids), skippablePacket)
+
+	// All varbinds were EndOfMibView — the device explicitly answered each
+	// column, so they count as visited and should NOT be carried forward.
+	assert.Empty(t, nextOids)
+}
+
+func Test_resultToColumnValues_truncatedResponse_preservesRequestCursor(t *testing.T) {
+	columnOids := []string{"1.1.1", "1.1.2"}
+	curOidsMap := map[string]string{
+		"1.1.1": "1.1.1.2",
+		"1.1.2": "1.1.2.4",
+	}
+	truncatedPacket := &gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.1.3",
+				Type:  gosnmp.TimeTicks,
+				Value: 13,
+			},
+		},
+	}
+
+	values, nextOids := ResultToColumnValues(columnOids, curOidsMap, truncatedPacket)
+
+	assert.Equal(t, ColumnResultValuesType{
+		"1.1.1": {
+			"3": ResultValue{Value: float64(13)},
+		},
+	}, values)
+	assert.Equal(t, map[string]string{
+		"1.1.1": "1.1.1.3",
+		"1.1.2": "1.1.2.4",
+	}, nextOids)
 }
 
 func Test_resultToScalarValues(t *testing.T) {

--- a/releasenotes/notes/snmp-getbulk-truncation-retry-3ff2698fa88a6c5c.yaml
+++ b/releasenotes/notes/snmp-getbulk-truncation-retry-3ff2698fa88a6c5c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    SNMP: Retry column OIDs that receive no response varbind due to GetBulk PDU truncation,
+    preventing silent metric loss on devices with large batch sizes.


### PR DESCRIPTION
### What does this PR do?

When a SNMP device returns a truncated GetBulk response (fewer varbinds than requested column OIDs), `ResultToColumnValues` now detects which OIDs received no varbind and carries them forward in `nextOidsMap` so the caller can retry them. `fetchColumnOids` allows these unvisited OIDs to be retried exactly once to prevent infinite loops.

**Changes:**

- **`ResultToColumnValues`** (`gosnmp_value.go`): Track which column OIDs were visited (had at least one varbind mapped). After processing, any unvisited OIDs are added to `nextOidsMap` with a self-referencing key (`nextOidsMap[oid] = oid`) as a sentinel signaling "retry from scratch."

- **`fetchColumnOids`** (`fetch_column.go`): After each GetBulk cycle, detect self-referencing entries in `curOids` (the sentinel from above) and allow them to be re-processed by removing them from `alreadyProcessedOids`. A `retriedOids` map caps this at one retry per OID.

### Motivation

When a GetBulk batch contains OIDs the device doesn't support, the device responds with MIB-tree wrap-around values (e.g., `sysDescr`). If these values are large, they can fill the UDP response PDU (~1500 bytes), causing the device to legitimately truncate the response.

`ResultToColumnValues` maps varbinds to column OIDs using `columnOids[i % len(columnOids)]`. When the response is truncated, only the first N column OIDs are evaluated. The remaining OIDs never appear in the response, are never added to `nextOidsMap`, and are silently dropped — no values collected, no retry attempted.

This affects any device where unsupported OIDs produce large wrap-around values that fill the PDU before supported OIDs receive their varbinds. In the reported case, unsupported LLDP OIDs (`1.0.8802.*`) sort before BGP OIDs (`1.3.6.1.2.1.15.*`), so BGP metrics are always the ones lost.

This is distinct from the existing batch size optimizer retry, which only triggers on hard SNMP errors (timeout, `tooBig`). Truncated responses are valid SNMP — `NoError` status, just fewer varbinds than expected — so the batch size optimizer never fires.

### Describe how you validated your changes

**Unit tests** (3 new test cases in `gosnmp_value_test.go`):

- `Test_resultToColumnValues_truncatedResponse`: 5 column OIDs, response truncated to 2 varbinds (wrap-around). Asserts that the 3 unvisited supported OIDs are carried forward in `nextOidsMap` while the 2 visited wrap-around OIDs are correctly removed.
- `Test_resultToColumnValues_emptyResponse`: 0 varbinds returned. All OIDs carried forward.
- `Test_resultToColumnValues_allSkippableResponse`: All varbinds are `EndOfMibView` (skipped). All OIDs carried forward.

**Manual testing** with a local SNMP test server (`snmp_test_server.py`) that simulates truncation by capping GetBulk responses to N varbinds:

- *Scenario 1 — Baseline*: Server returns full responses. Agent collects all metrics (ifInErrors, bgpPeerIdentifier, bgpPeerState). Pass.
- *Scenario 2 — Truncated GetBulk*: Server caps responses to 2 varbinds (`--truncate-after 2`). Agent requests 3 column OIDs; 1 OID is unvisited on first request. Retry fires, unvisited OID is collected on the subsequent request. All metrics present. Pass.

### Additional Notes

- The retry is capped at exactly once per OID via `retriedOids` to prevent infinite loops when an OID is genuinely unsupported (truncation would recur on every attempt).
- The self-referencing key pattern (`nextOidsMap[oid] = oid`) naturally distinguishes "never walked" from "continue walking" (where the value is the last-seen child OID). No new data structures needed.
- Existing behavior is unchanged for non-truncated responses — `visitedOids` will contain all column OIDs, so the carry-forward loop is a no-op.
