### PR TITLE
feat(e2e): Use a reduced clone to speed-up startup

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -67,6 +67,7 @@
     GIT_STRATEGY: "clone" # Needed because we use git merge-base
     GIT_CLONE_FLAGS: "--filter=blob:none"
     GIT_SPARSE_CHECKOUT_DIRS: "comp pkg test tasks tools internal .dda"
+    DISABLE_GIT_CACHE: "true" # S3 reference cache provides all objects locally, defeating --filter=blob:none
     DYNAMIC_TESTS_FLAG: "--impacted"
     SHOULD_RUN_IN_FLAKES_FINDER: "true"
     KUBERNETES_MEMORY_REQUEST: 12Gi

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -65,6 +65,8 @@
     - export WINDOWS_DDPROCMON_DRIVER=${WINDOWS_DDPROCMON_DRIVER:-$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDPROCMON_DRIVER" --no-worktree)}
   variables:
     GIT_STRATEGY: "clone" # Needed because we use git merge-base
+    GIT_CLONE_FLAGS: "--filter=blob:none"
+    GIT_SPARSE_CHECKOUT_DIRS: "comp pkg test tasks tools internal .dda"
     DYNAMIC_TESTS_FLAG: "--impacted"
     SHOULD_RUN_IN_FLAKES_FINDER: "true"
     KUBERNETES_MEMORY_REQUEST: 12Gi


### PR DESCRIPTION
### What does this PR do?
Use sparse + blob clone for e2e tests execution

### Motivation
Speed up the clone of the repo, which can take up to 1 min.

### Describe how you validated your changes
- CI execution should be green
- Code checkout should be less than 30s on most executions

### Additional Notes
There might be a follow-up PR: we are currently fetching `comp` and `pkg` whereas the only dependency we have between the test framework and the agent should be the definition of the agent payload structures.
