### PR TITLE
[gensim-eks] Fix orchestrator environment for broader episode compatibility

### DIFF
--- a/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
@@ -1,5 +1,5 @@
 set -euo pipefail
-apk add --no-cache aws-cli py3-requests py3-yaml lsof 2>/dev/null || true
+apk add --no-cache aws-cli py3-requests 2>/dev/null || true
 helm repo add datadog https://helm.datadoghq.com && helm repo update
 
 # ── Parse image into repo + tag ──────────────────────────────────────────

--- a/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
@@ -1,5 +1,5 @@
 set -euo pipefail
-apk add --no-cache aws-cli 2>/dev/null || true
+apk add --no-cache aws-cli py3-requests 2>/dev/null || true
 helm repo add datadog https://helm.datadoghq.com && helm repo update
 
 # ── Parse image into repo + tag ──────────────────────────────────────────

--- a/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
@@ -1,5 +1,5 @@
 set -euo pipefail
-apk add --no-cache aws-cli py3-requests 2>/dev/null || true
+apk add --no-cache aws-cli py3-requests lsof 2>/dev/null || true
 helm repo add datadog https://helm.datadoghq.com && helm repo update
 
 # ── Parse image into repo + tag ──────────────────────────────────────────
@@ -174,11 +174,11 @@ for EP_SPEC in "${EP_LIST[@]}"; do
   cp "/episodes/$EPISODE/$SCENARIO.yaml" "/workspace/episodes/$SCENARIO.yaml"
   mkdir -p /workspace/results
   cd /workspace
-  # Source shared postmortem helpers (defines postmortem_chain_exit_trap etc).
-  # Episodes that don't use these functions are unaffected.
+  # Inject shared postmortem helpers into play-episode.sh so functions like
+  # postmortem_chain_exit_trap are available in the bash subprocess.
   if [ -f "/episodes/_shared/env.sh" ]; then
-    # shellcheck source=/dev/null
-    source /episodes/_shared/env.sh
+    cp /episodes/_shared/env.sh /workspace/_shared_env.sh
+    sed -i '1s|^|source /workspace/_shared_env.sh\n|' /workspace/play-episode.sh
   fi
 
   # play-episode.sh requires DD_ENV, DD_API_KEY, DD_APP_KEY, KUBE_NAMESPACE.

--- a/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/orchestrator.sh.tmpl
@@ -1,5 +1,5 @@
 set -euo pipefail
-apk add --no-cache aws-cli py3-requests 2>/dev/null || true
+apk add --no-cache aws-cli py3-requests py3-yaml lsof 2>/dev/null || true
 helm repo add datadog https://helm.datadoghq.com && helm repo update
 
 # ── Parse image into repo + tag ──────────────────────────────────────────
@@ -174,6 +174,13 @@ for EP_SPEC in "${EP_LIST[@]}"; do
   cp "/episodes/$EPISODE/$SCENARIO.yaml" "/workspace/episodes/$SCENARIO.yaml"
   mkdir -p /workspace/results
   cd /workspace
+  # Source shared postmortem helpers (defines postmortem_chain_exit_trap etc).
+  # Episodes that don't use these functions are unaffected.
+  if [ -f "/episodes/_shared/env.sh" ]; then
+    # shellcheck source=/dev/null
+    source /episodes/_shared/env.sh
+  fi
+
   # play-episode.sh requires DD_ENV, DD_API_KEY, DD_APP_KEY, KUBE_NAMESPACE.
   # DD_API_KEY, DD_APP_KEY, KUBE_NAMESPACE are set on the Job env. DD_ENV must
   # be set to the episode helm release name (used for monitor scoping).

--- a/test/e2e-framework/scenarios/aws/gensim-eks/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/run.go
@@ -373,6 +373,38 @@ func deployOrchestratorJob(
 		})
 	}
 
+	// ── Shared postmortem helpers ConfigMap ─────────────────────────────────
+	// _shared/env.sh defines postmortem_chain_exit_trap and related helpers used
+	// by many postmortem episodes. Mount it at /episodes/_shared/ so episodes that
+	// source it work without modification.
+	sharedEnvPath := filepath.Join(episodeDataDir, "postmortems", "_shared", "env.sh")
+	if sharedEnvContent, err := os.ReadFile(sharedEnvPath); err == nil {
+		sharedCM, cmErr := corev1.NewConfigMap(ctx, awsEnv.Namer.ResourceName("ep-cm-shared"),
+			&corev1.ConfigMapArgs{
+				Metadata: metav1.ObjectMetaArgs{
+					Name:      pulumi.String("gensim-ep-shared"),
+					Namespace: pulumi.String(namespace),
+				},
+				Data: pulumi.StringMap{
+					"env.sh": pulumi.String(string(sharedEnvContent)),
+				},
+			}, kubeOpts...)
+		if cmErr != nil {
+			return cmErr
+		}
+		episodeConfigMaps = append(episodeConfigMaps, sharedCM)
+		episodeVolumes = append(episodeVolumes, corev1.VolumeArgs{
+			Name: pulumi.String("ep-shared"),
+			ConfigMap: &corev1.ConfigMapVolumeSourceArgs{
+				Name: pulumi.String("gensim-ep-shared"),
+			},
+		})
+		episodeVolumeMounts = append(episodeVolumeMounts, corev1.VolumeMountArgs{
+			Name:      pulumi.String("ep-shared"),
+			MountPath: pulumi.String("/episodes/_shared"),
+		})
+	}
+
 	// ── Agent values ConfigMap ───────────────────────────────────────────────
 	renderedValues, err := renderAgentValues(agentImage, mode)
 	if err != nil {

--- a/test/e2e-framework/scenarios/aws/gensim-eks/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/run.go
@@ -377,7 +377,12 @@ func deployOrchestratorJob(
 	// _shared/env.sh defines postmortem_chain_exit_trap and related helpers used
 	// by many postmortem episodes. Mount it at /episodes/_shared/ so episodes that
 	// source it work without modification.
-	sharedEnvPath := filepath.Join(episodeDataDir, "postmortems", "_shared", "env.sh")
+	// Support both repo-root (episodeDataDir=.../gensim-episodes) and legacy
+	// (episodeDataDir=.../postmortems) layouts when locating _shared/env.sh.
+	sharedEnvPath := filepath.Join(episodeDataDir, "_shared", "env.sh")
+	if _, statErr := os.Stat(sharedEnvPath); statErr != nil {
+		sharedEnvPath = filepath.Join(episodeDataDir, "postmortems", "_shared", "env.sh")
+	}
 	if sharedEnvContent, err := os.ReadFile(sharedEnvPath); err == nil {
 		sharedCM, cmErr := corev1.NewConfigMap(ctx, awsEnv.Namer.ResourceName("ep-cm-shared"),
 			&corev1.ConfigMapArgs{


### PR DESCRIPTION
## What

Fixes missing dependencies in the gensim-eks orchestrator container that caused episodes to fail silently or crash.

**`apk add` additions:**
- `py3-requests` — several postmortem episodes use `python3 -c "import requests..."` to call the Datadog API. The orchestrator's alpine container didn't have it, causing `ModuleNotFoundError` on any such episode.
- `lsof` — used by some episodes to kill port-forward processes. Not available on alpine by default.

**`_shared/env.sh` mount:**
- `postmortems/_shared/env.sh` defines `postmortem_chain_exit_trap` and related helpers. ~20 postmortem episodes rely on these functions. Previously, sourcing `env.sh` would fail silently since the file wasn't available in the orchestrator container.
- Added a shared ConfigMap in `run.go` that packages `_shared/env.sh` and mounts it at `/episodes/_shared/`. The orchestrator sources it before invoking each episode. Episodes that don't use it are unaffected.

## Test plan
- [x] Episode using `requests` (e.g. `093_cloudflare_byzantine_failure`) runs without `ModuleNotFoundError`
- [x] Episode using `postmortem_chain_exit_trap` (e.g. `221_Base_September_2024_Outage`) runs without `command not found`
- [x] Episode using `lsof` runs without `command not found`