### PR TITLE
Cleanup SNMP Autodiscovery

### DIFF
--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -176,7 +176,10 @@ func (l *SNMPListener) loadCache(subnet *snmpSubnet) {
 	// Create services sequentially
 	for i, device := range devices {
 		entityID := subnet.config.Digest(device.IP.String())
-		l.createService(entityID, subnet, device.IP.String(), deviceInfos[i], device.AuthIndex, device.Failures, true)
+		svc := l.createService(entityID, subnet, device.IP.String(), device.AuthIndex)
+		if svc != nil {
+			l.processService(svc, deviceInfos[i], device.AuthIndex, device.Failures, true)
+		}
 	}
 }
 
@@ -234,7 +237,10 @@ func (l *SNMPListener) checkDevice(job snmpJob) {
 		}
 
 		deviceInfo := l.checkDeviceInfo(authentication, job.subnet.config.Port, deviceIP)
-		l.createService(entityID, job.subnet, deviceIP, deviceInfo, authIndex, 0, false)
+		svc := l.createService(entityID, job.subnet, deviceIP, authIndex)
+		if svc != nil {
+			l.processService(svc, deviceInfo, authIndex, 0, false)
+		}
 
 		break
 	}
@@ -476,26 +482,18 @@ func (l *SNMPListener) checkDevices() {
 	}
 }
 
-func (l *SNMPListener) createService(
-	entityID string,
-	subnet *snmpSubnet,
-	deviceIP string,
-	deviceInfo devicededuper.DeviceInfo,
-	authIndex int,
-	deviceFailures int,
-	addedFromCache bool,
-) {
+func (l *SNMPListener) createService(entityID string, subnet *snmpSubnet, deviceIP string, authIndex int) *SNMPService {
 	l.Lock()
 	defer l.Unlock()
 
 	if _, present := l.services[entityID]; present {
-		return
+		return nil
 	}
 
 	config := subnet.config
 	if authIndex < 0 || authIndex >= len(config.Authentications) {
 		log.Errorf("Invalid authentication index %d for device %s (max: %d)", authIndex, deviceIP, len(config.Authentications)-1)
-		return
+		return nil
 	}
 	authentication := config.Authentications[authIndex]
 	config.Version = authentication.Version
@@ -510,7 +508,7 @@ func (l *SNMPListener) createService(
 	config.ContextEngineID = authentication.ContextEngineID
 	config.ContextName = authentication.ContextName
 
-	svc := SNMPService{
+	svc := &SNMPService{
 		adIdentifier: subnet.adIdentifier,
 		entityID:     entityID,
 		deviceIP:     deviceIP,
@@ -518,14 +516,17 @@ func (l *SNMPListener) createService(
 		subnet:       subnet,
 		pending:      true,
 	}
-	l.services[entityID] = &svc
+	l.services[entityID] = svc
+	return svc
+}
 
+func (l *SNMPListener) processService(svc *SNMPService, deviceInfo devicededuper.DeviceInfo, authIndex int, deviceFailures int, addedFromCache bool) {
 	pendingDevice := devicededuper.PendingDevice{
-		Config:         config,
+		Config:         svc.config,
 		Info:           deviceInfo,
 		AuthIndex:      authIndex,
 		AddedFromCache: addedFromCache,
-		IP:             deviceIP,
+		IP:             svc.deviceIP,
 		Failures:       deviceFailures,
 	}
 
@@ -551,6 +552,9 @@ func (l *SNMPListener) registerDedupedDevices() {
 }
 
 func (l *SNMPListener) registerService(pendingDevice devicededuper.PendingDevice) {
+	l.Lock()
+	defer l.Unlock()
+
 	entityID := pendingDevice.Config.Digest(pendingDevice.IP)
 
 	svc, ok := l.services[entityID]

--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -219,13 +219,11 @@ func (l *SNMPListener) checkDevice(job snmpJob) {
 	deviceFound := false
 	for authIndex, authentication := range job.subnet.config.Authentications {
 		deviceFound = l.checkDeviceReachable(authentication, job.subnet.config.Port, deviceIP)
+		l.deviceDeduper.RecordScanResult(deviceIP, deviceFound)
 
 		if !deviceFound {
-			l.deviceDeduper.DecrementIPCounter(deviceIP)
 			continue
 		}
-
-		l.deviceDeduper.MarkIPAsProcessed(deviceIP)
 
 		device, exists := job.subnet.devices[entityID]
 		if exists && device.Failures != 0 {

--- a/comp/core/autodiscovery/listeners/snmp_test.go
+++ b/comp/core/autodiscovery/listeners/snmp_test.go
@@ -594,7 +594,9 @@ func TestCreateServiceFromCacheRegistersImmediately(t *testing.T) {
 
 	// Simulate loading 192.168.0.1 from cache — should register immediately
 	entityID1 := subnet.config.Digest("192.168.0.1")
-	l.createService(entityID1, subnet, "192.168.0.1", deviceInfo, 0, 0, true)
+	svc1 := l.createService(entityID1, subnet, "192.168.0.1", 0)
+	require.NotNil(t, svc1)
+	l.processService(svc1, deviceInfo, 0, 0, true)
 
 	assert.Equal(t, 1, len(newSvc))
 	svc := (<-newSvc).(*SNMPService)
@@ -603,7 +605,9 @@ func TestCreateServiceFromCacheRegistersImmediately(t *testing.T) {
 
 	// Simulate scan discovering 192.168.0.2 — same physical device, should NOT register
 	entityID2 := subnet.config.Digest("192.168.0.2")
-	l.createService(entityID2, subnet, "192.168.0.2", deviceInfo, 0, 0, false)
+	svc2 := l.createService(entityID2, subnet, "192.168.0.2", 0)
+	require.NotNil(t, svc2)
+	l.processService(svc2, deviceInfo, 0, 0, false)
 
 	assert.Equal(t, 0, len(newSvc), "second IP for same device should not be registered")
 }

--- a/pkg/snmp/devicededuper/device_deduper.go
+++ b/pkg/snmp/devicededuper/device_deduper.go
@@ -48,8 +48,7 @@ func (d DeviceInfo) equal(other DeviceInfo) bool {
 
 // DeviceDeduper is an interface for deduplicating SNMP devices
 type DeviceDeduper interface {
-	DecrementIPCounter(ip string)
-	MarkIPAsProcessed(ip string)
+	RecordScanResult(ip string, deviceFound bool)
 	AddPendingDevice(device PendingDevice)
 	GetDedupedDevices() []PendingDevice
 	ResetCounters()
@@ -176,25 +175,21 @@ func (d *deviceDeduperImpl) GetDedupedDevices() []PendingDevice {
 	return dedupedDevices
 }
 
-// DecrementIPCounter decrements the counter for an IP by 1, representing one completed auth attempt.
-func (d *deviceDeduperImpl) DecrementIPCounter(ip string) {
+// RecordScanResult records the outcome of a single authentication attempt on an IP.
+func (d *deviceDeduperImpl) RecordScanResult(ip string, deviceFound bool) {
 	d.RLock()
 	defer d.RUnlock()
 	counter, exists := d.ipsCounter[ip]
-
-	if exists {
-		counter.Add(-1)
+	if !exists {
+		return
 	}
-}
 
-// MarkIPAsProcessed sets the counter for an IP to 0, signaling that the device was found and no further attempts are needed
-func (d *deviceDeduperImpl) MarkIPAsProcessed(ip string) {
-	d.RLock()
-	defer d.RUnlock()
-	counter, exists := d.ipsCounter[ip]
-
-	if exists {
+	if deviceFound {
+		// Device responded; mark IP as fully processed so no further auth attempts are needed
 		counter.Store(0)
+	} else {
+		// Auth attempt failed; decrement remaining attempts for this IP
+		counter.Add(-1)
 	}
 }
 

--- a/pkg/snmp/devicededuper/device_deduper_test.go
+++ b/pkg/snmp/devicededuper/device_deduper_test.go
@@ -175,7 +175,7 @@ func TestDeviceDeduper_Contains(t *testing.T) {
 	assert.False(t, deduper.contains(differentDevice))
 }
 
-func TestDeviceDeduper_DecrementIPCounter(t *testing.T) {
+func TestDeviceDeduper_RecordScanResultNotFound(t *testing.T) {
 	deduper := &deviceDeduperImpl{
 		deviceInfos:    make([]DeviceInfo, 0),
 		pendingDevices: make([]PendingDevice, 0),
@@ -190,25 +190,25 @@ func TestDeviceDeduper_DecrementIPCounter(t *testing.T) {
 	counter2.Store(1)
 	deduper.ipsCounter["192.168.1.2"] = counter2
 
-	deduper.DecrementIPCounter("192.168.1.1")
+	deduper.RecordScanResult("192.168.1.1", false)
 	count := deduper.ipsCounter["192.168.1.1"].Load()
 	assert.Equal(t, int32(1), count)
 
-	deduper.DecrementIPCounter("192.168.1.1")
+	deduper.RecordScanResult("192.168.1.1", false)
 	count = deduper.ipsCounter["192.168.1.1"].Load()
 	assert.Equal(t, int32(0), count)
 
-	deduper.DecrementIPCounter("192.168.1.2")
+	deduper.RecordScanResult("192.168.1.2", false)
 	count = deduper.ipsCounter["192.168.1.2"].Load()
 	assert.Equal(t, int32(0), count)
 
 	// Decrementing past 0 goes to -1, which checkPreviousIPs still treats as processed (count > 0 is false)
-	deduper.DecrementIPCounter("192.168.1.2")
+	deduper.RecordScanResult("192.168.1.2", false)
 	count = deduper.ipsCounter["192.168.1.2"].Load()
 	assert.Equal(t, int32(-1), count)
 }
 
-func TestDeviceDeduper_MarkIPAsProcessed(t *testing.T) {
+func TestDeviceDeduper_RecordScanResultFound(t *testing.T) {
 	deduper := &deviceDeduperImpl{
 		deviceInfos:    make([]DeviceInfo, 0),
 		pendingDevices: make([]PendingDevice, 0),
@@ -219,7 +219,7 @@ func TestDeviceDeduper_MarkIPAsProcessed(t *testing.T) {
 	counter1.Store(5)
 	deduper.ipsCounter["192.168.1.1"] = counter1
 
-	deduper.MarkIPAsProcessed("192.168.1.1")
+	deduper.RecordScanResult("192.168.1.1", true)
 	count := deduper.ipsCounter["192.168.1.1"].Load()
 	assert.Equal(t, int32(0), count)
 }
@@ -597,8 +597,8 @@ func TestDeviceDeduper_ResetCounters(t *testing.T) {
 	assert.Equal(t, int32(2), count)
 
 	// Process some IPs
-	deduper.DecrementIPCounter("192.168.1.1")
-	deduper.DecrementIPCounter("192.168.1.2")
+	deduper.RecordScanResult("192.168.1.1", false)
+	deduper.RecordScanResult("192.168.1.2", false)
 
 	count = deduperImpl.ipsCounter["192.168.1.1"].Load()
 	assert.Equal(t, int32(1), count)


### PR DESCRIPTION
### What does this PR do?

Cleans up the SNMP autodiscovery listener and device deduper:              
                                                                             
1. Combines DecrementIPCounter and MarkIPAsProcessed into a single RecordScanResult(ip, deviceFound) method on the DeviceDeduper interface. The caller just reports whether a device was found instead of choosing between two methods.                                      
2. Splits createService into createService and processService. createService now only creates and stores the SNMPService. processService handles the dedup/registration pipeline separately.

### Motivation

Both methods on the deduper interface represented the same event (an auth attempt completed) but split across two call sites. Merging them simplifies the interface and reduces coupling. Similarly, createService was mixing service creation with dedup routing — splitting it makes each method single-responsibility. 

### Describe how you validated your changes

Unit tests need to run successfully. Running locally needs to keep normal behavior.

### Additional Notes

No behavioral changes — this is a pure refactor. 
