### PR TITLE
APM: mark max eps config as deprecated

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1360,6 +1360,9 @@ api_key:
 #   # @param max_events_per_second - integer - optional - default: 200
 #   # @env DD_APM_MAX_EPS - integer - optional - default: 200
 #   # @env DD_MAX_EPS - integer - optional - default: 200
+#   # **Deprecated.** APM events are a deprecated feature related to legacy App Analytics. This setting
+#   # caps sampling for that legacy path only. It does not limit trace volume, spans, or general APM
+#   # ingestion; for trace sampling, see `max_traces_per_second` and `target_traces_per_second` above.
 #   # Maximum number of APM events per second to sample.
 #
 #   max_events_per_second: 200

--- a/releasenotes/notes/apm-max-eps-docs-f4dbf3452aed2875.yaml
+++ b/releasenotes/notes/apm-max-eps-docs-f4dbf3452aed2875.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    APM : Document that ``DD_APM_MAX_EPS`` is deprecated (legacy App Analytics APM events only) and does not affect trace or span volumes.


### PR DESCRIPTION
### What does this PR do?
Note that `DD_APM_MAX_EPS` is deprecated. This config option was part of the App Analytics events flow which has been deprecated and replaced for quite some time.

### Motivation
This config shouldn't be used by most customers and the name can be a bit confusing without this note. We've seen at least one customer think the "events" here meant spans which is not the case. 

### Describe how you validated your changes
No code change just docs, existing tests sufficient.

### Additional Notes
