### PR TITLE
Assert that compression of empty bytes produces valid frames

### DIFF
--- a/pkg/util/compression/compression.allium
+++ b/pkg/util/compression/compression.allium
@@ -85,9 +85,11 @@ contract Compression {
         -- decompress(compress(input)) = input
 
     @invariant ValidFrame
-        -- compress(empty) produces a valid compressed frame,
-        -- not empty output. This is a consequence of RoundtripIdentity
-        -- holding for empty input.
+        -- For compressors where kind != none: compress(empty)
+        -- produces a valid compressed frame, not empty output.
+        -- This is a consequence of RoundtripIdentity holding for
+        -- empty input. Noop is excluded: its Compress is the
+        -- identity function, so empty in produces empty out.
 
     @invariant CompressBoundCorrectness
         -- For all inputs:

--- a/pkg/util/compression/impl-gzip/gzip_strategy_test.go
+++ b/pkg/util/compression/impl-gzip/gzip_strategy_test.go
@@ -38,6 +38,40 @@ func FuzzGzipIdentity(f *testing.F) {
 	})
 }
 
+// Asserts that Compress(empty) produces a valid compressed frame (non-empty
+// output that roundtrips back to empty). Derived from the ValidFrame invariant
+// in compression.allium.
+func TestGzipValidFrameEmpty(t *testing.T) {
+	levels := []int{
+		gzip.HuffmanOnly,
+		gzip.NoCompression,
+		gzip.BestSpeed,
+		gzip.DefaultCompression,
+		gzip.BestCompression,
+	}
+
+	for _, level := range levels {
+		c := New(Requires{Level: level})
+		compressed, err := c.Compress([]byte{})
+		if err != nil {
+			t.Fatalf("Compress(empty) failed at level %d: %v", level, err)
+		}
+
+		if len(compressed) == 0 {
+			t.Errorf("Compress(empty) produced empty output at level %d; expected a valid gzip frame", level)
+		}
+
+		decompressed, err := c.Decompress(compressed)
+		if err != nil {
+			t.Fatalf("Decompress of empty frame failed at level %d: %v", level, err)
+		}
+
+		if !bytes.Equal(decompressed, []byte{}) {
+			t.Errorf("Roundtrip of empty input produced non-empty output at level %d: %v", level, decompressed)
+		}
+	}
+}
+
 // Asserts that len(compress(b)) <= CompressBound(len(b)) for all b and levels.
 func FuzzGzipCompressBound(f *testing.F) {
 	f.Add([]byte("hello world"), gzip.BestSpeed)

--- a/pkg/util/compression/impl-zlib/zlib_strategy_test.go
+++ b/pkg/util/compression/impl-zlib/zlib_strategy_test.go
@@ -37,6 +37,30 @@ func FuzzZlibIdentity(f *testing.F) {
 	})
 }
 
+// Asserts that Compress(empty) produces a valid compressed frame (non-empty
+// output that roundtrips back to empty). Derived from the ValidFrame invariant
+// in compression.allium.
+func TestZlibValidFrameEmpty(t *testing.T) {
+	c := New()
+	compressed, err := c.Compress([]byte{})
+	if err != nil {
+		t.Fatalf("Compress(empty) failed: %v", err)
+	}
+
+	if len(compressed) == 0 {
+		t.Errorf("Compress(empty) produced empty output; expected a valid zlib frame")
+	}
+
+	decompressed, err := c.Decompress(compressed)
+	if err != nil {
+		t.Fatalf("Decompress of empty frame failed: %v", err)
+	}
+
+	if !bytes.Equal(decompressed, []byte{}) {
+		t.Errorf("Roundtrip of empty input produced non-empty output: %v", decompressed)
+	}
+}
+
 // Asserts that len(compress(b)) <= CompressBound(len(b)) for all b.
 func FuzzZlibCompressBound(f *testing.F) {
 	f.Add([]byte("hello world"))

--- a/pkg/util/compression/impl-zstd-nocgo/zstd_nocgo_strategy_test.go
+++ b/pkg/util/compression/impl-zstd-nocgo/zstd_nocgo_strategy_test.go
@@ -39,6 +39,34 @@ func FuzzZstdNoCgoIdentity(f *testing.F) {
 	})
 }
 
+// Asserts that Compress(empty) produces a valid compressed frame (non-empty
+// output that roundtrips back to empty). Derived from the ValidFrame invariant
+// in compression.allium.
+func TestZstdNoCgoValidFrameEmpty(t *testing.T) {
+	levels := []int{1, 3, 5, 10, 15, 22}
+
+	for _, level := range levels {
+		c := New(Requires{Level: compression.ZstdCompressionLevel(level)})
+		compressed, err := c.Compress([]byte{})
+		if err != nil {
+			t.Fatalf("Compress(empty) failed at level %d: %v", level, err)
+		}
+
+		if len(compressed) == 0 {
+			t.Errorf("Compress(empty) produced empty output at level %d; expected a valid zstd frame", level)
+		}
+
+		decompressed, err := c.Decompress(compressed)
+		if err != nil {
+			t.Fatalf("Decompress of empty frame failed at level %d: %v", level, err)
+		}
+
+		if !bytes.Equal(decompressed, []byte{}) {
+			t.Errorf("Roundtrip of empty input produced non-empty output at level %d: %v", level, decompressed)
+		}
+	}
+}
+
 // Asserts that len(compress(b)) <= CompressBound(len(b)) for all b and levels.
 func FuzzZstdNoCgoCompressBound(f *testing.F) {
 	f.Add([]byte("hello world"), 1)

--- a/pkg/util/compression/impl-zstd/zstd_strategy_test.go
+++ b/pkg/util/compression/impl-zstd/zstd_strategy_test.go
@@ -39,6 +39,34 @@ func FuzzZstdIdentity(f *testing.F) {
 	})
 }
 
+// Asserts that Compress(empty) produces a valid compressed frame (non-empty
+// output that roundtrips back to empty). Derived from the ValidFrame invariant
+// in compression.allium.
+func TestZstdValidFrameEmpty(t *testing.T) {
+	levels := []int{1, 3, 5, 10, 15, 22}
+
+	for _, level := range levels {
+		c := New(Requires{Level: compression.ZstdCompressionLevel(level)})
+		compressed, err := c.Compress([]byte{})
+		if err != nil {
+			t.Fatalf("Compress(empty) failed at level %d: %v", level, err)
+		}
+
+		if len(compressed) == 0 {
+			t.Errorf("Compress(empty) produced empty output at level %d; expected a valid zstd frame", level)
+		}
+
+		decompressed, err := c.Decompress(compressed)
+		if err != nil {
+			t.Fatalf("Decompress of empty frame failed at level %d: %v", level, err)
+		}
+
+		if !bytes.Equal(decompressed, []byte{}) {
+			t.Errorf("Roundtrip of empty input produced non-empty output at level %d: %v", level, decompressed)
+		}
+	}
+}
+
 // Asserts that len(compress(b)) <= CompressBound(len(b)) for all b and levels.
 func FuzzZstdCompressBound(f *testing.F) {
 	f.Add([]byte("hello world"), 1)


### PR DESCRIPTION
### What does this PR do?

This commit introduces new, explicit tests asserting the ValidFrame invariant from compression.allium. That is, for all compression implementations that are not no-op compression of an empty []byte produces a valid frame. This is implied by our decompression fuzz tests but not explicitly enumerated.

### Additional Notes

While this is statistically covered by our fuzz testing explicit is better than implicit. Empty payloads are an edge case, to be sure, but we don't want to be sending invalid frames downstream to intake.
