### PR TITLE
Assert that streaming compression of empty produces valid frames

### DIFF
--- a/pkg/util/compression/impl-gzip/gzip_strategy_test.go
+++ b/pkg/util/compression/impl-gzip/gzip_strategy_test.go
@@ -72,6 +72,42 @@ func TestGzipValidFrameEmpty(t *testing.T) {
 	}
 }
 
+// Asserts that closing a StreamCompressor without writing produces a valid
+// compressed frame (non-empty output that decompresses to empty). Derived from
+// the EmptyStreamProducesValidFrame invariant in compression.allium.
+func TestGzipEmptyStreamProducesValidFrame(t *testing.T) {
+	levels := []int{
+		gzip.HuffmanOnly,
+		gzip.NoCompression,
+		gzip.BestSpeed,
+		gzip.DefaultCompression,
+		gzip.BestCompression,
+	}
+
+	for _, level := range levels {
+		c := New(Requires{Level: level})
+		var buf bytes.Buffer
+		stream := c.NewStreamCompressor(&buf)
+
+		if err := stream.Close(); err != nil {
+			t.Fatalf("Close failed at level %d: %v", level, err)
+		}
+
+		if buf.Len() == 0 {
+			t.Errorf("Close without Write produced empty output at level %d; expected a valid gzip frame", level)
+		}
+
+		decompressed, err := c.Decompress(buf.Bytes())
+		if err != nil {
+			t.Fatalf("Decompress of empty stream frame failed at level %d: %v", level, err)
+		}
+
+		if len(decompressed) != 0 {
+			t.Errorf("Empty stream frame decompressed to non-empty output at level %d: %v", level, decompressed)
+		}
+	}
+}
+
 // Asserts that len(compress(b)) <= CompressBound(len(b)) for all b and levels.
 func FuzzGzipCompressBound(f *testing.F) {
 	f.Add([]byte("hello world"), gzip.BestSpeed)

--- a/pkg/util/compression/impl-zlib/zlib_strategy_test.go
+++ b/pkg/util/compression/impl-zlib/zlib_strategy_test.go
@@ -61,6 +61,32 @@ func TestZlibValidFrameEmpty(t *testing.T) {
 	}
 }
 
+// Asserts that closing a StreamCompressor without writing produces a valid
+// compressed frame (non-empty output that decompresses to empty). Derived from
+// the EmptyStreamProducesValidFrame invariant in compression.allium.
+func TestZlibEmptyStreamProducesValidFrame(t *testing.T) {
+	c := New()
+	var buf bytes.Buffer
+	stream := c.NewStreamCompressor(&buf)
+
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Errorf("Close without Write produced empty output; expected a valid zlib frame")
+	}
+
+	decompressed, err := c.Decompress(buf.Bytes())
+	if err != nil {
+		t.Fatalf("Decompress of empty stream frame failed: %v", err)
+	}
+
+	if len(decompressed) != 0 {
+		t.Errorf("Empty stream frame decompressed to non-empty output: %v", decompressed)
+	}
+}
+
 // Asserts that len(compress(b)) <= CompressBound(len(b)) for all b.
 func FuzzZlibCompressBound(f *testing.F) {
 	f.Add([]byte("hello world"))

--- a/pkg/util/compression/impl-zstd-nocgo/zstd_nocgo_strategy_test.go
+++ b/pkg/util/compression/impl-zstd-nocgo/zstd_nocgo_strategy_test.go
@@ -67,6 +67,36 @@ func TestZstdNoCgoValidFrameEmpty(t *testing.T) {
 	}
 }
 
+// Asserts that closing a StreamCompressor without writing produces a valid
+// compressed frame (non-empty output that decompresses to empty). Derived from
+// the EmptyStreamProducesValidFrame invariant in compression.allium.
+func TestZstdNoCgoEmptyStreamProducesValidFrame(t *testing.T) {
+	levels := []int{1, 3, 5, 10, 15, 22}
+
+	for _, level := range levels {
+		c := New(Requires{Level: compression.ZstdCompressionLevel(level)})
+		var buf bytes.Buffer
+		stream := c.NewStreamCompressor(&buf)
+
+		if err := stream.Close(); err != nil {
+			t.Fatalf("Close failed at level %d: %v", level, err)
+		}
+
+		if buf.Len() == 0 {
+			t.Errorf("Close without Write produced empty output at level %d; expected a valid zstd frame", level)
+		}
+
+		decompressed, err := c.Decompress(buf.Bytes())
+		if err != nil {
+			t.Fatalf("Decompress of empty stream frame failed at level %d: %v", level, err)
+		}
+
+		if len(decompressed) != 0 {
+			t.Errorf("Empty stream frame decompressed to non-empty output at level %d: %v", level, decompressed)
+		}
+	}
+}
+
 // Asserts that len(compress(b)) <= CompressBound(len(b)) for all b and levels.
 func FuzzZstdNoCgoCompressBound(f *testing.F) {
 	f.Add([]byte("hello world"), 1)

--- a/pkg/util/compression/impl-zstd/zstd_strategy_test.go
+++ b/pkg/util/compression/impl-zstd/zstd_strategy_test.go
@@ -67,6 +67,36 @@ func TestZstdValidFrameEmpty(t *testing.T) {
 	}
 }
 
+// Asserts that closing a StreamCompressor without writing produces a valid
+// compressed frame (non-empty output that decompresses to empty). Derived from
+// the EmptyStreamProducesValidFrame invariant in compression.allium.
+func TestZstdEmptyStreamProducesValidFrame(t *testing.T) {
+	levels := []int{1, 3, 5, 10, 15, 22}
+
+	for _, level := range levels {
+		c := New(Requires{Level: compression.ZstdCompressionLevel(level)})
+		var buf bytes.Buffer
+		stream := c.NewStreamCompressor(&buf)
+
+		if err := stream.Close(); err != nil {
+			t.Fatalf("Close failed at level %d: %v", level, err)
+		}
+
+		if buf.Len() == 0 {
+			t.Errorf("Close without Write produced empty output at level %d; expected a valid zstd frame", level)
+		}
+
+		decompressed, err := c.Decompress(buf.Bytes())
+		if err != nil {
+			t.Fatalf("Decompress of empty stream frame failed at level %d: %v", level, err)
+		}
+
+		if len(decompressed) != 0 {
+			t.Errorf("Empty stream frame decompressed to non-empty output at level %d: %v", level, decompressed)
+		}
+	}
+}
+
 // Asserts that len(compress(b)) <= CompressBound(len(b)) for all b and levels.
 func FuzzZstdCompressBound(f *testing.F) {
 	f.Add([]byte("hello world"), 1)


### PR DESCRIPTION
### What does this PR do?

This PR asserts that streaming compression produces valid frames if no bytes are passed into the compressor before it is closed. These tests cover EmptyStreamProducesValidFrame invariant from compression.allium.

### Additional Notes

Similar to #49061. 