### PR TITLE
Ensure all stream compressors error on operations after close

### DIFF
--- a/pkg/util/compression/compression.allium
+++ b/pkg/util/compression/compression.allium
@@ -122,6 +122,11 @@ contract Streaming {
         -- compressed frame, consistent with the ValidFrame
         -- invariant on one-shot compression.
 
+    @invariant PostCloseRejection
+        -- Write and Flush on a closed StreamCompressor return
+        -- an error. This prevents silent data corruption when
+        -- caller code accidentally operates on a finalized stream.
+
     @guidance
         -- A StreamCompressor instance is NOT safe for concurrent use.
         -- Each goroutine should obtain its own StreamCompressor

--- a/pkg/util/compression/compression.go
+++ b/pkg/util/compression/compression.go
@@ -8,8 +8,13 @@ package compression
 
 import (
 	"bytes"
+	"errors"
 	"io"
 )
+
+// ErrStreamClosed is returned when Write, Flush, or Close is called on a
+// closed StreamCompressor.
+var ErrStreamClosed = errors.New("stream compressor is closed")
 
 // ZlibKind defines a const value for the zlib compressor
 const ZlibKind = "zlib"

--- a/pkg/util/compression/compression_test.go
+++ b/pkg/util/compression/compression_test.go
@@ -7,11 +7,156 @@ package compression_test
 
 import (
 	"bytes"
+	"compress/gzip"
+	"fmt"
 	"testing"
 
+	compression "github.com/DataDog/datadog-agent/pkg/util/compression"
+	gzipimpl "github.com/DataDog/datadog-agent/pkg/util/compression/impl-gzip"
+	zlibimpl "github.com/DataDog/datadog-agent/pkg/util/compression/impl-zlib"
 	zstdimpl "github.com/DataDog/datadog-agent/pkg/util/compression/impl-zstd"
 	zstdnocgoimpl "github.com/DataDog/datadog-agent/pkg/util/compression/impl-zstd-nocgo"
 )
+
+// compressorCase pairs a name with a compressor for table-driven tests.
+type compressorCase struct {
+	name       string
+	compressor compression.Compressor
+}
+
+// allCompressors returns the four compressor implementations that produce
+// compressed frames (excludes noop, which is the identity function).
+func allCompressors() []compressorCase {
+	return []compressorCase{
+		{"gzip", gzipimpl.New(gzipimpl.Requires{Level: gzip.DefaultCompression})},
+		{"zlib", zlibimpl.New()},
+		{"zstd-cgo", zstdimpl.New(zstdimpl.Requires{Level: 1})},
+		{"zstd-nocgo", zstdnocgoimpl.New(zstdnocgoimpl.Requires{Level: 1})},
+	}
+}
+
+// op represents a StreamCompressor operation.
+const (
+	opWrite = iota
+	opFlush
+	opClose
+	opCount // sentinel for modular arithmetic
+)
+
+// FuzzStreamStateMachine exercises the StreamCompressor state machine with
+// fuzz-generated operation sequences. For each compressor implementation:
+//
+//   - Interprets each byte of the fuzz input as an operation (Write, Flush, Close)
+//   - Tracks whether the stream is closed
+//   - Asserts that operations on a closed stream return errors
+//   - After Close, asserts the output is a valid decompressible frame
+//
+// Derived from the StreamCompressor transition graph in compression.allium.
+func FuzzStreamStateMachine(f *testing.F) {
+	// Seeds: various operation sequences
+	f.Add([]byte{0})             // single write
+	f.Add([]byte{1})             // single flush
+	f.Add([]byte{2})             // single close
+	f.Add([]byte{0, 2})          // write, close
+	f.Add([]byte{0, 1, 2})       // write, flush, close
+	f.Add([]byte{0, 0, 1, 0, 2}) // write, write, flush, write, close
+	f.Add([]byte{0, 1, 0, 1, 2}) // write, flush, write, flush, close
+	f.Add([]byte{2, 0})          // close, then write (post-close)
+	f.Add([]byte{2, 1})          // close, then flush (post-close)
+	f.Add([]byte{2, 2})          // close, then close (post-close)
+	f.Add([]byte{0, 2, 0, 1, 2}) // write, close, write, flush, close (post-close mix)
+
+	compressors := allCompressors()
+
+	f.Fuzz(func(t *testing.T, ops []byte) {
+		if len(ops) == 0 {
+			return
+		}
+
+		for _, cc := range compressors {
+			t.Run(cc.name, func(t *testing.T) {
+				var buf bytes.Buffer
+				stream := cc.compressor.NewStreamCompressor(&buf)
+				closed := false
+				wroteData := false
+
+				for i, b := range ops {
+					op := b % byte(opCount)
+
+					switch op {
+					case opWrite:
+						data := []byte(fmt.Sprintf("msg%d", i))
+						_, err := stream.Write(data)
+						if closed {
+							if err == nil {
+								t.Fatalf("op %d: Write after Close succeeded; expected error", i)
+							}
+						} else {
+							if err != nil {
+								t.Fatalf("op %d: Write failed: %v", i, err)
+							}
+							wroteData = true
+						}
+
+					case opFlush:
+						err := stream.Flush()
+						if closed {
+							if err == nil {
+								t.Fatalf("op %d: Flush after Close succeeded; expected error", i)
+							}
+						} else {
+							if err != nil {
+								t.Fatalf("op %d: Flush failed: %v", i, err)
+							}
+						}
+
+					case opClose:
+						err := stream.Close()
+						if !closed {
+							// Double close: behaviour varies by implementation.
+							// We don't mandate error vs nil, just don't panic.
+							//
+							// If not closed, output must be a valid decompressible frame.
+							if err != nil {
+								t.Fatalf("op %d: Close failed: %v", i, err)
+							}
+							closed = true
+
+							if buf.Len() == 0 && wroteData {
+								t.Fatalf("op %d: Close produced empty output after writes", i)
+							}
+
+							decompressed, err := cc.compressor.Decompress(buf.Bytes())
+							if err != nil {
+								t.Fatalf("op %d: Decompress of stream output failed: %v", i, err)
+							}
+
+							if !wroteData && len(decompressed) != 0 {
+								t.Fatalf("op %d: Empty stream decompressed to non-empty: %v", i, decompressed)
+							}
+						}
+					}
+				}
+
+				// If the stream was never closed, close it now and verify.
+				if !closed {
+					if err := stream.Close(); err != nil {
+						t.Fatalf("final Close failed: %v", err)
+					}
+
+					decompressed, err := cc.compressor.Decompress(buf.Bytes())
+					if err != nil {
+						t.Fatalf("Decompress of stream output failed: %v", err)
+					}
+
+					if !wroteData && len(decompressed) != 0 {
+						t.Fatalf("Empty stream decompressed to non-empty: %v", decompressed)
+					}
+				}
+			})
+		}
+	})
+}
 
 // Asserts that data compressed by zstd CGO can be decompressed by zstd NoCGO
 // and vice versa, for all b.

--- a/pkg/util/compression/impl-gzip/gzip_strategy.go
+++ b/pkg/util/compression/impl-gzip/gzip_strategy.go
@@ -142,5 +142,32 @@ func (s *GzipStrategy) NewStreamCompressor(output *bytes.Buffer) compression.Str
 		writer = gzip.NewWriter(output)
 	}
 
-	return writer
+	return &gzipStreamCompressor{inner: writer}
+}
+
+type gzipStreamCompressor struct {
+	inner  *gzip.Writer
+	closed bool
+}
+
+func (g *gzipStreamCompressor) Write(p []byte) (int, error) {
+	if g.closed {
+		return 0, compression.ErrStreamClosed
+	}
+	return g.inner.Write(p)
+}
+
+func (g *gzipStreamCompressor) Flush() error {
+	if g.closed {
+		return compression.ErrStreamClosed
+	}
+	return g.inner.Flush()
+}
+
+func (g *gzipStreamCompressor) Close() error {
+	if g.closed {
+		return compression.ErrStreamClosed
+	}
+	g.closed = true
+	return g.inner.Close()
 }

--- a/pkg/util/compression/impl-noop/no_strategy.go
+++ b/pkg/util/compression/impl-noop/no_strategy.go
@@ -42,20 +42,35 @@ func (s *NoopStrategy) ContentEncoding() string {
 
 // NewStreamCompressor implements the NewStreamCompressor method for NoopStrategy to satisfy the Compressor interface
 func (s *NoopStrategy) NewStreamCompressor(buf *bytes.Buffer) compression.StreamCompressor {
-	return &noopStreamCompressor{buf}
+	return &noopStreamCompressor{buf: buf}
 }
 
-// NoopStreamCompressor is a no-op implementation of StreamCompressor
+// noopStreamCompressor is a no-op implementation of StreamCompressor
 type noopStreamCompressor struct {
-	*bytes.Buffer
+	buf    *bytes.Buffer
+	closed bool
+}
+
+func (n *noopStreamCompressor) Write(p []byte) (int, error) {
+	if n.closed {
+		return 0, compression.ErrStreamClosed
+	}
+	return n.buf.Write(p)
 }
 
 // Close closes the underlying writer
 func (n *noopStreamCompressor) Close() error {
+	if n.closed {
+		return compression.ErrStreamClosed
+	}
+	n.closed = true
 	return nil
 }
 
 // Flush is a no-op
 func (n *noopStreamCompressor) Flush() error {
+	if n.closed {
+		return compression.ErrStreamClosed
+	}
 	return nil
 }

--- a/pkg/util/compression/impl-zlib/zlib_strategy.go
+++ b/pkg/util/compression/impl-zlib/zlib_strategy.go
@@ -92,5 +92,32 @@ func (s *ZlibStrategy) ContentEncoding() string {
 
 // NewStreamCompressor returns a new zlib writer
 func (s *ZlibStrategy) NewStreamCompressor(output *bytes.Buffer) compression.StreamCompressor {
-	return zlib.NewWriter(output)
+	return &zlibStreamCompressor{inner: zlib.NewWriter(output)}
+}
+
+type zlibStreamCompressor struct {
+	inner  *zlib.Writer
+	closed bool
+}
+
+func (z *zlibStreamCompressor) Write(p []byte) (int, error) {
+	if z.closed {
+		return 0, compression.ErrStreamClosed
+	}
+	return z.inner.Write(p)
+}
+
+func (z *zlibStreamCompressor) Flush() error {
+	if z.closed {
+		return compression.ErrStreamClosed
+	}
+	return z.inner.Flush()
+}
+
+func (z *zlibStreamCompressor) Close() error {
+	if z.closed {
+		return compression.ErrStreamClosed
+	}
+	z.closed = true
+	return z.inner.Close()
 }

--- a/pkg/util/compression/impl-zstd-nocgo/zstd_nocgo_strategy.go
+++ b/pkg/util/compression/impl-zstd-nocgo/zstd_nocgo_strategy.go
@@ -100,5 +100,32 @@ func (s *ZstdNoCgoStrategy) NewStreamCompressor(output *bytes.Buffer) compressio
 	writer, _ := zstd.NewWriter(output,
 		zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(s.level)),
 		zstd.WithZeroFrames(true))
-	return writer
+	return &zstdNoCgoStreamCompressor{inner: writer}
+}
+
+type zstdNoCgoStreamCompressor struct {
+	inner  *zstd.Encoder
+	closed bool
+}
+
+func (z *zstdNoCgoStreamCompressor) Write(p []byte) (int, error) {
+	if z.closed {
+		return 0, compression.ErrStreamClosed
+	}
+	return z.inner.Write(p)
+}
+
+func (z *zstdNoCgoStreamCompressor) Flush() error {
+	if z.closed {
+		return compression.ErrStreamClosed
+	}
+	return z.inner.Flush()
+}
+
+func (z *zstdNoCgoStreamCompressor) Close() error {
+	if z.closed {
+		return compression.ErrStreamClosed
+	}
+	z.closed = true
+	return z.inner.Close()
 }

--- a/pkg/util/compression/impl-zstd/zstd_strategy.go
+++ b/pkg/util/compression/impl-zstd/zstd_strategy.go
@@ -53,5 +53,32 @@ func (s *ZstdStrategy) ContentEncoding() string {
 
 // NewStreamCompressor returns a new zstd Writer
 func (s *ZstdStrategy) NewStreamCompressor(output *bytes.Buffer) compression.StreamCompressor {
-	return zstd.NewWriterLevel(output, s.level)
+	return &zstdStreamCompressor{inner: zstd.NewWriterLevel(output, s.level)}
+}
+
+type zstdStreamCompressor struct {
+	inner  *zstd.Writer
+	closed bool
+}
+
+func (z *zstdStreamCompressor) Write(p []byte) (int, error) {
+	if z.closed {
+		return 0, compression.ErrStreamClosed
+	}
+	return z.inner.Write(p)
+}
+
+func (z *zstdStreamCompressor) Flush() error {
+	if z.closed {
+		return compression.ErrStreamClosed
+	}
+	return z.inner.Flush()
+}
+
+func (z *zstdStreamCompressor) Close() error {
+	if z.closed {
+		return compression.ErrStreamClosed
+	}
+	z.closed = true
+	return z.inner.Close()
 }


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new invariant to the spec: PostCloseRejection. Some implementations allow operations -- write/flush -- after the stream is closed, some return errors. I judge that calling code needs a uniform behavior and that the error return behavior is better than the silent UB.

This invariant is enforced by implementations maintaining a 'closed' bool in their private state, safe as the interface does not guarantee synchronization. The invariant is check by a new fuzz state machine test.

### Motivation

Uniform behavior for stream compression regardless of underlying algorithm, user configuration.