### PR TITLE
 fix(cisco-sdwan): handle vpn_id as string in InterfaceStats and CloudXStatistics   

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client_test.go
@@ -306,6 +306,7 @@ func TestGetInterfacesMetrics(t *testing.T) {
 	require.Equal(t, float64(506), devices[0].TxErrors)
 	require.Equal(t, float64(6), devices[0].RxDrops)
 	require.Equal(t, float64(3), devices[0].TxDrops)
+	require.Equal(t, FlexFloat64(0), devices[0].VpnID)
 
 	// Ensure endpoint has been called 1 times
 	require.Equal(t, 1, handler.numberOfCalls())
@@ -580,7 +581,7 @@ func TestGetCloudExpressMetrics(t *testing.T) {
 	require.Equal(t, "FALSE", devices[0].BestPath)
 	require.Equal(t, "amazon_aws", devices[0].Application)
 	require.Equal(t, "amazon-group", devices[0].NbarAppGroupName)
-	require.Equal(t, float64(1), devices[0].VpnID)
+	require.Equal(t, FlexFloat64(1), devices[0].VpnID)
 	require.Equal(t, float64(1721819993833), devices[0].EntryTime)
 	require.Equal(t, float64(404), devices[0].Latency)
 	require.Equal(t, float64(0), devices[0].Loss)
@@ -623,4 +624,34 @@ func TestGetBGPNeighbors(t *testing.T) {
 
 	// Ensure endpoint has been called 1 times
 	require.Equal(t, 1, handler.numberOfCalls())
+}
+
+func TestFlexFloat64UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected FlexFloat64
+		wantErr  bool
+	}{
+		{name: "number", input: `512`, expected: 512},
+		{name: "number zero", input: `0`, expected: 0},
+		{name: "number float", input: `1.5`, expected: 1.5},
+		{name: "string integer", input: `"512"`, expected: 512},
+		{name: "string zero", input: `"0"`, expected: 0},
+		{name: "string float", input: `"1.5"`, expected: 1.5},
+		{name: "invalid string", input: `"notanumber"`, wantErr: true},
+		{name: "invalid type", input: `true`, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var f FlexFloat64
+			err := f.UnmarshalJSON([]byte(tc.input))
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, f)
+			}
+		})
+	}
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
@@ -5,6 +5,35 @@
 
 package client
 
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// FlexFloat64 unmarshals from both JSON number and JSON string representations.
+// Some Cisco vManage API versions return numeric fields such as vpn_id as strings.
+type FlexFloat64 float64
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (f *FlexFloat64) UnmarshalJSON(data []byte) error {
+	var n float64
+	if err := json.Unmarshal(data, &n); err == nil {
+		*f = FlexFloat64(n)
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal %q into FlexFloat64: %w", s, err)
+	}
+	*f = FlexFloat64(n)
+	return nil
+}
+
 type viewKeys struct {
 	UniqueKey     []string `json:"uniqueKey"`
 	PreferenceKey string   `json:"preferenceKey"`
@@ -225,39 +254,39 @@ type CEdgeInterfaceState struct {
 
 // InterfaceStats /dataservice/data/device/statistics/interfacestatistics
 type InterfaceStats struct {
-	DownCapacityPercentage float64 `json:"down_capacity_percentage"`
-	TxPps                  float64 `json:"tx_pps"`
-	TotalMbps              float64 `json:"total_mbps"`
-	DeviceModel            string  `json:"device_model"`
-	RxKbps                 float64 `json:"rx_kbps"`
-	Interface              string  `json:"interface"`
-	TxOctets               float64 `json:"tx_octets"`
-	OperStatus             string  `json:"oper_status"`
-	RxErrors               float64 `json:"rx_errors"`
-	BwDown                 float64 `json:"bw_down"`
-	TxPkts                 float64 `json:"tx_pkts"`
-	TxErrors               float64 `json:"tx_errors"`
-	RxOctets               float64 `json:"rx_octets"`
-	Statcycletime          float64 `json:"statcycletime"`
-	AdminStatus            string  `json:"admin_status"`
-	BwUp                   float64 `json:"bw_up"`
-	InterfaceType          string  `json:"interface_type"`
-	Tenant                 string  `json:"tenant"`
-	EntryTime              float64 `json:"entry_time"`
-	VipTime                float64 `json:"vip_time"`
-	AfType                 string  `json:"af_type"`
-	RxPkts                 float64 `json:"rx_pkts"`
-	RxPps                  float64 `json:"rx_pps"`
-	VmanageSystemIP        string  `json:"vmanage_system_ip"`
-	TxDrops                float64 `json:"tx_drops"`
-	RxDrops                float64 `json:"rx_drops"`
-	TxKbps                 float64 `json:"tx_kbps"`
-	VdeviceName            string  `json:"vdevice_name"`
-	UpCapacityPercentage   float64 `json:"up_capacity_percentage"`
-	VipIdx                 float64 `json:"vip_idx"`
-	HostName               string  `json:"host_name"`
-	VpnID                  float64 `json:"vpn_id"`
-	ID                     string  `json:"id"`
+	DownCapacityPercentage float64     `json:"down_capacity_percentage"`
+	TxPps                  float64     `json:"tx_pps"`
+	TotalMbps              float64     `json:"total_mbps"`
+	DeviceModel            string      `json:"device_model"`
+	RxKbps                 float64     `json:"rx_kbps"`
+	Interface              string      `json:"interface"`
+	TxOctets               float64     `json:"tx_octets"`
+	OperStatus             string      `json:"oper_status"`
+	RxErrors               float64     `json:"rx_errors"`
+	BwDown                 float64     `json:"bw_down"`
+	TxPkts                 float64     `json:"tx_pkts"`
+	TxErrors               float64     `json:"tx_errors"`
+	RxOctets               float64     `json:"rx_octets"`
+	Statcycletime          float64     `json:"statcycletime"`
+	AdminStatus            string      `json:"admin_status"`
+	BwUp                   float64     `json:"bw_up"`
+	InterfaceType          string      `json:"interface_type"`
+	Tenant                 string      `json:"tenant"`
+	EntryTime              float64     `json:"entry_time"`
+	VipTime                float64     `json:"vip_time"`
+	AfType                 string      `json:"af_type"`
+	RxPkts                 float64     `json:"rx_pkts"`
+	RxPps                  float64     `json:"rx_pps"`
+	VmanageSystemIP        string      `json:"vmanage_system_ip"`
+	TxDrops                float64     `json:"tx_drops"`
+	RxDrops                float64     `json:"rx_drops"`
+	TxKbps                 float64     `json:"tx_kbps"`
+	VdeviceName            string      `json:"vdevice_name"`
+	UpCapacityPercentage   float64     `json:"up_capacity_percentage"`
+	VipIdx                 float64     `json:"vip_idx"`
+	HostName               string      `json:"host_name"`
+	VpnID                  FlexFloat64 `json:"vpn_id"`
+	ID                     string      `json:"id"`
 }
 
 // DeviceCounters /dataservice/device/counters
@@ -411,34 +440,34 @@ type HardwareEnvironment struct {
 
 // CloudXStatistics /dataservice/data/device/statistics/cloudxstatistics
 type CloudXStatistics struct {
-	RemoteColor      string  `json:"remote_color"`
-	DeviceModel      string  `json:"device_model"`
-	Latency          float64 `json:"latency"`
-	Interface        string  `json:"interface"`
-	LocalColor       string  `json:"local_color"`
-	Loss             float64 `json:"loss"`
-	GatewaySystemIP  string  `json:"gateway_system_ip"`
-	SourcePublicIP   string  `json:"source_public_ip"`
-	Statcycletime    float64 `json:"statcycletime"`
-	LocalSystemIP    string  `json:"local_system_ip"`
-	Tenant           string  `json:"tenant"`
-	EntryTime        float64 `json:"entry_time"`
-	VqeStatus        string  `json:"vqe_status"`
-	ExitType         string  `json:"exit_type"`
-	VipTime          float64 `json:"vip_time"`
-	VmanageSystemIP  string  `json:"vmanage_system_ip"`
-	NbarAppGroupName string  `json:"nbar_app_group_name"`
-	Application      string  `json:"application"`
-	VdeviceName      string  `json:"vdevice_name"`
-	BestPath         string  `json:"best_path"`
-	VipIdx           float64 `json:"vip_idx"`
-	SiteID           float64 `json:"site_id"`
-	VqeScore         string  `json:"vqe_score"`
-	ServiceArea      string  `json:"service_area"`
-	HostName         string  `json:"host_name"`
-	VpnID            float64 `json:"vpn_id"`
-	AppURLHostIP     string  `json:"app_url_host_ip"`
-	ID               string  `json:"id"`
+	RemoteColor      string      `json:"remote_color"`
+	DeviceModel      string      `json:"device_model"`
+	Latency          float64     `json:"latency"`
+	Interface        string      `json:"interface"`
+	LocalColor       string      `json:"local_color"`
+	Loss             float64     `json:"loss"`
+	GatewaySystemIP  string      `json:"gateway_system_ip"`
+	SourcePublicIP   string      `json:"source_public_ip"`
+	Statcycletime    float64     `json:"statcycletime"`
+	LocalSystemIP    string      `json:"local_system_ip"`
+	Tenant           string      `json:"tenant"`
+	EntryTime        float64     `json:"entry_time"`
+	VqeStatus        string      `json:"vqe_status"`
+	ExitType         string      `json:"exit_type"`
+	VipTime          float64     `json:"vip_time"`
+	VmanageSystemIP  string      `json:"vmanage_system_ip"`
+	NbarAppGroupName string      `json:"nbar_app_group_name"`
+	Application      string      `json:"application"`
+	VdeviceName      string      `json:"vdevice_name"`
+	BestPath         string      `json:"best_path"`
+	VipIdx           float64     `json:"vip_idx"`
+	SiteID           float64     `json:"site_id"`
+	VqeScore         string      `json:"vqe_score"`
+	ServiceArea      string      `json:"service_area"`
+	HostName         string      `json:"host_name"`
+	VpnID            FlexFloat64 `json:"vpn_id"`
+	AppURLHostIP     string      `json:"app_url_host_ip"`
+	ID               string      `json:"id"`
 }
 
 // BGPNeighbor /dataservice/data/device/state/BGPNeighbor


### PR DESCRIPTION
### What does this PR do?
  Introduces FlexFloat64, a float64-backed type with a custom UnmarshalJSON that accepts both
  JSON number and JSON string representations. Applies it to VpnID in InterfaceStats and        
  CloudXStatistics in the Cisco SD-WAN client.

### Motivation
  Some Cisco vManage API versions return vpn_id as a JSON string (e.g. "0", "512") instead of a 
  number. This causes a fatal deserialization error on every check run that silently drops all
  cisco_sdwan.interface.* metrics:                                                              
                                                            
  json: cannot unmarshal string into Go struct field InterfaceStats.data.vpn_id of type float64

  Confirmed via customer flare (AGENT-15988, Zendesk 2820314, AmFamGroup org 57425).  

### Describe how you validated your changes
  - Added TestFlexFloat64UnmarshalJSON covering JSON number, JSON float, JSON string integer,   
  JSON string float, invalid string, and invalid non-string type
  - Updated TestGetInterfacesMetrics and TestGetCloudExpressMetrics to assert on VpnID with the 
  correct type                                                                                  
  - All tests pass: go test -tags test 
  ./pkg/collector/corechecks/network-devices/cisco-sdwan/...                                                                           

### Additional Notes
  - No changes needed in report/metrics.go — Go allows direct numeric conversion from named     
  numeric types, so all existing int(entry.VpnID) callsites compile unchanged.
  - CloudXStatistics.VpnID uses the same vpn_id JSON key and is proactively fixed alongside     
  InterfaceStats since it would hit the same failure under the same API versions.  