### PR TITLE
fix max_tracked_connections default type

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -182,7 +182,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 
 	cfg.BindEnvAndSetDefault("system_probe_config.offset_guess_threshold", int64(defaultOffsetThreshold))
 
-	cfg.BindEnvAndSetDefault("system_probe_config.max_tracked_connections", 65536)
+	cfg.BindEnvAndSetDefault("system_probe_config.max_tracked_connections", int64(65536))
 	cfg.BindEnv("system_probe_config.max_closed_connections_buffered")   //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	cfg.BindEnv("network_config.max_failed_connections_buffered")        //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	cfg.BindEnv("system_probe_config.closed_connection_flush_threshold") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'


### PR DESCRIPTION
### What does this PR do?

Fixes the default value type so it allows the full `int64` range.

### Motivation

`[Warn] Set('system_probe_config.max_tracked_connections'): converting value from int64 to int to match default type`

### Describe how you validated your changes

### Additional Notes
