### PR TITLE
Factor out Translate and manifest deduplication helpers into otel-mapping-go/otlp/logs

### DIFF
--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/logs v0.74.0-devel.0.20251125141836-2ae7a968751c
-	github.com/DataDog/datadog-agent/pkg/orchestrator/util v0.0.0-20251120165911-0b75c97e8b50
 	github.com/DataDog/datadog-agent/pkg/util/otel v0.74.0-devel.0.20251125141836-2ae7a968751c
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/version v0.77.0-devel.0.20260213154712-e02b9359151a
@@ -66,6 +65,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/rum v0.72.0-devel.0.20250907091827-dbb380833b5f // indirect
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
+	github.com/DataDog/datadog-agent/pkg/orchestrator/util v0.0.0-20251120165911-0b75c97e8b50 // indirect
 	github.com/DataDog/datadog-agent/pkg/proto v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/serializer v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/template v0.77.0-devel.0.20260213154712-e02b9359151a // indirect

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
@@ -19,19 +19,7 @@ import (
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	logsmapping "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/logs"
-	"github.com/DataDog/datadog-agent/pkg/orchestrator/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
-)
-
-const (
-	// manifestCacheTTL is the time-to-live for manifest cache entries (3 minutes, same as orchestrator collector)
-	manifestCacheTTL = 3 * time.Minute
-	// manifestCachePurge is the interval for purging expired cache entries
-	manifestCachePurge = 30 * time.Second
-	// maxManifestsPerPayload is the maximum number of manifests to send in a single payload
-	maxManifestsPerPayload = 100
-	// maxPayloadSizeBytes is the maximum serialized size of manifest content per payload (10 MB, same as orchestrator default)
-	maxPayloadSizeBytes = 10 * 1000 * 1000
 )
 
 type orchestratorExporter struct {
@@ -48,196 +36,22 @@ func newOrchestratorExporter(config OrchestratorConfig) orchestratorExporter {
 	}
 
 	if config.Enabled {
-		exporter.manifestCache = gocache.New(manifestCacheTTL, manifestCachePurge)
+		exporter.manifestCache = logsmapping.NewManifestCache()
 	}
 	return exporter
 }
 
-// shouldSkipManifest checks if the manifest was already sent recently.
-// Returns true if the manifest should be skipped (cache hit with same resourceVersion).
-// This follows the same pattern as pkg/orchestrator.SkipKubernetesResource.
-// Watch log events always bypass the cache to ensure real-time updates are sent.
-func shouldSkipManifest(manifest *agentmodel.Manifest, isWatchEvent bool, cache *gocache.Cache) bool {
-	if cache == nil || manifest == nil || manifest.Uid == "" {
-		return false
-	}
-
-	// Watch events should always bypass the cache to ensure real-time updates
-	if isWatchEvent {
-		return false
-	}
-
-	cacheKey := manifest.Uid
-
-	// Check if we have this resource in cache
-	value, hit := cache.Get(cacheKey)
-
-	if !hit {
-		// Cache miss - this is a new resource, add it to cache
-		cache.Set(cacheKey, manifest.ResourceVersion, manifestCacheTTL)
-		return false
-	}
-
-	// Cache hit - check if the resourceVersion changed
-	cachedVersion, ok := value.(string)
-	if !ok || cachedVersion != manifest.ResourceVersion {
-		// ResourceVersion changed - update cache and don't skip
-		cache.Set(cacheKey, manifest.ResourceVersion, manifestCacheTTL)
-		return false
-	}
-
-	// Cache hit with same resourceVersion - skip this manifest
-	return true
-}
-
-// chunkManifestsBySizeAndWeight chunks manifests based on both count and serialized size
-// to avoid intake endpoint rejections. This follows the same logic as the orchestrator collector.
-func chunkManifestsBySizeAndWeight(manifests []*agentmodel.Manifest, maxChunkSize, maxChunkWeight int) [][]*agentmodel.Manifest {
-	if len(manifests) == 0 {
-		return make([][]*agentmodel.Manifest, 0)
-	}
-
-	// Convert to interface{} for the chunking utility
-	interfaceManifests := make([]interface{}, 0, len(manifests))
-	for _, m := range manifests {
-		interfaceManifests = append(interfaceManifests, m)
-	}
-
-	chunker := &util.ChunkAllocator[[]interface{}, interface{}]{
-		AppendToChunk: func(chunk *[]interface{}, payloads []interface{}) {
-			*chunk = append(*chunk, payloads...)
-		},
-	}
-
-	list := &util.PayloadList[interface{}]{
-		Items: interfaceManifests,
-		WeightAt: func(i int) int {
-			// Use the serialized manifest content size as the weight
-			return len(manifests[i].Content)
-		},
-	}
-
-	util.ChunkPayloadsBySizeAndWeight[[]interface{}, interface{}](list, chunker, maxChunkSize, maxChunkWeight)
-
-	// Convert back to typed chunks
-	chunks := *chunker.GetChunks()
-	result := make([][]*agentmodel.Manifest, len(chunks))
-	for i, chunk := range chunks {
-		result[i] = make([]*agentmodel.Manifest, len(chunk))
-		for j, item := range chunk {
-			result[i][j] = item.(*agentmodel.Manifest)
-		}
-	}
-	return result
-}
-
-func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) (err error) {
-	var manifests []*agentmodel.Manifest
-
-	var nodes []*agentmodel.Manifest
-
-	var isWatchEvent bool
-
-	var clusterID string
-	var clusterName string
-
-	for i := 0; i < ld.ResourceLogs().Len(); i++ {
-		resourceLogs := ld.ResourceLogs().At(i)
-		resource := resourceLogs.Resource()
-
-		for j := 0; j < resourceLogs.ScopeLogs().Len(); j++ {
-			scopeLogs := resourceLogs.ScopeLogs().At(j)
-
-			for k := 0; k < scopeLogs.LogRecords().Len(); k++ {
-				logRecord := scopeLogs.LogRecords().At(k)
-
-				k8sClusterID, ok := resource.Attributes().Get("k8s.cluster.uid")
-				if ok {
-					clusterID = k8sClusterID.AsString()
-				} else {
-					e.set.Logger.Error("Failed to get cluster ID, skipping manifest payload", zap.Error(err))
-					continue
-				}
-
-				k8sClusterName, ok := resource.Attributes().Get("k8s.cluster.name")
-				if ok {
-					clusterName = k8sClusterName.AsString()
-				} else {
-					e.set.Logger.Error("Failed to get cluster name, skipping manifest payload", zap.Error(err))
-					continue
-				}
-
-				// Convert Kubernetes resource manifest to orchestrator payload format
-				var manifest *agentmodel.Manifest
-				manifest, isWatchEvent, err = logsmapping.ToManifest(logRecord)
-				if err != nil {
-					e.set.Logger.Error("Failed to convert to manifest: "+err.Error(), zap.Error(err))
-					continue
-				}
-
-				if manifest.Kind == "Node" {
-					nodes = append(nodes, manifest)
-				}
-
-				// Check cache to avoid sending the same manifest multiple times within 3 minutes
-				// Watch events bypass the cache to ensure real-time updates
-				if shouldSkipManifest(manifest, isWatchEvent, e.orchestratorExporter.manifestCache) {
-					e.set.Logger.Debug("Skipping manifest (cache hit)",
-						zap.String("uid", manifest.Uid),
-						zap.String("kind", manifest.Kind),
-						zap.String("resourceVersion", manifest.ResourceVersion))
-					continue
-				}
-
-				e.set.Logger.Debug("Sending manifest",
-					zap.String("uid", manifest.Uid),
-					zap.String("kind", manifest.Kind),
-					zap.String("resourceVersion", manifest.ResourceVersion))
-
-				manifests = append(manifests, manifest)
-			}
-		}
-	}
-
-	// Send a Cluster manifest once all nodes have been collected
-	if len(nodes) > 0 && !isWatchEvent {
-		e.set.Logger.Debug("Creating Cluster manifest after collecting nodes", zap.Int("total_nodes", len(nodes)))
-		clusterManifest := logsmapping.CreateClusterManifest(clusterID, nodes, e.set.Logger)
-
-		// Check cache for the cluster manifest too (not a watch event)
-		if !shouldSkipManifest(clusterManifest, false, e.orchestratorExporter.manifestCache) {
-			manifests = append(manifests, clusterManifest)
-			e.set.Logger.Debug("Added Cluster manifest to payload",
-				zap.String("uid", clusterManifest.Uid),
-				zap.Int("total_nodes", len(nodes)))
-		}
-	}
+func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) error {
+	result := logsmapping.TranslateK8sObjects(ld, e.orchestratorExporter.manifestCache, e.set.Logger)
 
 	hostname, err := e.orchestratorExporter.config.Hostname.Get(ctx)
 	if err != nil || hostname == "" {
 		e.set.Logger.Error("Failed to get hostname from config", zap.Error(err))
 	}
 
-	// Chunk manifests by both count and serialized size to avoid intake endpoint rejections.
-	// This follows the same logic as the orchestrator collector, ensuring payloads respect
-	// both the maximum number of manifests (100) and the maximum payload size (10 MB).
-	totalManifests := len(manifests)
-	chunks := chunkManifestsBySizeAndWeight(manifests, maxManifestsPerPayload, maxPayloadSizeBytes)
-
-	e.set.Logger.Debug("Sending manifests in chunks",
-		zap.Int("total_manifests", totalManifests),
-		zap.Int("chunk_count", len(chunks)),
-		zap.Int("max_manifests_per_chunk", maxManifestsPerPayload),
-		zap.Int("max_payload_size_bytes", maxPayloadSizeBytes))
-
-	for i, chunk := range chunks {
-		e.set.Logger.Debug("Sending manifest chunk",
-			zap.Int("chunk_index", i),
-			zap.Int("chunk_size", len(chunk)))
-
-		payload := logsmapping.ToManifestPayload(chunk, hostname, clusterName, clusterID)
-
-		if err := sendManifestPayload(ctx, e.orchestratorExporter.config.Endpoint, e.orchestratorExporter.config.Key, payload, hostname, clusterID, e.set.Logger); err != nil {
+	for i, chunk := range result.Chunks {
+		payload := logsmapping.ToManifestPayload(chunk, hostname, result.ClusterName, result.ClusterID)
+		if err := sendManifestPayload(ctx, e.orchestratorExporter.config.Endpoint, e.orchestratorExporter.config.Key, payload, hostname, result.ClusterID, e.set.Logger); err != nil {
 			e.set.Logger.Error("Failed to send collector manifest chunk",
 				zap.Int("chunk_index", i),
 				zap.Int("chunk_size", len(chunk)),

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
@@ -50,6 +50,9 @@ func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) error {
 	}
 
 	for i, chunk := range result.Chunks {
+		e.set.Logger.Debug("Sending manifest chunk",
+			zap.Int("chunk_index", i),
+			zap.Int("chunk_size", len(chunk)))
 		payload := logsmapping.ToManifestPayload(chunk, hostname, result.ClusterName, result.ClusterID)
 		if err := sendManifestPayload(ctx, e.orchestratorExporter.config.Endpoint, e.orchestratorExporter.config.Key, payload, hostname, result.ClusterID, e.set.Logger); err != nil {
 			e.set.Logger.Error("Failed to send collector manifest chunk",

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
@@ -53,7 +53,9 @@ func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) error {
 		e.set.Logger.Debug("Sending manifest chunk",
 			zap.Int("chunk_index", i),
 			zap.Int("chunk_size", len(chunk)))
+
 		payload := logsmapping.ToManifestPayload(chunk, hostname, result.ClusterName, result.ClusterID)
+
 		if err := sendManifestPayload(ctx, e.orchestratorExporter.config.Endpoint, e.orchestratorExporter.config.Key, payload, hostname, result.ClusterID, e.set.Logger); err != nil {
 			e.set.Logger.Error("Failed to send collector manifest chunk",
 				zap.Int("chunk_index", i),

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
@@ -21,111 +21,68 @@ import (
 	logsmapping "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/logs"
 )
 
-func TestShouldSkipManifest(t *testing.T) {
-	cache := gocache.New(manifestCacheTTL, manifestCachePurge)
-	tests := []struct {
-		name           string
-		manifest       *agentmodel.Manifest
-		isWatchEvent   bool
-		setupCache     func()
-		expectedSkip   bool
-		expectedCached bool
-		cachedVersion  string
-	}{
-		{
-			name:         "nil manifest",
-			manifest:     nil,
-			isWatchEvent: false,
-			expectedSkip: false,
-		},
-		{
-			name: "manifest without uid",
-			manifest: &agentmodel.Manifest{
-				Uid:             "",
-				ResourceVersion: "v1",
-			},
-			isWatchEvent: false,
-			expectedSkip: false,
-		},
-		{
-			name: "cache miss - new resource",
-			manifest: &agentmodel.Manifest{
-				Uid:             "test-uid-1",
-				ResourceVersion: "v1",
-			},
-			isWatchEvent:   false,
-			expectedSkip:   false,
-			expectedCached: true,
-			cachedVersion:  "v1",
-		},
-		{
-			name: "cache hit - same resource version",
-			manifest: &agentmodel.Manifest{
-				Uid:             "test-uid-2",
-				ResourceVersion: "v1",
-			},
-			isWatchEvent: false,
-			setupCache: func() {
-				cache.Set("test-uid-2", "v1", manifestCacheTTL)
-			},
-			expectedSkip:   true,
-			expectedCached: true,
-			cachedVersion:  "v1",
-		},
-		{
-			name: "cache hit - different resource version",
-			manifest: &agentmodel.Manifest{
-				Uid:             "test-uid-3",
-				ResourceVersion: "v2",
-			},
-			isWatchEvent: false,
-			setupCache: func() {
-				cache.Set("test-uid-3", "v1", manifestCacheTTL)
-			},
-			expectedSkip:   false,
-			expectedCached: true,
-			cachedVersion:  "v2",
-		},
-		{
-			name: "watch event - bypasses cache even with same resource version",
-			manifest: &agentmodel.Manifest{
-				Uid:             "test-uid-4",
-				ResourceVersion: "v1",
-			},
-			isWatchEvent: true,
-			setupCache: func() {
-				cache.Set("test-uid-4", "v1", manifestCacheTTL)
-			},
-			expectedSkip: false, // Watch events always bypass cache
-		},
-		{
-			name: "watch event - new resource",
-			manifest: &agentmodel.Manifest{
-				Uid:             "test-uid-5",
-				ResourceVersion: "v1",
-			},
-			isWatchEvent: true,
-			expectedSkip: false,
-		},
+// buildK8sLogs creates a plog.Logs with a single pod log record for testing.
+func buildK8sLogs(clusterID, clusterName, uid, resourceVersion string, isWatch bool) plog.Logs {
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("k8s.cluster.uid", clusterID)
+	rl.Resource().Attributes().PutStr("k8s.cluster.name", clusterName)
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+
+	var body string
+	if isWatch {
+		body = `{"type":"ADDED","object":{"apiVersion":"v1","kind":"Pod","metadata":{"uid":"` + uid + `","resourceVersion":"` + resourceVersion + `","name":"test-pod"}}}`
+	} else {
+		body = `{"apiVersion":"v1","kind":"Pod","metadata":{"uid":"` + uid + `","resourceVersion":"` + resourceVersion + `","name":"test-pod"}}`
 	}
+	lr.Body().SetStr(body)
+	return ld
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.setupCache != nil {
-				tt.setupCache()
-			}
+func TestTranslateK8sObjects_Deduplication(t *testing.T) {
+	logger := zap.NewNop()
 
-			skip := shouldSkipManifest(tt.manifest, tt.isWatchEvent, cache)
-			assert.Equal(t, tt.expectedSkip, skip)
+	t.Run("same manifest sent twice is deduplicated", func(t *testing.T) {
+		cache := logsmapping.NewManifestCache()
+		ld := buildK8sLogs("cluster-1", "my-cluster", "pod-uid-1", "v1", false)
 
-			// Verify cache state after the operation (only for non-watch events)
-			if !tt.isWatchEvent && tt.manifest != nil && tt.manifest.Uid != "" && tt.expectedCached {
-				val, found := cache.Get(tt.manifest.Uid)
-				assert.True(t, found)
-				assert.Equal(t, tt.cachedVersion, val)
-			}
-		})
-	}
+		first := logsmapping.TranslateK8sObjects(ld, cache, logger)
+		require.Len(t, first.Chunks, 1)
+		assert.Len(t, first.Chunks[0], 1)
+
+		second := logsmapping.TranslateK8sObjects(ld, cache, logger)
+		assert.Empty(t, second.Chunks, "duplicate pull manifest should be skipped")
+	})
+
+	t.Run("updated resourceVersion is not deduplicated", func(t *testing.T) {
+		cache := logsmapping.NewManifestCache()
+		ld1 := buildK8sLogs("cluster-1", "my-cluster", "pod-uid-2", "v1", false)
+		ld2 := buildK8sLogs("cluster-1", "my-cluster", "pod-uid-2", "v2", false)
+
+		logsmapping.TranslateK8sObjects(ld1, cache, logger)
+		second := logsmapping.TranslateK8sObjects(ld2, cache, logger)
+		require.Len(t, second.Chunks, 1)
+		assert.Len(t, second.Chunks[0], 1, "updated resourceVersion should not be skipped")
+	})
+
+	t.Run("watch events bypass deduplication cache", func(t *testing.T) {
+		cache := logsmapping.NewManifestCache()
+		ld := buildK8sLogs("cluster-1", "my-cluster", "pod-uid-3", "v1", true)
+
+		logsmapping.TranslateK8sObjects(ld, cache, logger)
+		second := logsmapping.TranslateK8sObjects(ld, cache, logger)
+		require.Len(t, second.Chunks, 1, "watch events should always be forwarded")
+	})
+
+	t.Run("nil cache disables deduplication", func(t *testing.T) {
+		ld := buildK8sLogs("cluster-1", "my-cluster", "pod-uid-4", "v1", false)
+
+		first := logsmapping.TranslateK8sObjects(ld, nil, logger)
+		second := logsmapping.TranslateK8sObjects(ld, nil, logger)
+		require.Len(t, first.Chunks, 1)
+		require.Len(t, second.Chunks, 1, "nil cache should not deduplicate")
+	})
 }
 
 // TestShouldSkipResourceKind tests that secrets and configmaps are rejected.

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -178,6 +178,7 @@ use_repo(
     "com_github_datadog_datadog_agent_pkg_opentelemetry_mapping_go_otlp_attributes",
     "com_github_datadog_datadog_agent_pkg_opentelemetry_mapping_go_otlp_rum",
     "com_github_datadog_datadog_agent_pkg_orchestrator_model",
+    "com_github_datadog_datadog_agent_pkg_orchestrator_util",
     "com_github_datadog_datadog_agent_pkg_process_util_api",
     "com_github_datadog_datadog_agent_pkg_proto",
     "com_github_datadog_datadog_agent_pkg_remoteconfig_state",

--- a/pkg/opentelemetry-mapping-go/otlp/logs/BUILD.bazel
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/BUILD.bazel
@@ -15,9 +15,11 @@ go_library(
         "//pkg/opentelemetry-mapping-go/otlp/attributes/source",
         "//pkg/opentelemetry-mapping-go/otlp/rum",
         "//pkg/orchestrator/model",
+        "//pkg/orchestrator/util",
         "@com_github_datadog_agent_payload_v5//process",
         "@com_github_datadog_datadog_api_client_go_v2//api/datadog",
         "@com_github_datadog_datadog_api_client_go_v2//api/datadogV2",
+        "@com_github_patrickmn_go_cache//:go-cache",
         "@com_github_twmb_murmur3//:murmur3",
         "@io_opentelemetry_go_collector_component//:component",
         "@io_opentelemetry_go_collector_pdata//pcommon",
@@ -33,6 +35,7 @@ go_test(
     srcs = [
         "orchestrator_test.go",
         "transform_test.go",
+        "translate_test.go",
     ],
     embed = [":logs"],
     deps = [
@@ -45,6 +48,7 @@ go_test(
         "@io_opentelemetry_go_collector_pdata//pcommon",
         "@io_opentelemetry_go_collector_pdata//plog",
         "@io_opentelemetry_go_otel//semconv/v1.6.1:v1_6_1",
+        "@org_uber_go_zap//:zap",
         "@org_uber_go_zap//zaptest",
     ],
 )

--- a/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/rum v0.72.0-devel.0.20250907091827-dbb380833b5f
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/datadog-api-client-go/v2 v2.55.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/stretchr/testify v1.11.1
 	github.com/twmb/murmur3 v1.1.8
 	go.opentelemetry.io/collector/component v1.53.0
@@ -43,7 +44,6 @@ require (
 	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.53.0 // indirect

--- a/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.73.0-rc.5
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/rum v0.72.0-devel.0.20250907091827-dbb380833b5f
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.77.0-devel.0.20260211235139-a5361978c2b6
+	github.com/DataDog/datadog-agent/pkg/orchestrator/util v0.0.0-20251120165911-0b75c97e8b50
 	github.com/DataDog/datadog-api-client-go/v2 v2.55.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/stretchr/testify v1.11.1

--- a/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
@@ -457,14 +457,14 @@ func TranslateK8sObjects(ld plog.Logs, cache *gocache.Cache, logger *zap.Logger)
 
 		cid, ok := resource.Attributes().Get("k8s.cluster.uid")
 		if !ok {
-			logger.Error("missing k8s.cluster.uid, skipping resource")
+			logger.Error("Failed to get k8s cluster ID, skipping manifest payload")
 			continue
 		}
 		clusterID = cid.AsString()
 
 		cname, ok := resource.Attributes().Get("k8s.cluster.name")
 		if !ok {
-			logger.Error("missing k8s.cluster.name, skipping resource")
+			logger.Error("Failed to get k8s cluster name, skipping manifest payload")
 			continue
 		}
 		clusterName = cname.AsString()
@@ -475,7 +475,7 @@ func TranslateK8sObjects(ld plog.Logs, cache *gocache.Cache, logger *zap.Logger)
 				lr := sl.LogRecords().At(k)
 				manifest, isWatch, err := ToManifest(lr)
 				if err != nil {
-					logger.Error("failed to convert to manifest", zap.Error(err))
+					logger.Error("Failed to convert to manifest: "+err.Error(), zap.Error(err))
 					continue
 				}
 				isWatchEvent = isWatch

--- a/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
@@ -20,20 +20,14 @@ import (
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	orchestratormodel "github.com/DataDog/datadog-agent/pkg/orchestrator/model"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator/util"
 )
 
 const (
-	// ManifestCacheTTL is the time-to-live for manifest cache entries.
-	// Matches the orchestrator collector's default (3 minutes).
-	ManifestCacheTTL = 3 * time.Minute
-	// ManifestCachePurge is the interval for purging expired cache entries.
-	ManifestCachePurge = 30 * time.Second
-	// MaxManifestsPerPayload is the maximum number of manifests per payload chunk.
-	// Matches the orchestrator collector's default.
-	MaxManifestsPerPayload = 100
-	// MaxPayloadSizeBytes is the maximum total manifest content size (in bytes) per payload chunk.
-	// Matches the orchestrator collector's default (10 MB).
-	MaxPayloadSizeBytes = 10 * 1000 * 1000
+	manifestCacheTTL       = 3 * time.Minute
+	manifestCachePurge     = 30 * time.Second
+	maxManifestsPerPayload = 100
+	maxPayloadSizeBytes    = 10 * 1000 * 1000
 )
 
 var (
@@ -357,7 +351,7 @@ func CreateClusterManifest(clusterID string, nodes []*agentmodel.Manifest, logge
 // NewManifestCache creates a new manifest deduplication cache with the standard TTL and purge interval.
 // Callers are responsible for managing the cache lifetime (e.g., as a singleton).
 func NewManifestCache() *gocache.Cache {
-	return gocache.New(ManifestCacheTTL, ManifestCachePurge)
+	return gocache.New(manifestCacheTTL, manifestCachePurge)
 }
 
 // shouldSkipManifest reports whether the manifest should be suppressed because an identical
@@ -368,40 +362,75 @@ func shouldSkipManifest(manifest *agentmodel.Manifest, isWatchEvent bool, cache 
 	if cache == nil || manifest == nil || manifest.Uid == "" {
 		return false
 	}
+
+	// Watch events should always bypass the cache to ensure real-time updates
 	if isWatchEvent {
 		return false
 	}
-	if cached, hit := cache.Get(manifest.Uid); hit {
-		if cachedVersion, ok := cached.(string); ok && cachedVersion == manifest.ResourceVersion {
-			return true
-		}
+
+	cacheKey := manifest.Uid
+
+	// Check if we have this resource in cache
+	value, hit := cache.Get(cacheKey)
+
+	if !hit {
+		// Cache miss - this is a new resource, add it to cache
+		cache.Set(cacheKey, manifest.ResourceVersion, manifestCacheTTL)
+		return false
 	}
-	cache.Set(manifest.Uid, manifest.ResourceVersion, ManifestCacheTTL)
-	return false
+
+	// Cache hit - check if the resourceVersion changed
+	cachedVersion, ok := value.(string)
+	if !ok || cachedVersion != manifest.ResourceVersion {
+		// ResourceVersion changed - update cache and don't skip
+		cache.Set(cacheKey, manifest.ResourceVersion, manifestCacheTTL)
+		return false
+	}
+
+	// Cache hit with same resourceVersion - skip this manifest
+	return true
 }
 
 // chunkManifests splits manifests into chunks that each respect both a maximum count
 // and a maximum total content size (in bytes). This mirrors the limits applied by the
 // orchestrator collector to avoid intake endpoint rejections.
 func chunkManifests(manifests []*agentmodel.Manifest, maxCount, maxBytes int) [][]*agentmodel.Manifest {
-	var chunks [][]*agentmodel.Manifest
-	var current []*agentmodel.Manifest
-	currentBytes := 0
+	if len(manifests) == 0 {
+		return make([][]*agentmodel.Manifest, 0)
+	}
 
+	// Convert to interface{} for the chunking utility
+	interfaceManifests := make([]interface{}, 0, len(manifests))
 	for _, m := range manifests {
-		size := len(m.Content)
-		if len(current) > 0 && (len(current) >= maxCount || currentBytes+size > maxBytes) {
-			chunks = append(chunks, current)
-			current = nil
-			currentBytes = 0
+		interfaceManifests = append(interfaceManifests, m)
+	}
+
+	chunker := &util.ChunkAllocator[[]interface{}, interface{}]{
+		AppendToChunk: func(chunk *[]interface{}, payloads []interface{}) {
+			*chunk = append(*chunk, payloads...)
+		},
+	}
+
+	list := &util.PayloadList[interface{}]{
+		Items: interfaceManifests,
+		WeightAt: func(i int) int {
+			// Use the serialized manifest content size as the weight
+			return len(manifests[i].Content)
+		},
+	}
+
+	util.ChunkPayloadsBySizeAndWeight[[]interface{}, interface{}](list, chunker, maxCount, maxBytes)
+
+	// Convert back to typed chunks
+	chunks := *chunker.GetChunks()
+	result := make([][]*agentmodel.Manifest, len(chunks))
+	for i, chunk := range chunks {
+		result[i] = make([]*agentmodel.Manifest, len(chunk))
+		for j, item := range chunk {
+			result[i][j] = item.(*agentmodel.Manifest)
 		}
-		current = append(current, m)
-		currentBytes += size
 	}
-	if len(current) > 0 {
-		chunks = append(chunks, current)
-	}
-	return chunks
+	return result
 }
 
 // K8sTranslationResult holds the output of TranslateK8sObjects.
@@ -455,23 +484,42 @@ func TranslateK8sObjects(ld plog.Logs, cache *gocache.Cache, logger *zap.Logger)
 					nodes = append(nodes, manifest)
 				}
 				if shouldSkipManifest(manifest, isWatch, cache) {
+					logger.Debug("Skipping manifest (cache hit)",
+						zap.String("uid", manifest.Uid),
+						zap.String("kind", manifest.Kind),
+						zap.String("resourceVersion", manifest.ResourceVersion))
 					continue
 				}
+				logger.Debug("Sending manifest",
+					zap.String("uid", manifest.Uid),
+					zap.String("kind", manifest.Kind),
+					zap.String("resourceVersion", manifest.ResourceVersion))
 				manifests = append(manifests, manifest)
 			}
 		}
 	}
 
 	if len(nodes) > 0 && !isWatchEvent {
+		logger.Debug("Creating Cluster manifest after collecting nodes", zap.Int("total_nodes", len(nodes)))
 		if clusterManifest := CreateClusterManifest(clusterID, nodes, logger); clusterManifest != nil {
 			if !shouldSkipManifest(clusterManifest, false, cache) {
 				manifests = append(manifests, clusterManifest)
+				logger.Debug("Added Cluster manifest to payload",
+					zap.String("uid", clusterManifest.Uid),
+					zap.Int("total_nodes", len(nodes)))
 			}
 		}
 	}
 
+	chunks := chunkManifests(manifests, maxManifestsPerPayload, maxPayloadSizeBytes)
+	logger.Debug("Sending manifests in chunks",
+		zap.Int("total_manifests", len(manifests)),
+		zap.Int("chunk_count", len(chunks)),
+		zap.Int("max_manifests_per_chunk", maxManifestsPerPayload),
+		zap.Int("max_payload_size_bytes", maxPayloadSizeBytes))
+
 	return &K8sTranslationResult{
-		Chunks:      chunkManifests(manifests, MaxManifestsPerPayload, MaxPayloadSizeBytes),
+		Chunks:      chunks,
 		ClusterName: clusterName,
 		ClusterID:   clusterID,
 	}

--- a/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
@@ -11,13 +11,23 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
+	gocache "github.com/patrickmn/go-cache"
 	"github.com/twmb/murmur3"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	orchestratormodel "github.com/DataDog/datadog-agent/pkg/orchestrator/model"
+)
+
+const (
+	// ManifestCacheTTL is the time-to-live for manifest cache entries.
+	// Matches the orchestrator collector's default (3 minutes).
+	ManifestCacheTTL = 3 * time.Minute
+	// ManifestCachePurge is the interval for purging expired cache entries.
+	ManifestCachePurge = 30 * time.Second
 )
 
 var (
@@ -336,6 +346,56 @@ func CreateClusterManifest(clusterID string, nodes []*agentmodel.Manifest, logge
 		ApiVersion:      "virtual.datadoghq.com/v1",
 		Kind:            "Cluster",
 	}
+}
+
+// NewManifestCache creates a new manifest deduplication cache with the standard TTL and purge interval.
+// Callers are responsible for managing the cache lifetime (e.g., as a singleton).
+func NewManifestCache() *gocache.Cache {
+	return gocache.New(ManifestCacheTTL, ManifestCachePurge)
+}
+
+// ShouldSkipManifest reports whether the manifest should be suppressed because an identical
+// (same UID + resourceVersion) manifest was already sent within the cache TTL.
+// Watch events always bypass the cache so real-time updates are never dropped.
+// cache must not be nil.
+func ShouldSkipManifest(manifest *agentmodel.Manifest, isWatchEvent bool, cache *gocache.Cache) bool {
+	if manifest == nil || manifest.Uid == "" {
+		return false
+	}
+	if isWatchEvent {
+		return false
+	}
+	if cached, hit := cache.Get(manifest.Uid); hit {
+		if cachedVersion, ok := cached.(string); ok && cachedVersion == manifest.ResourceVersion {
+			return true
+		}
+	}
+	cache.Set(manifest.Uid, manifest.ResourceVersion, ManifestCacheTTL)
+	return false
+}
+
+// ChunkManifests splits manifests into chunks that each respect both a maximum count
+// and a maximum total content size (in bytes). This mirrors the limits applied by the
+// orchestrator collector to avoid intake endpoint rejections.
+func ChunkManifests(manifests []*agentmodel.Manifest, maxCount, maxBytes int) [][]*agentmodel.Manifest {
+	var chunks [][]*agentmodel.Manifest
+	var current []*agentmodel.Manifest
+	currentBytes := 0
+
+	for _, m := range manifests {
+		size := len(m.Content)
+		if len(current) > 0 && (len(current) >= maxCount || currentBytes+size > maxBytes) {
+			chunks = append(chunks, current)
+			current = nil
+			currentBytes = 0
+		}
+		current = append(current, m)
+		currentBytes += size
+	}
+	if len(current) > 0 {
+		chunks = append(chunks, current)
+	}
+	return chunks
 }
 
 func getManifestType(kind string) int {

--- a/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
@@ -28,6 +28,12 @@ const (
 	ManifestCacheTTL = 3 * time.Minute
 	// ManifestCachePurge is the interval for purging expired cache entries.
 	ManifestCachePurge = 30 * time.Second
+	// MaxManifestsPerPayload is the maximum number of manifests per payload chunk.
+	// Matches the orchestrator collector's default.
+	MaxManifestsPerPayload = 100
+	// MaxPayloadSizeBytes is the maximum total manifest content size (in bytes) per payload chunk.
+	// Matches the orchestrator collector's default (10 MB).
+	MaxPayloadSizeBytes = 10 * 1000 * 1000
 )
 
 var (
@@ -354,12 +360,12 @@ func NewManifestCache() *gocache.Cache {
 	return gocache.New(ManifestCacheTTL, ManifestCachePurge)
 }
 
-// ShouldSkipManifest reports whether the manifest should be suppressed because an identical
+// shouldSkipManifest reports whether the manifest should be suppressed because an identical
 // (same UID + resourceVersion) manifest was already sent within the cache TTL.
 // Watch events always bypass the cache so real-time updates are never dropped.
-// cache must not be nil.
-func ShouldSkipManifest(manifest *agentmodel.Manifest, isWatchEvent bool, cache *gocache.Cache) bool {
-	if manifest == nil || manifest.Uid == "" {
+// If cache is nil, deduplication is skipped.
+func shouldSkipManifest(manifest *agentmodel.Manifest, isWatchEvent bool, cache *gocache.Cache) bool {
+	if cache == nil || manifest == nil || manifest.Uid == "" {
 		return false
 	}
 	if isWatchEvent {
@@ -374,10 +380,10 @@ func ShouldSkipManifest(manifest *agentmodel.Manifest, isWatchEvent bool, cache 
 	return false
 }
 
-// ChunkManifests splits manifests into chunks that each respect both a maximum count
+// chunkManifests splits manifests into chunks that each respect both a maximum count
 // and a maximum total content size (in bytes). This mirrors the limits applied by the
 // orchestrator collector to avoid intake endpoint rejections.
-func ChunkManifests(manifests []*agentmodel.Manifest, maxCount, maxBytes int) [][]*agentmodel.Manifest {
+func chunkManifests(manifests []*agentmodel.Manifest, maxCount, maxBytes int) [][]*agentmodel.Manifest {
 	var chunks [][]*agentmodel.Manifest
 	var current []*agentmodel.Manifest
 	currentBytes := 0
@@ -396,6 +402,79 @@ func ChunkManifests(manifests []*agentmodel.Manifest, maxCount, maxBytes int) []
 		chunks = append(chunks, current)
 	}
 	return chunks
+}
+
+// K8sTranslationResult holds the output of TranslateK8sObjects.
+type K8sTranslationResult struct {
+	// Chunks holds manifests split into payload-sized groups ready to send.
+	Chunks [][]*agentmodel.Manifest
+	// ClusterName extracted from k8s.cluster.name resource attribute.
+	ClusterName string
+	// ClusterID extracted from k8s.cluster.uid resource attribute.
+	ClusterID string
+}
+
+// TranslateK8sObjects converts k8sobjectsreceiver logs into chunked orchestrator manifest payloads.
+// It handles deduplication via cache (pass nil to disable), cluster manifest creation, and chunking.
+// Individual record errors are logged and skipped rather than aborting the batch.
+func TranslateK8sObjects(ld plog.Logs, cache *gocache.Cache, logger *zap.Logger) *K8sTranslationResult {
+	var manifests []*agentmodel.Manifest
+	var nodes []*agentmodel.Manifest
+	var isWatchEvent bool
+	var clusterID, clusterName string
+
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		rl := ld.ResourceLogs().At(i)
+		resource := rl.Resource()
+
+		cid, ok := resource.Attributes().Get("k8s.cluster.uid")
+		if !ok {
+			logger.Error("missing k8s.cluster.uid, skipping resource")
+			continue
+		}
+		clusterID = cid.AsString()
+
+		cname, ok := resource.Attributes().Get("k8s.cluster.name")
+		if !ok {
+			logger.Error("missing k8s.cluster.name, skipping resource")
+			continue
+		}
+		clusterName = cname.AsString()
+
+		for j := 0; j < rl.ScopeLogs().Len(); j++ {
+			sl := rl.ScopeLogs().At(j)
+			for k := 0; k < sl.LogRecords().Len(); k++ {
+				lr := sl.LogRecords().At(k)
+				manifest, isWatch, err := ToManifest(lr)
+				if err != nil {
+					logger.Error("failed to convert to manifest", zap.Error(err))
+					continue
+				}
+				isWatchEvent = isWatch
+				if manifest.Kind == "Node" {
+					nodes = append(nodes, manifest)
+				}
+				if shouldSkipManifest(manifest, isWatch, cache) {
+					continue
+				}
+				manifests = append(manifests, manifest)
+			}
+		}
+	}
+
+	if len(nodes) > 0 && !isWatchEvent {
+		if clusterManifest := CreateClusterManifest(clusterID, nodes, logger); clusterManifest != nil {
+			if !shouldSkipManifest(clusterManifest, false, cache) {
+				manifests = append(manifests, clusterManifest)
+			}
+		}
+	}
+
+	return &K8sTranslationResult{
+		Chunks:      chunkManifests(manifests, MaxManifestsPerPayload, MaxPayloadSizeBytes),
+		ClusterName: clusterName,
+		ClusterID:   clusterID,
+	}
 }
 
 func getManifestType(kind string) int {

--- a/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
@@ -391,10 +391,9 @@ func shouldSkipManifest(manifest *agentmodel.Manifest, isWatchEvent bool, cache 
 	return true
 }
 
-// chunkManifests splits manifests into chunks that each respect both a maximum count
-// and a maximum total content size (in bytes). This mirrors the limits applied by the
-// orchestrator collector to avoid intake endpoint rejections.
-func chunkManifests(manifests []*agentmodel.Manifest, maxCount, maxBytes int) [][]*agentmodel.Manifest {
+// chunkManifestsBySizeAndWeight chunks manifests based on both count and serialized size
+// to avoid intake endpoint rejections. This follows the same logic as the orchestrator collector.
+func chunkManifestsBySizeAndWeight(manifests []*agentmodel.Manifest, maxChunkSize, maxChunkWeight int) [][]*agentmodel.Manifest {
 	if len(manifests) == 0 {
 		return make([][]*agentmodel.Manifest, 0)
 	}
@@ -419,7 +418,7 @@ func chunkManifests(manifests []*agentmodel.Manifest, maxCount, maxBytes int) []
 		},
 	}
 
-	util.ChunkPayloadsBySizeAndWeight[[]interface{}, interface{}](list, chunker, maxCount, maxBytes)
+	util.ChunkPayloadsBySizeAndWeight[[]interface{}, interface{}](list, chunker, maxChunkSize, maxChunkWeight)
 
 	// Convert back to typed chunks
 	chunks := *chunker.GetChunks()
@@ -511,7 +510,7 @@ func TranslateK8sObjects(ld plog.Logs, cache *gocache.Cache, logger *zap.Logger)
 		}
 	}
 
-	chunks := chunkManifests(manifests, maxManifestsPerPayload, maxPayloadSizeBytes)
+	chunks := chunkManifestsBySizeAndWeight(manifests, maxManifestsPerPayload, maxPayloadSizeBytes)
 	logger.Debug("Sending manifests in chunks",
 		zap.Int("total_manifests", len(manifests)),
 		zap.Int("chunk_count", len(chunks)),

--- a/pkg/opentelemetry-mapping-go/otlp/logs/transform_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/transform_test.go
@@ -152,7 +152,6 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -179,7 +178,6 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -210,7 +208,6 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -241,7 +238,6 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -272,7 +268,6 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -301,7 +296,6 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -330,7 +324,6 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "alert",
@@ -363,7 +356,6 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"message":          "This is log",
 					"app":              "test",
@@ -396,7 +388,6 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"message":      "This is log",
 					"app":          "test",
@@ -427,9 +418,9 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString("service:otlp_col,otel_source:test"),
-				Message: *datadog.PtrString(""),
-				Service: datadog.PtrString("otlp_col"),
+				Ddtags:   datadog.PtrString("service:otlp_col,otel_source:test"),
+				Message:  *datadog.PtrString(""),
+				Service:  datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",

--- a/pkg/opentelemetry-mapping-go/otlp/logs/transform_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/transform_test.go
@@ -427,9 +427,9 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:   datadog.PtrString("service:otlp_col,otel_source:test"),
-				Message:  *datadog.PtrString(""),
-				Service:  datadog.PtrString("otlp_col"),
+				Ddtags:  datadog.PtrString("service:otlp_col,otel_source:test"),
+				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",

--- a/pkg/opentelemetry-mapping-go/otlp/logs/transform_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/transform_test.go
@@ -152,6 +152,7 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -178,6 +179,7 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -208,6 +210,7 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -238,6 +241,7 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -268,6 +272,7 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -296,6 +301,7 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
@@ -324,6 +330,7 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "alert",
@@ -356,6 +363,7 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"message":          "This is log",
 					"app":              "test",
@@ -388,6 +396,7 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]interface{}{
 					"message":      "This is log",
 					"app":          "test",

--- a/pkg/opentelemetry-mapping-go/otlp/logs/translate_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/translate_test.go
@@ -24,6 +24,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	semconv16 "go.opentelemetry.io/otel/semconv/v1.6.1"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 // buildLogs is a helper that assembles a plog.Logs from a single resource, scope, and log record.
@@ -41,8 +43,7 @@ func TestTranslate_Basic(t *testing.T) {
 	lr.Body().SetStr("hello world")
 	lr.SetSeverityNumber(9) // info
 
-	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
-	require.NoError(t, err)
+	payloads := Translate(buildLogs(pcommon.NewResource(), lr), zap.NewNop(), false)
 	require.Len(t, payloads, 1)
 
 	got := payloads[0]
@@ -60,8 +61,7 @@ func TestTranslate_HostFromResource(t *testing.T) {
 	lr := plog.NewLogRecord()
 	lr.Body().SetStr("msg")
 
-	payloads, err := Translate(buildLogs(res, lr))
-	require.NoError(t, err)
+	payloads := Translate(buildLogs(res, lr), zap.NewNop(), false)
 	require.Len(t, payloads, 1)
 
 	got := payloads[0]
@@ -76,8 +76,7 @@ func TestTranslate_NoHostOrServiceWhenAbsentFromResource(t *testing.T) {
 	lr.Attributes().PutStr(string(semconv16.ServiceNameKey), "record-service")
 	lr.Body().SetStr("msg")
 
-	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
-	require.NoError(t, err)
+	payloads := Translate(buildLogs(pcommon.NewResource(), lr), zap.NewNop(), false)
 	require.Len(t, payloads, 1)
 
 	assert.Nil(t, payloads[0].Hostname)
@@ -107,8 +106,7 @@ func TestTranslate_SeverityMapping(t *testing.T) {
 			lr.SetSeverityText(tc.text)
 		}
 
-		payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
-		require.NoError(t, err)
+		payloads := Translate(buildLogs(pcommon.NewResource(), lr), zap.NewNop(), false)
 		require.Len(t, payloads, 1)
 		assert.Equal(t, tc.wantDD, payloads[0].AdditionalProperties[ddStatus], "severity %v text %q", tc.num, tc.text)
 	}
@@ -125,8 +123,7 @@ func TestTranslate_NestedMap(t *testing.T) {
 		},
 	})
 
-	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
-	require.NoError(t, err)
+	payloads := Translate(buildLogs(pcommon.NewResource(), lr), zap.NewNop(), false)
 	require.Len(t, payloads, 1)
 
 	assert.Equal(t, "value", payloads[0].AdditionalProperties["root.child.leaf"])
@@ -139,8 +136,7 @@ func TestTranslate_NestedList(t *testing.T) {
 		"items": []any{"a", "b", "c"},
 	})
 
-	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
-	require.NoError(t, err)
+	payloads := Translate(buildLogs(pcommon.NewResource(), lr), zap.NewNop(), false)
 	require.Len(t, payloads, 1)
 
 	assert.Equal(t, []interface{}{"a", "b", "c"}, payloads[0].AdditionalProperties["items"])
@@ -156,8 +152,7 @@ func TestTranslate_ListOfMaps(t *testing.T) {
 		},
 	})
 
-	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
-	require.NoError(t, err)
+	payloads := Translate(buildLogs(pcommon.NewResource(), lr), zap.NewNop(), false)
 	require.Len(t, payloads, 1)
 
 	want := []interface{}{
@@ -176,8 +171,7 @@ func TestTranslate_NestedListsOfLists(t *testing.T) {
 		},
 	})
 
-	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
-	require.NoError(t, err)
+	payloads := Translate(buildLogs(pcommon.NewResource(), lr), zap.NewNop(), false)
 	require.Len(t, payloads, 1)
 
 	want := []interface{}{
@@ -190,25 +184,18 @@ func TestTranslate_NestedListsOfLists(t *testing.T) {
 func TestTranslate_MultipleResourcesAndRecords(t *testing.T) {
 	ld := plog.NewLogs()
 
-	// First resource: two log records
 	rl1 := ld.ResourceLogs().AppendEmpty()
 	rl1.Resource().Attributes().PutStr(string(semconv16.HostNameKey), "host-1")
 	rl1.Resource().Attributes().PutStr(string(semconv16.ServiceNameKey), "svc-1")
 	sl1 := rl1.ScopeLogs().AppendEmpty()
-	lr1a := sl1.LogRecords().AppendEmpty()
-	lr1a.Body().SetStr("msg-1a")
-	lr1b := sl1.LogRecords().AppendEmpty()
-	lr1b.Body().SetStr("msg-1b")
+	sl1.LogRecords().AppendEmpty().Body().SetStr("msg-1a")
+	sl1.LogRecords().AppendEmpty().Body().SetStr("msg-1b")
 
-	// Second resource: one log record
 	rl2 := ld.ResourceLogs().AppendEmpty()
 	rl2.Resource().Attributes().PutStr(string(semconv16.HostNameKey), "host-2")
-	sl2 := rl2.ScopeLogs().AppendEmpty()
-	lr2 := sl2.LogRecords().AppendEmpty()
-	lr2.Body().SetStr("msg-2")
+	rl2.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("msg-2")
 
-	payloads, err := Translate(ld)
-	require.NoError(t, err)
+	payloads := Translate(ld, zap.NewNop(), false)
 	require.Len(t, payloads, 3)
 
 	assert.Equal(t, "msg-1a", payloads[0].GetMessage())
@@ -224,28 +211,21 @@ func TestTranslate_MultipleResourcesAndRecords(t *testing.T) {
 }
 
 func TestTranslate_EmptyLogs(t *testing.T) {
-	payloads, err := Translate(plog.NewLogs())
-	require.NoError(t, err)
+	payloads := Translate(plog.NewLogs(), zap.NewNop(), false)
 	assert.Empty(t, payloads)
 }
 
 func TestTranslate_TagsFromResourceAttributes(t *testing.T) {
 	res := pcommon.NewResource()
 	res.Attributes().PutStr(string(semconv16.ServiceNameKey), "my-svc")
-	res.Attributes().PutStr("env", "prod")
 
 	lr := plog.NewLogRecord()
 	lr.Body().SetStr("tagged")
 
-	payloads, err := Translate(buildLogs(res, lr))
-	require.NoError(t, err)
+	payloads := Translate(buildLogs(res, lr), zap.NewNop(), false)
 	require.Len(t, payloads, 1)
 
-	// Tags are derived from resource attributes via TagsFromAttributes.
-	got := payloads[0]
-	require.NotNil(t, got.Ddtags)
-	ddtags := got.GetDdtags()
-	assert.Contains(t, ddtags, "service:my-svc")
+	assert.Contains(t, payloads[0].GetDdtags(), "service:my-svc")
 }
 
 func TestTranslate_TraceAndSpanIDs(t *testing.T) {
@@ -256,8 +236,7 @@ func TestTranslate_TraceAndSpanIDs(t *testing.T) {
 	lr.SetTraceID(traceID)
 	lr.SetSpanID(spanID)
 
-	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
-	require.NoError(t, err)
+	payloads := Translate(buildLogs(pcommon.NewResource(), lr), zap.NewNop(), false)
 	require.Len(t, payloads, 1)
 
 	got := payloads[0].AdditionalProperties
@@ -267,16 +246,25 @@ func TestTranslate_TraceAndSpanIDs(t *testing.T) {
 	assert.NotEmpty(t, got[otelSpanID])
 }
 
+func TestTranslate_UsesProvidedLogger(t *testing.T) {
+	// Verify that the provided logger is used (e.g. for trace/span decode warnings).
+	logger := zaptest.NewLogger(t)
+
+	lr := plog.NewLogRecord()
+	lr.Attributes().PutStr("traceid", "invalid-trace-id")
+
+	payloads := Translate(buildLogs(pcommon.NewResource(), lr), logger, false)
+	require.Len(t, payloads, 1)
+}
+
 func TestTranslate_ReturnsHTTPLogItems(t *testing.T) {
-	// Verify the return type matches datadogV2.HTTPLogItem (compile-time check via usage).
 	var _ []datadogV2.HTTPLogItem
 	res := pcommon.NewResource()
 	res.Attributes().PutStr(string(semconv16.ServiceNameKey), "svc")
 	lr := plog.NewLogRecord()
 	lr.Body().SetStr("check type")
 
-	payloads, err := Translate(buildLogs(res, lr))
-	require.NoError(t, err)
+	payloads := Translate(buildLogs(res, lr), zap.NewNop(), false)
 	require.Len(t, payloads, 1)
 	assert.IsType(t, datadogV2.HTTPLogItem{}, payloads[0])
 }

--- a/pkg/opentelemetry-mapping-go/otlp/logs/translate_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/translate_test.go
@@ -69,8 +69,8 @@ func TestTranslate_HostFromResource(t *testing.T) {
 	assert.Equal(t, datadog.PtrString("my-service"), got.Service)
 }
 
-func TestTranslate_HostFromLogAttrs(t *testing.T) {
-	// HACK: host and service absent from resource but present in log record attributes.
+func TestTranslate_NoHostOrServiceWhenAbsentFromResource(t *testing.T) {
+	// host/service on log record attributes are ignored — must come from resource.
 	lr := plog.NewLogRecord()
 	lr.Attributes().PutStr(string(semconv16.HostNameKey), "record-host")
 	lr.Attributes().PutStr(string(semconv16.ServiceNameKey), "record-service")
@@ -80,27 +80,8 @@ func TestTranslate_HostFromLogAttrs(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, payloads, 1)
 
-	got := payloads[0]
-	assert.Equal(t, datadog.PtrString("record-host"), got.Hostname)
-	assert.Equal(t, datadog.PtrString("record-service"), got.Service)
-}
-
-func TestTranslate_ResourceHostTakesPrecedenceOverLogAttrs(t *testing.T) {
-	res := pcommon.NewResource()
-	res.Attributes().PutStr(string(semconv16.HostNameKey), "resource-host")
-	res.Attributes().PutStr(string(semconv16.ServiceNameKey), "resource-service")
-
-	lr := plog.NewLogRecord()
-	lr.Attributes().PutStr(string(semconv16.HostNameKey), "record-host")
-	lr.Attributes().PutStr(string(semconv16.ServiceNameKey), "record-service")
-
-	payloads, err := Translate(buildLogs(res, lr))
-	require.NoError(t, err)
-	require.Len(t, payloads, 1)
-
-	got := payloads[0]
-	assert.Equal(t, datadog.PtrString("resource-host"), got.Hostname)
-	assert.Equal(t, datadog.PtrString("resource-service"), got.Service)
+	assert.Nil(t, payloads[0].Hostname)
+	assert.Nil(t, payloads[0].Service)
 }
 
 func TestTranslate_SeverityMapping(t *testing.T) {

--- a/pkg/opentelemetry-mapping-go/otlp/logs/translate_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/translate_test.go
@@ -1,0 +1,301 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	semconv16 "go.opentelemetry.io/otel/semconv/v1.6.1"
+)
+
+// buildLogs is a helper that assembles a plog.Logs from a single resource, scope, and log record.
+func buildLogs(res pcommon.Resource, lr plog.LogRecord) plog.Logs {
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	res.CopyTo(rl.Resource())
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr.CopyTo(sl.LogRecords().AppendEmpty())
+	return ld
+}
+
+func TestTranslate_Basic(t *testing.T) {
+	lr := plog.NewLogRecord()
+	lr.Body().SetStr("hello world")
+	lr.SetSeverityNumber(9) // info
+
+	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+
+	got := payloads[0]
+	assert.Equal(t, "hello world", got.GetMessage())
+	assert.Nil(t, got.Hostname)
+	assert.Nil(t, got.Service)
+	assert.Equal(t, "info", got.AdditionalProperties[ddStatus])
+}
+
+func TestTranslate_HostFromResource(t *testing.T) {
+	res := pcommon.NewResource()
+	res.Attributes().PutStr(string(semconv16.HostNameKey), "my-host")
+	res.Attributes().PutStr(string(semconv16.ServiceNameKey), "my-service")
+
+	lr := plog.NewLogRecord()
+	lr.Body().SetStr("msg")
+
+	payloads, err := Translate(buildLogs(res, lr))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+
+	got := payloads[0]
+	assert.Equal(t, datadog.PtrString("my-host"), got.Hostname)
+	assert.Equal(t, datadog.PtrString("my-service"), got.Service)
+}
+
+func TestTranslate_HostFromLogAttrs(t *testing.T) {
+	// HACK: host and service absent from resource but present in log record attributes.
+	lr := plog.NewLogRecord()
+	lr.Attributes().PutStr(string(semconv16.HostNameKey), "record-host")
+	lr.Attributes().PutStr(string(semconv16.ServiceNameKey), "record-service")
+	lr.Body().SetStr("msg")
+
+	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+
+	got := payloads[0]
+	assert.Equal(t, datadog.PtrString("record-host"), got.Hostname)
+	assert.Equal(t, datadog.PtrString("record-service"), got.Service)
+}
+
+func TestTranslate_ResourceHostTakesPrecedenceOverLogAttrs(t *testing.T) {
+	res := pcommon.NewResource()
+	res.Attributes().PutStr(string(semconv16.HostNameKey), "resource-host")
+	res.Attributes().PutStr(string(semconv16.ServiceNameKey), "resource-service")
+
+	lr := plog.NewLogRecord()
+	lr.Attributes().PutStr(string(semconv16.HostNameKey), "record-host")
+	lr.Attributes().PutStr(string(semconv16.ServiceNameKey), "record-service")
+
+	payloads, err := Translate(buildLogs(res, lr))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+
+	got := payloads[0]
+	assert.Equal(t, datadog.PtrString("resource-host"), got.Hostname)
+	assert.Equal(t, datadog.PtrString("resource-service"), got.Service)
+}
+
+func TestTranslate_SeverityMapping(t *testing.T) {
+	cases := []struct {
+		num    plog.SeverityNumber
+		text   string
+		wantDD string
+	}{
+		{3, "", logLevelTrace},
+		{5, "", logLevelDebug},
+		{9, "", logLevelInfo},
+		{13, "", logLevelWarn},
+		{17, "", logLevelError},
+		{21, "", logLevelFatal},
+		// SeverityText takes precedence when both are set
+		{5, "critical", "critical"},
+	}
+
+	for _, tc := range cases {
+		lr := plog.NewLogRecord()
+		lr.SetSeverityNumber(tc.num)
+		if tc.text != "" {
+			lr.SetSeverityText(tc.text)
+		}
+
+		payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
+		require.NoError(t, err)
+		require.Len(t, payloads, 1)
+		assert.Equal(t, tc.wantDD, payloads[0].AdditionalProperties[ddStatus], "severity %v text %q", tc.num, tc.text)
+	}
+}
+
+func TestTranslate_NestedMap(t *testing.T) {
+	lr := plog.NewLogRecord()
+	lr.Body().SetStr("nested")
+	lr.Attributes().FromRaw(map[string]any{
+		"root": map[string]any{
+			"child": map[string]any{
+				"leaf": "value",
+			},
+		},
+	})
+
+	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+
+	assert.Equal(t, "value", payloads[0].AdditionalProperties["root.child.leaf"])
+}
+
+func TestTranslate_NestedList(t *testing.T) {
+	lr := plog.NewLogRecord()
+	lr.Body().SetStr("list")
+	lr.Attributes().FromRaw(map[string]any{
+		"items": []any{"a", "b", "c"},
+	})
+
+	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+
+	assert.Equal(t, []interface{}{"a", "b", "c"}, payloads[0].AdditionalProperties["items"])
+}
+
+func TestTranslate_ListOfMaps(t *testing.T) {
+	lr := plog.NewLogRecord()
+	lr.Body().SetStr("list of maps")
+	lr.Attributes().FromRaw(map[string]any{
+		"events": []any{
+			map[string]any{"name": "click", "count": int64(3)},
+			map[string]any{"name": "view", "count": int64(7)},
+		},
+	})
+
+	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+
+	want := []interface{}{
+		map[string]interface{}{"name": "click", "count": int64(3)},
+		map[string]interface{}{"name": "view", "count": int64(7)},
+	}
+	assert.Equal(t, want, payloads[0].AdditionalProperties["events"])
+}
+
+func TestTranslate_NestedListsOfLists(t *testing.T) {
+	lr := plog.NewLogRecord()
+	lr.Attributes().FromRaw(map[string]any{
+		"matrix": []any{
+			[]any{"a", "b"},
+			[]any{"c", "d"},
+		},
+	})
+
+	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+
+	want := []interface{}{
+		[]interface{}{"a", "b"},
+		[]interface{}{"c", "d"},
+	}
+	assert.Equal(t, want, payloads[0].AdditionalProperties["matrix"])
+}
+
+func TestTranslate_MultipleResourcesAndRecords(t *testing.T) {
+	ld := plog.NewLogs()
+
+	// First resource: two log records
+	rl1 := ld.ResourceLogs().AppendEmpty()
+	rl1.Resource().Attributes().PutStr(string(semconv16.HostNameKey), "host-1")
+	rl1.Resource().Attributes().PutStr(string(semconv16.ServiceNameKey), "svc-1")
+	sl1 := rl1.ScopeLogs().AppendEmpty()
+	lr1a := sl1.LogRecords().AppendEmpty()
+	lr1a.Body().SetStr("msg-1a")
+	lr1b := sl1.LogRecords().AppendEmpty()
+	lr1b.Body().SetStr("msg-1b")
+
+	// Second resource: one log record
+	rl2 := ld.ResourceLogs().AppendEmpty()
+	rl2.Resource().Attributes().PutStr(string(semconv16.HostNameKey), "host-2")
+	sl2 := rl2.ScopeLogs().AppendEmpty()
+	lr2 := sl2.LogRecords().AppendEmpty()
+	lr2.Body().SetStr("msg-2")
+
+	payloads, err := Translate(ld)
+	require.NoError(t, err)
+	require.Len(t, payloads, 3)
+
+	assert.Equal(t, "msg-1a", payloads[0].GetMessage())
+	assert.Equal(t, datadog.PtrString("host-1"), payloads[0].Hostname)
+	assert.Equal(t, datadog.PtrString("svc-1"), payloads[0].Service)
+
+	assert.Equal(t, "msg-1b", payloads[1].GetMessage())
+	assert.Equal(t, datadog.PtrString("host-1"), payloads[1].Hostname)
+
+	assert.Equal(t, "msg-2", payloads[2].GetMessage())
+	assert.Equal(t, datadog.PtrString("host-2"), payloads[2].Hostname)
+	assert.Nil(t, payloads[2].Service)
+}
+
+func TestTranslate_EmptyLogs(t *testing.T) {
+	payloads, err := Translate(plog.NewLogs())
+	require.NoError(t, err)
+	assert.Empty(t, payloads)
+}
+
+func TestTranslate_TagsFromResourceAttributes(t *testing.T) {
+	res := pcommon.NewResource()
+	res.Attributes().PutStr(string(semconv16.ServiceNameKey), "my-svc")
+	res.Attributes().PutStr("env", "prod")
+
+	lr := plog.NewLogRecord()
+	lr.Body().SetStr("tagged")
+
+	payloads, err := Translate(buildLogs(res, lr))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+
+	// Tags are derived from resource attributes via TagsFromAttributes.
+	got := payloads[0]
+	require.NotNil(t, got.Ddtags)
+	ddtags := got.GetDdtags()
+	assert.Contains(t, ddtags, "service:my-svc")
+}
+
+func TestTranslate_TraceAndSpanIDs(t *testing.T) {
+	traceID := pcommon.TraceID([16]byte{0x08, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x0, 0x0, 0x0, 0x0, 0x0a})
+	spanID := pcommon.SpanID([8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08})
+
+	lr := plog.NewLogRecord()
+	lr.SetTraceID(traceID)
+	lr.SetSpanID(spanID)
+
+	payloads, err := Translate(buildLogs(pcommon.NewResource(), lr))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+
+	got := payloads[0].AdditionalProperties
+	assert.NotEmpty(t, got[ddTraceID])
+	assert.NotEmpty(t, got[ddSpanID])
+	assert.NotEmpty(t, got[otelTraceID])
+	assert.NotEmpty(t, got[otelSpanID])
+}
+
+func TestTranslate_ReturnsHTTPLogItems(t *testing.T) {
+	// Verify the return type matches datadogV2.HTTPLogItem (compile-time check via usage).
+	var _ []datadogV2.HTTPLogItem
+	res := pcommon.NewResource()
+	res.Attributes().PutStr(string(semconv16.ServiceNameKey), "svc")
+	lr := plog.NewLogRecord()
+	lr.Body().SetStr("check type")
+
+	payloads, err := Translate(buildLogs(res, lr))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+	assert.IsType(t, datadogV2.HTTPLogItem{}, payloads[0])
+}

--- a/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
@@ -240,14 +240,41 @@ func Translate(ld plog.Logs, logger *zap.Logger, shouldFallbackOnLogAttributes b
 
 // MapLogs from OTLP format to Datadog format.
 // Deprecated: Deprecated in favor of MapLogsAndRouteRUMEvents.
-func (t *Translator) MapLogs(_ context.Context, ld plog.Logs, _ attributes.HostFromAttributesHandler) []datadogV2.HTTPLogItem {
-	payloads := Translate(ld, t.set.Logger, true)
-	for i := range payloads {
-		ddtags := payloads[i].GetDdtags()
-		if ddtags != "" {
-			payloads[i].SetDdtags(ddtags + "," + t.otelTag)
-		} else {
-			payloads[i].SetDdtags(t.otelTag)
+func (t *Translator) MapLogs(ctx context.Context, ld plog.Logs, hostFromAttributesHandler attributes.HostFromAttributesHandler) []datadogV2.HTTPLogItem {
+	rsl := ld.ResourceLogs()
+	var payloads []datadogV2.HTTPLogItem
+	for i := 0; i < rsl.Len(); i++ {
+		rl := rsl.At(i)
+		sls := rl.ScopeLogs()
+		res := rl.Resource()
+		host, service := t.hostNameAndServiceNameFromResource(ctx, res, hostFromAttributesHandler)
+		for j := 0; j < sls.Len(); j++ {
+			sl := sls.At(j)
+			lsl := sl.LogRecords()
+			scope := sl.Scope()
+			// iterate over Logs
+			for k := 0; k < lsl.Len(); k++ {
+				log := lsl.At(k)
+				// HACK: Check for host and service in log record attributes
+				// This is not aligned with the specification and will be removed in the future.
+				if host == "" {
+					host = t.hostFromAttributes(ctx, log.Attributes())
+				}
+				if service == "" {
+					if s, ok := log.Attributes().Get(string(conventions.ServiceNameKey)); ok {
+						service = s.AsString()
+					}
+				}
+
+				payload := transform(log, host, service, res, scope, t.set.Logger)
+				ddtags := payload.GetDdtags()
+				if ddtags != "" {
+					payload.SetDdtags(ddtags + "," + t.otelTag)
+				} else {
+					payload.SetDdtags(t.otelTag)
+				}
+				payloads = append(payloads, payload)
+			}
 		}
 	}
 	return payloads

--- a/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
@@ -179,7 +179,7 @@ func (t *Translator) MapLogsAndRouteRUMEvents(ctx context.Context, ld plog.Logs,
 						service = s.AsString()
 					}
 				}
-				
+
 				payload := transform(logRecord, host, service, res, scope, t.set.Logger)
 				ddtags := payload.GetDdtags()
 				if ddtags != "" {

--- a/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
@@ -170,6 +170,7 @@ func (t *Translator) MapLogsAndRouteRUMEvents(ctx context.Context, ld plog.Logs,
 					}
 				}
 				// HACK: Check for host and service in log record attributes
+				// This is not aligned with the specification and will be removed in the future.
 				if host == "" {
 					host = t.hostFromAttributes(ctx, logRecord.Attributes())
 				}
@@ -178,6 +179,7 @@ func (t *Translator) MapLogsAndRouteRUMEvents(ctx context.Context, ld plog.Logs,
 						service = s.AsString()
 					}
 				}
+				
 				payload := transform(logRecord, host, service, res, scope, t.set.Logger)
 				ddtags := payload.GetDdtags()
 				if ddtags != "" {

--- a/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
@@ -94,6 +94,7 @@ func (t *Translator) hostFromAttributes(ctx context.Context, attrs pcommon.Map) 
 }
 
 // MapLogsAndRouteRUMEvents from OTLP format to Datadog format if shouldForwardOTLPRUMToDDRUM is true.
+// Deprecated: This was part of a previous attempt to implement RUM <> OTel integration, now abandoned.
 func (t *Translator) MapLogsAndRouteRUMEvents(ctx context.Context, ld plog.Logs, hostFromAttributesHandler attributes.HostFromAttributesHandler, shouldForwardOTLPRUMToDDRUM bool, rumIntakeURL string) ([]datadogV2.HTTPLogItem, error) {
 	if t.httpClient == nil {
 		return nil, errors.New("httpClient is nil")
@@ -168,6 +169,15 @@ func (t *Translator) MapLogsAndRouteRUMEvents(ctx context.Context, ld plog.Logs,
 						continue
 					}
 				}
+				// HACK: Check for host and service in log record attributes
+				if host == "" {
+					host = t.hostFromAttributes(ctx, logRecord.Attributes())
+				}
+				if service == "" {
+					if s, ok := logRecord.Attributes().Get(string(conventions.ServiceNameKey)); ok {
+						service = s.AsString()
+					}
+				}
 				payload := transform(logRecord, host, service, res, scope, t.set.Logger)
 				ddtags := payload.GetDdtags()
 				if ddtags != "" {
@@ -182,21 +192,25 @@ func (t *Translator) MapLogsAndRouteRUMEvents(ctx context.Context, ld plog.Logs,
 	return payloads, nil
 }
 
-// Translate converts plog.Logs to Datadog log items without requiring a Translator instance,
-// logger, or context. It uses attributes.GetHost and attributes.GetService to extract
+// Translate converts plog.Logs to Datadog log items without requiring a Translator instance
+// or context. It uses attributes.GetHost and attributes.GetService to extract
 // hostname and service from resource attributes.
-func Translate(ld plog.Logs) ([]datadogV2.HTTPLogItem, error) {
+//
+// When shouldFallbackOnLogAttributes is true, host and service are also looked up on
+// individual log record attributes if absent from the resource. This preserves backwards
+// compatibility for existing consumers (e.g. datadogexporter) that relied on this behaviour.
+// New consumers should pass false.
+func Translate(ld plog.Logs, logger *zap.Logger, shouldFallbackOnLogAttributes bool) []datadogV2.HTTPLogItem {
 	rsl := ld.ResourceLogs()
 	var payloads []datadogV2.HTTPLogItem
-	logger := zap.NewNop()
 	for i := 0; i < rsl.Len(); i++ {
 		rl := rsl.At(i)
 		res := rl.Resource()
 
-		host := attributes.GetHost(res.Attributes(), "")
-		svc := attributes.GetService(res.Attributes(), false)
-		if svc == attributes.DefaultServiceName {
-			svc = ""
+		resHost := attributes.GetHost(res.Attributes(), "")
+		resSvc := attributes.GetService(res.Attributes(), false)
+		if resSvc == attributes.DefaultServiceName {
+			resSvc = ""
 		}
 
 		sls := rl.ScopeLogs()
@@ -206,17 +220,28 @@ func Translate(ld plog.Logs) ([]datadogV2.HTTPLogItem, error) {
 			scope := sl.Scope()
 			for k := 0; k < lsl.Len(); k++ {
 				lr := lsl.At(k)
+				host, svc := resHost, resSvc
+				if shouldFallbackOnLogAttributes {
+					if host == "" {
+						host = attributes.GetHost(lr.Attributes(), "")
+					}
+					if svc == "" {
+						if s := attributes.GetService(lr.Attributes(), false); s != attributes.DefaultServiceName {
+							svc = s
+						}
+					}
+				}
 				payloads = append(payloads, transform(lr, host, svc, res, scope, logger))
 			}
 		}
 	}
-	return payloads, nil
+	return payloads
 }
 
 // MapLogs from OTLP format to Datadog format.
 // Deprecated: Deprecated in favor of MapLogsAndRouteRUMEvents.
 func (t *Translator) MapLogs(_ context.Context, ld plog.Logs, _ attributes.HostFromAttributesHandler) []datadogV2.HTTPLogItem {
-	payloads, _ := Translate(ld)
+	payloads := Translate(ld, t.set.Logger, true)
 	for i := range payloads {
 		ddtags := payloads[i].GetDdtags()
 		if ddtags != "" {

--- a/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
@@ -168,17 +168,6 @@ func (t *Translator) MapLogsAndRouteRUMEvents(ctx context.Context, ld plog.Logs,
 						continue
 					}
 				}
-				// HACK: Check for host and service in log record attributes
-				// This is not aligned with the specification and will be removed in the future.
-				if host == "" {
-					host = t.hostFromAttributes(ctx, logRecord.Attributes())
-				}
-				if service == "" {
-					if s, ok := logRecord.Attributes().Get(string(conventions.ServiceNameKey)); ok {
-						service = s.AsString()
-					}
-				}
-
 				payload := transform(logRecord, host, service, res, scope, t.set.Logger)
 				ddtags := payload.GetDdtags()
 				if ddtags != "" {
@@ -195,8 +184,7 @@ func (t *Translator) MapLogsAndRouteRUMEvents(ctx context.Context, ld plog.Logs,
 
 // Translate converts plog.Logs to Datadog log items without requiring a Translator instance,
 // logger, or context. It uses attributes.GetHost and attributes.GetService to extract
-// hostname and service from resource attributes, with a per-record fallback to log
-// record attributes (for backwards compatibility with existing behaviour).
+// hostname and service from resource attributes.
 func Translate(ld plog.Logs) ([]datadogV2.HTTPLogItem, error) {
 	rsl := ld.ResourceLogs()
 	var payloads []datadogV2.HTTPLogItem
@@ -205,10 +193,10 @@ func Translate(ld plog.Logs) ([]datadogV2.HTTPLogItem, error) {
 		rl := rsl.At(i)
 		res := rl.Resource()
 
-		resHost := attributes.GetHost(res.Attributes(), "")
-		resSvc := attributes.GetService(res.Attributes(), false)
-		if resSvc == attributes.DefaultServiceName {
-			resSvc = ""
+		host := attributes.GetHost(res.Attributes(), "")
+		svc := attributes.GetService(res.Attributes(), false)
+		if svc == attributes.DefaultServiceName {
+			svc = ""
 		}
 
 		sls := rl.ScopeLogs()
@@ -218,23 +206,7 @@ func Translate(ld plog.Logs) ([]datadogV2.HTTPLogItem, error) {
 			scope := sl.Scope()
 			for k := 0; k < lsl.Len(); k++ {
 				lr := lsl.At(k)
-
-				// HACK: Check for host and service in log record attributes
-				// if not present in resource attributes.
-				// This is not aligned with the specification and will be removed in the future.
-				host := resHost
-				service := resSvc
-				if host == "" {
-					host = attributes.GetHost(lr.Attributes(), "")
-				}
-				if service == "" {
-					svc := attributes.GetService(lr.Attributes(), false)
-					if svc != attributes.DefaultServiceName {
-						service = svc
-					}
-				}
-
-				payloads = append(payloads, transform(lr, host, service, res, scope, logger))
+				payloads = append(payloads, transform(lr, host, svc, res, scope, logger))
 			}
 		}
 	}
@@ -243,41 +215,14 @@ func Translate(ld plog.Logs) ([]datadogV2.HTTPLogItem, error) {
 
 // MapLogs from OTLP format to Datadog format.
 // Deprecated: Deprecated in favor of MapLogsAndRouteRUMEvents.
-func (t *Translator) MapLogs(ctx context.Context, ld plog.Logs, hostFromAttributesHandler attributes.HostFromAttributesHandler) []datadogV2.HTTPLogItem {
-	rsl := ld.ResourceLogs()
-	var payloads []datadogV2.HTTPLogItem
-	for i := 0; i < rsl.Len(); i++ {
-		rl := rsl.At(i)
-		sls := rl.ScopeLogs()
-		res := rl.Resource()
-		host, service := t.hostNameAndServiceNameFromResource(ctx, res, hostFromAttributesHandler)
-		for j := 0; j < sls.Len(); j++ {
-			sl := sls.At(j)
-			lsl := sl.LogRecords()
-			scope := sl.Scope()
-			// iterate over Logs
-			for k := 0; k < lsl.Len(); k++ {
-				log := lsl.At(k)
-				// HACK: Check for host and service in log record attributes
-				// This is not aligned with the specification and will be removed in the future.
-				if host == "" {
-					host = t.hostFromAttributes(ctx, log.Attributes())
-				}
-				if service == "" {
-					if s, ok := log.Attributes().Get(string(conventions.ServiceNameKey)); ok {
-						service = s.AsString()
-					}
-				}
-
-				payload := transform(log, host, service, res, scope, t.set.Logger)
-				ddtags := payload.GetDdtags()
-				if ddtags != "" {
-					payload.SetDdtags(ddtags + "," + t.otelTag)
-				} else {
-					payload.SetDdtags(t.otelTag)
-				}
-				payloads = append(payloads, payload)
-			}
+func (t *Translator) MapLogs(_ context.Context, ld plog.Logs, _ attributes.HostFromAttributesHandler) []datadogV2.HTTPLogItem {
+	payloads, _ := Translate(ld)
+	for i := range payloads {
+		ddtags := payloads[i].GetDdtags()
+		if ddtags != "" {
+			payloads[i].SetDdtags(ddtags + "," + t.otelTag)
+		} else {
+			payloads[i].SetDdtags(t.otelTag)
 		}
 	}
 	return payloads

--- a/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/translator.go
@@ -193,6 +193,54 @@ func (t *Translator) MapLogsAndRouteRUMEvents(ctx context.Context, ld plog.Logs,
 	return payloads, nil
 }
 
+// Translate converts plog.Logs to Datadog log items without requiring a Translator instance,
+// logger, or context. It uses attributes.GetHost and attributes.GetService to extract
+// hostname and service from resource attributes, with a per-record fallback to log
+// record attributes (for backwards compatibility with existing behaviour).
+func Translate(ld plog.Logs) ([]datadogV2.HTTPLogItem, error) {
+	rsl := ld.ResourceLogs()
+	var payloads []datadogV2.HTTPLogItem
+	logger := zap.NewNop()
+	for i := 0; i < rsl.Len(); i++ {
+		rl := rsl.At(i)
+		res := rl.Resource()
+
+		resHost := attributes.GetHost(res.Attributes(), "")
+		resSvc := attributes.GetService(res.Attributes(), false)
+		if resSvc == attributes.DefaultServiceName {
+			resSvc = ""
+		}
+
+		sls := rl.ScopeLogs()
+		for j := 0; j < sls.Len(); j++ {
+			sl := sls.At(j)
+			lsl := sl.LogRecords()
+			scope := sl.Scope()
+			for k := 0; k < lsl.Len(); k++ {
+				lr := lsl.At(k)
+
+				// HACK: Check for host and service in log record attributes
+				// if not present in resource attributes.
+				// This is not aligned with the specification and will be removed in the future.
+				host := resHost
+				service := resSvc
+				if host == "" {
+					host = attributes.GetHost(lr.Attributes(), "")
+				}
+				if service == "" {
+					svc := attributes.GetService(lr.Attributes(), false)
+					if svc != attributes.DefaultServiceName {
+						service = svc
+					}
+				}
+
+				payloads = append(payloads, transform(lr, host, service, res, scope, logger))
+			}
+		}
+	}
+	return payloads, nil
+}
+
 // MapLogs from OTLP format to Datadog format.
 // Deprecated: Deprecated in favor of MapLogsAndRouteRUMEvents.
 func (t *Translator) MapLogs(ctx context.Context, ld plog.Logs, hostFromAttributesHandler attributes.HostFromAttributesHandler) []datadogV2.HTTPLogItem {

--- a/releasenotes/notes/otlp-logs-shared-helpers-1eed388c955ce346.yaml
+++ b/releasenotes/notes/otlp-logs-shared-helpers-1eed388c955ce346.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    Added Translate, ShouldSkipManifest, NewManifestCache, and
+    ChunkManifests to otlp/logs so exporters can share log translation
+    and manifest deduplication logic without duplicating code.
+deprecations:
+  - |
+    MapLogsAndRouteRUMEvents on the logs Translator is deprecated
+    (abandoned RUM/OTel integration attempt).

--- a/releasenotes/notes/otlp-logs-shared-helpers-1eed388c955ce346.yaml
+++ b/releasenotes/notes/otlp-logs-shared-helpers-1eed388c955ce346.yaml
@@ -1,9 +1,9 @@
 ---
 enhancements:
   - |
-    Added Translate, ShouldSkipManifest, NewManifestCache, and
-    ChunkManifests to otlp/logs so exporters can share log translation
-    and manifest deduplication logic without duplicating code.
+    Added Translate, TranslateK8sObjects, and NewManifestCache to
+    otlp/logs so exporters can share log translation and manifest
+    deduplication logic without duplicating code.
 deprecations:
   - |
     MapLogsAndRouteRUMEvents on the logs Translator is deprecated


### PR DESCRIPTION
- Add Translate(plog.Logs) to otel-mapping-go/otlp/logs for the dd-source logs exporter                                                       - Add NewManifestCache, ShouldSkipManifest, and ChunkManifests to orchestrator.go so the dd-source K8s exporter can share manifest dedup/chunking logic instead of duplicating it from logsagentexporter 