### PR TITLE
[procmgr] Refactor CLI client to use transport::connect()

### DIFF
--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -50,6 +50,7 @@ rust_library(
         ":cpp_stdlib",
         ":process_manager_rust_proto",
         "@crates//:anyhow",
+        "@crates//:hyper-util",
         "@crates//:log",
         "@crates//:nix",
         "@crates//:prost",
@@ -59,6 +60,7 @@ rust_library(
         "@crates//:tokio-stream",
         "@crates//:tonic",
         "@crates//:tonic-reflection",
+        "@crates//:tower",
         "@crates//:uuid",
     ],
 )
@@ -97,11 +99,9 @@ rust_binary(
     deps = [
         ":dd-procmgrd-lib",
         "@crates//:clap",
-        "@crates//:hyper-util",
         "@crates//:serde_json",
         "@crates//:tokio",
         "@crates//:tonic",
-        "@crates//:tower",
     ],
 )
 

--- a/pkg/procmgr/rust/src/bins/dd-procmgr.rs
+++ b/pkg/procmgr/rust/src/bins/dd-procmgr.rs
@@ -6,12 +6,11 @@
 use clap::{Parser, Subcommand};
 use dd_procmgrd::grpc::proto;
 use dd_procmgrd::grpc::proto::process_manager_client::ProcessManagerClient;
-use dd_procmgrd::grpc::server::socket_path;
+use dd_procmgrd::transport;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::ExitCode;
-use tonic::transport::{Channel, Endpoint};
-use tower::service_fn;
+use tonic::transport::Channel;
 
 #[derive(Parser)]
 #[command(name = "dd-procmgr", about = "CLI for dd-procmgrd process manager")]
@@ -116,18 +115,9 @@ async fn main() -> ExitCode {
 async fn connect(socket_override: Option<&str>) -> Result<ProcessManagerClient<Channel>, String> {
     let path: PathBuf = match socket_override {
         Some(s) => PathBuf::from(s),
-        None => socket_path(),
+        None => transport::ipc_path(),
     };
-    let path_clone = path.clone();
-    let channel = Endpoint::from_static(dd_procmgrd::transport::DUMMY_ENDPOINT)
-        .connect_with_connector(service_fn(move |_| {
-            let p = path_clone.clone();
-            async move {
-                tokio::net::UnixStream::connect(p)
-                    .await
-                    .map(hyper_util::rt::TokioIo::new)
-            }
-        }))
+    let channel = transport::connect(&path)
         .await
         .map_err(|e| format!("failed to connect to {}: {e}", path.display()))?;
     Ok(ProcessManagerClient::new(channel))

--- a/pkg/procmgr/rust/src/grpc/server.rs
+++ b/pkg/procmgr/rust/src/grpc/server.rs
@@ -12,10 +12,6 @@ use anyhow::{Context, Result};
 use tokio::sync::mpsc;
 use tonic::transport::Server;
 
-pub fn socket_path() -> std::path::PathBuf {
-    transport::ipc_path()
-}
-
 pub async fn run(
     mgr: ProcessManager,
     cmd_tx: mpsc::Sender<Command>,

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -31,4 +31,8 @@ where
     anyhow::bail!("Named Pipe transport is not yet implemented on Windows")
 }
 
+pub async fn connect(_path: &Path) -> Result<tonic::transport::Channel> {
+    anyhow::bail!("Named Pipe client transport is not yet implemented on Windows")
+}
+
 pub fn cleanup(_path: &Path) {}

--- a/pkg/procmgr/rust/src/transport/uds.rs
+++ b/pkg/procmgr/rust/src/transport/uds.rs
@@ -72,6 +72,22 @@ where
     Ok(())
 }
 
+pub async fn connect(path: &Path) -> Result<tonic::transport::Channel> {
+    let path = path.to_path_buf();
+    let channel = tonic::transport::Endpoint::from_static(DUMMY_ENDPOINT)
+        .connect_with_connector(tower::service_fn(move |_| {
+            let p = path.clone();
+            async move {
+                tokio::net::UnixStream::connect(p)
+                    .await
+                    .map(hyper_util::rt::TokioIo::new)
+            }
+        }))
+        .await
+        .context("failed to connect to Unix socket")?;
+    Ok(channel)
+}
+
 pub fn cleanup(path: &Path) {
     match std::fs::remove_file(path) {
         Ok(()) => {}


### PR DESCRIPTION
### What does this PR do?

Moves the UDS client connection logic out of `dd-procmgr.rs` and into `transport::connect()`, making the CLI binary fully platform-agnostic. Removes the `socket_path()` wrapper from `grpc/server.rs` in favour of the canonical `transport::ipc_path()`. Adds a `connect()` stub to the Windows named_pipe transport.

### Motivation

After abstracted the server side behind the transport layer, the client side (`dd-procmgr`) still had inline `tokio::net::UnixStream` code. This PR completes the transport abstraction so both server and client use the same `transport::` module, unblocking the future Named Pipe implementation.

### Describe how you validated your changes

- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo test`
- `cargo test --test e2e --features test-helpers`

### Additional Notes