### PR TITLE
Assert that noop is the 'unknown' fallback for compression

### DIFF
--- a/pkg/util/compression/selector/selector_test.go
+++ b/pkg/util/compression/selector/selector_test.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package selector
+
+import (
+	"testing"
+)
+
+// Asserts that an unrecognized compression kind falls back to noop.
+// Derived from rule CompressorFallback in compression.allium.
+func TestUnrecognizedKindFallsBackToNoop(t *testing.T) {
+	for _, kind := range []string{"bogus", "lz4", "", "ZSTD"} {
+		c := NewCompressor(kind, 0)
+		if c == nil {
+			t.Fatalf("NewCompressor(%q, 0) returned nil", kind)
+		}
+		if got := c.ContentEncoding(); got != "identity" {
+			t.Errorf("NewCompressor(%q, 0).ContentEncoding() = %q, want %q (noop)", kind, got, "identity")
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR introduces a test to demonstrate that 'noop' is the fallback compressor when serializer_compressor_kind is not one of "zlib", "zstd", "gzip" or "none". The allium spec describes what is, not what should be, as does this test. However, I do find this behavior surprising and think we should fallback to zlib or something or error out and refuse to start, as a config validation step.

### Motivation

Document what is, but also open a conversation line on what should be. I find the current behavior surprising.
