### PR TITLE
[procmgr] Move default config dir to platform module

### DIFF
--- a/pkg/procmgr/rust/src/config.rs
+++ b/pkg/procmgr/rust/src/config.rs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+use crate::platform;
 use anyhow::{Context, Result};
 use log::{debug, info, warn};
 use serde::Deserialize;
@@ -137,8 +138,6 @@ impl ConfigLoader for YamlConfigLoader {
         configs
     }
 }
-
-const DEFAULT_CONFIG_DIR: &str = "/etc/datadog-agent/processes.d";
 
 fn default_true() -> bool {
     true
@@ -278,7 +277,7 @@ impl ProcessConfig {
 pub fn config_dir() -> PathBuf {
     std::env::var("DD_PM_CONFIG_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(DEFAULT_CONFIG_DIR))
+        .unwrap_or_else(|_| platform::default_config_dir())
 }
 
 /// Scan a directory for `*.yaml` files and parse each into a ProcessConfig.

--- a/pkg/procmgr/rust/src/platform/unix.rs
+++ b/pkg/procmgr/rust/src/platform/unix.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
 use std::os::unix::process::ExitStatusExt;
+use std::path::PathBuf;
 
 /// Place the child in its own process group so signals don't propagate
 /// to the daemon itself and SIGTERM can target all descendants.
@@ -39,6 +40,10 @@ pub fn send_force_kill(pid: u32) -> Result<()> {
 /// terminated by a signal.
 pub fn last_signal(status: &std::process::ExitStatus) -> Option<i32> {
     status.signal()
+}
+
+pub fn default_config_dir() -> PathBuf {
+    PathBuf::from("/etc/datadog-agent/processes.d")
 }
 
 /// Wait for a shutdown trigger (SIGTERM or SIGINT).

--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -4,6 +4,7 @@
 // Copyright 2026-present Datadog, Inc.
 
 use anyhow::Result;
+use std::path::PathBuf;
 
 /// Configure the child process for Windows: create a new process group
 /// and assign to a Job Object so all descendants can be managed together.
@@ -24,6 +25,11 @@ pub fn send_force_kill(_pid: u32) -> Result<()> {
 /// On Windows, processes don't have Unix signals.
 pub fn last_signal(_status: &std::process::ExitStatus) -> Option<i32> {
     None
+}
+
+pub fn default_config_dir() -> PathBuf {
+    let base = std::env::var("ProgramData").unwrap_or_else(|_| r"C:\ProgramData".to_string());
+    PathBuf::from(base).join(r"Datadog\dd-procmgr\processes.d")
 }
 
 /// Wait for a shutdown trigger (Ctrl+C or service stop event).


### PR DESCRIPTION
### What does this PR do?

Moves the hardcoded Linux default config directory (`/etc/datadog-agent/processes.d`) out of `config.rs` and into `platform::default_config_dir()`, with a Windows implementation that resolves `%ProgramData%\Datadog\dd-procmgr\processes.d`. `config_dir()` now delegates to the platform module when `DD_PM_CONFIG_DIR` is not set.

### Motivation

Part of the Windows port. The config module had a hardcoded Unix path that would be wrong on Windows. Following the established pattern of centralising OS-specific logic in the `platform` module, this PR makes the default config directory platform-aware.

### Describe how you validated your changes

- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo test`

### Additional Notes