### PR TITLE
Try to decrease the size of the agent packages

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -142,6 +142,10 @@ build do
             # removing the local folder to reduce package size by ~0.5MB
             delete "#{install_dir}/embedded/share/locale"
 
+            # Drop bundled unit-test directories from embedded Python wheels/deps (not used at agent runtime).
+            # Deepest paths first so nested tests/ trees are removed safely.
+            command "find #{install_dir}/embedded/lib -path '*/site-packages/*' -depth -type d -name tests -exec rm -rf {} +"
+
             # remove some debug ebpf object files to reduce the size of the package
             delete "#{install_dir}/embedded/share/system-probe/ebpf/co-re/oom-kill-debug.o"
             delete "#{install_dir}/embedded/share/system-probe/ebpf/co-re/tcp-queue-length-debug.o"

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -860,8 +860,8 @@ def rpath_edit(ctx, install_path, target_rpath_dd_folder, platform="linux"):
 
 @task
 def deduplicate_files(ctx, directory):
-    # Matches: .so, .so.X, .so.X.Y, .so.X.Y.Z, .bundle, .dll, .dylib, .pyd
-    LIB_PATTERN = re.compile(r"\.(bundle|dll|dylib|pyd|so(?:\.\d+)*)$")
+    # Matches: .a, .so, .so.X, .so.X.Y, .so.X.Y.Z, .bundle, .dll, .dylib, .pyd
+    LIB_PATTERN = re.compile(r"\.(a|bundle|dll|dylib|pyd|so(?:\.\d+)*)$")
 
     def hash_file(filepath):
         """Returns the SHA-256 hash of the file's contents."""


### PR DESCRIPTION
### What does this PR do?

- **`omnibus/config/software/datadog-agent-finalize.rb` (Linux):** After existing embedded cleanup, remove every directory named `tests` under `embedded/lib/.../site-packages/`. Uses `find -path '*/site-packages/*' -depth -type d -name tests -exec rm -rf {} +` so nested trees are removed safely and the behavior is POSIX-`sh` friendly.
- **`tasks/omnibus.py`:** Extend `omnibus.deduplicate-files` to treat duplicate **static archives (`.a`)** like shared libs—replace byte-identical copies with symlinks under `embedded/`.

Together these reduce **on-disk** footprint of deb/rpm/suse/docker agent artifacts (static quality gates measure extracted install tree size).

### Motivation

Static quality gate **on-disk** headroom for main agent packages (deb/rpm/suse and aligned flavors) is very tight. Dependency wheels installed from integrations-core lockfiles can still ship test payloads—notably a **top-level** `site-packages/tests/` tree (e.g. cryptography’s upstream wheel layout). Stripping tests in integrations-core wheels does not cover every layout; this Omnibus step is a **defense in depth** after pip install.

[#44106](https://github.com/DataDog/datadog-agent/pull/44106) moved most per-package test deletion out of `datadog-agent-integrations-py3.rb` in favor of wheel-time stripping; this PR adds a **final** sweep without re-listing package names.

### Describe how you validated your changes

- `python3 -m pytest tasks/unit_tests/omnibus_tests.py tasks/unit_tests/static_quality_gates_tests.py`
- CI: Omnibus / static quality gates job on this branch (see bot comment on inventory + SQG table for `.deb` vs ancestor).

### Additional Notes

- **No product features removed**—only test-only directories under `site-packages` and duplicate `.a` files.
- **Risk:** A dependency that incorrectly imports from its bundled `tests/` at runtime could break; that is uncommon; the scope is only `*/site-packages/*/tests` directories.
- Optional follow-up: tighten or adjust **integrations-core** / wheel builds so fewer tests reach the install tree; this change remains useful as a safety net.
