### PR TITLE
fix(ci): Add CODEOWNERS entry to suppress notifications for rust LICENSE files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,7 @@
 /NOTICE                                 @DataDog/agent-delivery
 
 /LICENSE*                               # do not notify anyone
+/rust/LICENSE*				# do not notify anyone
 
 /mkdocs.yml                             @DataDog/agent-devx
 /release.json                           @DataDog/agent-build @DataDog/agent-delivery @DataDog/agent-integrations


### PR DESCRIPTION
### What does this PR do?

Adds a CODEOWNERS entry for `/rust/LICENSE*` so that changes to Rust license files do not trigger review notifications, matching the existing behavior for top-level `/LICENSE*` files.

### Motivation

Rust dependency updates (e.g. via Dependabot or cargo-bazel-tidy) can touch `rust/LICENSE*` files. These are auto-generated license files and should not trigger CODEOWNERS notifications, just like the existing top-level `LICENSE*` files.

### Describe how you validated your changes

Verified the CODEOWNERS syntax matches the existing pattern used for `/LICENSE*`.

### Additional Notes

Follows the same `# do not notify anyone` pattern already in place at line 47 of `.github/CODEOWNERS`.