### PR TITLE
Extending the schema linter

### DIFF
--- a/tasks/schema/generate.py
+++ b/tasks/schema/generate.py
@@ -18,6 +18,15 @@ SYSPROBE_TEMPLATE = os.path.join("pkg", "config", "system-probe_template.yaml")
 _SCRIPTS_DIR = os.path.dirname(__file__)
 
 
+def str_presenter(dumper, data):
+    if "\n" in data:
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+
+
+yaml.add_representer(str, str_presenter)
+
+
 @task
 def generate(ctx, agent_bin, output_dir=SCHEMA_DIR):
     """
@@ -75,9 +84,9 @@ def generate(ctx, agent_bin, output_dir=SCHEMA_DIR):
     sysprobe_schema["description"] = "The schema to validate the system-probe.yaml configuration for the DataDog Agent"
 
     with open(core, "w") as f:
-        yaml.safe_dump(core_schema, f, sort_keys=False)
+        yaml.dump(core_schema, f, sort_keys=False)
     with open(sysprobe, "w") as f:
-        yaml.safe_dump(sysprobe_schema, f, sort_keys=False)
+        yaml.dump(sysprobe_schema, f, sort_keys=False)
 
     print("Schema generation complete. Output files:")
     print(f"  {core}")

--- a/tasks/schema/lint.py
+++ b/tasks/schema/lint.py
@@ -9,6 +9,7 @@ a set of quality rules. Run with:
 
 import glob
 import os
+import re
 
 import yaml
 from invoke import task
@@ -366,6 +367,167 @@ def check_platform_default_keys(path, schema):
 
 
 # ---------------------------------------------------------------------------
+# Check 9: Every section has at least one child
+# ---------------------------------------------------------------------------
+
+
+def check_sections_have_children(path, schema):
+    """
+    Check that every section node has a non-empty 'properties' mapping.
+
+    A section with no children is structurally invalid regardless of visibility.
+
+    Returns a list of error strings.
+    """
+    errors = []
+    for node_path, node in walk_nodes(schema):
+        if node.get("node_type") != "section":
+            continue
+        props = node.get("properties")
+        if not isinstance(props, dict) or len(props) == 0:
+            errors.append(
+                f"{path}: [{node_path}] Section has no children (empty or missing 'properties'). "
+                f"Fix: add at least one child setting or sub-section, or remove the section."
+            )
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Check 10: Public sections have at least one direct public child
+# ---------------------------------------------------------------------------
+
+
+def check_public_section_has_public_child(path, schema):
+    """
+    Check that every public section has at least one direct child with
+    visibility='public'.
+
+    A public section with only private children is meaningless from a
+    documentation perspective.
+
+    Returns a list of error strings.
+    """
+    errors = []
+    for node_path, node in walk_nodes(schema):
+        if node.get("node_type") != "section":
+            continue
+        if node.get("visibility") != "public":
+            continue
+        props = node.get("properties") or {}
+        has_public_child = any(
+            isinstance(child, dict) and child.get("visibility") == "public" for child in props.values()
+        )
+        if not has_public_child:
+            errors.append(
+                f"{path}: [{node_path}] Public section has no direct public child. "
+                f"Fix: set 'visibility: public' on at least one direct child setting or "
+                f"sub-section, or remove 'visibility: public' from this section."
+            )
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Check 11: Text fields (description, example, title) must not contain
+#           literal \\n escape sequences and use scalars instead
+# ---------------------------------------------------------------------------
+
+_TEXT_LINEBREAK_RE = re.compile(r'(?m)^\s*(description|example|title):\s*"[^"]*\\n')
+
+
+def check_text_scalar_mode(path):
+    """
+    Check that 'description', 'example', and 'title' fields do not contain
+    literal \\n escape sequences in double-quoted YAML strings.
+
+    Reads the raw file (no YAML parsing) and searches for the literal two-character
+    sequence backslash-n inside double-quoted values for those fields.
+
+    Returns a list of error strings.
+    """
+    with open(path) as f:
+        raw = f.read()
+    errors = []
+    for m in _TEXT_LINEBREAK_RE.finditer(raw):
+        field = m.group(1)
+        lineno = raw[: m.start()].count("\n") + 1
+        errors.append(
+            f"{path}:{lineno}: Field '{field}' contains a literal \\n escape sequence. "
+            f"Fix: remove the embedded \\n and use a literal style scalar instead to "
+            f"improve readability of the schema (see: https://yaml.org/spec/1.2.2/#literal-style)."
+        )
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Check 12: Relative defaults use known variables
+# ---------------------------------------------------------------------------
+
+VALID_RELATIVE_DEFAULT_VARS = {"run_path", "install_path", "conf_path", "log_path"}
+
+
+def _check_relative_value(path, node_path, value):
+    """Check a single default value for well-formed and known ${var} placeholders."""
+    errors = []
+    if not isinstance(value, str) or "${" not in value:
+        return errors
+
+    pos = 0
+    while True:
+        idx = value.find("${", pos)
+        if idx == -1:
+            break
+        close = value.find("}", idx + 2)
+        if close == -1:
+            errors.append(
+                f"{path}: [{node_path}] Default value contains an unclosed '${{' "
+                f"placeholder: '{value}'. "
+                f"Fix: close the placeholder with '}}'."
+            )
+            break
+        var_name = value[idx + 2 : close]
+        if var_name not in VALID_RELATIVE_DEFAULT_VARS:
+            errors.append(
+                f"{path}: [{node_path}] Default value uses unknown variable "
+                f"'${{{var_name}}}' in '{value}'. "
+                f"Allowed variables: {sorted(VALID_RELATIVE_DEFAULT_VARS)}. "
+                f"Fix: use one of the allowed variables."
+            )
+        pos = close + 1
+
+    return errors
+
+
+def check_relative_defaults(path, schema):
+    """
+    Check that relative default values (those containing ${var} placeholders) use
+    only known variables and have well-formed syntax.
+
+    Applies to both 'default' and each value inside 'platform_default'.
+
+    Returns a list of error strings.
+    """
+    errors = []
+    for node_path, node in walk_nodes(schema):
+        if node.get("node_type") != "setting":
+            continue
+
+        errors.extend(_check_relative_value(path, node_path, node.get("default")))
+
+        platform_default = node.get("platform_default")
+        if isinstance(platform_default, dict):
+            for platform_key, platform_value in platform_default.items():
+                errors.extend(
+                    _check_relative_value(
+                        path,
+                        f"{node_path}[platform_default.{platform_key}]",
+                        platform_value,
+                    )
+                )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
 # Exception list loading
 # ---------------------------------------------------------------------------
 
@@ -424,7 +586,6 @@ def lint(ctx, schema_dir=SCHEMA_DIR, exceptions_file=EXCEPTIONS_FILE):
         with open(schema_path) as f:
             schema = yaml.safe_load(f)
 
-        # Checks 2–8
         all_errors.extend(check_json_schema_structure(schema_path, schema, exc["array_no_items"]))
         all_errors.extend(check_public_descriptions(schema_path, schema))
         all_errors.extend(check_public_parent_sections(schema_path, schema))
@@ -432,6 +593,10 @@ def lint(ctx, schema_dir=SCHEMA_DIR, exceptions_file=EXCEPTIONS_FILE):
         all_errors.extend(check_settings_have_default(schema_path, schema, exc["no_default"]))
         all_errors.extend(check_settings_have_type(schema_path, schema, exc["no_type"]))
         all_errors.extend(check_platform_default_keys(schema_path, schema))
+        all_errors.extend(check_sections_have_children(schema_path, schema))
+        all_errors.extend(check_public_section_has_public_child(schema_path, schema))
+        all_errors.extend(check_text_scalar_mode(schema_path))
+        all_errors.extend(check_relative_defaults(schema_path, schema))
 
     if all_errors:
         print(f"\nFound {len(all_errors)} schema linting error(s):\n")

--- a/tasks/unit_tests/schema_lint_tests.py
+++ b/tasks/unit_tests/schema_lint_tests.py
@@ -217,5 +217,127 @@ class TestCheckPlatformDefaultKeys(unittest.TestCase):
         self.assertFalse(any("valid_all_platforms" in e for e in errors))
 
 
+class TestCheckSectionsHaveChildren(unittest.TestCase):
+    def test_valid_schema_produces_no_errors(self):
+        errors = errors_for(lint.check_sections_have_children, "valid.yaml")
+        self.assertEqual(errors, [])
+
+    def test_section_with_empty_properties_is_error(self):
+        errors = errors_for(lint.check_sections_have_children, "empty_section.yaml")
+        self.assertTrue(
+            any("empty_props_section" in e for e in errors),
+            f"Expected error for empty_props_section, got: {errors}",
+        )
+
+    def test_section_with_no_properties_key_is_error(self):
+        errors = errors_for(lint.check_sections_have_children, "empty_section.yaml")
+        self.assertTrue(
+            any("no_props_section" in e for e in errors),
+            f"Expected error for no_props_section, got: {errors}",
+        )
+
+    def test_section_with_children_passes(self):
+        errors = errors_for(lint.check_sections_have_children, "empty_section.yaml")
+        self.assertFalse(any("valid_section" in e for e in errors))
+
+
+class TestCheckPublicSectionHasPublicChild(unittest.TestCase):
+    def test_valid_schema_produces_no_errors(self):
+        errors = errors_for(lint.check_public_section_has_public_child, "valid.yaml")
+        self.assertEqual(errors, [])
+
+    def test_public_section_with_only_private_children_is_error(self):
+        errors = errors_for(lint.check_public_section_has_public_child, "public_section_no_public_child.yaml")
+        self.assertTrue(
+            any("all_private_children" in e for e in errors),
+            f"Expected error for all_private_children, got: {errors}",
+        )
+
+    def test_public_section_with_public_child_passes(self):
+        errors = errors_for(lint.check_public_section_has_public_child, "public_section_no_public_child.yaml")
+        self.assertFalse(any("has_public_child" in e for e in errors))
+
+    def test_private_section_with_no_public_children_passes(self):
+        errors = errors_for(lint.check_public_section_has_public_child, "public_section_no_public_child.yaml")
+        self.assertFalse(any("private_section_no_public_child" in e for e in errors))
+
+
+class TestCheckTextScalarMode(unittest.TestCase):
+    def test_valid_schema_produces_no_errors(self):
+        errors = lint.check_text_scalar_mode(fixture("valid.yaml"))
+        self.assertEqual(errors, [])
+
+    def test_description_with_linebreak_is_error(self):
+        errors = lint.check_text_scalar_mode(fixture("text_linebreaks.yaml"))
+        self.assertTrue(
+            any("desc_with_linebreak" in e or "description" in e.lower() for e in errors),
+            f"Expected error for description with \\n, got: {errors}",
+        )
+
+    def test_example_with_linebreak_is_error(self):
+        errors = lint.check_text_scalar_mode(fixture("text_linebreaks.yaml"))
+        self.assertTrue(
+            any("example_with_linebreak" in e or "example" in e.lower() for e in errors),
+            f"Expected error for example with \\n, got: {errors}",
+        )
+
+    def test_title_with_linebreak_is_error(self):
+        errors = lint.check_text_scalar_mode(fixture("text_linebreaks.yaml"))
+        self.assertTrue(
+            any("title_with_linebreak" in e or "title" in e.lower() for e in errors),
+            f"Expected error for title with \\n, got: {errors}",
+        )
+
+    def test_no_linebreak_passes(self):
+        errors = lint.check_text_scalar_mode(fixture("text_linebreaks.yaml"))
+        self.assertFalse(any("no_linebreak" in e for e in errors))
+
+
+class TestCheckRelativeDefaults(unittest.TestCase):
+    def test_valid_schema_produces_no_errors(self):
+        errors = errors_for(lint.check_relative_defaults, "valid.yaml")
+        self.assertEqual(errors, [])
+
+    def test_unknown_variable_is_error(self):
+        errors = errors_for(lint.check_relative_defaults, "bad_relative_defaults.yaml")
+        self.assertTrue(
+            any("unknown_var" in e for e in errors),
+            f"Expected error for unknown_var, got: {errors}",
+        )
+
+    def test_malformed_placeholder_is_error(self):
+        errors = errors_for(lint.check_relative_defaults, "bad_relative_defaults.yaml")
+        self.assertTrue(
+            any("malformed_placeholder" in e for e in errors),
+            f"Expected error for malformed_placeholder, got: {errors}",
+        )
+
+    def test_valid_relative_default_passes(self):
+        errors = errors_for(lint.check_relative_defaults, "bad_relative_defaults.yaml")
+        self.assertFalse(any("valid_relative" in e for e in errors))
+
+    def test_platform_default_with_bad_variable_is_error(self):
+        errors = errors_for(lint.check_relative_defaults, "bad_relative_defaults.yaml")
+        self.assertTrue(
+            any("platform_bad_var" in e for e in errors),
+            f"Expected error for platform_bad_var, got: {errors}",
+        )
+
+    def test_platform_default_with_malformed_placeholder_is_error(self):
+        errors = errors_for(lint.check_relative_defaults, "bad_relative_defaults.yaml")
+        self.assertTrue(
+            any("platform_malformed" in e for e in errors),
+            f"Expected error for platform_malformed, got: {errors}",
+        )
+
+    def test_non_relative_default_passes(self):
+        errors = errors_for(lint.check_relative_defaults, "bad_relative_defaults.yaml")
+        self.assertFalse(any("non_relative" in e for e in errors))
+
+    def test_valid_conf_path_passes(self):
+        errors = errors_for(lint.check_relative_defaults, "bad_relative_defaults.yaml")
+        self.assertFalse(any("valid_conf_path" in e for e in errors))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tasks/unit_tests/testdata/schema_lint/bad_relative_defaults.yaml
+++ b/tasks/unit_tests/testdata/schema_lint/bad_relative_defaults.yaml
@@ -1,0 +1,32 @@
+properties:
+  unknown_var:
+    node_type: setting
+    type: string
+    default: "${bad_var}/some/path"
+  malformed_placeholder:
+    node_type: setting
+    type: string
+    default: "${unclosed/path"
+  valid_relative:
+    node_type: setting
+    type: string
+    default: "${run_path}/something"
+  platform_bad_var:
+    node_type: setting
+    type: string
+    platform_default:
+      other: "${unknown_var}/path"
+      linux: "${install_path}/bin"
+  platform_malformed:
+    node_type: setting
+    type: string
+    platform_default:
+      other: "${unclosed"
+  non_relative:
+    node_type: setting
+    type: string
+    default: "/absolute/path"
+  valid_conf_path:
+    node_type: setting
+    type: string
+    default: "${conf_path}/conf.d"

--- a/tasks/unit_tests/testdata/schema_lint/empty_section.yaml
+++ b/tasks/unit_tests/testdata/schema_lint/empty_section.yaml
@@ -1,0 +1,13 @@
+properties:
+  empty_props_section:
+    node_type: section
+    properties: {}
+  no_props_section:
+    node_type: section
+  valid_section:
+    node_type: section
+    properties:
+      child:
+        node_type: setting
+        type: string
+        default: hello

--- a/tasks/unit_tests/testdata/schema_lint/public_section_no_public_child.yaml
+++ b/tasks/unit_tests/testdata/schema_lint/public_section_no_public_child.yaml
@@ -1,0 +1,28 @@
+properties:
+  all_private_children:
+    node_type: section
+    description: A public section whose direct children are all private.
+    visibility: public
+    properties:
+      private_child:
+        node_type: setting
+        type: string
+        default: hello
+  has_public_child:
+    node_type: section
+    description: A public section with one public child.
+    visibility: public
+    properties:
+      public_child:
+        node_type: setting
+        type: string
+        default: hello
+        description: A public child.
+        visibility: public
+  private_section_no_public_child:
+    node_type: section
+    properties:
+      private_child:
+        node_type: setting
+        type: string
+        default: hello

--- a/tasks/unit_tests/testdata/schema_lint/text_linebreaks.yaml
+++ b/tasks/unit_tests/testdata/schema_lint/text_linebreaks.yaml
@@ -1,0 +1,24 @@
+properties:
+  desc_with_linebreak:
+    node_type: setting
+    type: string
+    default: hello
+    description: "First line\\nSecond line"
+    visibility: public
+  example_with_linebreak:
+    node_type: setting
+    type: string
+    default: hello
+    example: "example line one\\nexample line two"
+    visibility: public
+  title_with_linebreak:
+    node_type: setting
+    type: string
+    default: hello
+    title: "Title first\\nTitle second"
+  no_linebreak:
+    node_type: setting
+    type: string
+    default: hello
+    description: A plain single-line description.
+    visibility: public


### PR DESCRIPTION
### What does this PR do?

This PR add:
- Relative path validation
- Enforce scalar types for multiline string
- Enforce that any public section has at least one public child
- Every section has at least one child