### PR TITLE
[config] Delete unused "ac_load_timeout" option

### DIFF
--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1320,11 +1320,6 @@ func autoconfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("include_ephemeral_containers", false)
 	config.BindEnvAndSetDefault("ac_include", []string{})
 	config.BindEnvAndSetDefault("ac_exclude", []string{})
-	// ac_load_timeout is used to delay the introduction of sources other than
-	// the ones automatically loaded by the AC, into the logs agent.
-	// It is mainly here to delay the introduction of the container_collect_all
-	// in the logs agent, to avoid it to tail all the available containers.
-	config.BindEnvAndSetDefault("ac_load_timeout", 30000) // in milliseconds
 	config.BindEnvAndSetDefault("container_include", []string{})
 	config.BindEnvAndSetDefault("container_exclude", []string{})
 	config.BindEnvAndSetDefault("container_include_metrics", []string{})


### PR DESCRIPTION
### What does this PR do?

Deletes the unused "ac_load_timeout" option.
It should have been deleted in https://github.com/DataDog/datadog-agent/pull/37534

### Describe how you validated your changes

CI