### PR TITLE
[observer/evals] Add eval pipeline

### DIFF
--- a/tasks/libs/q/eval.py
+++ b/tasks/libs/q/eval.py
@@ -1,0 +1,923 @@
+"""Evaluation library for the observer eval tasks (extracted from tasks/q.py).
+
+Contains all non-@task symbols: constants, helpers, and extracted logic blocks.
+The @task-decorated entry points remain in tasks/q.py and delegate here.
+"""
+
+import json
+import os
+import random
+import re
+import shlex
+import shutil
+import tempfile
+import zipfile
+
+from tasks.libs.common.color import Color, color_message
+
+# --- Constants ---
+
+SCENARIOS = ["213_pagerduty", "353_postmark", "food_delivery_redis"]
+
+# Maps short scenario names to episode names used in runs.jsonl
+SCENARIO_EPISODE_NAMES = {
+    "213_pagerduty": "213_PagerDuty_June_2014_Outage",
+    "353_postmark": "353_postmark_upstream_cloud_provider_outage",
+    "food_delivery_redis": "food-delivery-redis-cpu-saturation",
+}
+
+S3_BUCKET = "qbranch-gensim-recordings"
+AWS_PROFILE = "sso-agent-sandbox-account-admin"
+
+# All available detectors and correlators for ablation / combination search.
+# passthrough is intentionally excluded: it is designed for TP scoring (eval_tp),
+# not for Gaussian F1 eval (eval_scenarios / eval_combinations).
+DETECTORS = ["bocpd", "cusum", "rrcf", "scanmw", "scanwelch"]
+CORRELATORS = ["cross_signal", "time_cluster"]
+
+# Log metrics extractors (component_catalog extractors). Not part of the random
+# ablation grid: eval_combinations always enables all of them unless force-disabled.
+EXTRACTORS = [
+    "log_metrics_extractor",
+    "connection_error_extractor",
+    "log_pattern_extractor",
+]
+
+# Fixed anchor subsets used by eval_component to anchor the evaluation at known
+# reference configurations regardless of the random seed.
+#   [0] minimal: smallest meaningful stack (1 detector + 1 correlator)
+#   [1] medium:  a richer mid-complexity stack for a second anchor point
+# Components missing from the pool (because they are force-disabled or are the
+# evaluated component) are stripped; an anchor is omitted entirely if it ends up
+# with no detectors or no correlators after filtering.
+ANCHOR_COMBOS = [
+    {"detectors": ["bocpd"], "correlators": ["time_cluster"]},
+    {"detectors": ["bocpd", "rrcf"], "correlators": ["cross_signal", "time_cluster"]},
+]
+
+_BENCH_FILTER = "BenchmarkDetection|BenchmarkIngestion|BenchmarkLogExtraction"
+
+
+# --- StepLogger ---
+
+
+class StepLogger:
+    """Hierarchical progress logger that always shows the full ancestor chain.
+
+    Each step prints [root X/N > ... > this X/N]  title, so every line carries
+    complete context regardless of nesting depth. Create a root logger with
+    StepLogger(total, label), then nest via .child() which captures the parent.
+
+    Example output (depth 0 → 1 → 2):
+        [Bayesian run 1/30]  without/subset_000/run_000
+          [Bayesian run 1/30 > Trial 2/5]  trial_001
+            [Bayesian run 1/30 > Trial 2/5 > Scenario 1/3]  213_pagerduty
+    """
+
+    def __init__(self, total: int, label: str, depth: int = 0, parent: "StepLogger | None" = None):
+        self.total = total
+        self.label = label
+        self.depth = depth
+        self._parent = parent
+        self._current = 0
+
+    @property
+    def _indent(self) -> str:
+        return "  " * self.depth
+
+    def _ancestor_tag(self) -> str:
+        """Build 'root X/N > ... > this X/N' chain from the root down to this logger."""
+        parts = []
+        node: StepLogger | None = self
+        while node is not None:
+            parts.append(f"{node.label} {node._current}/{node.total}")
+            node = node._parent
+        return " > ".join(reversed(parts))
+
+    def step(self, title: str = "", color: Color = Color.BLUE) -> "StepLogger":
+        """Increment counter and print full-context progress line. Returns self for chaining."""
+        self._current += 1
+        tag = f"[{self._ancestor_tag()}]"
+        msg = f"{self._indent}{tag}  {title}" if title else f"{self._indent}{tag}"
+        print(color_message(msg, color))
+        return self
+
+    def detail(self, message: str, color: Color = Color.BLUE) -> None:
+        """Print an indented detail line under the current step."""
+        print(color_message(f"{self._indent}  {message}", color))
+
+    def score(self, value: float) -> None:
+        """Print a score line, green if positive, red otherwise."""
+        clr = Color.GREEN if value > 0 else Color.RED
+        print(color_message(f"{self._indent}  score: {value:.4f}", clr))
+
+    def child(self, total: int, label: str) -> "StepLogger":
+        """Create a nested logger one level deeper, capturing self as parent."""
+        return StepLogger(total, label, depth=self.depth + 1, parent=self)
+
+
+# --- Phase 1: Helper functions ---
+
+
+def _prepare_eval_output_dir(output_dir: str, *, overwrite: bool) -> bool:
+    """Ensure ``output_dir`` is empty and ready for a fresh eval run.
+
+    If the path exists and contains ``report.json``, the run is aborted unless
+    ``overwrite`` is True (avoids silently deleting completed experiments).
+
+    Returns True if the directory is ready, False if the caller should stop.
+    """
+    if os.path.isfile(output_dir):
+        print(color_message(f"Error: output path is a file, not a directory: {output_dir}", Color.RED))
+        return False
+    report_path = os.path.join(output_dir, "report.json")
+    if os.path.isfile(report_path) and not overwrite:
+        print(
+            color_message(
+                f"Error: output directory already contains report.json: {report_path}\n"
+                f"Use --overwrite to replace it, or choose a different --output-dir.",
+                Color.RED,
+            )
+        )
+        return False
+    if os.path.exists(output_dir):
+        shutil.rmtree(output_dir)
+    os.makedirs(output_dir)
+    return True
+
+
+def _scenario_f1_from_bayesian_report(report: dict | None) -> dict[str, float]:
+    """Per-scenario F1 from the best trial's eval_scenarios report (metadata)."""
+    if not report:
+        return {}
+    best = report.get("best_combination")
+    if not isinstance(best, dict):
+        return {}
+    path = best.get("report_path")
+    if not path or not os.path.isfile(path):
+        return {}
+    try:
+        with open(path) as f:
+            main = json.load(f)
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+    meta = main.get("metadata")
+    if not isinstance(meta, dict):
+        return {}
+    out: dict[str, float] = {}
+    for name, row in meta.items():
+        if isinstance(row, dict) and "f1" in row:
+            try:
+                out[str(name)] = float(row["f1"])
+            except (TypeError, ValueError):
+                continue
+    return out
+
+
+def _best_run_index(runs: list[dict]) -> int:
+    """Index of the run with highest best_score among non-failed runs (first on ties).
+
+    Returns -1 if there are no runs or all runs failed.
+    """
+    valid = [i for i, r in enumerate(runs) if not r.get("failed") and r.get("best_score") is not None]
+    if not valid:
+        return -1
+    return max(valid, key=lambda i: runs[i]["best_score"])
+
+
+def _full_stack_combo(force_disable: list | None = None) -> dict:
+    """All detectors and correlators not in force_disable (for eval baseline)."""
+    fd = set(force_disable or [])
+    return {
+        "detectors": sorted(d for d in DETECTORS if d not in fd),
+        "correlators": sorted(c for c in CORRELATORS if c not in fd),
+    }
+
+
+def _anchor_combos(force_disable: list | None = None, force_enable: list | None = None) -> list[dict]:
+    """Fixed anchor subsets derived from ANCHOR_COMBOS after filtering force_disable.
+
+    Each anchor that ends up with at least one detector and one correlator is
+    included.  Anchors whose key components are all removed are silently skipped
+    so that evaluating a component that appears in an anchor does not break the
+    run.  force_enable components are unconditionally added to every anchor.
+    """
+    fd = set(force_disable or [])
+    fe_dets = sorted(d for d in (force_enable or []) if d in DETECTORS and d not in fd)
+    fe_cors = sorted(c for c in (force_enable or []) if c in CORRELATORS and c not in fd)
+    anchors = []
+    seen_keys: set = set()
+    for combo in ANCHOR_COMBOS:
+        dets = sorted({d for d in combo["detectors"] if d not in fd} | set(fe_dets))
+        cors = sorted({c for c in combo["correlators"] if c not in fd} | set(fe_cors))
+        if not dets or not cors:
+            continue
+        key = (tuple(dets), tuple(cors))
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        anchors.append({"detectors": dets, "correlators": cors})
+    return anchors
+
+
+def random_component_combinations(
+    n: int,
+    seed: int = None,
+    force_enable: list = None,
+    force_disable: list = None,
+    exclude_combo_keys: set | None = None,
+) -> list:
+    """
+    Generate up to n distinct random component combinations, each guaranteed to
+    contain at least 1 detector (from DETECTORS) and 1 correlator (from CORRELATORS).
+
+    Args:
+        n: Target number of distinct combinations to generate.
+        seed: Random seed for reproducibility (None = non-deterministic).
+        force_enable: Components always present in every combination.
+        force_disable: Components never present in any combination (removed from pool).
+        exclude_combo_keys: Optional set of (tuple(detectors), tuple(correlators)) keys
+            to skip (e.g. the full-stack combo reserved for combo_000).
+
+    Returns:
+        List of dicts: {"detectors": [...], "correlators": [...]}
+        May be shorter than n if the combinatorial space is exhausted.
+    """
+    force_enable = set(force_enable or [])
+    force_disable = set(force_disable or [])
+
+    det_pool = [d for d in DETECTORS if d not in force_disable]
+    cor_pool = [c for c in CORRELATORS if c not in force_disable]
+    forced_dets = sorted(d for d in force_enable if d in DETECTORS)
+    forced_cors = sorted(c for c in force_enable if c in CORRELATORS)
+
+    # After forcing, we need at least one detector and one correlator in each combo.
+    # If force_enable already covers a category, the random part for that category
+    # can be empty; otherwise sample at least 1 from the remaining pool.
+    rng = random.Random(seed)
+    combos = []
+    seen: set = set(exclude_combo_keys or [])
+    max_attempts = n * 100
+    attempts = 0
+    while len(combos) < n and attempts < max_attempts:
+        attempts += 1
+
+        # Random detectors from the pool (excluding forced, which are added back below)
+        free_det_pool = [d for d in det_pool if d not in force_enable]
+        if forced_dets:
+            # forced already satisfies the ≥1 detector requirement
+            extra_dets = sorted(rng.sample(free_det_pool, rng.randint(0, len(free_det_pool)))) if free_det_pool else []
+        else:
+            if not free_det_pool:
+                break  # no detectors available at all
+            extra_dets = sorted(rng.sample(free_det_pool, rng.randint(1, len(free_det_pool))))
+        dets = sorted(set(forced_dets + extra_dets))
+
+        free_cor_pool = [c for c in cor_pool if c not in force_enable]
+        if forced_cors:
+            extra_cors = sorted(rng.sample(free_cor_pool, rng.randint(0, len(free_cor_pool)))) if free_cor_pool else []
+        else:
+            if not free_cor_pool:
+                break  # no correlators available at all
+            extra_cors = sorted(rng.sample(free_cor_pool, rng.randint(1, len(free_cor_pool))))
+        cors = sorted(set(forced_cors + extra_cors))
+
+        key = (tuple(dets), tuple(cors))
+        if key in seen:
+            continue
+        seen.add(key)
+        combos.append({"detectors": dets, "correlators": cors})
+    if attempts >= max_attempts:
+        print(
+            color_message(
+                f"Warning: Only generated {len(combos)} unique combinations (max attempts={max_attempts})", Color.ORANGE
+            )
+        )
+    return combos
+
+
+def _combo_to_config(
+    detectors: list,
+    correlators: list,
+    force_disable: list | None = None,
+) -> dict:
+    """
+    Build a testbench JSON params config enabling exactly the listed detectors
+    and correlators, explicitly disabling all other detectors/correlators.
+
+    All EXTRACTORS are enabled unless listed in force_disable (explicit
+    ``{"enabled": false}`` so ablation stays stable if catalog defaults change).
+
+    The config follows the TestbenchParamsFile format consumed by --config:
+        {"components": {"bocpd": {"enabled": true}, "rrcf": {"enabled": false}, ...}}
+    """
+    force_disable_set = set(force_disable or [])
+    enabled_set = set(detectors + correlators)
+    components = {}
+    for name in DETECTORS + CORRELATORS:
+        components[name] = {"enabled": name in enabled_set}
+    for name in EXTRACTORS:
+        components[name] = {"enabled": name not in force_disable_set}
+    return {"components": components}
+
+
+def _sample_component_params(trial, component: str) -> dict:
+    """Sample Optuna hyperparameters for a named component that supports parseJSON.
+
+    Each component's params are wrapped in a lambda so that suggest_* calls are
+    only executed for the active component. Returns an empty dict for components
+    with no tunable hyperparameters (scanmw, scanwelch, log_metrics_extractor,
+    connection_error_extractor).
+    """
+    # Commented hyperparameters are the ones that have the less impact, this is used
+    # to reduce the search space and speed up the evaluation
+    space = {
+        "bocpd": lambda: {
+            # "warmup_points": trial.suggest_int("bocpd.warmup_points", 40, 300),
+            "hazard": trial.suggest_float("bocpd.hazard", 1e-3, 0.2, log=True),
+            "cp_threshold": trial.suggest_float("bocpd.cp_threshold", 0.35, 0.9),
+            # "short_run_length": trial.suggest_int("bocpd.short_run_length", 2, 20),
+            # "cp_mass_threshold": trial.suggest_float("bocpd.cp_mass_threshold", 0.4, 0.95),
+            # "max_run_length": trial.suggest_int("bocpd.max_run_length", 50, 400),
+            # "prior_variance_scale": trial.suggest_float("bocpd.prior_variance_scale", 1.0, 50.0),
+            # "min_variance": trial.suggest_float("bocpd.min_variance", 0.01, 5.0, log=True),
+            # "recovery_points": trial.suggest_int("bocpd.recovery_points", 3, 40),
+        },
+        "cusum": lambda: {
+            # "min_points": trial.suggest_int("cusum.min_points", 3, 30),
+            # "baseline_fraction": trial.suggest_float("cusum.baseline_fraction", 0.05, 0.5),
+            # "slack_factor": trial.suggest_float("cusum.slack_factor", 0.1, 2.0),
+            "threshold_factor": trial.suggest_float("cusum.threshold_factor", 2.0, 10.0),
+        },
+        "rrcf": lambda: {
+            # "num_trees": trial.suggest_int("rrcf.num_trees", 20, 200),
+            # "tree_size": trial.suggest_int("rrcf.tree_size", 64, 512),
+            "shingle_size": trial.suggest_int("rrcf.shingle_size", 1, 16),
+            "threshold_sigma": trial.suggest_float("rrcf.threshold_sigma", 0.5, 6.0),
+        },
+        "cross_signal": lambda: {
+            # "window_seconds": trial.suggest_int("cross_signal.window_seconds", 5, 180),
+        },
+        "time_cluster": lambda: {
+            # "proximity_seconds": trial.suggest_int("time_cluster.proximity_seconds", 2, 60),
+            # "window_seconds": trial.suggest_int("time_cluster.window_seconds", 30, 600),
+            # "min_cluster_size": trial.suggest_int("time_cluster.min_cluster_size", 1, 8),
+        },
+        "log_pattern_extractor": lambda: {
+            # "disable_optimizations": trial.suggest_categorical(
+            #     "log_pattern_extractor.disable_optimizations", [True, False]
+            # ),
+            # "min_cluster_size_before_emit": trial.suggest_int(
+            #     "log_pattern_extractor.min_cluster_size_before_emit", 1, 30
+            # ),
+            # "max_tokenized_string_length": trial.suggest_int(
+            #     "log_pattern_extractor.max_tokenized_string_length", 2000, 16000
+            # ),
+            # "max_num_tokens": trial.suggest_int("log_pattern_extractor.max_num_tokens", 32, 512),
+            # "parse_hex_dump": trial.suggest_categorical("log_pattern_extractor.parse_hex_dump", [True, False]),
+            "min_token_match_ratio": trial.suggest_float("log_pattern_extractor.min_token_match_ratio", 0.2, 0.95),
+            # "cluster_time_to_live_sec": trial.suggest_int("log_pattern_extractor.cluster_time_to_live_sec", 600, 86400),
+            # "garbage_collection_interval_sec": trial.suggest_int(
+            #     "log_pattern_extractor.garbage_collection_interval_sec", 60, 7200
+            # ),
+        },
+    }
+    fn = space.get(component)
+    return fn() if fn else {}
+
+
+def _build_optuna_config(
+    trial,
+    components: list,
+    locked: set,
+) -> dict:
+    """Build a TestbenchParamsFile config dict for one Optuna trial.
+
+    Enables exactly the listed components, disables all others in the catalog.
+    Components in `locked` are enabled but their hyperparameters are not sampled
+    (Go catalog defaults apply), effectively fixing them during the search.
+    """
+    active_set = set(components)
+    result = {}
+
+    for name in DETECTORS + CORRELATORS + EXTRACTORS:
+        if name not in active_set:
+            result[name] = {"enabled": False}
+
+    for name in components:
+        params = {"enabled": True}
+        if name not in locked:
+            params.update(_sample_component_params(trial, name))
+        result[name] = params
+
+    return {"components": result}
+
+
+def _resolve_zip_from_runs_jsonl(ctx, name):
+    """Resolve the latest zip key for a scenario from runs.jsonl in S3."""
+    episode_name = SCENARIO_EPISODE_NAMES.get(name)
+    if not episode_name:
+        return None
+
+    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w") as tmp:
+        tmp_path = tmp.name
+
+    try:
+        result = ctx.run(
+            f"aws-vault exec {AWS_PROFILE} -- aws s3 cp s3://{S3_BUCKET}/runs.jsonl {shlex.quote(tmp_path)}",
+            warn=True,
+        )
+        if result is None or result.failed:
+            return None
+
+        with open(tmp_path) as f:
+            lines = []
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    lines.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue  # skip malformed records
+
+        # Find the latest entry matching this episode
+        matches = [entry for entry in lines if entry.get("episode") == episode_name]
+        if not matches:
+            return None
+
+        latest = matches[-1]
+        zip_key = latest.get("zip")
+        if zip_key:
+            print(
+                color_message(
+                    f"Resolved '{name}' from runs.jsonl: {zip_key} "
+                    f"(image: {latest.get('image', '?')}, {latest.get('timestamp', '?')})",
+                    Color.BLUE,
+                )
+            )
+        return zip_key
+    except (OSError, json.JSONDecodeError):
+        return None
+    finally:
+        os.unlink(tmp_path)
+
+
+def _ensure_parquets(ctx, name, parquet_dir):
+    """Download and extract parquet files from S3 via runs.jsonl."""
+    zip_key = _resolve_zip_from_runs_jsonl(ctx, name)
+    if not zip_key:
+        print(
+            color_message(
+                f"No recording found for '{name}' in runs.jsonl. Run a gensim-eks episode to produce one.",
+                Color.RED,
+            )
+        )
+        return
+
+    print(color_message(f"Downloading {zip_key} from S3...", Color.BLUE))
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        result = ctx.run(
+            f"aws-vault exec {AWS_PROFILE} -- aws s3 cp s3://{S3_BUCKET}/{zip_key} {shlex.quote(tmp_path)}",
+            warn=True,
+        )
+        if result is None or result.failed:
+            print(color_message(f"Failed to download {zip_key} from S3", Color.RED))
+            return
+
+        scenario_dir = os.path.dirname(parquet_dir)
+        os.makedirs(parquet_dir, exist_ok=True)
+        try:
+            with zipfile.ZipFile(tmp_path) as zf:
+                for member in zf.namelist():
+                    if member.startswith("tmp/gensim-archive/parquet/") and not member.endswith("/"):
+                        filename = os.path.basename(member)
+                        with zf.open(member) as src, open(os.path.join(parquet_dir, filename), "wb") as dst:
+                            dst.write(src.read())
+                    elif member.startswith("tmp/gensim-archive/results/") and member.endswith(".json"):
+                        with zf.open(member) as src, open(os.path.join(scenario_dir, "episode.json"), "wb") as dst:
+                            dst.write(src.read())
+        except (zipfile.BadZipFile, OSError) as e:
+            print(color_message(f"Failed to extract {zip_key}: {e}", Color.RED))
+            shutil.rmtree(parquet_dir, ignore_errors=True)
+            return
+
+        print(color_message(f"Extracted parquet files to {parquet_dir}", Color.GREEN))
+    finally:
+        os.unlink(tmp_path)
+
+
+def _print_benchmark_summary(output):
+    """Parse go benchmark output and print a grouped readable summary."""
+    # Matches: BenchmarkFoo/param=val-NCPU  count  ns/op  [B/op  allocs/op]
+    line_re = re.compile(
+        r'^(Benchmark[A-Za-z_]+)(?:/([\w=.,/-]+?))?-\d+\s+\d+\s+([\d.]+)\s+ns/op'
+        r'(?:\s+([\d.]+)\s+B/op\s+([\d.]+)\s+allocs/op)?'
+    )
+
+    groups = {}  # family -> [(param, ns_op, b_op, allocs)]
+    for line in output.splitlines():
+        m = line_re.match(line)
+        if not m:
+            continue
+        family, param, ns_op, b_op, allocs = m.groups()
+        groups.setdefault(family, []).append(
+            (
+                param or "",
+                float(ns_op),
+                float(b_op or 0),
+                float(allocs or 0),
+            )
+        )
+
+    if not groups:
+        return
+
+    print(color_message(f"\n{'=' * 65}", Color.GREEN))
+    print(color_message("  Observer Benchmark Summary", Color.GREEN))
+    print(color_message(f"{'=' * 65}\n", Color.GREEN))
+
+    for family, rows in groups.items():
+        print(color_message(family, Color.BLUE))
+        has_params = any(r[0] for r in rows)
+        if has_params:
+            print(f"  {'param':<22}  {'time/op':>10}  {'B/op':>8}  {'allocs':>7}")
+            print(f"  {'-' * 54}")
+            for param, ns_op, b_op, allocs in rows:
+                print(f"  {param:<22}  {_fmt_ns(ns_op):>10}  {b_op:>8.0f}  {allocs:>7.0f}")
+        else:
+            print(f"  {'time/op':>10}  {'B/op':>8}  {'allocs':>7}")
+            print(f"  {'-' * 30}")
+            for _, ns_op, b_op, allocs in rows:
+                print(f"  {_fmt_ns(ns_op):>10}  {b_op:>8.0f}  {allocs:>7.0f}")
+        print()
+
+
+def _fmt_ns(ns):
+    """Format nanoseconds into a human-readable string."""
+    if ns >= 1_000_000_000:
+        return f"{ns / 1_000_000_000:.2f}s"
+    if ns >= 1_000_000:
+        return f"{ns / 1_000_000:.2f}ms"
+    if ns >= 1_000:
+        return f"{ns / 1_000:.2f}µs"
+    return f"{ns:.0f}ns"
+
+
+# --- Phase 2: Extracted logic blocks ---
+
+
+def _fmt_wall_dur(s: float) -> str:
+    """Format a duration in seconds into a human-readable h/m/s string."""
+    if s >= 3600:
+        return f"{int(s // 3600)}h {int((s % 3600) // 60)}m {s % 60:.1f}s"
+    if s >= 60:
+        return f"{int(s // 60)}m {s % 60:.1f}s"
+    return f"{s:.1f}s"
+
+
+def aggregate_eval_component_results(
+    variant_results: dict,
+    n_subsets: int,
+) -> dict:
+    """Aggregate per-subset and per-scenario comparison between without/with variants.
+
+    Returns a dict with keys:
+        per_subset, per_subset_scenario, per_scenario_summary,
+        valid_deltas_max, valid_deltas_mean,
+        n_failed_subsets, total_failed_runs,
+        delta_max, delta_mean,
+        avg_max_without, avg_max_with, avg_mean_without, avg_mean_with,
+        recommendation, rec_clr
+    """
+    # --- aggregate per-subset comparison ---
+    per_subset = []
+    for si in range(n_subsets):
+        wo = variant_results["without"][si]
+        wi = variant_results["with"][si]
+        wo_max = wo["max_score"]
+        wi_max = wi["max_score"]
+        wo_mean = wo["mean_score"]
+        wi_mean = wi["mean_score"]
+        delta_max_ps = (wi_max - wo_max) if wo_max is not None and wi_max is not None else None
+        delta_mean_ps = (wi_mean - wo_mean) if wo_mean is not None and wi_mean is not None else None
+        failed_runs_total = wo["failed_runs"] + wi["failed_runs"]
+        per_subset.append(
+            {
+                "subset": wo["subset"],
+                "detectors": wo["detectors"],
+                "correlators": wo["correlators"],
+                "without_max": wo_max,
+                "with_max": wi_max,
+                "delta_max": delta_max_ps,
+                "without_mean": wo_mean,
+                "with_mean": wi_mean,
+                "delta_mean": delta_mean_ps,
+                "failed_runs": failed_runs_total,
+                "without_run_scores": wo["run_scores"],
+                "with_run_scores": wi["run_scores"],
+            }
+        )
+
+    # --- per-scenario deltas (best run per variant per subset) ---
+    per_subset_scenario: list[dict] = []
+    for si in range(n_subsets):
+        wo_runs = variant_results["without"][si]["runs"]
+        wi_runs = variant_results["with"][si]["runs"]
+        iwo = _best_run_index(wo_runs)
+        iwi = _best_run_index(wi_runs)
+        wo_f1 = wo_runs[iwo]["scenario_f1"] if iwo >= 0 else {}
+        wi_f1 = wi_runs[iwi]["scenario_f1"] if iwi >= 0 else {}
+        names = sorted(set(wo_f1.keys()) | set(wi_f1.keys()))
+        by_scenario: dict[str, dict] = {}
+        for s in names:
+            a = wo_f1.get(s)
+            b = wi_f1.get(s)
+            delta = (b - a) if a is not None and b is not None else None
+            by_scenario[s] = {
+                "without_f1": a,
+                "with_f1": b,
+                "delta_f1": delta,
+            }
+        per_subset_scenario.append(
+            {
+                "subset": variant_results["without"][si]["subset"],
+                "by_scenario": by_scenario,
+            }
+        )
+
+    all_scenario_names: set[str] = set()
+    for pss in per_subset_scenario:
+        all_scenario_names.update(pss["by_scenario"].keys())
+
+    per_scenario_summary: dict[str, dict] = {}
+    for s in sorted(all_scenario_names):
+        deltas = []
+        for pss in per_subset_scenario:
+            row = pss["by_scenario"].get(s)
+            if row and row.get("delta_f1") is not None:
+                deltas.append(row["delta_f1"])
+        if not deltas:
+            per_scenario_summary[s] = {
+                "mean_delta_f1": None,
+                "min_delta_f1": None,
+                "max_delta_f1": None,
+                "n_subsets": 0,
+            }
+        else:
+            per_scenario_summary[s] = {
+                "mean_delta_f1": sum(deltas) / len(deltas),
+                "min_delta_f1": min(deltas),
+                "max_delta_f1": max(deltas),
+                "n_subsets": len(deltas),
+            }
+
+    # Only include subsets where both variants produced at least one successful run.
+    valid_deltas_max = [ps["delta_max"] for ps in per_subset if ps["delta_max"] is not None]
+    valid_deltas_mean = [ps["delta_mean"] for ps in per_subset if ps["delta_mean"] is not None]
+    n_failed_subsets = sum(1 for ps in per_subset if ps["delta_max"] is None)
+    total_failed_runs = sum(ps["failed_runs"] for ps in per_subset)
+
+    if n_failed_subsets > 0:
+        print(
+            color_message(
+                f"Warning: {n_failed_subsets}/{n_subsets} subsets had fully failed runs and are excluded from the final delta.",
+                Color.ORANGE,
+            )
+        )
+    if total_failed_runs > 0 and n_failed_subsets == 0:
+        print(
+            color_message(
+                f"Warning: {total_failed_runs} individual run(s) failed across subsets; "
+                "partial results were excluded from per-subset scores.",
+                Color.ORANGE,
+            )
+        )
+
+    delta_max = sum(valid_deltas_max) / len(valid_deltas_max) if valid_deltas_max else None
+    delta_mean = sum(valid_deltas_mean) / len(valid_deltas_mean) if valid_deltas_mean else None
+
+    avg_max_without_vals = [ps["without_max"] for ps in per_subset if ps["without_max"] is not None]
+    avg_max_with_vals = [ps["with_max"] for ps in per_subset if ps["with_max"] is not None]
+    avg_mean_without_vals = [ps["without_mean"] for ps in per_subset if ps["without_mean"] is not None]
+    avg_mean_with_vals = [ps["with_mean"] for ps in per_subset if ps["with_mean"] is not None]
+
+    avg_max_without = sum(avg_max_without_vals) / len(avg_max_without_vals) if avg_max_without_vals else None
+    avg_max_with = sum(avg_max_with_vals) / len(avg_max_with_vals) if avg_max_with_vals else None
+    avg_mean_without = sum(avg_mean_without_vals) / len(avg_mean_without_vals) if avg_mean_without_vals else None
+    avg_mean_with = sum(avg_mean_with_vals) / len(avg_mean_with_vals) if avg_mean_with_vals else None
+
+    if delta_max is None:
+        recommendation = "inconclusive"
+        rec_clr = Color.ORANGE
+    elif delta_max > 0:
+        recommendation = "keep"
+        rec_clr = Color.GREEN
+    else:
+        recommendation = "discard"
+        rec_clr = Color.RED
+
+    return {
+        "per_subset": per_subset,
+        "per_subset_scenario": per_subset_scenario,
+        "per_scenario_summary": per_scenario_summary,
+        "valid_deltas_max": valid_deltas_max,
+        "valid_deltas_mean": valid_deltas_mean,
+        "n_failed_subsets": n_failed_subsets,
+        "total_failed_runs": total_failed_runs,
+        "delta_max": delta_max,
+        "delta_mean": delta_mean,
+        "avg_max_without": avg_max_without,
+        "avg_max_with": avg_max_with,
+        "avg_mean_without": avg_mean_without,
+        "avg_mean_with": avg_mean_with,
+        "recommendation": recommendation,
+        "rec_clr": rec_clr,
+    }
+
+
+def _scenario_sort_key(item: tuple[str, dict]) -> tuple:
+    m = item[1].get("mean_delta_f1")
+    if m is None:
+        return (1, 0.0)
+    return (0, -m)
+
+
+def _fmt(v: float | None, signed: bool = False) -> str:
+    if v is None:
+        return "n/a"
+    return f"{v:+.4f}" if signed else f"{v:.4f}"
+
+
+def print_eval_component_summary(
+    component: str,
+    per_subset: list,
+    per_scenario_summary: dict,
+    aggregated: dict,
+    wall_str: str,
+) -> None:
+    """Print the full component evaluation summary to stdout."""
+    delta_max = aggregated["delta_max"]
+    delta_mean = aggregated["delta_mean"]
+    avg_max_without = aggregated["avg_max_without"]
+    avg_max_with = aggregated["avg_max_with"]
+    avg_mean_without = aggregated["avg_mean_without"]
+    avg_mean_with = aggregated["avg_mean_with"]
+    recommendation = aggregated["recommendation"]
+    rec_clr = aggregated["rec_clr"]
+
+    print(color_message(f"\n{'=' * 70}", Color.GREEN))
+    print(color_message("  Component Evaluation Summary", Color.GREEN))
+    print(color_message(f"{'=' * 70}\n", Color.GREEN))
+    print(color_message(f"  Component: {component}\n", Color.GREEN))
+
+    header = f"  {'Subset':<12}  {'Without':>8}  {'With':>8}  {'Delta':>8}"
+    print(header)
+    print(f"  {'-' * 44}")
+    for ps in per_subset:
+        wo_str = f"{ps['without_max']:>8.4f}" if ps["without_max"] is not None else f"{'FAILED':>8}"
+        wi_str = f"{ps['with_max']:>8.4f}" if ps["with_max"] is not None else f"{'FAILED':>8}"
+        if ps["delta_max"] is None:
+            delta_str = color_message(f"{'n/a':>8}", Color.ORANGE)
+        else:
+            delta_clr = Color.GREEN if ps["delta_max"] > 0 else Color.RED
+            delta_str = color_message(f"{ps['delta_max']:>+8.4f}", delta_clr)
+        fail_note = f"  [{ps['failed_runs']} run(s) failed]" if ps["failed_runs"] > 0 else ""
+        print(f"  {ps['subset']:<12}  {wo_str}  {wi_str}  {delta_str}{fail_note}")
+
+    print()
+    print(
+        color_message(
+            "  Per-scenario Δ F1 (best Bayesian trial per run; best run per variant per subset)",
+            Color.BLUE,
+        )
+    )
+    print(
+        color_message(
+            "  Columns: mean / min / max of Δ across subsets (helps spot inconsistent scenarios)",
+            Color.BLUE,
+        )
+    )
+    ps_header = f"  {'Scenario':<26}  {'mean Δ':>8}  {'min Δ':>8}  {'max Δ':>8}"
+    print(ps_header)
+    print(f"  {'-' * len(ps_header.strip())}")
+
+    for scen, row in sorted(per_scenario_summary.items(), key=_scenario_sort_key):
+        mean_d = row["mean_delta_f1"]
+        min_d = row["min_delta_f1"]
+        max_d = row["max_delta_f1"]
+        if mean_d is None:
+            print(color_message(f"  {scen:<26}  {'n/a':>8}  {'n/a':>8}  {'n/a':>8}", Color.ORANGE))
+        else:
+            mean_clr = Color.GREEN if mean_d > 0 else Color.RED if mean_d < 0 else Color.BLUE
+            msg = f"  {scen:<26}  {mean_d:>+8.4f}  {min_d:>+8.4f}  {max_d:>+8.4f}"
+            print(color_message(msg, mean_clr))
+
+    print()
+    print(color_message("  Secondary: mean of trial-mean scores (across subsets)", Color.BLUE))
+    print(color_message(f"  Avg mean score without: {_fmt(avg_mean_without)}", Color.BLUE))
+    print(color_message(f"  Avg mean score with:    {_fmt(avg_mean_with)}", Color.BLUE))
+    if delta_mean is None:
+        print(color_message("  Delta (mean):           n/a (no valid subsets)", Color.ORANGE))
+    else:
+        delta_clr = Color.GREEN if delta_mean > 0 else Color.RED
+        print(color_message(f"  Delta (mean):           {delta_mean:+.4f}", delta_clr))
+
+    print()
+    print(color_message(f"  {'-' * 66}", Color.GREEN))
+    print(color_message("  Primary metric — max best-trial score (avg across subsets)", Color.GREEN))
+    print(color_message(f"  {'-' * 66}", Color.GREEN))
+    print(color_message(f"  Avg max score without:  {_fmt(avg_max_without)}", Color.GREEN))
+    print(color_message(f"  Avg max score with:     {_fmt(avg_max_with)}", Color.GREEN))
+    if delta_max is None:
+        print(color_message("  Delta (max):            n/a (no valid subsets)", Color.ORANGE))
+    else:
+        delta_clr = Color.GREEN if delta_max > 0 else Color.RED
+        print(color_message(f"  Delta (max):            {delta_max:+.4f}", delta_clr))
+    print()
+    print(color_message(f"  Recommendation: {recommendation.upper()} {component}", rec_clr))
+    if recommendation == "inconclusive":
+        print(color_message("  All subsets failed — cannot make a reliable recommendation.", Color.ORANGE))
+    elif recommendation == "keep":
+        print(color_message("  Next step: update your config, then tune the new component using:", Color.BOLD))
+        print(color_message(f"    dda inv q.eval-bayesian --only {component}", Color.BOLD))
+    print(color_message(f"  Full eval wall time: {wall_str}", Color.GREEN))
+    print(color_message(f"{'=' * 70}", Color.GREEN))
+
+
+def print_eval_scenarios_summary(results: list, sigma: float) -> None:
+    """Print the Observer Eval Summary table to stdout."""
+    if not results:
+        return
+
+    print(color_message(f"\n{'=' * 60}", Color.GREEN))
+    print(color_message("  Observer Eval Summary", Color.GREEN))
+    print(color_message(f"{'=' * 60}\n", Color.GREEN))
+
+    header = f"{'Scenario':<25}  {'F1':>6}  {'Precision':>9}  {'Recall':>6}  {'Alpha':>7}  {'Scored':>6}  {'Baseline FPs':>12}  {'Warmup (excl)':>13}  {'Cascading (excl)':>16}"
+    print(header)
+    print("-" * len(header))
+
+    total_baseline_fps = 0
+    total_baseline_duration = 0
+    for r in results:
+        alpha = r.get("alpha", -1)
+        alpha_str = f"{alpha:.4f}" if alpha >= 0 else "  n/a"
+        timed_out_suffix = "  [TIMEOUT]" if r.get("timed_out") else ""
+        print(
+            f"{r['name']:<25}  {r['f1']:>6.4f}  {r['precision']:>9.4f}  {r['recall']:>6.4f}"
+            f"  {alpha_str:>7}  {r['num_predictions']:>6}  {r['num_baseline_fps']:>12}  {r['num_filtered_warmup']:>13}  {r['num_filtered_cascading']:>16}"
+            f"{timed_out_suffix}"
+        )
+        duration = r.get("baseline_duration_seconds", 0)
+        if duration > 0:
+            total_baseline_fps += r["num_baseline_fps"]
+            total_baseline_duration += duration
+
+    if total_baseline_duration > 0:
+        pooled_alpha = total_baseline_fps / total_baseline_duration
+        print(f"\n  Pooled α: {pooled_alpha:.4f}  ({total_baseline_fps} FPs over {total_baseline_duration}s baseline)")
+
+    print(f"\nOutput JSONs: /tmp/observer-eval-*.json (sigma={sigma}s)")
+
+
+def print_eval_bayesian_summary(
+    completed_trials: list,
+    best: dict | None,
+    max_score: float,
+    avg_score: float,
+    output_dir: str,
+    study_path: str,
+) -> None:
+    """Print the Bayesian Optimization Summary table and final report paths."""
+    if completed_trials:
+        print(color_message(f"\n{'=' * 70}", Color.GREEN))
+        print(color_message("  Bayesian Optimization Summary", Color.GREEN))
+        print(color_message(f"{'=' * 70}\n", Color.GREEN))
+        header = f"{'Rank':<5}  {'Trial':<12}  {'Score':>6}"
+        print(header)
+        print("-" * 30)
+        for rank, t in enumerate(completed_trials[:10], 1):
+            print(f"{rank:<5}  {t['label']:<12}  {t['score']:>6.4f}")
+        if len(completed_trials) > 10:
+            print(f"  ... {len(completed_trials) - 10} more trials")
+
+        if best:
+            print(color_message(f"\n  Best: {best['label']}  (score={best['score']:.4f})", Color.GREEN))
+            print(color_message("  Best parameters:", Color.GREEN))
+            for key, val in sorted(best["params"].items()):
+                print(color_message(f"    {key}: {val}", Color.GREEN))
+            print(color_message(f"  config: {best['config_path']}", Color.GREEN))
+            print(color_message(f"  report: {best['report_path']}", Color.GREEN))
+
+    report_path = os.path.join(output_dir, "report.json")
+    print(color_message(f"\n{'=' * 70}", Color.GREEN))
+    print(color_message(f"  Report: {report_path}", Color.GREEN))
+    print(color_message(f"  score (best):    {max_score:.4f}", Color.GREEN))
+    print(color_message(f"  avg_eval_score:  {avg_score:.4f}", Color.GREEN))
+    print(color_message(f"  study:           {study_path}", Color.GREEN))
+    print(color_message(f"  Per-trial:       {output_dir}/trial_*/report.json", Color.GREEN))
+    print(color_message(f"{'=' * 70}", Color.GREEN))

--- a/tasks/libs/q/eval.py
+++ b/tasks/libs/q/eval.py
@@ -842,7 +842,9 @@ def print_eval_component_summary(
     if recommendation == "inconclusive":
         print(color_message("  All subsets failed — cannot make a reliable recommendation.", Color.ORANGE))
     elif recommendation == "keep":
-        print(color_message("  Next step: update your config, then tune the new component using:", Color.BOLD))
+        print(color_message("  Next step: tune the full pipeline with the new component:", Color.BOLD))
+        print(color_message(f"    dda inv q.eval-pipeline --force-enable {component}", Color.BOLD))
+        print(color_message("  Or tune only this component's hyperparameters:", Color.BOLD))
         print(color_message(f"    dda inv q.eval-bayesian --only {component}", Color.BOLD))
     print(color_message(f"  Full eval wall time: {wall_str}", Color.GREEN))
     print(color_message(f"{'=' * 70}", Color.GREEN))

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -542,7 +542,7 @@ def eval_combinations(
 @task
 def eval_bayesian(
     ctx,
-    components: str = ",".join(DETECTORS + CORRELATORS + EXTRACTORS),
+    components: str = "",
     lock: str = "",
     only: str = "",
     n_trials: int = 10,
@@ -572,7 +572,10 @@ def eval_bayesian(
     Args:
         components: Comma-separated component names to enable (detectors, correlators, extractors; default: all).
         lock: Comma-separated components to enable but not tune (keep at Go defaults).
-        only: Shorthand: enable all components but tune only the listed ones (locks everything else).
+        only: Tune only the listed components; lock everything else.
+            Without --components: enables all components and locks all except --only targets.
+            With --components: enables only the given subset and locks all except --only targets
+            (--only targets must be a subset of --components).
             Mutually exclusive with --lock.
         n_trials: Number of Optuna trials (default: 50).
         output_dir: Root output directory. If it already contains report.json,
@@ -591,7 +594,8 @@ def eval_bayesian(
         dda inv q.bayesian-eval                                                                       # all components
         dda inv q.bayesian-eval --components bocpd,rrcf,time_cluster,log_pattern_extractor            # fixed subset
         dda inv q.bayesian-eval --components bocpd,rrcf,time_cluster --lock time_cluster              # freeze one
-        dda inv q.bayesian-eval --only bocpd                                                          # tune one, lock rest
+        dda inv q.bayesian-eval --only bocpd                                                          # tune one, lock rest (all components enabled)
+        dda inv q.bayesian-eval --components bocpd,rrcf,time_cluster --only bocpd                     # tune bocpd, lock rrcf+time_cluster, disable the rest
         dda inv q.bayesian-eval --n-trials 100 --seed 42
     """
     import pickle
@@ -612,15 +616,29 @@ def eval_bayesian(
     components_list = [c.strip() for c in components.split(",") if c.strip()]
 
     if only_list:
-        # Expand to full component set and lock everything except the --only targets.
         all_components = DETECTORS + CORRELATORS + EXTRACTORS
         unknown_only = set(only_list) - set(all_components)
         if unknown_only:
             print(color_message(f"Error: unknown components in --only: {', '.join(sorted(unknown_only))}", Color.RED))
             return
-        components_list = all_components
-        locked_set = {c for c in all_components if c not in set(only_list)}
+        if not components_list:
+            # No --components given: expand to full set and lock everything except --only.
+            components_list = all_components
+        else:
+            # --components was given: respect it, lock within that subset.
+            unknown_only_in_subset = set(only_list) - set(components_list)
+            if unknown_only_in_subset:
+                print(
+                    color_message(
+                        f"Error: --only targets not in --components: {', '.join(sorted(unknown_only_in_subset))}",
+                        Color.RED,
+                    )
+                )
+                return
+        locked_set = {c for c in components_list if c not in set(only_list)}
     else:
+        if not components_list:
+            components_list = DETECTORS + CORRELATORS + EXTRACTORS
         locked_set = {c.strip() for c in lock.split(",") if c.strip()}
 
     if not components_list:

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -812,6 +812,371 @@ def eval_bayesian(
     return final_report
 
 
+# --- Shared helpers ---
+
+
+def _run_bayesian_runs(
+    ctx,
+    components_list: list,
+    m_runs: int,
+    n_trials: int,
+    seeds: list,
+    output_dir: str,
+    scenarios_dir: str,
+    sigma: float,
+    timeout: int,
+    scenarios: str,
+    lock: str = "",
+    run_logger: StepLogger | None = None,
+    step_label_prefix: str = "",
+) -> dict:
+    """Run M independent Bayesian optimisations on a fixed component set.
+
+    Each run gets its own subdirectory (``output_dir/run_NNN``) and seed.
+    Logs progress through ``run_logger`` when provided.
+
+    Returns a dict with keys:
+        run_scores, run_details, max_score, mean_score, failed_runs
+    """
+    run_scores: list[float] = []
+    run_details: list[dict] = []
+
+    for ri in range(m_runs):
+        run_label = f"run_{ri:03d}"
+        run_dir = os.path.join(output_dir, run_label)
+        run_seed = seeds[ri]
+
+        if run_logger:
+            step_title = (
+                f"{step_label_prefix} / {run_label}  (seed={run_seed})"
+                if step_label_prefix
+                else f"{run_label}  (seed={run_seed})"
+            )
+            run_logger.step(step_title)
+            run_logger.detail(f"components: {', '.join(components_list)}")
+
+        trial_logger = run_logger.child(n_trials, "Trial") if run_logger else None
+        report = eval_bayesian(
+            ctx,
+            components=",".join(components_list),
+            lock=lock,
+            n_trials=n_trials,
+            output_dir=run_dir,
+            scenarios_dir=scenarios_dir,
+            sigma=sigma,
+            seed=run_seed,
+            build=False,
+            overwrite=True,
+            timeout=timeout,
+            scenarios=scenarios,
+            _logger=trial_logger,
+        )
+
+        run_failed = report is None or report.get("completed_trials", 0) == 0
+        if run_failed and run_logger:
+            if report is None:
+                reason = "eval_bayesian returned None (aborted before producing a report)"
+            else:
+                n_ft = report.get("failed_trials", 0)
+                reason = f"all {n_ft} trials failed — no completed trials in report"
+            run_logger.detail(f"Warning: {run_label} failed: {reason}", Color.RED)
+
+        best_score = report.get("score") if report and not run_failed else None
+        avg_score_val = report.get("avg_eval_score") if report and not run_failed else None
+        if not run_failed:
+            run_scores.append(best_score)
+        run_details.append(
+            {
+                "run": run_label,
+                "seed": run_seed,
+                "failed": run_failed,
+                "best_score": best_score,
+                "avg_score": avg_score_val,
+                "report_path": os.path.join(run_dir, "report.json"),
+                "scenario_f1": _scenario_f1_from_bayesian_report(report) if not run_failed else {},
+            }
+        )
+
+    return {
+        "run_scores": run_scores,
+        "run_details": run_details,
+        "max_score": max(run_scores) if run_scores else None,
+        "mean_score": sum(run_scores) / len(run_scores) if run_scores else None,
+        "failed_runs": sum(1 for r in run_details if r["failed"]),
+    }
+
+
+# --- Pipeline Fine-Tuning ---
+
+
+@task
+def eval_pipeline(
+    ctx,
+    n_combos: int = 10,
+    n_trials_search: int = 5,
+    n_trials_tune: int = 20,
+    m_runs: int = 1,
+    output_dir: str = "/tmp/observer-pipeline-eval",
+    scenarios_dir: str = "./comp/observer/scenarios",
+    sigma: float = 30.0,
+    seed: int = None,
+    build: bool = True,
+    overwrite: bool = False,
+    force_enable: str = "",
+    force_disable: str = "",
+    timeout: int = 0,
+    scenarios: str = "",
+):
+    """
+    Full pipeline fine-tuning: Bayesian search over component combinations, then deep tuning on the winner.
+
+    Step 1 — Search: for each of n_combos combinations (full stack + anchor subsets + random),
+        run Bayesian HP optimisation with n_trials_search trials. The combination with the
+        highest optimised score wins. Fixed subsets (full stack, minimal, medium anchors)
+        are always included regardless of n_combos.
+    Step 2 — Tune: runs a deeper Bayesian optimisation (n_trials_tune trials) on the winner.
+
+    Use --force-enable to pin a newly added component to every combination after
+    eval_component recommends KEEP for it.
+
+    All seeds are derived deterministically from a single base seed.
+
+    Output layout:
+        <output_dir>/search/combo_NNN/run_NNN/  - Bayesian search runs per combination
+        <output_dir>/tune/                      - deep Bayesian tuning on the winner
+        <output_dir>/report.json                - best combo, best HP config, final score
+
+    Args:
+        n_combos: Target number of combinations to evaluate in Step 1 (default: 10).
+            Fixed subsets (full stack + anchors) are always included; random combinations
+            fill up to n_combos. Actual count may exceed n_combos if fixed subsets do.
+        n_trials_search: Optuna trials per combination during the search phase (default: 5).
+        n_trials_tune: Optuna trials for the final fine-tuning pass on the winner (default: 20).
+        m_runs: Independent Bayesian runs per combination (averages out randomness; default: 1).
+        output_dir: Root output directory. Aborts if report.json exists unless overwrite is True.
+        overwrite: Allow replacing an existing output_dir that contains report.json.
+        scenarios_dir: Directory containing scenario subdirectories.
+        sigma: Gaussian width in seconds for F1 scoring.
+        seed: Base seed for deterministic reproducibility.
+        build: Whether to build testbench and scorer first.
+        force_enable: Comma-separated components always present in every combination.
+        force_disable: Comma-separated components never included (also excluded from extractors).
+        timeout: Per-scenario time budget in seconds (0 = no limit).
+        scenarios: Comma-separated scenario names to run (default: all SCENARIOS).
+
+    Examples:
+        dda inv q.eval-pipeline
+        dda inv q.eval-pipeline --n-combos 20 --n-trials-search 10 --n-trials-tune 50 --seed 42
+        dda inv q.eval-pipeline --force-enable scanmw  # after eval_component KEEP for scanmw
+        dda inv q.eval-pipeline --force-disable cusum,scanwelch
+    """
+    if not _prepare_eval_output_dir(output_dir, overwrite=overwrite):
+        return
+
+    if seed is None:
+        seed = random.randint(0, 2**32 - 1)
+
+    rng = random.Random(seed)
+    force_enable_list = [c.strip() for c in force_enable.split(",") if c.strip()]
+    force_disable_list = [c.strip() for c in force_disable.split(",") if c.strip()]
+
+    # --- generate combinations (same pattern as eval_component subset generation) ---
+    full_combo = _full_stack_combo(force_disable=force_disable_list)
+    anchor_list = _anchor_combos(force_disable=force_disable_list, force_enable=force_enable_list)
+    fixed_combos = [full_combo] + anchor_list
+    fixed_keys = {(tuple(c["detectors"]), tuple(c["correlators"])) for c in fixed_combos}
+    combo_seed = rng.randint(0, 2**32 - 1)
+    random_count = max(0, n_combos - len(fixed_combos))
+    random_combos = random_component_combinations(
+        random_count,
+        seed=combo_seed,
+        force_enable=force_enable_list,
+        force_disable=force_disable_list,
+        exclude_combo_keys=fixed_keys,
+    )
+    combos = fixed_combos + random_combos
+    actual_n_combos = len(combos)
+
+    # --- derive seeds deterministically ---
+    combo_run_seeds = [[rng.randint(0, 2**32 - 1) for _ in range(m_runs)] for _ in range(actual_n_combos)]
+    tune_seed = rng.randint(0, 2**32 - 1)
+
+    n_scenarios = len([s.strip() for s in scenarios.split(",") if s.strip()] if scenarios else SCENARIOS)
+    total_search_runs = actual_n_combos * m_runs
+    total_testbench_runs = total_search_runs * n_trials_search * n_scenarios
+
+    if build:
+        build_testbench(ctx)
+        build_scorer(ctx)
+
+    download_scenarios(ctx, scenarios_dir=scenarios_dir, skip_existing=True)
+
+    print(color_message(f"\n{'=' * 70}", Color.BLUE))
+    print(color_message("  Observer Pipeline Eval", Color.BLUE))
+    print(color_message(f"{'=' * 70}", Color.BLUE))
+    print(color_message(f"  n_combos:            {actual_n_combos}", Color.BLUE))
+    print(color_message(f"  n_trials_search:     {n_trials_search} (per combo)", Color.BLUE))
+    print(color_message(f"  n_trials_tune:       {n_trials_tune} (winner fine-tune)", Color.BLUE))
+    print(color_message(f"  m_runs:              {m_runs}", Color.BLUE))
+    print(color_message(f"  total search runs:   {total_search_runs}", Color.BLUE))
+    print(color_message(f"  total testbench:     {total_testbench_runs}", Color.BLUE))
+    print(color_message(f"  seed:                {seed}", Color.BLUE))
+    print(color_message(f"  output_dir:          {output_dir}", Color.BLUE))
+    if force_enable_list:
+        print(color_message(f"  force-enabled:       {', '.join(force_enable_list)}", Color.BLUE))
+    if force_disable_list:
+        print(color_message(f"  force-disabled:      {', '.join(force_disable_list)}", Color.BLUE))
+    print(color_message(f"{'=' * 70}\n", Color.BLUE))
+
+    # --- Step 1: search ---
+    print(color_message(f"\n{'=' * 70}", Color.BLUE))
+    print(color_message("  Pipeline Eval — Step 1/2: Combination Search", Color.BLUE))
+    print(color_message(f"{'=' * 70}", Color.BLUE))
+
+    search_dir = os.path.join(output_dir, "search")
+    os.makedirs(search_dir, exist_ok=True)
+    run_logger = StepLogger(total_search_runs, "Search run")
+
+    combo_results = []
+    for ci, combo in enumerate(combos):
+        combo_label = f"combo_{ci:03d}"
+        combo_dir = os.path.join(search_dir, combo_label)
+        os.makedirs(combo_dir, exist_ok=True)
+
+        components_list = sorted(
+            set(
+                list(combo["detectors"])
+                + list(combo["correlators"])
+                + [e for e in EXTRACTORS if e not in force_disable_list]
+            )
+        )
+
+        combo_name = f"{combo_label} (full stack)" if ci == 0 else combo_label
+        run_logger.detail(combo_name)
+        run_logger.detail(f"detectors:   {', '.join(combo['detectors'])}")
+        run_logger.detail(f"correlators: {', '.join(combo['correlators'])}")
+
+        run_result = _run_bayesian_runs(
+            ctx,
+            components_list=components_list,
+            m_runs=m_runs,
+            n_trials=n_trials_search,
+            seeds=combo_run_seeds[ci],
+            output_dir=combo_dir,
+            scenarios_dir=scenarios_dir,
+            sigma=sigma,
+            timeout=timeout,
+            scenarios=scenarios,
+            run_logger=run_logger,
+            step_label_prefix=combo_label,
+        )
+
+        combo_results.append(
+            {
+                "combo": combo_label,
+                "detectors": combo["detectors"],
+                "correlators": combo["correlators"],
+                "components": components_list,
+                "max_score": run_result["max_score"],
+                "mean_score": run_result["mean_score"],
+                "failed_runs": run_result["failed_runs"],
+                "runs": run_result["run_details"],
+            }
+        )
+
+    # rank by max_score
+    valid_combos = [c for c in combo_results if c["max_score"] is not None]
+    if not valid_combos:
+        print(color_message("Error: all combinations failed — aborting.", Color.RED))
+        return
+
+    valid_combos.sort(key=lambda c: c["max_score"], reverse=True)
+    best_combo = valid_combos[0]
+
+    print(color_message(f"\n{'=' * 60}", Color.GREEN))
+    print(color_message("  Combination Search Summary", Color.GREEN))
+    print(color_message(f"{'=' * 60}\n", Color.GREEN))
+    header = f"  {'Combo':<12}  {'Score':>6}  {'Detectors':<30}  Correlators"
+    print(header)
+    print(f"  {'-' * 70}")
+    for c in valid_combos:
+        print(
+            f"  {c['combo']:<12}  {c['max_score']:>6.4f}"
+            f"  {', '.join(c['detectors']):<30}  {', '.join(c['correlators'])}"
+        )
+
+    # --- Step 2: fine-tune on winner ---
+    print(color_message(f"\n{'=' * 70}", Color.BLUE))
+    print(color_message("  Pipeline Eval — Step 2/2: Fine-Tuning on Winner", Color.BLUE))
+    print(color_message(f"{'=' * 70}", Color.BLUE))
+    print(
+        color_message(f"  Winner:     {best_combo['combo']}  (search score={best_combo['max_score']:.4f})", Color.BLUE)
+    )
+    print(color_message(f"  Components: {', '.join(best_combo['components'])}", Color.BLUE))
+
+    tune_dir = os.path.join(output_dir, "tune")
+    tune_result = eval_bayesian(
+        ctx,
+        components=",".join(best_combo["components"]),
+        n_trials=n_trials_tune,
+        output_dir=tune_dir,
+        scenarios_dir=scenarios_dir,
+        sigma=sigma,
+        seed=tune_seed,
+        build=False,
+        overwrite=True,
+        timeout=timeout,
+        scenarios=scenarios,
+    )
+
+    if not tune_result:
+        print(color_message("Error: fine-tuning produced no results.", Color.RED))
+        return
+
+    final_score = tune_result.get("score", 0.0)
+    best_config_path = os.path.join(tune_dir, "best_config.json")
+
+    report = {
+        "score": final_score,
+        "seed": seed,
+        "force_enable": force_enable_list,
+        "force_disable": force_disable_list,
+        "n_combos": actual_n_combos,
+        "n_trials_search": n_trials_search,
+        "n_trials_tune": n_trials_tune,
+        "best_combo": best_combo,
+        "tune": {
+            "components": best_combo["components"],
+            "score": final_score,
+            "best_config_path": best_config_path,
+            "report_path": os.path.join(tune_dir, "report.json"),
+        },
+        "combo_results": combo_results,
+    }
+    report_path = os.path.join(output_dir, "report.json")
+    with open(report_path, "w") as f:
+        json.dump(report, f, indent=4)
+
+    print(color_message(f"\n{'=' * 70}", Color.GREEN))
+    print(color_message("  Pipeline Eval — Final Summary", Color.GREEN))
+    print(color_message(f"{'=' * 70}", Color.GREEN))
+    print(
+        color_message(
+            f"  Winner:        {best_combo['combo']}  ({', '.join(best_combo['detectors'] + best_combo['correlators'])})",
+            Color.GREEN,
+        )
+    )
+    print(color_message(f"  Search score:  {best_combo['max_score']:.4f}", Color.GREEN))
+    print(color_message(f"  Final score:   {final_score:.4f}", Color.GREEN))
+    print(color_message(f"  Best config:   {best_config_path}", Color.GREEN))
+    print(color_message(f"  Report:        {report_path}", Color.GREEN))
+    print(color_message("\n  Verify with:", Color.BOLD))
+    print(color_message(f"    dda inv q.eval-scenarios --config {best_config_path}", Color.BOLD))
+    print(color_message(f"{'=' * 70}", Color.GREEN))
+
+    return report
+
+
 # --- Component Evaluation ---
 
 
@@ -1058,70 +1423,30 @@ def eval_component(
                 components_list.append(component)
             components_list = sorted(set(components_list))
 
-            run_scores: list[float] = []
-            run_details: list[dict] = []
+            active_set = set(components_list)
+            # Only lock components that are actually active in this run; extra_lock_list
+            # entries absent from the subset would cause eval_bayesian to abort with
+            # "locked components not in active set".
+            lock_components = [c for c in extra_lock_list if c in active_set]
+            if variant == "with" and not tune_evaluated_component:
+                lock_components.append(component)
+            lock_for_run = ",".join(sorted(set(lock_components)))
 
-            for ri in range(m_runs):
-                run_label = f"run_{ri:03d}"
-                run_dir = os.path.join(subset_dir, run_label)
-                run_seed = run_seeds[(variant, si)][ri]
-
-                run_logger.step(f"{variant} / {subset_label} / {run_label}  (seed={run_seed})")
-                run_logger.detail(f"components: {', '.join(components_list)}")
-                active_set = set(components_list)
-                # Only lock components that are actually active in this run; extra_lock_list
-                # entries absent from the subset would cause eval_bayesian to abort with
-                # "locked components not in active set".
-                lock_components = [c for c in extra_lock_list if c in active_set]
-                if variant == "with" and not tune_evaluated_component:
-                    lock_components.append(component)
-                lock_for_run = ",".join(sorted(set(lock_components)))
-
-                trial_logger = run_logger.child(n_trials, "Trial")
-                report = eval_bayesian(
-                    ctx,
-                    components=",".join(components_list),
-                    lock=lock_for_run,
-                    n_trials=n_trials,
-                    output_dir=run_dir,
-                    scenarios_dir=scenarios_dir,
-                    sigma=sigma,
-                    seed=run_seed,
-                    build=False,
-                    overwrite=True,
-                    timeout=timeout,
-                    scenarios=scenarios,
-                    _logger=trial_logger,
-                )
-
-                run_failed = report is None or report.get("completed_trials", 0) == 0
-                if run_failed:
-                    if report is None:
-                        reason = "eval_bayesian returned None (aborted before producing a report)"
-                    else:
-                        n_ft = report.get("failed_trials", 0)
-                        reason = f"all {n_ft} trials failed — no completed trials in report"
-                    run_logger.detail(f"Warning: {variant}/{subset_label}/{run_label} failed: {reason}", Color.RED)
-
-                best_score = report.get("score") if report and not run_failed else None
-                avg_score_val = report.get("avg_eval_score") if report and not run_failed else None
-                if not run_failed:
-                    run_scores.append(best_score)
-                run_details.append(
-                    {
-                        "run": run_label,
-                        "seed": run_seed,
-                        "failed": run_failed,
-                        "best_score": best_score,
-                        "avg_score": avg_score_val,
-                        "report_path": os.path.join(run_dir, "report.json"),
-                        "scenario_f1": _scenario_f1_from_bayesian_report(report) if not run_failed else {},
-                    }
-                )
-
-            max_score = max(run_scores) if run_scores else None
-            mean_score = sum(run_scores) / len(run_scores) if run_scores else None
-            n_failed_runs = sum(1 for r in run_details if r["failed"])
+            run_result = _run_bayesian_runs(
+                ctx,
+                components_list=components_list,
+                m_runs=m_runs,
+                n_trials=n_trials,
+                seeds=run_seeds[(variant, si)],
+                output_dir=subset_dir,
+                scenarios_dir=scenarios_dir,
+                sigma=sigma,
+                timeout=timeout,
+                scenarios=scenarios,
+                lock=lock_for_run,
+                run_logger=run_logger,
+                step_label_prefix=f"{variant} / {subset_label}",
+            )
 
             variant_results[variant].append(
                 {
@@ -1129,11 +1454,11 @@ def eval_component(
                     "detectors": subset["detectors"],
                     "correlators": subset["correlators"],
                     "components": components_list,
-                    "run_scores": run_scores,
-                    "max_score": max_score,
-                    "mean_score": mean_score,
-                    "failed_runs": n_failed_runs,
-                    "runs": run_details,
+                    "run_scores": run_result["run_scores"],
+                    "max_score": run_result["max_score"],
+                    "mean_score": run_result["mean_score"],
+                    "failed_runs": run_result["failed_runs"],
+                    "runs": run_result["run_details"],
                 }
             )
 
@@ -1496,6 +1821,65 @@ def eval_component_workspace_report(
         print(color_message(f"report.json copied to {dest}/report.json", Color.GREEN))
     else:
         # scp -r copies the remote directory tree into dest.
+        ctx.run(f"scp -r {shlex.quote(f'{ssh_host}:{output_dir}/.')} {shlex.quote(dest)}/")
+        print(color_message(f"Results copied to {dest}/", Color.GREEN))
+
+    print(color_message(f"  report.json: {os.path.join(dest, 'report.json')}", Color.GREEN))
+
+
+@task
+def eval_pipeline_workspace_report(
+    ctx,
+    workspace_name: str,
+    output_dir: str = "/tmp/observer-pipeline-eval",
+    local_dir: str = "",
+    only_report: bool = False,
+):
+    """
+    After ``q.eval-pipeline`` on a remote dev workspace, copy results to your machine.
+
+    Args:
+        workspace_name: Workspace name (SSH: ``workspace-<name>``).
+        output_dir:     Remote directory passed to ``q.eval-pipeline`` (default: ``/tmp/observer-pipeline-eval``).
+        local_dir:      Local destination (default: ``./eval-results/<workspace_name>``).
+        only_report:    Copy only ``report.json`` instead of the full output directory.
+
+    Examples:
+        dda inv q.eval-pipeline-workspace-report --workspace-name finetune
+        dda inv q.eval-pipeline-workspace-report --workspace-name finetune --only-report
+    """
+    ws_name = workspace_name.strip()
+    if not ws_name:
+        raise Exit("workspace_name is required")
+
+    ssh_host = f"workspace-{ws_name}"
+    remote_report = f"{output_dir}/report.json"
+
+    check = ctx.run(
+        f"ssh {shlex.quote(ssh_host)} test -f {shlex.quote(remote_report)}",
+        warn=True,
+        hide=True,
+    )
+    if check is None or check.failed:
+        print(
+            color_message(
+                f"Report not found at {remote_report} on {ssh_host} — eval may still be running.",
+                Color.ORANGE,
+            )
+        )
+        print(color_message("  Reattach to the workspace tmux session to watch progress:", Color.BLUE))
+        print(color_message(f"    dda inv workspaces.tmux-attach --name {ws_name}", Color.BLUE))
+        return
+
+    dest = local_dir.strip() or os.path.join("eval-results", ws_name)
+    os.makedirs(dest, exist_ok=True)
+
+    print(color_message(f"Copying report from {ssh_host}:{output_dir} to {dest}...", Color.BLUE))
+
+    if only_report:
+        ctx.run(f"scp {shlex.quote(f'{ssh_host}:{remote_report}')} {shlex.quote(dest)}/")
+        print(color_message(f"report.json copied to {dest}/report.json", Color.GREEN))
+    else:
         ctx.run(f"scp -r {shlex.quote(f'{ssh_host}:{output_dir}/.')} {shlex.quote(dest)}/")
         print(color_message(f"Results copied to {dest}/", Color.GREEN))
 

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -980,6 +980,12 @@ def eval_pipeline(
     force_enable_list = [c.strip() for c in force_enable.split(",") if c.strip()]
     force_disable_list = [c.strip() for c in force_disable.split(",") if c.strip()]
 
+    all_known = DETECTORS + CORRELATORS + EXTRACTORS
+    unknown = set(force_enable_list + force_disable_list) - set(all_known)
+    if unknown:
+        print(color_message(f"Error: unknown components: {', '.join(sorted(unknown))}", Color.RED))
+        return
+
     # --- generate combinations (same pattern as eval_component subset generation) ---
     full_combo = _full_stack_combo(force_disable=force_disable_list)
     anchor_list = _anchor_combos(force_disable=force_disable_list, force_enable=force_enable_list)
@@ -1129,7 +1135,7 @@ def eval_pipeline(
         scenarios=scenarios,
     )
 
-    if not tune_result:
+    if not tune_result or tune_result.get("completed_trials", 0) == 0:
         print(color_message("Error: fine-tuning produced no results.", Color.RED))
         return
 

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -2,109 +2,35 @@ import glob
 import json
 import os
 import random
-import re
 import shlex
 import shutil
-import tempfile
 import time
-import zipfile
 
 from invoke import Exit, task
 
 from tasks.libs.common.color import Color, color_message
-
-SCENARIOS = ["213_pagerduty", "353_postmark", "food_delivery_redis"]
-
-# Maps short scenario names to episode names used in runs.jsonl
-SCENARIO_EPISODE_NAMES = {
-    "213_pagerduty": "213_PagerDuty_June_2014_Outage",
-    "353_postmark": "353_postmark_upstream_cloud_provider_outage",
-    "food_delivery_redis": "food-delivery-redis-cpu-saturation",
-}
-
-S3_BUCKET = "qbranch-gensim-recordings"
-AWS_PROFILE = "sso-agent-sandbox-account-admin"
-
-# All available detectors and correlators for ablation / combination search.
-# passthrough is intentionally excluded: it is designed for TP scoring (eval_tp),
-# not for Gaussian F1 eval (eval_scenarios / eval_combinations).
-DETECTORS = ["bocpd", "cusum", "rrcf", "scanmw", "scanwelch"]
-CORRELATORS = ["cross_signal", "time_cluster"]
-
-# Log metrics extractors (component_catalog extractors). Not part of the random
-# ablation grid: eval_combinations always enables all of them unless force-disabled.
-EXTRACTORS = [
-    "log_metrics_extractor",
-    "connection_error_extractor",
-    "log_pattern_extractor",
-]
-
-# Fixed anchor subsets used by eval_component to anchor the evaluation at known
-# reference configurations regardless of the random seed.
-#   [0] minimal: smallest meaningful stack (1 detector + 1 correlator)
-#   [1] medium:  a richer mid-complexity stack for a second anchor point
-# Components missing from the pool (because they are force-disabled or are the
-# evaluated component) are stripped; an anchor is omitted entirely if it ends up
-# with no detectors or no correlators after filtering.
-ANCHOR_COMBOS = [
-    {"detectors": ["bocpd"], "correlators": ["time_cluster"]},
-    {"detectors": ["bocpd", "rrcf"], "correlators": ["cross_signal", "time_cluster"]},
-]
-
-
-class StepLogger:
-    """Hierarchical progress logger that always shows the full ancestor chain.
-
-    Each step prints [root X/N > ... > this X/N]  title, so every line carries
-    complete context regardless of nesting depth. Create a root logger with
-    StepLogger(total, label), then nest via .child() which captures the parent.
-
-    Example output (depth 0 → 1 → 2):
-        [Bayesian run 1/30]  without/subset_000/run_000
-          [Bayesian run 1/30 > Trial 2/5]  trial_001
-            [Bayesian run 1/30 > Trial 2/5 > Scenario 1/3]  213_pagerduty
-    """
-
-    def __init__(self, total: int, label: str, depth: int = 0, parent: "StepLogger | None" = None):
-        self.total = total
-        self.label = label
-        self.depth = depth
-        self._parent = parent
-        self._current = 0
-
-    @property
-    def _indent(self) -> str:
-        return "  " * self.depth
-
-    def _ancestor_tag(self) -> str:
-        """Build 'root X/N > ... > this X/N' chain from the root down to this logger."""
-        parts = []
-        node: StepLogger | None = self
-        while node is not None:
-            parts.append(f"{node.label} {node._current}/{node.total}")
-            node = node._parent
-        return " > ".join(reversed(parts))
-
-    def step(self, title: str = "", color: Color = Color.BLUE) -> "StepLogger":
-        """Increment counter and print full-context progress line. Returns self for chaining."""
-        self._current += 1
-        tag = f"[{self._ancestor_tag()}]"
-        msg = f"{self._indent}{tag}  {title}" if title else f"{self._indent}{tag}"
-        print(color_message(msg, color))
-        return self
-
-    def detail(self, message: str, color: Color = Color.BLUE) -> None:
-        """Print an indented detail line under the current step."""
-        print(color_message(f"{self._indent}  {message}", color))
-
-    def score(self, value: float) -> None:
-        """Print a score line, green if positive, red otherwise."""
-        clr = Color.GREEN if value > 0 else Color.RED
-        print(color_message(f"{self._indent}  score: {value:.4f}", clr))
-
-    def child(self, total: int, label: str) -> "StepLogger":
-        """Create a nested logger one level deeper, capturing self as parent."""
-        return StepLogger(total, label, depth=self.depth + 1, parent=self)
+from tasks.libs.q.eval import (
+    _BENCH_FILTER,
+    CORRELATORS,
+    DETECTORS,
+    EXTRACTORS,
+    SCENARIOS,
+    StepLogger,
+    _anchor_combos,
+    _build_optuna_config,
+    _combo_to_config,
+    _ensure_parquets,
+    _fmt_wall_dur,
+    _full_stack_combo,
+    _prepare_eval_output_dir,
+    _print_benchmark_summary,
+    _scenario_f1_from_bayesian_report,
+    aggregate_eval_component_results,
+    print_eval_bayesian_summary,
+    print_eval_component_summary,
+    print_eval_scenarios_summary,
+    random_component_combinations,
+)
 
 
 # --- Build ---
@@ -122,72 +48,6 @@ def build_scorer(ctx):
     Builds the observer-scorer binary.
     """
     ctx.run("go build -o bin/observer-scorer ./cmd/observer-scorer")
-
-
-def _prepare_eval_output_dir(output_dir: str, *, overwrite: bool) -> bool:
-    """Ensure ``output_dir`` is empty and ready for a fresh eval run.
-
-    If the path exists and contains ``report.json``, the run is aborted unless
-    ``overwrite`` is True (avoids silently deleting completed experiments).
-
-    Returns True if the directory is ready, False if the caller should stop.
-    """
-    if os.path.isfile(output_dir):
-        print(color_message(f"Error: output path is a file, not a directory: {output_dir}", Color.RED))
-        return False
-    report_path = os.path.join(output_dir, "report.json")
-    if os.path.isfile(report_path) and not overwrite:
-        print(
-            color_message(
-                f"Error: output directory already contains report.json: {report_path}\n"
-                f"Use --overwrite to replace it, or choose a different --output-dir.",
-                Color.RED,
-            )
-        )
-        return False
-    if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
-    os.makedirs(output_dir)
-    return True
-
-
-def _scenario_f1_from_bayesian_report(report: dict | None) -> dict[str, float]:
-    """Per-scenario F1 from the best trial's eval_scenarios report (metadata)."""
-    if not report:
-        return {}
-    best = report.get("best_combination")
-    if not isinstance(best, dict):
-        return {}
-    path = best.get("report_path")
-    if not path or not os.path.isfile(path):
-        return {}
-    try:
-        with open(path) as f:
-            main = json.load(f)
-    except (OSError, json.JSONDecodeError, TypeError):
-        return {}
-    meta = main.get("metadata")
-    if not isinstance(meta, dict):
-        return {}
-    out: dict[str, float] = {}
-    for name, row in meta.items():
-        if isinstance(row, dict) and "f1" in row:
-            try:
-                out[str(name)] = float(row["f1"])
-            except (TypeError, ValueError):
-                continue
-    return out
-
-
-def _best_run_index(runs: list[dict]) -> int:
-    """Index of the run with highest best_score among non-failed runs (first on ties).
-
-    Returns -1 if there are no runs or all runs failed.
-    """
-    valid = [i for i, r in enumerate(runs) if not r.get("failed") and r.get("best_score") is not None]
-    if not valid:
-        return -1
-    return max(valid, key=lambda i: runs[i]["best_score"])
 
 
 # --- Eval ---
@@ -349,40 +209,7 @@ def eval_scenarios(
         )
         results.append({"name": name, **score})
 
-    # Print summary table
-    if results:
-        print(color_message(f"\n{'=' * 60}", Color.GREEN))
-        print(color_message("  Observer Eval Summary", Color.GREEN))
-        print(color_message(f"{'=' * 60}\n", Color.GREEN))
-
-        # Header
-        header = f"{'Scenario':<25}  {'F1':>6}  {'Precision':>9}  {'Recall':>6}  {'Alpha':>7}  {'Scored':>6}  {'Baseline FPs':>12}  {'Warmup (excl)':>13}  {'Cascading (excl)':>16}"
-        print(header)
-        print("-" * len(header))
-
-        total_baseline_fps = 0
-        total_baseline_duration = 0
-        for r in results:
-            alpha = r.get("alpha", -1)
-            alpha_str = f"{alpha:.4f}" if alpha >= 0 else "  n/a"
-            timed_out_suffix = "  [TIMEOUT]" if r.get("timed_out") else ""
-            print(
-                f"{r['name']:<25}  {r['f1']:>6.4f}  {r['precision']:>9.4f}  {r['recall']:>6.4f}"
-                f"  {alpha_str:>7}  {r['num_predictions']:>6}  {r['num_baseline_fps']:>12}  {r['num_filtered_warmup']:>13}  {r['num_filtered_cascading']:>16}"
-                f"{timed_out_suffix}"
-            )
-            duration = r.get("baseline_duration_seconds", 0)
-            if duration > 0:
-                total_baseline_fps += r["num_baseline_fps"]
-                total_baseline_duration += duration
-
-        if total_baseline_duration > 0:
-            pooled_alpha = total_baseline_fps / total_baseline_duration
-            print(
-                f"\n  Pooled α: {pooled_alpha:.4f}  ({total_baseline_fps} FPs over {total_baseline_duration}s baseline)"
-            )
-
-        print(f"\nOutput JSONs: /tmp/observer-eval-*.json (sigma={sigma}s)")
+    print_eval_scenarios_summary(results, sigma)
 
     # Create main report
     f1_scores: list[float] = [float(r["f1"]) for r in results]
@@ -519,142 +346,6 @@ def eval_tp(
 
 
 # --- Combination search ---
-
-
-def _full_stack_combo(force_disable: list | None = None) -> dict:
-    """All detectors and correlators not in force_disable (for eval baseline)."""
-    fd = set(force_disable or [])
-    return {
-        "detectors": sorted(d for d in DETECTORS if d not in fd),
-        "correlators": sorted(c for c in CORRELATORS if c not in fd),
-    }
-
-
-def _anchor_combos(force_disable: list | None = None, force_enable: list | None = None) -> list[dict]:
-    """Fixed anchor subsets derived from ANCHOR_COMBOS after filtering force_disable.
-
-    Each anchor that ends up with at least one detector and one correlator is
-    included.  Anchors whose key components are all removed are silently skipped
-    so that evaluating a component that appears in an anchor does not break the
-    run.  force_enable components are unconditionally added to every anchor.
-    """
-    fd = set(force_disable or [])
-    fe_dets = sorted(d for d in (force_enable or []) if d in DETECTORS and d not in fd)
-    fe_cors = sorted(c for c in (force_enable or []) if c in CORRELATORS and c not in fd)
-    anchors = []
-    seen_keys: set = set()
-    for combo in ANCHOR_COMBOS:
-        dets = sorted({d for d in combo["detectors"] if d not in fd} | set(fe_dets))
-        cors = sorted({c for c in combo["correlators"] if c not in fd} | set(fe_cors))
-        if not dets or not cors:
-            continue
-        key = (tuple(dets), tuple(cors))
-        if key in seen_keys:
-            continue
-        seen_keys.add(key)
-        anchors.append({"detectors": dets, "correlators": cors})
-    return anchors
-
-
-def random_component_combinations(
-    n: int,
-    seed: int = None,
-    force_enable: list = None,
-    force_disable: list = None,
-    exclude_combo_keys: set | None = None,
-) -> list:
-    """
-    Generate up to n distinct random component combinations, each guaranteed to
-    contain at least 1 detector (from DETECTORS) and 1 correlator (from CORRELATORS).
-
-    Args:
-        n: Target number of distinct combinations to generate.
-        seed: Random seed for reproducibility (None = non-deterministic).
-        force_enable: Components always present in every combination.
-        force_disable: Components never present in any combination (removed from pool).
-        exclude_combo_keys: Optional set of (tuple(detectors), tuple(correlators)) keys
-            to skip (e.g. the full-stack combo reserved for combo_000).
-
-    Returns:
-        List of dicts: {"detectors": [...], "correlators": [...]}
-        May be shorter than n if the combinatorial space is exhausted.
-    """
-    force_enable = set(force_enable or [])
-    force_disable = set(force_disable or [])
-
-    det_pool = [d for d in DETECTORS if d not in force_disable]
-    cor_pool = [c for c in CORRELATORS if c not in force_disable]
-    forced_dets = sorted(d for d in force_enable if d in DETECTORS)
-    forced_cors = sorted(c for c in force_enable if c in CORRELATORS)
-
-    # After forcing, we need at least one detector and one correlator in each combo.
-    # If force_enable already covers a category, the random part for that category
-    # can be empty; otherwise sample at least 1 from the remaining pool.
-    rng = random.Random(seed)
-    combos = []
-    seen: set = set(exclude_combo_keys or [])
-    max_attempts = n * 100
-    attempts = 0
-    while len(combos) < n and attempts < max_attempts:
-        attempts += 1
-
-        # Random detectors from the pool (excluding forced, which are added back below)
-        free_det_pool = [d for d in det_pool if d not in force_enable]
-        if forced_dets:
-            # forced already satisfies the ≥1 detector requirement
-            extra_dets = sorted(rng.sample(free_det_pool, rng.randint(0, len(free_det_pool)))) if free_det_pool else []
-        else:
-            if not free_det_pool:
-                break  # no detectors available at all
-            extra_dets = sorted(rng.sample(free_det_pool, rng.randint(1, len(free_det_pool))))
-        dets = sorted(set(forced_dets + extra_dets))
-
-        free_cor_pool = [c for c in cor_pool if c not in force_enable]
-        if forced_cors:
-            extra_cors = sorted(rng.sample(free_cor_pool, rng.randint(0, len(free_cor_pool)))) if free_cor_pool else []
-        else:
-            if not free_cor_pool:
-                break  # no correlators available at all
-            extra_cors = sorted(rng.sample(free_cor_pool, rng.randint(1, len(free_cor_pool))))
-        cors = sorted(set(forced_cors + extra_cors))
-
-        key = (tuple(dets), tuple(cors))
-        if key in seen:
-            continue
-        seen.add(key)
-        combos.append({"detectors": dets, "correlators": cors})
-    if attempts >= max_attempts:
-        print(
-            color_message(
-                f"Warning: Only generated {len(combos)} unique combinations (max attempts={max_attempts})", Color.ORANGE
-            )
-        )
-    return combos
-
-
-def _combo_to_config(
-    detectors: list,
-    correlators: list,
-    force_disable: list | None = None,
-) -> dict:
-    """
-    Build a testbench JSON params config enabling exactly the listed detectors
-    and correlators, explicitly disabling all other detectors/correlators.
-
-    All EXTRACTORS are enabled unless listed in force_disable (explicit
-    ``{"enabled": false}`` so ablation stays stable if catalog defaults change).
-
-    The config follows the TestbenchParamsFile format consumed by --config:
-        {"components": {"bocpd": {"enabled": true}, "rrcf": {"enabled": false}, ...}}
-    """
-    force_disable_set = set(force_disable or [])
-    enabled_set = set(detectors + correlators)
-    components = {}
-    for name in DETECTORS + CORRELATORS:
-        components[name] = {"enabled": name in enabled_set}
-    for name in EXTRACTORS:
-        components[name] = {"enabled": name not in force_disable_set}
-    return {"components": components}
 
 
 @task
@@ -846,98 +537,6 @@ def eval_combinations(
 
 
 # --- Bayesian Optimization ---
-
-
-def _sample_component_params(trial, component: str) -> dict:
-    """Sample Optuna hyperparameters for a named component that supports parseJSON.
-
-    Each component's params are wrapped in a lambda so that suggest_* calls are
-    only executed for the active component. Returns an empty dict for components
-    with no tunable hyperparameters (scanmw, scanwelch, log_metrics_extractor,
-    connection_error_extractor).
-    """
-    # Commented hyperparameters are the ones that have the less impact, this is used
-    # to reduce the search space and speed up the evaluation
-    space = {
-        "bocpd": lambda: {
-            # "warmup_points": trial.suggest_int("bocpd.warmup_points", 40, 300),
-            "hazard": trial.suggest_float("bocpd.hazard", 1e-3, 0.2, log=True),
-            "cp_threshold": trial.suggest_float("bocpd.cp_threshold", 0.35, 0.9),
-            # "short_run_length": trial.suggest_int("bocpd.short_run_length", 2, 20),
-            # "cp_mass_threshold": trial.suggest_float("bocpd.cp_mass_threshold", 0.4, 0.95),
-            # "max_run_length": trial.suggest_int("bocpd.max_run_length", 50, 400),
-            # "prior_variance_scale": trial.suggest_float("bocpd.prior_variance_scale", 1.0, 50.0),
-            # "min_variance": trial.suggest_float("bocpd.min_variance", 0.01, 5.0, log=True),
-            # "recovery_points": trial.suggest_int("bocpd.recovery_points", 3, 40),
-        },
-        "cusum": lambda: {
-            # "min_points": trial.suggest_int("cusum.min_points", 3, 30),
-            # "baseline_fraction": trial.suggest_float("cusum.baseline_fraction", 0.05, 0.5),
-            # "slack_factor": trial.suggest_float("cusum.slack_factor", 0.1, 2.0),
-            "threshold_factor": trial.suggest_float("cusum.threshold_factor", 2.0, 10.0),
-        },
-        "rrcf": lambda: {
-            # "num_trees": trial.suggest_int("rrcf.num_trees", 20, 200),
-            # "tree_size": trial.suggest_int("rrcf.tree_size", 64, 512),
-            "shingle_size": trial.suggest_int("rrcf.shingle_size", 1, 16),
-            "threshold_sigma": trial.suggest_float("rrcf.threshold_sigma", 0.5, 6.0),
-        },
-        "cross_signal": lambda: {
-            # "window_seconds": trial.suggest_int("cross_signal.window_seconds", 5, 180),
-        },
-        "time_cluster": lambda: {
-            # "proximity_seconds": trial.suggest_int("time_cluster.proximity_seconds", 2, 60),
-            # "window_seconds": trial.suggest_int("time_cluster.window_seconds", 30, 600),
-            # "min_cluster_size": trial.suggest_int("time_cluster.min_cluster_size", 1, 8),
-        },
-        "log_pattern_extractor": lambda: {
-            # "disable_optimizations": trial.suggest_categorical(
-            #     "log_pattern_extractor.disable_optimizations", [True, False]
-            # ),
-            # "min_cluster_size_before_emit": trial.suggest_int(
-            #     "log_pattern_extractor.min_cluster_size_before_emit", 1, 30
-            # ),
-            # "max_tokenized_string_length": trial.suggest_int(
-            #     "log_pattern_extractor.max_tokenized_string_length", 2000, 16000
-            # ),
-            # "max_num_tokens": trial.suggest_int("log_pattern_extractor.max_num_tokens", 32, 512),
-            # "parse_hex_dump": trial.suggest_categorical("log_pattern_extractor.parse_hex_dump", [True, False]),
-            "min_token_match_ratio": trial.suggest_float("log_pattern_extractor.min_token_match_ratio", 0.2, 0.95),
-            # "cluster_time_to_live_sec": trial.suggest_int("log_pattern_extractor.cluster_time_to_live_sec", 600, 86400),
-            # "garbage_collection_interval_sec": trial.suggest_int(
-            #     "log_pattern_extractor.garbage_collection_interval_sec", 60, 7200
-            # ),
-        },
-    }
-    fn = space.get(component)
-    return fn() if fn else {}
-
-
-def _build_optuna_config(
-    trial,
-    components: list,
-    locked: set,
-) -> dict:
-    """Build a TestbenchParamsFile config dict for one Optuna trial.
-
-    Enables exactly the listed components, disables all others in the catalog.
-    Components in `locked` are enabled but their hyperparameters are not sampled
-    (Go catalog defaults apply), effectively fixing them during the search.
-    """
-    active_set = set(components)
-    result = {}
-
-    for name in DETECTORS + CORRELATORS + EXTRACTORS:
-        if name not in active_set:
-            result[name] = {"enabled": False}
-
-    for name in components:
-        params = {"enabled": True}
-        if name not in locked:
-            params.update(_sample_component_params(trial, name))
-        result[name] = params
-
-    return {"components": result}
 
 
 @task
@@ -1166,26 +765,6 @@ def eval_bayesian(
         if not completed_trials:
             print(color_message("Error: all trials failed — scores are meaningless.", Color.RED))
 
-    if completed_trials:
-        print(color_message(f"\n{'=' * 70}", Color.GREEN))
-        print(color_message("  Bayesian Optimization Summary", Color.GREEN))
-        print(color_message(f"{'=' * 70}\n", Color.GREEN))
-        header = f"{'Rank':<5}  {'Trial':<12}  {'Score':>6}"
-        print(header)
-        print("-" * 30)
-        for rank, t in enumerate(completed_trials[:10], 1):
-            print(f"{rank:<5}  {t['label']:<12}  {t['score']:>6.4f}")
-        if len(completed_trials) > 10:
-            print(f"  ... {len(completed_trials) - 10} more trials")
-
-        if best:
-            print(color_message(f"\n  Best: {best['label']}  (score={best['score']:.4f})", Color.GREEN))
-            print(color_message("  Best parameters:", Color.GREEN))
-            for key, val in sorted(best["params"].items()):
-                print(color_message(f"    {key}: {val}", Color.GREEN))
-            print(color_message(f"  config: {best['config_path']}", Color.GREEN))
-            print(color_message(f"  report: {best['report_path']}", Color.GREEN))
-
     final_report = {
         "score": max_score,
         "avg_eval_score": avg_score,
@@ -1210,13 +789,7 @@ def eval_bayesian(
         with open(best_config_path, "w") as f:
             json.dump(best_config, f, indent=4)
 
-    print(color_message(f"\n{'=' * 70}", Color.GREEN))
-    print(color_message(f"  Report: {report_path}", Color.GREEN))
-    print(color_message(f"  score (best):    {max_score:.4f}", Color.GREEN))
-    print(color_message(f"  avg_eval_score:  {avg_score:.4f}", Color.GREEN))
-    print(color_message(f"  study:           {study_path}", Color.GREEN))
-    print(color_message(f"  Per-trial:       {output_dir}/trial_*/report.json", Color.GREEN))
-    print(color_message(f"{'=' * 70}", Color.GREEN))
+    print_eval_bayesian_summary(completed_trials, best, max_score, avg_score, output_dir, study_path)
 
     return final_report
 
@@ -1546,233 +1119,19 @@ def eval_component(
                 }
             )
 
-    # --- aggregate per-subset comparison ---
-    per_subset = []
-    for si in range(n_subsets):
-        wo = variant_results["without"][si]
-        wi = variant_results["with"][si]
-        wo_max = wo["max_score"]
-        wi_max = wi["max_score"]
-        wo_mean = wo["mean_score"]
-        wi_mean = wi["mean_score"]
-        delta_max_ps = (wi_max - wo_max) if wo_max is not None and wi_max is not None else None
-        delta_mean_ps = (wi_mean - wo_mean) if wo_mean is not None and wi_mean is not None else None
-        failed_runs_total = wo["failed_runs"] + wi["failed_runs"]
-        per_subset.append(
-            {
-                "subset": wo["subset"],
-                "detectors": wo["detectors"],
-                "correlators": wo["correlators"],
-                "without_max": wo_max,
-                "with_max": wi_max,
-                "delta_max": delta_max_ps,
-                "without_mean": wo_mean,
-                "with_mean": wi_mean,
-                "delta_mean": delta_mean_ps,
-                "failed_runs": failed_runs_total,
-                "without_run_scores": wo["run_scores"],
-                "with_run_scores": wi["run_scores"],
-            }
-        )
-
-    # --- per-scenario deltas (best run per variant per subset) ---
-    per_subset_scenario: list[dict] = []
-    for si in range(n_subsets):
-        wo_runs = variant_results["without"][si]["runs"]
-        wi_runs = variant_results["with"][si]["runs"]
-        iwo = _best_run_index(wo_runs)
-        iwi = _best_run_index(wi_runs)
-        wo_f1 = wo_runs[iwo]["scenario_f1"] if iwo >= 0 else {}
-        wi_f1 = wi_runs[iwi]["scenario_f1"] if iwi >= 0 else {}
-        names = sorted(set(wo_f1.keys()) | set(wi_f1.keys()))
-        by_scenario: dict[str, dict] = {}
-        for s in names:
-            a = wo_f1.get(s)
-            b = wi_f1.get(s)
-            delta = (b - a) if a is not None and b is not None else None
-            by_scenario[s] = {
-                "without_f1": a,
-                "with_f1": b,
-                "delta_f1": delta,
-            }
-        per_subset_scenario.append(
-            {
-                "subset": variant_results["without"][si]["subset"],
-                "by_scenario": by_scenario,
-            }
-        )
-
-    all_scenario_names: set[str] = set()
-    for pss in per_subset_scenario:
-        all_scenario_names.update(pss["by_scenario"].keys())
-
-    per_scenario_summary: dict[str, dict] = {}
-    for s in sorted(all_scenario_names):
-        deltas = []
-        for pss in per_subset_scenario:
-            row = pss["by_scenario"].get(s)
-            if row and row.get("delta_f1") is not None:
-                deltas.append(row["delta_f1"])
-        if not deltas:
-            per_scenario_summary[s] = {
-                "mean_delta_f1": None,
-                "min_delta_f1": None,
-                "max_delta_f1": None,
-                "n_subsets": 0,
-            }
-        else:
-            per_scenario_summary[s] = {
-                "mean_delta_f1": sum(deltas) / len(deltas),
-                "min_delta_f1": min(deltas),
-                "max_delta_f1": max(deltas),
-                "n_subsets": len(deltas),
-            }
-
-    # Only include subsets where both variants produced at least one successful run.
-    valid_deltas_max = [ps["delta_max"] for ps in per_subset if ps["delta_max"] is not None]
-    valid_deltas_mean = [ps["delta_mean"] for ps in per_subset if ps["delta_mean"] is not None]
-    n_failed_subsets = sum(1 for ps in per_subset if ps["delta_max"] is None)
-    total_failed_runs = sum(ps["failed_runs"] for ps in per_subset)
-
-    if n_failed_subsets > 0:
-        print(
-            color_message(
-                f"Warning: {n_failed_subsets}/{n_subsets} subsets had fully failed runs and are excluded from the final delta.",
-                Color.ORANGE,
-            )
-        )
-    if total_failed_runs > 0 and n_failed_subsets == 0:
-        print(
-            color_message(
-                f"Warning: {total_failed_runs} individual run(s) failed across subsets; "
-                "partial results were excluded from per-subset scores.",
-                Color.ORANGE,
-            )
-        )
-
-    delta_max = sum(valid_deltas_max) / len(valid_deltas_max) if valid_deltas_max else None
-    delta_mean = sum(valid_deltas_mean) / len(valid_deltas_mean) if valid_deltas_mean else None
-
-    avg_max_without_vals = [ps["without_max"] for ps in per_subset if ps["without_max"] is not None]
-    avg_max_with_vals = [ps["with_max"] for ps in per_subset if ps["with_max"] is not None]
-    avg_mean_without_vals = [ps["without_mean"] for ps in per_subset if ps["without_mean"] is not None]
-    avg_mean_with_vals = [ps["with_mean"] for ps in per_subset if ps["with_mean"] is not None]
-
-    avg_max_without = sum(avg_max_without_vals) / len(avg_max_without_vals) if avg_max_without_vals else None
-    avg_max_with = sum(avg_max_with_vals) / len(avg_max_with_vals) if avg_max_with_vals else None
-    avg_mean_without = sum(avg_mean_without_vals) / len(avg_mean_without_vals) if avg_mean_without_vals else None
-    avg_mean_with = sum(avg_mean_with_vals) / len(avg_mean_with_vals) if avg_mean_with_vals else None
-
-    if delta_max is None:
-        recommendation = "inconclusive"
-        rec_clr = Color.ORANGE
-    elif delta_max > 0:
-        recommendation = "keep"
-        rec_clr = Color.GREEN
-    else:
-        recommendation = "discard"
-        rec_clr = Color.RED
+    # --- aggregate and print summary ---
+    aggregated = aggregate_eval_component_results(variant_results, n_subsets)
 
     full_eval_wall_time_seconds = round(time.perf_counter() - eval_start, 3)
+    _wall_str = f"{_fmt_wall_dur(full_eval_wall_time_seconds)} ({full_eval_wall_time_seconds:.3f}s)"
 
-    def _fmt_wall_dur(s: float) -> str:
-        if s >= 3600:
-            return f"{int(s // 3600)}h {int((s % 3600) // 60)}m {s % 60:.1f}s"
-        if s >= 60:
-            return f"{int(s // 60)}m {s % 60:.1f}s"
-        return f"{s:.1f}s"
-
-    _wall_str = _fmt_wall_dur(full_eval_wall_time_seconds)
-
-    # --- print summary (primary max-score block last) ---
-    print(color_message(f"\n{'=' * 70}", Color.GREEN))
-    print(color_message("  Component Evaluation Summary", Color.GREEN))
-    print(color_message(f"{'=' * 70}\n", Color.GREEN))
-    print(color_message(f"  Component: {component}\n", Color.GREEN))
-
-    header = f"  {'Subset':<12}  {'Without':>8}  {'With':>8}  {'Delta':>8}"
-    print(header)
-    print(f"  {'-' * 44}")
-    for ps in per_subset:
-        wo_str = f"{ps['without_max']:>8.4f}" if ps["without_max"] is not None else f"{'FAILED':>8}"
-        wi_str = f"{ps['with_max']:>8.4f}" if ps["with_max"] is not None else f"{'FAILED':>8}"
-        if ps["delta_max"] is None:
-            delta_str = color_message(f"{'n/a':>8}", Color.ORANGE)
-        else:
-            delta_clr = Color.GREEN if ps["delta_max"] > 0 else Color.RED
-            delta_str = color_message(f"{ps['delta_max']:>+8.4f}", delta_clr)
-        fail_note = f"  [{ps['failed_runs']} run(s) failed]" if ps["failed_runs"] > 0 else ""
-        print(f"  {ps['subset']:<12}  {wo_str}  {wi_str}  {delta_str}{fail_note}")
-
-    print()
-    print(
-        color_message(
-            "  Per-scenario Δ F1 (best Bayesian trial per run; best run per variant per subset)",
-            Color.BLUE,
-        )
+    print_eval_component_summary(
+        component,
+        aggregated["per_subset"],
+        aggregated["per_scenario_summary"],
+        aggregated,
+        _wall_str,
     )
-    print(
-        color_message(
-            "  Columns: mean / min / max of Δ across subsets (helps spot inconsistent scenarios)",
-            Color.BLUE,
-        )
-    )
-    ps_header = f"  {'Scenario':<26}  {'mean Δ':>8}  {'min Δ':>8}  {'max Δ':>8}"
-    print(ps_header)
-    print(f"  {'-' * len(ps_header.strip())}")
-
-    def _scenario_sort_key(item: tuple[str, dict]) -> tuple:
-        m = item[1].get("mean_delta_f1")
-        if m is None:
-            return (1, 0.0)
-        return (0, -m)
-
-    for scen, row in sorted(per_scenario_summary.items(), key=_scenario_sort_key):
-        mean_d = row["mean_delta_f1"]
-        min_d = row["min_delta_f1"]
-        max_d = row["max_delta_f1"]
-        if mean_d is None:
-            print(color_message(f"  {scen:<26}  {'n/a':>8}  {'n/a':>8}  {'n/a':>8}", Color.ORANGE))
-        else:
-            mean_clr = Color.GREEN if mean_d > 0 else Color.RED if mean_d < 0 else Color.BLUE
-            msg = f"  {scen:<26}  {mean_d:>+8.4f}  {min_d:>+8.4f}  {max_d:>+8.4f}"
-            print(color_message(msg, mean_clr))
-
-    def _fmt(v: float | None, signed: bool = False) -> str:
-        if v is None:
-            return "n/a"
-        return f"{v:+.4f}" if signed else f"{v:.4f}"
-
-    print()
-    print(color_message("  Secondary: mean of trial-mean scores (across subsets)", Color.BLUE))
-    print(color_message(f"  Avg mean score without: {_fmt(avg_mean_without)}", Color.BLUE))
-    print(color_message(f"  Avg mean score with:    {_fmt(avg_mean_with)}", Color.BLUE))
-    if delta_mean is None:
-        print(color_message("  Delta (mean):           n/a (no valid subsets)", Color.ORANGE))
-    else:
-        delta_clr = Color.GREEN if delta_mean > 0 else Color.RED
-        print(color_message(f"  Delta (mean):           {delta_mean:+.4f}", delta_clr))
-
-    print()
-    print(color_message(f"  {'-' * 66}", Color.GREEN))
-    print(color_message("  Primary metric — max best-trial score (avg across subsets)", Color.GREEN))
-    print(color_message(f"  {'-' * 66}", Color.GREEN))
-    print(color_message(f"  Avg max score without:  {_fmt(avg_max_without)}", Color.GREEN))
-    print(color_message(f"  Avg max score with:     {_fmt(avg_max_with)}", Color.GREEN))
-    if delta_max is None:
-        print(color_message("  Delta (max):            n/a (no valid subsets)", Color.ORANGE))
-    else:
-        delta_clr = Color.GREEN if delta_max > 0 else Color.RED
-        print(color_message(f"  Delta (max):            {delta_max:+.4f}", delta_clr))
-    print()
-    print(color_message(f"  Recommendation: {recommendation.upper()} {component}", rec_clr))
-    if recommendation == "inconclusive":
-        print(color_message("  All subsets failed — cannot make a reliable recommendation.", Color.ORANGE))
-    elif recommendation == "keep":
-        print(color_message("  Next step: update your config, then tune the new component using:", Color.BOLD))
-        print(color_message(f"    dda inv q.eval-bayesian --only {component}", Color.BOLD))
-    print(color_message(f"  Full eval wall time: {_wall_str} ({full_eval_wall_time_seconds:.3f}s)", Color.GREEN))
-    print(color_message(f"{'=' * 70}", Color.GREEN))
 
     # --- copy best "with" config to root ---
     all_with_runs = [run for subset in variant_results["with"] for run in subset["runs"] if not run.get("failed")]
@@ -1788,7 +1147,7 @@ def eval_component(
     final_report = {
         "component": component,
         "tune_evaluated_component": tune_evaluated_component,
-        "recommendation": recommendation,
+        "recommendation": aggregated["recommendation"],
         "seed": seed,
         "n_subsets": n_subsets,
         "m_runs": m_runs,
@@ -1799,18 +1158,18 @@ def eval_component(
         "best_config_path": best_config_path,
         "best_with_run": best_with_run,
         "summary": {
-            "avg_max_score_without": avg_max_without,
-            "avg_max_score_with": avg_max_with,
-            "delta_max": delta_max,
-            "avg_mean_score_without": avg_mean_without,
-            "avg_mean_score_with": avg_mean_with,
-            "delta_mean": delta_mean,
-            "failed_subsets": n_failed_subsets,
-            "total_failed_runs": total_failed_runs,
+            "avg_max_score_without": aggregated["avg_max_without"],
+            "avg_max_score_with": aggregated["avg_max_with"],
+            "delta_max": aggregated["delta_max"],
+            "avg_mean_score_without": aggregated["avg_mean_without"],
+            "avg_mean_score_with": aggregated["avg_mean_with"],
+            "delta_mean": aggregated["delta_mean"],
+            "failed_subsets": aggregated["n_failed_subsets"],
+            "total_failed_runs": aggregated["total_failed_runs"],
         },
-        "per_subset": per_subset,
-        "per_subset_scenario": per_subset_scenario,
-        "per_scenario_summary": per_scenario_summary,
+        "per_subset": aggregated["per_subset"],
+        "per_subset_scenario": aggregated["per_subset_scenario"],
+        "per_scenario_summary": aggregated["per_scenario_summary"],
         "without": variant_results["without"],
         "with": variant_results["with"],
     }
@@ -1819,7 +1178,7 @@ def eval_component(
         json.dump(final_report, f, indent=4)
 
     print(color_message(f"\n  Report:      {report_path}", Color.GREEN))
-    print(color_message(f"  Wall time:   {_wall_str} ({full_eval_wall_time_seconds:.3f}s)", Color.GREEN))
+    print(color_message(f"  Wall time:   {_wall_str}", Color.GREEN))
     if best_config_path:
         score_str = (
             f"{best_with_run['best_score']:.4f}" if best_with_run and best_with_run["best_score"] is not None else "n/a"
@@ -1827,103 +1186,6 @@ def eval_component(
         print(color_message(f"  Best config: {best_config_path}  (score={score_str})", Color.GREEN))
 
     return final_report
-
-
-def _resolve_zip_from_runs_jsonl(ctx, name):
-    """Resolve the latest zip key for a scenario from runs.jsonl in S3."""
-    episode_name = SCENARIO_EPISODE_NAMES.get(name)
-    if not episode_name:
-        return None
-
-    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w") as tmp:
-        tmp_path = tmp.name
-
-    try:
-        result = ctx.run(
-            f"aws-vault exec {AWS_PROFILE} -- aws s3 cp s3://{S3_BUCKET}/runs.jsonl {shlex.quote(tmp_path)}",
-            warn=True,
-        )
-        if result is None or result.failed:
-            return None
-
-        with open(tmp_path) as f:
-            lines = []
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    lines.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue  # skip malformed records
-
-        # Find the latest entry matching this episode
-        matches = [entry for entry in lines if entry.get("episode") == episode_name]
-        if not matches:
-            return None
-
-        latest = matches[-1]
-        zip_key = latest.get("zip")
-        if zip_key:
-            print(
-                color_message(
-                    f"Resolved '{name}' from runs.jsonl: {zip_key} "
-                    f"(image: {latest.get('image', '?')}, {latest.get('timestamp', '?')})",
-                    Color.BLUE,
-                )
-            )
-        return zip_key
-    except (OSError, json.JSONDecodeError):
-        return None
-    finally:
-        os.unlink(tmp_path)
-
-
-def _ensure_parquets(ctx, name, parquet_dir):
-    """Download and extract parquet files from S3 via runs.jsonl."""
-    zip_key = _resolve_zip_from_runs_jsonl(ctx, name)
-    if not zip_key:
-        print(
-            color_message(
-                f"No recording found for '{name}' in runs.jsonl. Run a gensim-eks episode to produce one.",
-                Color.RED,
-            )
-        )
-        return
-
-    print(color_message(f"Downloading {zip_key} from S3...", Color.BLUE))
-    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-        tmp_path = tmp.name
-
-    try:
-        result = ctx.run(
-            f"aws-vault exec {AWS_PROFILE} -- aws s3 cp s3://{S3_BUCKET}/{zip_key} {shlex.quote(tmp_path)}",
-            warn=True,
-        )
-        if result is None or result.failed:
-            print(color_message(f"Failed to download {zip_key} from S3", Color.RED))
-            return
-
-        scenario_dir = os.path.dirname(parquet_dir)
-        os.makedirs(parquet_dir, exist_ok=True)
-        try:
-            with zipfile.ZipFile(tmp_path) as zf:
-                for member in zf.namelist():
-                    if member.startswith("tmp/gensim-archive/parquet/") and not member.endswith("/"):
-                        filename = os.path.basename(member)
-                        with zf.open(member) as src, open(os.path.join(parquet_dir, filename), "wb") as dst:
-                            dst.write(src.read())
-                    elif member.startswith("tmp/gensim-archive/results/") and member.endswith(".json"):
-                        with zf.open(member) as src, open(os.path.join(scenario_dir, "episode.json"), "wb") as dst:
-                            dst.write(src.read())
-        except (zipfile.BadZipFile, OSError) as e:
-            print(color_message(f"Failed to extract {zip_key}: {e}", Color.RED))
-            shutil.rmtree(parquet_dir, ignore_errors=True)
-            return
-
-        print(color_message(f"Extracted parquet files to {parquet_dir}", Color.GREEN))
-    finally:
-        os.unlink(tmp_path)
 
 
 @task
@@ -2125,8 +1387,6 @@ def fetch_k8s_observer_parquet(ctx, dest: str = "/tmp/k8s-observer-metrics"):
 
 # --- Benchmarks ---
 
-_BENCH_FILTER = "BenchmarkDetection|BenchmarkIngestion|BenchmarkLogExtraction"
-
 
 @task
 def benchmark(ctx, bench=_BENCH_FILTER, benchtime="3s", count=1, only=""):
@@ -2156,63 +1416,6 @@ def benchmark(ctx, bench=_BENCH_FILTER, benchtime="3s", count=1, only=""):
         print(color_message("\nBenchmarks failed.", Color.RED))
         return
     _print_benchmark_summary(result.stdout if result else "")
-
-
-def _print_benchmark_summary(output):
-    """Parse go benchmark output and print a grouped readable summary."""
-    # Matches: BenchmarkFoo/param=val-NCPU  count  ns/op  [B/op  allocs/op]
-    line_re = re.compile(
-        r'^(Benchmark[A-Za-z_]+)(?:/([\w=.,/-]+?))?-\d+\s+\d+\s+([\d.]+)\s+ns/op'
-        r'(?:\s+([\d.]+)\s+B/op\s+([\d.]+)\s+allocs/op)?'
-    )
-
-    groups = {}  # family -> [(param, ns_op, b_op, allocs)]
-    for line in output.splitlines():
-        m = line_re.match(line)
-        if not m:
-            continue
-        family, param, ns_op, b_op, allocs = m.groups()
-        groups.setdefault(family, []).append(
-            (
-                param or "",
-                float(ns_op),
-                float(b_op or 0),
-                float(allocs or 0),
-            )
-        )
-
-    if not groups:
-        return
-
-    print(color_message(f"\n{'=' * 65}", Color.GREEN))
-    print(color_message("  Observer Benchmark Summary", Color.GREEN))
-    print(color_message(f"{'=' * 65}\n", Color.GREEN))
-
-    for family, rows in groups.items():
-        print(color_message(family, Color.BLUE))
-        has_params = any(r[0] for r in rows)
-        if has_params:
-            print(f"  {'param':<22}  {'time/op':>10}  {'B/op':>8}  {'allocs':>7}")
-            print(f"  {'-' * 54}")
-            for param, ns_op, b_op, allocs in rows:
-                print(f"  {param:<22}  {_fmt_ns(ns_op):>10}  {b_op:>8.0f}  {allocs:>7.0f}")
-        else:
-            print(f"  {'time/op':>10}  {'B/op':>8}  {'allocs':>7}")
-            print(f"  {'-' * 30}")
-            for _, ns_op, b_op, allocs in rows:
-                print(f"  {_fmt_ns(ns_op):>10}  {b_op:>8.0f}  {allocs:>7.0f}")
-        print()
-
-
-def _fmt_ns(ns):
-    """Format nanoseconds into a human-readable string."""
-    if ns >= 1_000_000_000:
-        return f"{ns / 1_000_000_000:.2f}s"
-    if ns >= 1_000_000:
-        return f"{ns / 1_000_000:.2f}ms"
-    if ns >= 1_000:
-        return f"{ns / 1_000:.2f}µs"
-    return f"{ns:.0f}ns"
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

This adds `eval_pipeline` to fine tune all components of our pipeline in two steps:
1. (Similar to eval_component) select component subsets and do bayesian optimization on each of them
2. Pick the best config and fine tune it further with bayesian optimization

Also fixes a bug in eval_bayesian (all components always enabled if --only passed)

### Motivation

### Describe how you validated your changes

### Additional Notes
