### PR TITLE
fix(orchestrator): prevent duplicate OOTB CRD collectors caused by v1/v1beta1 prefix match

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
@@ -190,9 +190,17 @@ func (d *DiscoveryCollector) List(group, version, kind string) []CollectorVersio
 			continue
 		}
 
-		// Match version prefix
-		if !strings.HasPrefix(cv.GroupVersion, groupVersion) {
-			continue
+		// Match version: use prefix when version is empty (match any version within
+		// the group), otherwise require exact equality to avoid "v1" accidentally
+		// matching "v1beta1" via prefix.
+		if version == "" {
+			if !strings.HasPrefix(cv.GroupVersion, groupVersion) {
+				continue
+			}
+		} else {
+			if cv.GroupVersion != groupVersion {
+				continue
+			}
 		}
 
 		// If kind is specified, only include matching name

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
@@ -176,42 +176,39 @@ func (d *DiscoveryCollector) isSupportTerminatedPodCollector(collector collector
 func (d *DiscoveryCollector) List(group, version, kind string) []CollectorVersion {
 	var result []CollectorVersion
 
-	// Construct groupVersion prefix for matching
-	var groupVersion string
-	if group == "" {
-		groupVersion = version
-	} else {
-		groupVersion = fmt.Sprintf("%s/%s", group, version)
-	}
-
 	for cv := range d.cache.CollectorForVersion {
-		// Skip "/status" entries
 		if strings.HasSuffix(cv.Kind, "/status") {
 			continue
 		}
-
-		// Match version: use prefix when version is empty (match any version within
-		// the group), otherwise require exact equality to avoid "v1" accidentally
-		// matching "v1beta1" via prefix.
-		if version == "" {
-			if !strings.HasPrefix(cv.GroupVersion, groupVersion) {
-				continue
-			}
-		} else {
-			if cv.GroupVersion != groupVersion {
-				continue
-			}
+		if !matchesGroupVersion(cv.GroupVersion, group, version) {
+			continue
 		}
-
-		// If kind is specified, only include matching name
 		if kind != "" && cv.Kind != kind {
 			continue
 		}
-
 		result = append(result, cv)
 	}
 
 	return result
+}
+
+// matchesGroupVersion reports whether a cached GroupVersion string (e.g. "apps/v1")
+// matches the requested group and version filter.
+// An empty group or version acts as a wildcard.
+func matchesGroupVersion(cv, group, version string) bool {
+	switch {
+	case group == "" && version == "":
+		return true
+	case version == "":
+		// Match any version within the group. Use "group/" prefix to avoid
+		// "apps" incorrectly matching "appsextended/v1".
+		return strings.HasPrefix(cv, group+"/")
+	case group == "":
+		// Core-group resources are stored without a group prefix (e.g. "v1").
+		return cv == version
+	default:
+		return cv == group+"/"+version
+	}
 }
 
 // OptimalVersion returns the best available version for a given group.

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
@@ -402,3 +402,40 @@ func TestDiscoveryCollector_OptimalVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchesGroupVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		cv       string
+		group    string
+		version  string
+		expected bool
+	}{
+		// both empty → match all
+		{name: "both empty matches anything", cv: "apps/v1", group: "", version: "", expected: true},
+		{name: "both empty matches core group", cv: "v1", group: "", version: "", expected: true},
+
+		// version empty → match any version in the group (prefix)
+		{name: "version empty matches any version in group", cv: "apps/v1", group: "apps", version: "", expected: true},
+		{name: "version empty matches v1beta1 in group", cv: "apps/v1beta1", group: "apps", version: "", expected: true},
+		{name: "version empty does not match different group", cv: "extensions/v1beta1", group: "apps", version: "", expected: false},
+		{name: "version empty does not match group with shared prefix", cv: "appsextended/v1", group: "apps", version: "", expected: false},
+
+		// group empty → core group exact version match
+		{name: "group empty matches exact core version", cv: "v1", group: "", version: "v1", expected: true},
+		{name: "group empty does not match v1beta1 when v1 requested", cv: "v1beta1", group: "", version: "v1", expected: false},
+		{name: "group empty does not match grouped resource", cv: "apps/v1", group: "", version: "v1", expected: false},
+
+		// both set → exact match
+		{name: "exact match", cv: "apps/v1", group: "apps", version: "v1", expected: true},
+		{name: "does not match v1beta1 when v1 requested", cv: "apps/v1beta1", group: "apps", version: "v1", expected: false},
+		{name: "does not match different group", cv: "extensions/v1", group: "apps", version: "v1", expected: false},
+		{name: "does not match different version", cv: "apps/v2", group: "apps", version: "v1", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, matchesGroupVersion(tt.cv, tt.group, tt.version))
+		})
+	}
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
@@ -131,6 +131,46 @@ func TestDiscoveryCollector_List(t *testing.T) {
 			},
 		},
 		{
+			name: "does not match v1beta1 when exact version v1 is requested",
+			setup: func() *DiscoveryCollector {
+				return &DiscoveryCollector{
+					cache: DiscoveryCache{
+						CollectorForVersion: map[CollectorVersion]struct{}{
+							{GroupVersion: "eks.amazonaws.com/v1", Kind: "nodeclasses"}:      {},
+							{GroupVersion: "eks.amazonaws.com/v1beta1", Kind: "nodeclasses"}: {},
+						},
+					},
+				}
+			},
+			group:   "eks.amazonaws.com",
+			version: "v1",
+			kind:    "nodeclasses",
+			expected: []CollectorVersion{
+				{GroupVersion: "eks.amazonaws.com/v1", Kind: "nodeclasses"},
+			},
+		},
+		{
+			name: "does not match v1beta1 resources when v1 is requested without kind filter",
+			setup: func() *DiscoveryCollector {
+				return &DiscoveryCollector{
+					cache: DiscoveryCache{
+						CollectorForVersion: map[CollectorVersion]struct{}{
+							{GroupVersion: "apps/v1", Kind: "deployments"}:      {},
+							{GroupVersion: "apps/v1beta1", Kind: "deployments"}: {},
+							{GroupVersion: "apps/v1", Kind: "statefulsets"}:     {},
+						},
+					},
+				}
+			},
+			group:   "apps",
+			version: "v1",
+			kind:    "",
+			expected: []CollectorVersion{
+				{GroupVersion: "apps/v1", Kind: "deployments"},
+				{GroupVersion: "apps/v1", Kind: "statefulsets"},
+			},
+		},
+		{
 			name: "no matches",
 			setup: func() *DiscoveryCollector {
 				return &DiscoveryCollector{


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where the Orchestrator check would create duplicate collectors for the same built-in (OOTB) Kubernetes custom resource when both \`v1\` and \`v1beta1\` of that resource are available on the cluster at the same time.

Also refactors the version-matching logic into a small helper function to make it easier to understand and test.

### Motivation

When a CRD is upgraded (e.g. EKS \`nodeclasses\` moving from \`v1beta1\` to \`v1\`), Kubernetes clusters often serve both versions at the same time during the transition. The code that picks which OOTB resources to collect was using a string prefix check — so when it was told to collect \`v1\`, it would accidentally also match \`v1beta1\` (because \`"eks.amazonaws.com/v1beta1"\` starts with \`"eks.amazonaws.com/v1"\`). This caused two collectors to run for the same resource and send duplicate data.

**Scope:** this only affects OOTB built-in CRDs (Karpenter, EKS Auto Mode). User-configured CRDs via \`crd_collectors\` are not affected as they go through a different code path that takes an exact \`group/version/resource\` string.

### Describe how you validated your changes

- Added two regression tests to \`TestDiscoveryCollector_List\` that put both \`v1\` and \`v1beta1\` entries in the cache and confirm only \`v1\` is returned.
- Added \`TestMatchesGroupVersion\` with 13 cases covering all four matching scenarios: both wildcards, version wildcard only, group wildcard only, and both specified.

\`\`\`bash
dda inv test --targets=./pkg/collector/corechecks/cluster/orchestrator/discovery/... \
    --build-include=kubeapiserver,orchestrator
\`\`\`

### Additional Notes

The wildcard behaviour (\`version=""\` = match any version in the group) is preserved — only the case where a specific version is requested is changed to use exact matching.