### PR TITLE
[procmgr] Add select() for platform-specific Bazel deps

### DIFF
--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -52,17 +52,24 @@ rust_library(
         "@crates//:anyhow",
         "@crates//:hyper-util",
         "@crates//:log",
-        "@crates//:nix",
         "@crates//:prost",
         "@crates//:serde",
         "@crates//:serde_yaml",
         "@crates//:tokio",
-        "@crates//:tokio-stream",
         "@crates//:tonic",
         "@crates//:tonic-reflection",
         "@crates//:tower",
         "@crates//:uuid",
-    ],
+    ] + select({
+        "@platforms//os:linux": [
+            "@crates//:nix",
+            "@crates//:tokio-stream",
+        ],
+        "@platforms//os:windows": [
+            "@crates//:windows-sys",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 # ============================================================================


### PR DESCRIPTION
### What does this PR do?

Moves `nix` and `tokio-stream` into a `select()` block under `@platforms//os:linux` and adds `windows-sys` under `@platforms//os:windows` in the `dd-procmgrd-lib` library target, mirroring the `cfg`-gated dependencies in `Cargo.toml`.

### Motivation

The Bazel build had all platform-specific crates listed as unconditional deps. This PR makes them conditional so the dependency graph is correct when a Windows Bazel toolchain is available. The `target_compatible_with` constraint stays Linux-only for now because the proto generation toolchain and `cpp_stdlib` linkopts are not yet platform-aware (planned for later).

### Describe how you validated your changes

- Bazel `select()` syntax reviewed against existing patterns in the repo (`pkg/util/system/BUILD.bazel`, `pkg/fleet/installer/packages/user/windows/BUILD.bazel`)
- Linux CI will validate the `@platforms//os:linux` branch of the select is resolved correctly

### Additional Notes