### PR TITLE
[CWS] fix private variable flag not propagated to variable store

### DIFF
--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -601,6 +601,7 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 					errs = appendRuleLoadError(errs, rule, fmt.Errorf("invalid type '%s' for variable '%s' (%+v): %w", reflect.TypeOf(variableValue), actionDef.Set.Name, actionDef.Set, err))
 					continue
 				}
+				variable.SetVariableOpts(opts)
 
 				if existingVariable := rs.evalOpts.VariableStore.Get(varName); existingVariable != nil && reflect.TypeOf(variable) != reflect.TypeOf(existingVariable) {
 					errs = appendRuleLoadError(errs, rule, fmt.Errorf("conflicting types for variable '%s': %s != %s", varName, reflect.TypeOf(variable), reflect.TypeOf(existingVariable)))

--- a/pkg/security/tests/variables_test.go
+++ b/pkg/security/tests/variables_test.go
@@ -9,12 +9,16 @@
 package tests
 
 import (
+	"errors"
 	"os"
 	"testing"
 
+	"github.com/avast/retry-go/v4"
+	"github.com/oliveagle/jsonpath"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestVariableAnyField(t *testing.T) {
@@ -44,4 +48,66 @@ func TestVariableAnyField(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.Remove(filename1)
+}
+
+func TestVariablePrivateField(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	ruleDefs := []*rules.RuleDefinition{{
+		ID:         "test_rule_private_variable",
+		Expression: `open.file.path == "{{.Root}}/test-private-var"`,
+		Actions: []*rules.ActionDefinition{
+			{
+				Set: &rules.SetDefinition{
+					Name:  "public_var",
+					Value: true,
+				},
+			},
+			{
+				Set: &rules.SetDefinition{
+					Name:    "private_var",
+					Value:   true,
+					Private: true,
+				},
+			},
+		},
+	}}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	var filename string
+
+	test.WaitSignalFromRule(t, func() error {
+		filename, _, err = test.Create("test-private-var")
+		return err
+	}, func(_ *model.Event, _ *rules.Rule) {}, "test_rule_private_variable")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(filename)
+
+	err = retry.Do(func() error {
+		msg := test.msgSender.getMsg("test_rule_private_variable")
+		if msg == nil {
+			return errors.New("message not found")
+		}
+
+		jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
+			if _, err := jsonpath.JsonPathLookup(obj, `$.evt.variables.public_var`); err != nil {
+				t.Errorf("public variable should be present in serialized event: %v", err)
+			}
+			if _, err := jsonpath.JsonPathLookup(obj, `$.evt.variables.private_var`); err == nil {
+				t.Errorf("private variable should not be present in serialized event")
+			}
+		})
+
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
 }


### PR DESCRIPTION
Variable opts (including the Private flag) were never applied to the variable object before it was added to the store, so the serializer could not distinguish private from public variables, causing private variable values to leak into serialized events.

Call SetVariableOpts() on the variable before storing it so that the Private flag is honored when building the event's variables context.

Add a functional test that triggers a rule with both a public and a private set action, then asserts via jsonpath that the public variable appears under $.evt.variables while the private one is absent.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
