### PR TITLE
Remove redundant build tags from platform exclusion lists

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -267,18 +267,15 @@ AGENT_TEST_TAGS = AGENT_TAGS.union({"clusterchecks"})
 ### Tag exclusion lists
 
 # List of tags to always remove when not building on Linux
-LINUX_ONLY_TAGS = {"netcgo", "systemd", "jetson", "linux_bpf", "nvml", "pcap", "podman", "trivy"}
+LINUX_ONLY_TAGS = {"netcgo", "systemd", "jetson", "linux_bpf", "nvml", "pcap", "podman", "trivy", "crio"}
 
 # List of tags to always remove when building on Windows
 WINDOWS_EXCLUDE_TAGS = {
-    "linux_bpf",
-    "nvml",
     "requirefips",
-    "crio",
 }
 
 # List of tags to always remove when building on Darwin/macOS
-DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "nvml", "cri", "crio"}
+DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "cri"}
 
 # Unit test build tags
 UNIT_TEST_TAGS = {"test"}


### PR DESCRIPTION
### What does this PR do?

Remove build tags from `WINDOWS_EXCLUDE_TAGS` and `DARWIN_EXCLUDED_TAGS` that are already covered by `LINUX_ONLY_TAGS`, and move `crio` to `LINUX_ONLY_TAGS` since CRI-O is a Linux-only container runtime.

Specifically:
- Remove `linux_bpf` and `nvml` from `WINDOWS_EXCLUDE_TAGS` (already excluded via `LINUX_ONLY_TAGS` since Windows is not Linux)
- Remove `nvml` from `DARWIN_EXCLUDED_TAGS` (same reason)
- Move `crio` from `WINDOWS_EXCLUDE_TAGS` and `DARWIN_EXCLUDED_TAGS` into `LINUX_ONLY_TAGS` (CRI-O only supports Linux; `cmd/sbomgen` already enforces `linux && crio`)

No behavior change: the effective set of tags used for each platform remains identical.

### Motivation

Reduce redundancy and make the intent of each exclusion list clearer.

### Describe how you validated your changes

No code change — the effective tag sets are unchanged. CI is sufficient.

### Additional Notes