### PR TITLE
[procmgr] Port test helpers to cross-platform support

### DIFF
--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -3,7 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+#[cfg(unix)]
 use nix::sys::signal::{self, Signal};
+#[cfg(unix)]
 use nix::unistd::Pid;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -41,40 +43,14 @@ impl DaemonHandle {
         let stdout = child.stdout.take().expect("failed to capture stdout");
         let stderr = child.stderr.take().expect("failed to capture stderr");
         let log_lines = Arc::new(Mutex::new(Vec::<String>::new()));
-        let lines_clone = Arc::clone(&log_lines);
-        let lines_clone2 = Arc::clone(&log_lines);
 
-        // simple_logger writes INFO to stdout, WARN/ERROR to stderr.
-        let reader_thread = std::thread::spawn(move || {
-            let reader = BufReader::new(stdout);
-            for line in reader.lines() {
-                match line {
-                    Ok(l) => {
-                        eprintln!("[daemon] {l}");
-                        lines_clone.lock().unwrap().push(l);
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-
-        let _stderr_thread = std::thread::spawn(move || {
-            let reader = BufReader::new(stderr);
-            for line in reader.lines() {
-                match line {
-                    Ok(l) => {
-                        eprintln!("[daemon:err] {l}");
-                        lines_clone2.lock().unwrap().push(l);
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
+        let _reader_thread = spawn_log_reader(stdout, "daemon", Arc::clone(&log_lines));
+        let _stderr_thread = spawn_log_reader(stderr, "daemon:err", Arc::clone(&log_lines));
 
         Self {
             child,
             log_lines,
-            _reader_thread: reader_thread,
+            _reader_thread,
             _stderr_thread,
         }
     }
@@ -125,15 +101,21 @@ impl DaemonHandle {
         }
     }
 
-    /// Send a signal to the daemon process.
+    /// Send a Unix signal to the daemon process.
+    #[cfg(unix)]
     pub fn send_signal(&self, sig: Signal) {
         let pid = self.child.id() as i32;
         signal::kill(Pid::from_raw(pid), sig).expect("failed to send signal to daemon");
     }
 
-    /// Send SIGTERM and wait for the daemon to exit. Returns the exit status.
+    /// Gracefully stop the daemon and wait for exit.
     pub fn stop(&mut self) -> ExitStatus {
+        #[cfg(unix)]
         self.send_signal(Signal::SIGTERM);
+        #[cfg(windows)]
+        {
+            let _ = self.child.kill();
+        }
         self.wait_with_timeout(DEFAULT_TIMEOUT)
     }
 
@@ -210,24 +192,7 @@ impl CliOutput {
 
     /// Parse "Label:  value" lines and assert the field matches.
     pub fn assert_field(&self, label: &str, expected: &str) -> &Self {
-        let needle = format!("{label}:");
-        let value = self
-            .stdout
-            .lines()
-            .find_map(|line| {
-                let trimmed = line.trim();
-                if trimmed.starts_with(&needle) {
-                    Some(trimmed[needle.len()..].trim().to_string())
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_else(|| {
-                panic!(
-                    "field '{label}' not found in output\nstdout: {}",
-                    self.stdout
-                )
-            });
+        let value = self.field_value(label);
         assert_eq!(
             value, expected,
             "field '{label}': expected '{expected}', got '{value}'",
@@ -297,15 +262,7 @@ impl CliOutput {
     /// header positions (supports multi-word headers like "LAST EXIT").
     pub fn assert_table_row(&self, row_name: &str, expected: &[(&str, &str)]) -> &Self {
         let (columns, rows) = self.parse_table();
-        let row = rows
-            .iter()
-            .find(|r| extract_column(r, 0, &columns).as_str() == row_name)
-            .unwrap_or_else(|| {
-                panic!(
-                    "row '{row_name}' not found in table\nstdout: {}",
-                    self.stdout
-                )
-            });
+        let row = self.find_table_row(row_name, &columns, &rows);
         for &(col_name, expected_val) in expected {
             let col_idx = columns
                 .iter()
@@ -334,15 +291,7 @@ impl CliOutput {
 
     pub fn pid_from_table_row(&self, row_name: &str) -> u32 {
         let (columns, rows) = self.parse_table();
-        let row = rows
-            .iter()
-            .find(|r| extract_column(r, 0, &columns).as_str() == row_name)
-            .unwrap_or_else(|| {
-                panic!(
-                    "row '{row_name}' not found in table\nstdout: {}",
-                    self.stdout
-                )
-            });
+        let row = self.find_table_row(row_name, &columns, &rows);
         let pid_idx = columns
             .iter()
             .position(|&(name, _)| name == "PID")
@@ -350,6 +299,22 @@ impl CliOutput {
         let val = extract_column(row, pid_idx, &columns);
         val.parse::<u32>()
             .unwrap_or_else(|_| panic!("PID '{val}' is not a u32 for row '{row_name}'"))
+    }
+
+    fn find_table_row<'a>(
+        &self,
+        row_name: &str,
+        columns: &[(&str, usize)],
+        rows: &[&'a str],
+    ) -> &'a str {
+        rows.iter()
+            .find(|r| extract_column(r, 0, columns).as_str() == row_name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "row '{row_name}' not found in table\nstdout: {}",
+                    self.stdout
+                )
+            })
     }
 
     fn parse_table(&self) -> (Vec<(&str, usize)>, Vec<&str>) {
@@ -520,6 +485,26 @@ impl Drop for TestEnv {
 // Free functions
 // ---------------------------------------------------------------------------
 
+fn spawn_log_reader<R: std::io::Read + Send + 'static>(
+    stream: R,
+    tag: &str,
+    lines: Arc<Mutex<Vec<String>>>,
+) -> std::thread::JoinHandle<()> {
+    let tag = tag.to_string();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stream);
+        for line in reader.lines() {
+            match line {
+                Ok(l) => {
+                    eprintln!("[{tag}] {l}");
+                    lines.lock().unwrap().push(l);
+                }
+                Err(_) => break,
+            }
+        }
+    })
+}
+
 /// Write a YAML config file into `dir` with the given process `name`.
 pub fn write_config(dir: &Path, name: &str, yaml: &str) {
     let path = dir.join(format!("{name}.yaml"));
@@ -528,8 +513,23 @@ pub fn write_config(dir: &Path, name: &str, yaml: &str) {
 }
 
 /// Check if a PID is still alive.
+#[cfg(unix)]
 pub fn pid_is_alive(pid: u32) -> bool {
     signal::kill(Pid::from_raw(pid as i32), None).is_ok()
+}
+
+#[cfg(windows)]
+pub fn pid_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return false;
+        }
+        CloseHandle(handle);
+        true
+    }
 }
 
 /// Wait until a PID is no longer alive, or timeout.

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -521,14 +521,19 @@ pub fn pid_is_alive(pid: u32) -> bool {
 #[cfg(windows)]
 pub fn pid_is_alive(pid: u32) -> bool {
     use windows_sys::Win32::Foundation::CloseHandle;
-    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    const STILL_ACTIVE: u32 = 259;
     unsafe {
         let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
         if handle.is_null() {
             return false;
         }
+        let mut exit_code: u32 = 0;
+        let ok = GetExitCodeProcess(handle, &mut exit_code);
         CloseHandle(handle);
-        true
+        ok != 0 && exit_code == STILL_ACTIVE
     }
 }
 

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -112,6 +112,9 @@ impl DaemonHandle {
     pub fn stop(&mut self) -> ExitStatus {
         #[cfg(unix)]
         self.send_signal(Signal::SIGTERM);
+        // TODO(S19): replace with GenerateConsoleCtrlEvent for graceful shutdown;
+        // child.kill() is a force-kill placeholder until the Windows platform
+        // module implements proper signal delivery.
         #[cfg(windows)]
         {
             let _ = self.child.kill();


### PR DESCRIPTION
### What does this PR do?

Makes `tests/helpers/mod.rs` cross-platform by cfg-gating Unix-specific code and adding Windows alternatives:
- `send_signal()` gated to `#[cfg(unix)]` (uses `nix::Signal`)
- `stop()` uses SIGTERM on Unix, `child.kill()` on Windows
- `pid_is_alive()` uses `kill(pid, 0)` on Unix, `OpenProcess` on Windows

Also cleans up the module:
- Extracts `spawn_log_reader()` to deduplicate reader thread closures
- Extracts `find_table_row()` to deduplicate row lookup logic
- `assert_field()` now delegates to `field_value()` instead of duplicating field extraction

### Motivation

The E2E test helpers (`DaemonHandle`, `pid_is_alive`, `TestEnv`) used Unix-only APIs directly. This PR makes them compile on both platforms, unblocking E2E test porting.

### Describe how you validated your changes

- `cargo clippy --all-targets --features test-helpers -- -D warnings`
- `cargo fmt --check`
- `cargo test --test e2e --features test-helpers`
- `cargo test --lib`

### Additional Notes