### PR TITLE
[ACTP] Derive PAR DDApiHost from site

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -187,6 +187,7 @@ func (p *PrivateActionRunner) start(ctx context.Context) error {
 	p.logger.Info("Private action runner starting")
 	p.logger.Info("==> Version : " + parversion.RunnerVersion)
 	p.logger.Info("==> Site : " + cfg.DatadogSite)
+	p.logger.Info("==> API Host : " + cfg.DDApiHost)
 	p.logger.Info("==> URN : " + cfg.Urn)
 
 	keysManager := taskverifier.NewKeyManager(p.rcClient)

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -86,7 +86,7 @@ func FromDDConfig(config config.Component) (*Config, error) {
 		AllowIMDSEndpoint:         config.GetBool(setup.PARHttpAllowImdsEndpoint),
 		RShellAllowedPaths:        config.GetStringSlice(setup.PARRestrictedShellAllowedPaths),
 		DDHost:                    ddHost,
-		DDApiHost:                 ddHost,
+		DDApiHost:                 "api." + ddSite,
 		Modes:                     []modes.Mode{modes.ModePull},
 		OrgId:                     orgID,
 		PrivateKey:                privateKey,

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -224,8 +224,8 @@ func TestFromDDConfig(t *testing.T) {
 			assert.Equal(t, tt.expectedDDHost, cfg.DDHost, "DDHost mismatch")
 			assert.Equal(t, tt.expectedDDSite, cfg.DatadogSite, "DatadogSite mismatch")
 
-			// Verify DDApiHost is also set to the same value as DDHost
-			assert.Equal(t, tt.expectedDDHost, cfg.DDApiHost, "DDApiHost should match DDHost")
+			// Verify DDApiHost is derived from site, not from dd_url
+			assert.Equal(t, "api."+tt.expectedDDSite, cfg.DDApiHost, "DDApiHost should be api.<site>")
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

`DDApiHost` in the PAR config is now always `api.<site>` (derived from the configured `site`), rather than being extracted from the global `dd_url` endpoint URL.

### Motivation

Enrollment and connections already construct their base URL as `"https://api." + ddSite` inline. `DDApiHost` was derived differently — via `getDatadogHost(GetMainEndpoint(..., "dd_url"))` — which strips the scheme from whatever `dd_url` is set to. This made the field inconsistent with how the rest of PAR builds its API URLs. Unifying on `"api." + ddSite` makes the source of truth consistent and surfaces the value clearly in startup logs.

### Describe how you validated your changes

- `TestFromDDConfig` updated to assert `DDApiHost == "api.<site>"` for all site variants (US, EU, Gov, dd_url override).
- `go build ./pkg/privateactionrunner/... ./comp/privateactionrunner/...` passes clean.

### Additional Notes

`DDHost` (used only in tests) is unchanged and still derived from `dd_url` via `getDatadogHost`.