### PR TITLE
[AGTHEAL-128] feat(agenttelemetry): export agent error logs to COAT (POC)

### DIFF
--- a/comp/core/agenttelemetry/impl/agenttelemetry.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry.go
@@ -485,7 +485,11 @@ func (a *atel) reportAgentLogs(session *senderSession, p *Profile) {
 		return
 	}
 
-	captured := a.logComp.DrainErrorLogs()
+	drainer, ok := a.logComp.(log.LogDrainer)
+	if !ok {
+		return
+	}
+	captured := drainer.DrainErrorLogs()
 	if len(captured) == 0 {
 		return
 	}

--- a/comp/core/agenttelemetry/impl/agenttelemetry.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry.go
@@ -477,6 +477,64 @@ func (a *atel) reportAgentMetrics(session *senderSession, pms []*telemetry.Metri
 	a.sender.sendAgentMetricPayloads(session, metrics)
 }
 
+// reportAgentLogs drains the error/critical log buffer, deduplicates entries by
+// (level + message), enriches with global metadata, and queues them for sending.
+// Enrichment with hostname/OS/version is handled by the sender (via AgentLogsPayload.Metadata).
+func (a *atel) reportAgentLogs(session *senderSession, p *Profile) {
+	if p.Logs == nil || !p.Logs.Enabled {
+		return
+	}
+
+	captured := a.logComp.DrainErrorLogs()
+	if len(captured) == 0 {
+		return
+	}
+
+	a.logComp.Debugf("Collect Agent Log telemetry for profile %s (%d entries)", p.Name, len(captured))
+
+	// Deduplicate by (level + message); preserve first-seen order.
+	type dedupKey struct{ level, message string }
+	type dedupEntry struct {
+		payload LogPayload
+		count   int
+	}
+	seen := make(map[dedupKey]*dedupEntry, len(captured))
+	order := make([]dedupKey, 0, len(captured))
+
+	for _, cl := range captured {
+		k := dedupKey{cl.Level, cl.Message}
+		if e, ok := seen[k]; ok {
+			e.count++
+		} else {
+			attrs := make(map[string]string, len(cl.Attrs))
+			for ak, av := range cl.Attrs {
+				attrs[ak] = av
+			}
+			seen[k] = &dedupEntry{
+				payload: LogPayload{
+					Level:       cl.Level,
+					Message:     cl.Message,
+					TimestampMs: cl.Timestamp.UnixMilli(),
+					Attrs:       attrs,
+				},
+				count: 1,
+			}
+			order = append(order, k)
+		}
+	}
+
+	logs := make([]LogPayload, 0, len(order))
+	for _, k := range order {
+		e := seen[k]
+		if e.count > 1 {
+			e.payload.Attrs["count"] = strconv.Itoa(e.count)
+		}
+		logs = append(logs, e.payload)
+	}
+
+	a.sender.sendAgentLogPayloads(session, logs)
+}
+
 func (a *atel) loadPayloads(profiles []*Profile) (*senderSession, error) {
 	// Gather all prom metrics. Currently Gather() does not allow filtering by
 	// metric name, so we need to gather all metrics and filter them on our own.
@@ -504,6 +562,7 @@ func (a *atel) loadPayloads(profiles []*Profile) (*senderSession, error) {
 	session := a.sender.startSession(a.cancelCtx)
 	for _, p := range profiles {
 		a.reportAgentMetrics(session, pms, p)
+		a.reportAgentLogs(session, p)
 	}
 	return session, nil
 }

--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -64,6 +64,8 @@ func (s *senderMock) flushSession(_ *senderSession) error {
 func (s *senderMock) sendAgentMetricPayloads(_ *senderSession, metrics []*agentmetric) {
 	s.sentMetrics = append(s.sentMetrics, metrics...)
 }
+func (s *senderMock) sendAgentLogPayloads(_ *senderSession, _ []LogPayload) {
+}
 func (s *senderMock) sendEventPayload(_ *senderSession, _ *Event, _ map[string]interface{}) {
 }
 

--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -271,6 +271,8 @@ var defaultProfiles = `
           aggregate_tags:
             - code
             - endpoint
+    logs:
+      enabled: true
     schedule:
       start_after: 30
       iterations: 0

--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -37,6 +37,7 @@ type Profile struct {
 	// parsed
 	Name     string             `yaml:"name"`
 	Metric   *AgentMetricConfig `yaml:"metric,omitempty"`
+	Logs     *AgentLogConfig    `yaml:"logs,omitempty"`
 	Schedule *Schedule          `yaml:"schedule,omitempty"`
 	Events   []*Event           `yaml:"events"`
 
@@ -44,6 +45,12 @@ type Profile struct {
 	metricsMap        map[string]*MetricConfig
 	excludeZeroMetric bool
 	excludeTagsMap    map[string]any
+}
+
+// AgentLogConfig specifies whether agent error/critical logs should be collected
+// and exported to COAT as part of this profile's schedule.
+type AgentLogConfig struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 // AgentMetricConfig specifies agent telemetry metrics payloads to be generated and emitted

--- a/comp/core/agenttelemetry/impl/sender.go
+++ b/comp/core/agenttelemetry/impl/sender.go
@@ -39,6 +39,7 @@ const (
 	telemetryPath                   = "/api/v2/apmtelemetry"
 
 	metricPayloadType = "agent-metrics"
+	logPayloadType    = "agent-logs"
 	batchPayloadType  = "message-batch"
 
 	httpClientResetInterval = 5 * time.Minute
@@ -52,6 +53,7 @@ type sender interface {
 	flushSession(ss *senderSession) error
 
 	sendAgentMetricPayloads(ss *senderSession, metrics []*agentmetric)
+	sendAgentLogPayloads(ss *senderSession, logs []LogPayload)
 	sendEventPayload(ss *senderSession, eventInfo *Event, eventPayload map[string]interface{})
 }
 
@@ -122,6 +124,9 @@ type senderSession struct {
 	// metric payloads
 	metricPayloads []*AgentMetricsPayload
 
+	// log payload
+	logPayload *AgentLogsPayload
+
 	// event payload
 	eventInfo    *Event
 	eventPayload map[string]interface{}
@@ -141,6 +146,27 @@ type BatchPayloadWrapper struct {
 type AgentMetricsPayload struct {
 	Message string                 `json:"message"`
 	Metrics map[string]interface{} `json:"metrics"`
+}
+
+// -------------------
+// AGENT LOGS
+//
+
+// AgentLogsPayload is the top-level payload for a batch of internal agent error logs.
+type AgentLogsPayload struct {
+	Message  string               `json:"message"`
+	Metadata AgentMetadataPayload `json:"agent_metadata"`
+	Logs     []LogPayload         `json:"logs"`
+}
+
+// LogPayload is a single captured log entry. Attrs contains both the engineer-defined
+// slog attributes and a "count" field when deduplication collapsed multiple identical
+// (level + message) records within the collection window.
+type LogPayload struct {
+	Level       string            `json:"level"`
+	Message     string            `json:"message"`
+	TimestampMs int64             `json:"timestamp_ms"`
+	Attrs       map[string]string `json:"attrs,omitempty"`
 }
 
 // MetricPayload defines Metric object
@@ -348,6 +374,9 @@ func (s *senderImpl) startSession(cancelCtx context.Context) *senderSession {
 
 func (ss *senderSession) payloadCount() int {
 	payloadCount := len(ss.metricPayloads)
+	if ss.logPayload != nil {
+		payloadCount++
+	}
 	if ss.eventPayload != nil {
 		payloadCount++
 	}
@@ -358,6 +387,7 @@ func (ss *senderSession) flush() Payload {
 	defer func() {
 		// Clear payloads when done
 		ss.metricPayloads = nil
+		ss.logPayload = nil
 		ss.eventInfo = nil
 		ss.eventPayload = nil
 	}()
@@ -375,12 +405,15 @@ func (ss *senderSession) flush() Payload {
 	}
 
 	if ss.payloadCount() == 1 {
-		// Either metric or event payload (single payload will be sent directly using the request type of the payload)
-		if len(ss.metricPayloads) == 1 {
-			mp := ss.metricPayloads[0]
+		// Single payload: send directly with its own request type
+		switch {
+		case len(ss.metricPayloads) == 1:
 			payload.RequestType = metricPayloadType
-			payload.Payload = mp
-		} else {
+			payload.Payload = ss.metricPayloads[0]
+		case ss.logPayload != nil:
+			payload.RequestType = logPayloadType
+			payload.Payload = ss.logPayload
+		default:
 			payload.RequestType = ss.eventInfo.RequestType
 			payload.Payload = eventWrapPayload
 		}
@@ -392,6 +425,14 @@ func (ss *senderSession) flush() Payload {
 				BatchPayloadWrapper{
 					RequestType: metricPayloadType,
 					Payload:     payloadInfo{metricPayloadType, mp}.payload,
+				})
+		}
+		// add log payload if present
+		if ss.logPayload != nil {
+			batch = append(batch,
+				BatchPayloadWrapper{
+					RequestType: logPayloadType,
+					Payload:     payloadInfo{logPayloadType, ss.logPayload}.payload,
 				})
 		}
 		// add event payload if present
@@ -500,6 +541,17 @@ func (s *senderImpl) sendAgentMetricPayloads(ss *senderSession, metrics []*agent
 			payload = ss.metricPayloads[idx]
 			s.addMetricPayload(am.name, am.family, m, payload)
 		}
+	}
+}
+
+func (s *senderImpl) sendAgentLogPayloads(ss *senderSession, logs []LogPayload) {
+	if len(logs) == 0 {
+		return
+	}
+	ss.logPayload = &AgentLogsPayload{
+		Message:  "Agent logs",
+		Metadata: s.metadataPayloadTemplate,
+		Logs:     logs,
 	}
 }
 

--- a/comp/core/log/def/component.go
+++ b/comp/core/log/def/component.go
@@ -67,9 +67,13 @@ type Component interface {
 
 	// Flush will flush the contents of the logs to the sinks
 	Flush()
+}
 
+// LogDrainer is an optional extension of Component implemented by log components
+// that support buffering Error/Critical entries for export (e.g. to COAT).
+// Callers should type-assert Component to LogDrainer before calling DrainErrorLogs.
+type LogDrainer interface {
 	// DrainErrorLogs returns and clears all Error/Critical log entries buffered
-	// since the last call. Intended for use by agenttelemetry to export internal
-	// agent error logs to COAT. Returns nil if no entries were captured.
+	// since the last call. Returns nil if no entries were captured.
 	DrainErrorLogs() []CapturedLog
 }

--- a/comp/core/log/def/component.go
+++ b/comp/core/log/def/component.go
@@ -14,7 +14,18 @@
 // logging output to `t.Log(..)`, for ease of investigation when a test fails.
 package log
 
+import "time"
+
 // team: agent-runtimes
+
+// CapturedLog holds a single Error or Critical log entry buffered for export to COAT.
+type CapturedLog struct {
+	Level     string
+	Message   string
+	Timestamp time.Time
+	// Attrs contains attributes attached by the emitting code via slog structured logging.
+	Attrs map[string]string
+}
 
 // Component is the component type.
 type Component interface {
@@ -56,4 +67,9 @@ type Component interface {
 
 	// Flush will flush the contents of the logs to the sinks
 	Flush()
+
+	// DrainErrorLogs returns and clears all Error/Critical log entries buffered
+	// since the last call. Intended for use by agenttelemetry to export internal
+	// agent error logs to COAT. Returns nil if no entries were captured.
+	DrainErrorLogs() []CapturedLog
 }

--- a/comp/core/log/impl-systemprobe/systemprobe_logger.go
+++ b/comp/core/log/impl-systemprobe/systemprobe_logger.go
@@ -17,6 +17,27 @@ import (
 	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
 )
 
+type logComponent struct {
+	*pkglog.Wrapper
+}
+
+func (l *logComponent) DrainErrorLogs() []logdef.CapturedLog {
+	raw := pkglog.DrainCapturedLogs()
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]logdef.CapturedLog, len(raw))
+	for i, cl := range raw {
+		out[i] = logdef.CapturedLog{
+			Level:     cl.Level,
+			Message:   cl.Message,
+			Timestamp: cl.Timestamp,
+			Attrs:     cl.Attrs,
+		}
+	}
+	return out
+}
+
 // Requires declares the input types to the logger component constructor
 type Requires struct {
 	Lc     compdef.Lifecycle
@@ -48,7 +69,7 @@ func NewComponent(deps Requires) (Provides, error) {
 		return Provides{}, err
 	}
 
-	l := pkglog.NewWrapper(2)
+	l := &logComponent{pkglog.NewWrapper(2)}
 	deps.Lc.Append(compdef.Hook{OnStop: func(context.Context) error {
 		l.Flush()
 		return nil

--- a/comp/core/log/impl-trace/trace_logger.go
+++ b/comp/core/log/impl-trace/trace_logger.go
@@ -19,6 +19,27 @@ import (
 	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
 )
 
+type logComponent struct {
+	*pkglog.Wrapper
+}
+
+func (l *logComponent) DrainErrorLogs() []logdef.CapturedLog {
+	raw := pkglog.DrainCapturedLogs()
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]logdef.CapturedLog, len(raw))
+	for i, cl := range raw {
+		out[i] = logdef.CapturedLog{
+			Level:     cl.Level,
+			Message:   cl.Message,
+			Timestamp: cl.Timestamp,
+			Attrs:     cl.Attrs,
+		}
+	}
+	return out
+}
+
 // Requires declares the input types to the logger component constructor
 type Requires struct {
 	Lc     compdef.Lifecycle
@@ -50,8 +71,9 @@ func NewComponent(deps Requires) (Provides, error) {
 		return Provides{}, fmt.Errorf("Cannot create logger: %v", err)
 	}
 
-	l := pkglog.NewWrapper(3)
-	tracelog.SetLogger(l)
+	w := pkglog.NewWrapper(3)
+	tracelog.SetLogger(w)
+	l := &logComponent{w}
 	deps.Lc.Append(compdef.Hook{OnStop: func(context.Context) error {
 		l.Flush()
 		return nil

--- a/comp/core/log/impl/logger.go
+++ b/comp/core/log/impl/logger.go
@@ -17,6 +17,31 @@ import (
 	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
 )
 
+// logComponent wraps *pkglog.Wrapper and adds DrainErrorLogs, which requires
+// converting between handlers.CapturedLog and logdef.CapturedLog. This conversion
+// lives here because comp/core/log/impl already imports both packages; putting it
+// in pkg/util/log would invert the dependency direction.
+type logComponent struct {
+	*pkglog.Wrapper
+}
+
+func (l *logComponent) DrainErrorLogs() []logdef.CapturedLog {
+	raw := pkglog.DrainCapturedLogs()
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]logdef.CapturedLog, len(raw))
+	for i, cl := range raw {
+		out[i] = logdef.CapturedLog{
+			Level:     cl.Level,
+			Message:   cl.Message,
+			Timestamp: cl.Timestamp,
+			Attrs:     cl.Attrs,
+		}
+	}
+	return out
+}
+
 // NewTemporaryLoggerWithoutInit returns a logger component instance. It assumes the logger has already been
 // initialized beforehand.
 //
@@ -30,7 +55,7 @@ import (
 // - When the instance of logger.Component is reachable in less than 5 stack frames.
 // - It doesn't make the migration to log.Component easier.
 func NewTemporaryLoggerWithoutInit() logdef.Component {
-	return pkglog.NewWrapper(2)
+	return &logComponent{pkglog.NewWrapper(2)}
 }
 
 // Requires declares the input types to the logger component constructor
@@ -64,7 +89,7 @@ func NewComponent(deps Requires) (Provides, error) {
 		return Provides{}, err
 	}
 
-	l := pkglog.NewWrapper(2)
+	l := &logComponent{pkglog.NewWrapper(2)}
 	deps.Lc.Append(compdef.Hook{OnStop: func(context.Context) error {
 		l.Flush()
 		return nil

--- a/comp/core/log/mock/mock.go
+++ b/comp/core/log/mock/mock.go
@@ -15,6 +15,28 @@ import (
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// mockComponent wraps *pkglog.Wrapper and satisfies log.Component including DrainErrorLogs.
+type mockComponent struct {
+	*pkglog.Wrapper
+}
+
+func (m *mockComponent) DrainErrorLogs() []log.CapturedLog {
+	raw := pkglog.DrainCapturedLogs()
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]log.CapturedLog, len(raw))
+	for i, cl := range raw {
+		out[i] = log.CapturedLog{
+			Level:     cl.Level,
+			Message:   cl.Message,
+			Timestamp: cl.Timestamp,
+			Attrs:     cl.Attrs,
+		}
+	}
+	return out
+}
+
 // tbWriter is an implementation of io.Writer that sends lines to
 // testing.TB#Log.
 type tbWriter struct {
@@ -46,5 +68,5 @@ func New(t testing.TB) log.Component {
 	// install the logger into pkg/util/log
 	pkglog.SetupLogger(iface, pkglog.DebugStr)
 
-	return pkglog.NewWrapper(2)
+	return &mockComponent{pkglog.NewWrapper(2)}
 }

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "log",
     srcs = [
+        "capture.go",
         "klog_redirect.go",
         "levels.go",
         "log.go",
@@ -18,6 +19,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/log/slog",
+        "//pkg/util/log/slog/handlers",
         "//pkg/util/log/types",
         "//pkg/util/scrubber",
         "@org_golang_x_time//rate",

--- a/pkg/util/log/capture.go
+++ b/pkg/util/log/capture.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package log
+
+import "github.com/DataDog/datadog-agent/pkg/util/log/slog/handlers"
+
+// globalCapture is the capture handler registered during logger setup.
+// It is accessed by the log component's DrainErrorLogs() method.
+var globalCapture *handlers.Capture
+
+// RegisterCaptureHandler stores the capture handler so that DrainCapturedLogs
+// can be called later. Called once during SetupLogger.
+func RegisterCaptureHandler(h *handlers.Capture) {
+	globalCapture = h
+}
+
+// DrainCapturedLogs returns and clears all buffered Error/Critical log entries
+// since the last call. Returns nil if no capture handler has been registered.
+func DrainCapturedLogs() []handlers.CapturedLog {
+	if globalCapture == nil {
+		return nil
+	}
+	return globalCapture.Drain()
+}

--- a/pkg/util/log/setup/internal/seelog/seelog_config.go
+++ b/pkg/util/log/setup/internal/seelog/seelog_config.go
@@ -112,6 +112,12 @@ func (c *Config) SlogLogger() (types.LoggerInterface, *stdslog.LevelVar, error) 
 	levelVar.Set(types.ToSlogLevel(lvl))
 	levelHandler := handlers.NewLevel(levelVar, asyncHandler)
 
+	// capture handler sits above the level handler so that Error/Critical records
+	// are buffered regardless of the configured output log level.
+	const captureBufSize = 1000
+	captureHandler := handlers.NewCapture(levelHandler, captureBufSize)
+	log.RegisterCaptureHandler(captureHandler)
+
 	// Close async handler first so it drains and stops writing, then close writers.
 	// Otherwise the async goroutine can still call Write() while the file writer is closed (data race).
 	closeFunc := func() {
@@ -121,7 +127,7 @@ func (c *Config) SlogLogger() (types.LoggerInterface, *stdslog.LevelVar, error) 
 		}
 	}
 
-	logger := slog.NewWrapperWithCloseAndFlush(levelHandler, asyncHandler.Flush, closeFunc)
+	logger := slog.NewWrapperWithCloseAndFlush(captureHandler, asyncHandler.Flush, closeFunc)
 
 	return logger, levelVar, nil
 }

--- a/pkg/util/log/slog/handlers/BUILD.bazel
+++ b/pkg/util/log/slog/handlers/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "handlers",
     srcs = [
         "async.go",
+        "capture.go",
         "disabled.go",
         "docs.go",
         "format.go",

--- a/pkg/util/log/slog/handlers/capture.go
+++ b/pkg/util/log/slog/handlers/capture.go
@@ -1,0 +1,136 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// CapturedLog holds a single intercepted log entry.
+type CapturedLog struct {
+	Level     string
+	Message   string
+	Timestamp time.Time
+	// Attrs contains attributes attached to the log record by the emitting code,
+	// plus any attributes accumulated via WithAttrs on this handler.
+	Attrs map[string]string
+}
+
+// captureSharedState is the shared mutable buffer across all Capture handlers
+// derived from the same root via WithAttrs/WithGroup. This ensures Drain() sees
+// all captured records regardless of which derived handler emitted them.
+type captureSharedState struct {
+	mu      sync.Mutex
+	buf     []CapturedLog
+	maxSize int
+}
+
+func (s *captureSharedState) add(entry CapturedLog) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.buf) >= s.maxSize {
+		s.buf = s.buf[1:] // drop oldest when full
+	}
+	s.buf = append(s.buf, entry)
+}
+
+func (s *captureSharedState) drain() []CapturedLog {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.buf
+	s.buf = nil
+	return out
+}
+
+// Capture is a slog.Handler that intercepts Error and Critical log records into a
+// bounded ring buffer without affecting normal log output. It wraps an inner
+// handler to which all records are still forwarded normally.
+//
+// Multiple Capture handlers derived via WithAttrs/WithGroup share the same buffer,
+// so a single Drain() call from agenttelemetry sees all captured records.
+type Capture struct {
+	*captureSharedState
+	inner    slog.Handler
+	preAttrs map[string]string // attrs accumulated via WithAttrs, injected into each captured entry
+}
+
+// NewCapture creates a Capture handler wrapping inner. maxSize is the ring buffer
+// capacity; when full the oldest entry is dropped.
+func NewCapture(inner slog.Handler, maxSize int) *Capture {
+	return &Capture{
+		captureSharedState: &captureSharedState{maxSize: maxSize},
+		inner:              inner,
+		preAttrs:           map[string]string{},
+	}
+}
+
+// Enabled always returns true so that Error/Critical records reach Handle regardless
+// of the configured output level. The inner handler applies its own level gating.
+func (h *Capture) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+// Handle intercepts records at Error level or above into the ring buffer, then
+// forwards the record to the inner handler.
+func (h *Capture) Handle(ctx context.Context, r slog.Record) error {
+	if r.Level >= slog.LevelError {
+		entry := CapturedLog{
+			Level:     r.Level.String(),
+			Message:   r.Message,
+			Timestamp: r.Time,
+			Attrs:     make(map[string]string, len(h.preAttrs)),
+		}
+		for k, v := range h.preAttrs {
+			entry.Attrs[k] = v
+		}
+		r.Attrs(func(a slog.Attr) bool {
+			entry.Attrs[a.Key] = a.Value.String()
+			return true
+		})
+		h.add(entry)
+	}
+	if h.inner.Enabled(ctx, r.Level) {
+		return h.inner.Handle(ctx, r)
+	}
+	return nil
+}
+
+// WithAttrs returns a derived Capture handler that shares the same ring buffer
+// and enriches every captured entry with the given attributes.
+func (h *Capture) WithAttrs(attrs []slog.Attr) slog.Handler {
+	newPreAttrs := make(map[string]string, len(h.preAttrs)+len(attrs))
+	for k, v := range h.preAttrs {
+		newPreAttrs[k] = v
+	}
+	for _, a := range attrs {
+		newPreAttrs[a.Key] = a.Value.String()
+	}
+	return &Capture{
+		captureSharedState: h.captureSharedState,
+		inner:              h.inner.WithAttrs(attrs),
+		preAttrs:           newPreAttrs,
+	}
+}
+
+// WithGroup returns a derived Capture handler that shares the same ring buffer.
+// Group namespacing is delegated to the inner handler; the capture side does not
+// prefix attrs with the group name (POC simplification).
+func (h *Capture) WithGroup(name string) slog.Handler {
+	return &Capture{
+		captureSharedState: h.captureSharedState,
+		inner:              h.inner.WithGroup(name),
+		preAttrs:           h.preAttrs,
+	}
+}
+
+// Drain removes and returns all buffered log entries since the last call.
+// It is safe to call concurrently with Handle.
+func (h *Capture) Drain() []CapturedLog {
+	return h.drain()
+}


### PR DESCRIPTION
### What does this PR do?

POC implementation for exporting internal agent Error/Critical logs to COAT via the `agenttelemetry` component, mirroring how metrics are already exported.

**RFC:** https://datadoghq.atlassian.net/wiki/spaces/AGTH/pages/6528631920/Export+Error+logs+to+COAT

### Architecture

```
agent log call  →  slog handler chain  →  [CaptureHandler]  →  file/stdout (unchanged)
                                                  ↓
                                         bounded ring buffer (1000 entries, thread-safe)
                                                  ↓  DrainErrorLogs() on schedule
                                         agenttelemetry drains + deduplicates
                                                  ↓  enriches with global metadata
                                         AgentLogsPayload  →  COAT
```

### Changes

| Package | Change |
|---|---|
| `pkg/util/log/slog/handlers` | New `CaptureHandler`: wraps inner handler, intercepts Error/Critical into shared ring buffer, supports `WithAttrs`/`WithGroup` via shared state pointer |
| `pkg/util/log` | `RegisterCaptureHandler` / `DrainCapturedLogs` package-level singleton |
| `pkg/util/log/setup/internal/seelog` | Insert `CaptureHandler` **above** the level handler so Error/Critical are captured regardless of configured output log level |
| `comp/core/log/def` | New `CapturedLog` type + `DrainErrorLogs() []CapturedLog` on `Component` interface |
| `comp/core/log/impl*` | `logComponent` struct wrapping `*pkglog.Wrapper`, implements `DrainErrorLogs()` with handler→def type conversion (keeps import direction correct) |
| `comp/core/agenttelemetry/impl` | New `AgentLogsPayload`/`LogPayload` types; `sendAgentLogPayloads()` sender method; `reportAgentLogs()` with dedup by (level+message); `AgentLogConfig` profile config section |

### Key design decisions

- **No component allowlist**: engineers define context via slog attrs at the call site; agenttelemetry adds global attrs (hostname, OS, agent version) at send time
- **Deduplication**: identical (level + message) pairs within a collection window collapsed into one entry with a `count` attr
- **Ring buffer**: bounded at 1000 entries; oldest dropped when full to cap memory
- **Scrubbing**: handled by the existing `scrubber.ScrubJSON` call in `flushSession`, no extra code needed

### Known POC limitations / open questions

- `request_type` for logs (`"agent-logs"`) not yet confirmed with COAT/APM intake team
- `WithGroup` in CaptureHandler does not prefix captured attrs with group name (simplification)
- `logComponent` struct is duplicated across `impl`, `impl-systemprobe`, `impl-trace` — could be extracted to a shared helper if needed

### Describe how you validated your changes

- `go build ./comp/core/log/... ./pkg/util/log/... ./comp/core/agenttelemetry/impl` — clean
- `go test -tags test ./comp/core/agenttelemetry/impl ./comp/core/log/... ./pkg/util/log/slog/handlers/...` — all pass

### Additional Notes

Depends on COAT team confirming the `request_type` string for log payloads before this can be wired to a real intake.