### PR TITLE
trace/semantics: migrate hardcoded span attribute key reads to semantics library

### DIFF
--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -28,16 +28,12 @@ const (
 	// tagOrigin specifies the origin of the trace.
 	// DEPRECATED: Origin is now specified as a TraceChunk field.
 	tagOrigin = "_dd.origin"
-	// tagSamplingPriority specifies the sampling priority of the trace.
-	// DEPRECATED: Priority is now specified as a TraceChunk field.
-	tagSamplingPriority = "_sampling_priority_v1"
 )
 
 var (
 	// Year2000NanosecTS is an arbitrary cutoff to spot weird-looking values
 	Year2000NanosecTS = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC).UnixNano()
-	// normalizerRegistry is the semantic registry used for tag lookups in span normalization.
-	normalizerRegistry = semantics.DefaultRegistry()
+	registry          = semantics.DefaultRegistry()
 )
 
 // normalizeService handles service normalization for both pb.Span and idx.InternalSpan
@@ -235,15 +231,15 @@ func (a *Agent) normalize(ts *info.TagStats, s *pb.Span) error {
 	s.Service = svc
 
 	spanAccessor := semantics.NewDDSpanAccessor(s.Meta, s.Metrics)
-	if pSvc := semantics.LookupString(normalizerRegistry, spanAccessor, semantics.ConceptPeerService); pSvc != "" {
+	if pSvc := semantics.LookupString(registry, spanAccessor, semantics.ConceptPeerService); pSvc != "" {
 		s.Meta[string(semantics.ConceptPeerService)] = a.normalizePeerService(ts, pSvc)
 	}
-	if bSvc := semantics.LookupString(normalizerRegistry, spanAccessor, semantics.ConceptDDBaseService); bSvc != "" {
+	if bSvc := semantics.LookupString(registry, spanAccessor, semantics.ConceptDDBaseService); bSvc != "" {
 		s.Meta[string(semantics.ConceptDDBaseService)] = a.normalizeBaseService(ts, bSvc)
 	}
 
 	if a.conf.HasFeature("component2name") {
-		if v := semantics.LookupString(normalizerRegistry, spanAccessor, semantics.ConceptComponent); v != "" {
+		if v := semantics.LookupString(registry, spanAccessor, semantics.ConceptComponent); v != "" {
 			s.Name = v
 		}
 	}
@@ -266,7 +262,7 @@ func (a *Agent) normalize(ts *info.TagStats, s *pb.Span) error {
 
 	s.Type = a.validateAndFixType(ts, s.Type)
 
-	if env, ok := s.Meta["env"]; ok {
+	if env := semantics.LookupString(registry, spanAccessor, semantics.ConceptDDEnv); env != "" {
 		s.Meta["env"] = normalizeutil.NormalizeTagValue(env)
 	}
 
@@ -296,10 +292,10 @@ func (a *Agent) normalizeV1(ts *info.TagStats, s *idx.InternalSpan) error {
 	s.SetService(svc)
 
 	spanAccessorV1 := semantics.NewDDSpanAccessorV1(s)
-	if pSvc := semantics.LookupString(normalizerRegistry, spanAccessorV1, semantics.ConceptPeerService); pSvc != "" {
+	if pSvc := semantics.LookupString(registry, spanAccessorV1, semantics.ConceptPeerService); pSvc != "" {
 		s.SetStringAttribute(string(semantics.ConceptPeerService), a.normalizePeerService(ts, pSvc))
 	}
-	if bSvc := semantics.LookupString(normalizerRegistry, spanAccessorV1, semantics.ConceptDDBaseService); bSvc != "" {
+	if bSvc := semantics.LookupString(registry, spanAccessorV1, semantics.ConceptDDBaseService); bSvc != "" {
 		s.SetStringAttribute(string(semantics.ConceptDDBaseService), a.normalizeBaseService(ts, bSvc))
 	}
 
@@ -356,11 +352,11 @@ func setChunkAttributes(chunk *pb.TraceChunk, root *pb.Span) {
 	// check if priority is already populated
 	if chunk.Priority == int32(sampler.PriorityNone) {
 		// Older tracers set sampling priority in the root span.
-		if p, ok := root.Metrics[tagSamplingPriority]; ok {
+		if p, ok := semantics.LookupFloat64(registry, semantics.NewMetricsMapAccessor(root.Metrics), semantics.ConceptSamplingPriority); ok {
 			chunk.Priority = int32(p)
 		} else {
 			for _, s := range chunk.Spans {
-				if p, ok := s.Metrics[tagSamplingPriority]; ok {
+				if p, ok := semantics.LookupFloat64(registry, semantics.NewMetricsMapAccessor(s.Metrics), semantics.ConceptSamplingPriority); ok {
 					chunk.Priority = int32(p)
 					break
 				}
@@ -369,7 +365,7 @@ func setChunkAttributes(chunk *pb.TraceChunk, root *pb.Span) {
 	}
 	if chunk.Origin == "" && root.Meta != nil {
 		// Older tracers set origin in the root span.
-		chunk.Origin = root.Meta[tagOrigin]
+		chunk.Origin = semantics.LookupString(registry, semantics.NewStringMapAccessor(root.Meta), semantics.ConceptDDOrigin)
 	}
 
 	if _, ok := chunk.Tags[tagDecisionMaker]; !ok {

--- a/pkg/trace/api/converter.go
+++ b/pkg/trace/api/converter.go
@@ -14,7 +14,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
+	"github.com/DataDog/datadog-agent/pkg/trace/semantics"
 )
+
+var registry = semantics.DefaultRegistry()
 
 // isPromotedTag returns true if the key is a promoted tag that should be set as a field instead of an attribute
 func isPromotedTag(key string) bool {
@@ -53,12 +56,12 @@ func ConvertToIdx(payload *pb.TracerPayload, originPayloadVersion string) *idx.I
 					},
 				}
 			}
+			if p, ok := semantics.LookupFloat64(registry, semantics.NewMetricsMapAccessor(span.Metrics), semantics.ConceptSamplingPriority); ok {
+				spanConvertedFields.SamplingPriority = int32(p)
+			}
 			for k, v := range span.Metrics {
 				if isPromotedTag(k) {
 					continue
-				}
-				if k == "_sampling_priority_v1" {
-					spanConvertedFields.SamplingPriority = int32(v)
 				}
 				spanAttrs[stringTable.Add(k)] = &idx.AnyValue{
 					Value: &idx.AnyValue_DoubleValue{
@@ -100,27 +103,27 @@ func ConvertToIdx(payload *pb.TracerPayload, originPayloadVersion string) *idx.I
 
 			// Each span gets its own env/version based on its meta, but we also promote
 			// the first occurrence to chunk/payload level via spanConvertedFields
+			metaAccessor := semantics.NewStringMapAccessor(span.Meta)
 			var spanEnvRef, spanVersionRef uint32
-			if env, ok := span.Meta["env"]; ok && env != "" {
+			if env := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDEnv); env != "" {
 				spanEnvRef = stringTable.Add(env)
 				if spanConvertedFields.EnvRef == 0 {
 					spanConvertedFields.EnvRef = spanEnvRef
 				}
 			}
-			if spanHost, ok := span.Meta["_dd.hostname"]; ok && spanConvertedFields.HostnameRef == 0 {
+			if spanHost := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDHostname); spanHost != "" && spanConvertedFields.HostnameRef == 0 {
 				spanConvertedFields.HostnameRef = stringTable.Add(spanHost)
 			}
-			if spanVersion, ok := span.Meta["version"]; ok && spanVersion != "" {
+			if spanVersion := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDVersion); spanVersion != "" {
 				spanVersionRef = stringTable.Add(spanVersion)
 				if spanConvertedFields.AppVersionRef == 0 {
 					spanConvertedFields.AppVersionRef = spanVersionRef
 				}
 			}
-			if spanGitCommitSha, ok := span.Meta["_dd.git.commit.sha"]; ok && spanConvertedFields.GitCommitShaRef == 0 {
-
+			if spanGitCommitSha := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDGitCommitSHA); spanGitCommitSha != "" && spanConvertedFields.GitCommitShaRef == 0 {
 				spanConvertedFields.GitCommitShaRef = stringTable.Add(spanGitCommitSha)
 			}
-			if spanDecisionMaker, ok := span.Meta["_dd.p.dm"]; ok && spanConvertedFields.SamplingMechanism == 0 {
+			if spanDecisionMaker := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDDecisionMaker); spanDecisionMaker != "" && spanConvertedFields.SamplingMechanism == 0 {
 				spanDecisionMaker, _ = strings.CutPrefix(spanDecisionMaker, "-")
 				samplingMechanism, err := strconv.ParseUint(spanDecisionMaker, 10, 32)
 				if err != nil {
@@ -128,14 +131,14 @@ func ConvertToIdx(payload *pb.TracerPayload, originPayloadVersion string) *idx.I
 				}
 				spanConvertedFields.SamplingMechanism = uint32(samplingMechanism)
 			}
-			if spanAPMMode, ok := span.Meta["_dd.apm_mode"]; ok && spanConvertedFields.APMModeRef == 0 {
+			if spanAPMMode := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDAPMMode); spanAPMMode != "" && spanConvertedFields.APMModeRef == 0 {
 				spanConvertedFields.APMModeRef = stringTable.Add(spanAPMMode)
 			}
-			if spanOrigin, ok := span.Meta["_dd.origin"]; ok && spanConvertedFields.OriginRef == 0 {
+			if spanOrigin := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDOrigin); spanOrigin != "" && spanConvertedFields.OriginRef == 0 {
 				spanConvertedFields.OriginRef = stringTable.Add(spanOrigin)
 			}
-			component := span.Meta["component"]
-			kindStr := span.Meta["span.kind"]
+			component := semantics.LookupString(registry, metaAccessor, semantics.ConceptComponent)
+			kindStr := semantics.LookupString(registry, metaAccessor, semantics.ConceptSpanKind)
 			var kind idx.SpanKind
 			switch kindStr {
 			case "server":

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -346,7 +346,7 @@ func (o *OTLPReceiver) receiveResourceSpansV2(ctx context.Context, rspans ptrace
 			}
 			ddspan := transform.OtelSpanToDDSpan(otelspan, otelres, libspans.Scope(), o.conf)
 
-			if p, ok := ddspan.Metrics["_sampling_priority_v1"]; ok {
+			if p, ok := semantics.LookupFloat64(registry, semantics.NewMetricsMapAccessor(ddspan.Metrics), semantics.ConceptSamplingPriority); ok {
 				priorityByID[traceID] = sampler.SamplingPriority(p)
 			}
 			tracesByID[traceID] = append(tracesByID[traceID], ddspan)
@@ -394,13 +394,6 @@ func (o *OTLPReceiver) receiveResourceSpansV1(ctx context.Context, rspans ptrace
 	// each rspans is coming from a different resource and should be considered
 	// a separate payload; typically there is only one item in this slice
 	src, srcok := o.conf.OTLPReceiver.AttributesTranslator.ResourceToSource(ctx, rspans.Resource(), transform.SignalTypeSet, hostFromAttributesHandler)
-	hostFromMap := func(m map[string]string, key string) {
-		// hostFromMap sets the hostname to m[key] if it is set.
-		if v, ok := m[key]; ok {
-			src = source.Source{Kind: source.HostnameKind, Identifier: v}
-			srcok = true
-		}
-	}
 
 	attr := rspans.Resource().Attributes()
 	rattr := make(map[string]string, attr.Len())
@@ -409,7 +402,10 @@ func (o *OTLPReceiver) receiveResourceSpansV1(ctx context.Context, rspans ptrace
 		return true
 	})
 	if !srcok {
-		hostFromMap(rattr, "_dd.hostname")
+		if v := semantics.LookupString(registry, semantics.NewStringMapAccessor(rattr), semantics.ConceptDDHostname); v != "" {
+			src = source.Source{Kind: source.HostnameKind, Identifier: v}
+			srcok = true
+		}
 	}
 	_, env := transform.GetFirstFromMap(rattr, string(semconv127.DeploymentEnvironmentNameKey), string(semconv.DeploymentEnvironmentKey))
 	lang := rattr[string(semconv.TelemetrySDKLanguageKey)]
@@ -448,11 +444,14 @@ func (o *OTLPReceiver) receiveResourceSpansV1(ctx context.Context, rspans ptrace
 			if !srcok {
 				// if we didn't find a hostname at the resource level
 				// try and see if the span has a hostname set
-				hostFromMap(ddspan.Meta, "_dd.hostname")
+				if v := semantics.LookupString(registry, semantics.NewStringMapAccessor(ddspan.Meta), semantics.ConceptDDHostname); v != "" {
+					src = source.Source{Kind: source.HostnameKind, Identifier: v}
+					srcok = true
+				}
 			}
 			if env == "" {
 				// no env at resource level, try the first span
-				if v := ddspan.Meta["env"]; v != "" {
+				if v := semantics.LookupString(registry, semantics.NewStringMapAccessor(ddspan.Meta), semantics.ConceptDDEnv); v != "" {
 					env = v
 				}
 			}
@@ -460,7 +459,7 @@ func (o *OTLPReceiver) receiveResourceSpansV1(ctx context.Context, rspans ptrace
 				// no cid at resource level, grab what we can
 				_, containerID = transform.GetFirstFromMap(ddspan.Meta, string(semconv.ContainerIDKey), string(semconv.K8SPodUIDKey))
 			}
-			if p, ok := ddspan.Metrics["_sampling_priority_v1"]; ok {
+			if p, ok := semantics.LookupFloat64(registry, semantics.NewMetricsMapAccessor(ddspan.Metrics), semantics.ConceptSamplingPriority); ok {
 				priorityByID[traceID] = sampler.SamplingPriority(p)
 			}
 			tracesByID[traceID] = append(tracesByID[traceID], ddspan)

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -394,6 +394,13 @@ func (o *OTLPReceiver) receiveResourceSpansV1(ctx context.Context, rspans ptrace
 	// each rspans is coming from a different resource and should be considered
 	// a separate payload; typically there is only one item in this slice
 	src, srcok := o.conf.OTLPReceiver.AttributesTranslator.ResourceToSource(ctx, rspans.Resource(), transform.SignalTypeSet, hostFromAttributesHandler)
+	hostFromMap := func(m map[string]string, key string) {
+		// hostFromMap sets the hostname to m[key] if it is set.
+		if v, ok := m[key]; ok {
+			src = source.Source{Kind: source.HostnameKind, Identifier: v}
+			srcok = true
+		}
+	}
 
 	attr := rspans.Resource().Attributes()
 	rattr := make(map[string]string, attr.Len())
@@ -402,10 +409,7 @@ func (o *OTLPReceiver) receiveResourceSpansV1(ctx context.Context, rspans ptrace
 		return true
 	})
 	if !srcok {
-		if v := semantics.LookupString(registry, semantics.NewStringMapAccessor(rattr), semantics.ConceptDDHostname); v != "" {
-			src = source.Source{Kind: source.HostnameKind, Identifier: v}
-			srcok = true
-		}
+		hostFromMap(rattr, "_dd.hostname")
 	}
 	_, env := transform.GetFirstFromMap(rattr, string(semconv127.DeploymentEnvironmentNameKey), string(semconv.DeploymentEnvironmentKey))
 	lang := rattr[string(semconv.TelemetrySDKLanguageKey)]
@@ -444,14 +448,11 @@ func (o *OTLPReceiver) receiveResourceSpansV1(ctx context.Context, rspans ptrace
 			if !srcok {
 				// if we didn't find a hostname at the resource level
 				// try and see if the span has a hostname set
-				if v := semantics.LookupString(registry, semantics.NewStringMapAccessor(ddspan.Meta), semantics.ConceptDDHostname); v != "" {
-					src = source.Source{Kind: source.HostnameKind, Identifier: v}
-					srcok = true
-				}
+				hostFromMap(ddspan.Meta, "_dd.hostname")
 			}
 			if env == "" {
 				// no env at resource level, try the first span
-				if v := semantics.LookupString(registry, semantics.NewStringMapAccessor(ddspan.Meta), semantics.ConceptDDEnv); v != "" {
+				if v := ddspan.Meta["env"]; v != "" {
 					env = v
 				}
 			}
@@ -459,7 +460,7 @@ func (o *OTLPReceiver) receiveResourceSpansV1(ctx context.Context, rspans ptrace
 				// no cid at resource level, grab what we can
 				_, containerID = transform.GetFirstFromMap(ddspan.Meta, string(semconv.ContainerIDKey), string(semconv.K8SPodUIDKey))
 			}
-			if p, ok := semantics.LookupFloat64(registry, semantics.NewMetricsMapAccessor(ddspan.Metrics), semantics.ConceptSamplingPriority); ok {
+			if p, ok := ddspan.Metrics["_sampling_priority_v1"]; ok {
 				priorityByID[traceID] = sampler.SamplingPriority(p)
 			}
 			tracesByID[traceID] = append(tracesByID[traceID], ddspan)

--- a/pkg/trace/sampler/probabilistic.go
+++ b/pkg/trace/sampler/probabilistic.go
@@ -15,7 +15,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/DataDog/datadog-agent/pkg/trace/semantics"
 )
+
+var registry = semantics.DefaultRegistry()
 
 const (
 	// These constants exist to match the behavior of the OTEL probabilistic sampler.
@@ -112,8 +115,9 @@ func (ps *ProbabilisticSampler) SampleV1(traceID []byte, root *idx.InternalSpan)
 }
 
 func get128BitTraceID(span *trace.Span) ([]byte, error) {
-	// If it's an otel span the whole trace ID is in otel.trace
-	if tid, ok := span.Meta["otel.trace_id"]; ok {
+	metaAccessor := semantics.NewStringMapAccessor(span.Meta)
+	// If it's an otel span the whole trace ID is in otel.trace_id
+	if tid := semantics.LookupString(registry, metaAccessor, semantics.ConceptOTelTraceID); tid != "" {
 		bs, err := hex.DecodeString(tid)
 		if err != nil {
 			return nil, err
@@ -124,7 +128,7 @@ func get128BitTraceID(span *trace.Span) ([]byte, error) {
 	binary.BigEndian.PutUint64(tid[8:], span.TraceID)
 	// Get hex encoded upper bits for datadog spans
 	// If no value is found we can use the default `0` value as that's what will have been propagated
-	if upper, ok := span.Meta["_dd.p.tid"]; ok {
+	if upper := semantics.LookupString(registry, metaAccessor, semantics.ConceptDDTraceIDHigh); upper != "" {
 		u, err := strconv.ParseUint(upper, 16, 64)
 		if err != nil {
 			return nil, err

--- a/pkg/trace/semantics/mappings.json
+++ b/pkg/trace/semantics/mappings.json
@@ -310,7 +310,13 @@
     "_dd.partial_version": {
       "canonical": "_dd.partial_version",
       "fallbacks": [
-        {"name": "_dd.partial_version", "provider": "datadog", "type": "string"}
+        {"name": "_dd.partial_version", "provider": "datadog", "type": "float64"}
+      ]
+    },
+    "_dd.origin": {
+      "canonical": "_dd.origin",
+      "fallbacks": [
+        {"name": "_dd.origin", "provider": "datadog", "type": "string"}
       ]
     },
     "service.name": {
@@ -404,6 +410,42 @@
       "canonical": "k8s.pod.uid",
       "fallbacks": [
         {"name": "k8s.pod.uid", "provider": "otel", "type": "string"}
+      ]
+    },
+    "env": {
+      "canonical": "env",
+      "fallbacks": [
+        {"name": "env", "provider": "datadog", "type": "string"}
+      ]
+    },
+    "version": {
+      "canonical": "version",
+      "fallbacks": [
+        {"name": "version", "provider": "datadog", "type": "string"}
+      ]
+    },
+    "_dd.hostname": {
+      "canonical": "_dd.hostname",
+      "fallbacks": [
+        {"name": "_dd.hostname", "provider": "datadog", "type": "string"}
+      ]
+    },
+    "_dd.git.commit.sha": {
+      "canonical": "_dd.git.commit.sha",
+      "fallbacks": [
+        {"name": "_dd.git.commit.sha", "provider": "datadog", "type": "string"}
+      ]
+    },
+    "_dd.p.dm": {
+      "canonical": "_dd.p.dm",
+      "fallbacks": [
+        {"name": "_dd.p.dm", "provider": "datadog", "type": "string"}
+      ]
+    },
+    "_dd.apm_mode": {
+      "canonical": "_dd.apm_mode",
+      "fallbacks": [
+        {"name": "_dd.apm_mode", "provider": "datadog", "type": "string"}
       ]
     }
   }

--- a/pkg/trace/semantics/semantics.go
+++ b/pkg/trace/semantics/semantics.go
@@ -115,6 +115,17 @@ const (
 	ConceptOTelTraceID      Concept = "otel.trace_id"
 	ConceptDDTraceIDHigh    Concept = "_dd.p.tid"
 	ConceptDDPartialVersion Concept = "_dd.partial_version"
+	ConceptDDOrigin         Concept = "_dd.origin"
+)
+
+// DD tags
+const (
+	ConceptDDEnv           Concept = "env"
+	ConceptDDVersion       Concept = "version"
+	ConceptDDHostname      Concept = "_dd.hostname"
+	ConceptDDGitCommitSHA  Concept = "_dd.git.commit.sha"
+	ConceptDDDecisionMaker Concept = "_dd.p.dm"
+	ConceptDDAPMMode       Concept = "_dd.apm_mode"
 )
 
 // TagInfo contains metadata about a semantic attribute and its location.

--- a/pkg/trace/semantics/semantics_test.go
+++ b/pkg/trace/semantics/semantics_test.go
@@ -80,12 +80,12 @@ func TestDDTagConceptLookup(t *testing.T) {
 	require.NoError(t, err)
 
 	meta := map[string]string{
-		"env":               "production",
-		"version":           "1.2.3",
-		"_dd.hostname":      "my-host",
+		"env":                "production",
+		"version":            "1.2.3",
+		"_dd.hostname":       "my-host",
 		"_dd.git.commit.sha": "abc123",
-		"_dd.p.dm":          "-4",
-		"_dd.apm_mode":      "apm",
+		"_dd.p.dm":           "-4",
+		"_dd.apm_mode":       "apm",
 	}
 	accessor := NewStringMapAccessor(meta)
 

--- a/pkg/trace/semantics/semantics_test.go
+++ b/pkg/trace/semantics/semantics_test.go
@@ -39,3 +39,60 @@ func TestDefaultRegistry(t *testing.T) {
 	require.NotNil(t, r)
 	assert.NotNil(t, r.GetAttributePrecedence(ConceptDBStatement))
 }
+
+func TestPartialVersionRegistryType(t *testing.T) {
+	r, err := NewEmbeddedRegistry()
+	require.NoError(t, err)
+	tags := r.GetAttributePrecedence(ConceptDDPartialVersion)
+	require.Len(t, tags, 1, "ConceptDDPartialVersion should have exactly one fallback")
+	assert.Equal(t, ValueTypeFloat64, tags[0].Type, "_dd.partial_version must be float64 to match the Metrics map storage type")
+}
+
+func TestDDTagConceptsRegistered(t *testing.T) {
+	r, err := NewEmbeddedRegistry()
+	require.NoError(t, err)
+
+	concepts := []struct {
+		concept Concept
+		key     string
+	}{
+		{ConceptDDEnv, "env"},
+		{ConceptDDVersion, "version"},
+		{ConceptDDHostname, "_dd.hostname"},
+		{ConceptDDGitCommitSHA, "_dd.git.commit.sha"},
+		{ConceptDDDecisionMaker, "_dd.p.dm"},
+		{ConceptDDAPMMode, "_dd.apm_mode"},
+	}
+
+	for _, tc := range concepts {
+		t.Run(string(tc.concept), func(t *testing.T) {
+			tags := r.GetAttributePrecedence(tc.concept)
+			require.Len(t, tags, 1, "concept should have exactly one fallback")
+			assert.Equal(t, tc.key, tags[0].Name)
+			assert.Equal(t, ProviderDatadog, tags[0].Provider)
+			assert.Equal(t, ValueTypeString, tags[0].Type)
+		})
+	}
+}
+
+func TestDDTagConceptLookup(t *testing.T) {
+	r, err := NewEmbeddedRegistry()
+	require.NoError(t, err)
+
+	meta := map[string]string{
+		"env":               "production",
+		"version":           "1.2.3",
+		"_dd.hostname":      "my-host",
+		"_dd.git.commit.sha": "abc123",
+		"_dd.p.dm":          "-4",
+		"_dd.apm_mode":      "apm",
+	}
+	accessor := NewStringMapAccessor(meta)
+
+	assert.Equal(t, "production", LookupString(r, accessor, ConceptDDEnv))
+	assert.Equal(t, "1.2.3", LookupString(r, accessor, ConceptDDVersion))
+	assert.Equal(t, "my-host", LookupString(r, accessor, ConceptDDHostname))
+	assert.Equal(t, "abc123", LookupString(r, accessor, ConceptDDGitCommitSHA))
+	assert.Equal(t, "-4", LookupString(r, accessor, ConceptDDDecisionMaker))
+	assert.Equal(t, "apm", LookupString(r, accessor, ConceptDDAPMMode))
+}


### PR DESCRIPTION
### What does this PR do?

Replace hardcoded `span.Meta`/`span.Metrics` key reads in `normalizer.go`, `converter.go`, `otlp.go`, and `sampler/probabilistic.go` with the semantics registry accessor pattern (`LookupString`/`LookupFloat64` with typed `Accessor` objects), so all span attribute reads go through the registry instead of direct map accesses. 

Adds six new DD tag concepts to the registry (`env`, `version`, `_dd.hostname`, `_dd.git.commit.sha`, `_dd.p.dm`, `_dd.apm_mode`) as single-fallback entries kept separate from their OTel equivalents, fixes the `_dd.partial_version` registry type (`string` → `float64` to match its storage in the `Metrics` map), and adds the `_dd.origin` concept. The `hostFromMap` closure in `otlp.go` is removed in favor of inline lookups.

### Motivation

Further integrate the semantics library in pkg/trace: See #48354 

### Describe how you validated your changes
Unit tests for each replacement (existing or new)

### Additional Notes
