### PR TITLE
SQG: don't run the per-PR thershold checks in the merge queue

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -838,6 +838,7 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
     ancestor = get_ancestor(ctx, branch)
     current_commit = get_commit_sha(ctx)
     is_on_main_branch = ancestor == current_commit
+    is_merge_queue = branch.startswith("mq-working-branch-")
     metric_handler.generate_relative_size(ancestor=ancestor)
 
     # Post-process gate failures: mark as non-blocking if delta <= 0
@@ -860,24 +861,26 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
                         )
 
         # Check per-PR threshold: if any gate increased by more than PER_PR_THRESHOLD, mark it as failing
-        per_pr_exceeding = identify_gates_exceeding_pr_threshold(metric_handler)
-        if per_pr_exceeding:
-            threshold_str = byte_to_string(PER_PR_THRESHOLD)
-            print(
-                color_message(
-                    f"Per-PR threshold ({threshold_str}) exceeded by: {', '.join(per_pr_exceeding)}",
-                    "red",
-                )
-            )
-            for gate_state in gate_states:
-                if gate_state["name"] in per_pr_exceeding and gate_state["state"] is True:
-                    delta = metric_handler.metrics.get(gate_state["name"], {}).get("relative_on_disk_size", 0)
-                    gate_state["state"] = False
-                    gate_state["error_type"] = "PerPRThresholdExceeded"
-                    gate_state["message"] = (
-                        f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}"
+        # Skip for merge queue jobs: the MQ working branch is an ephemeral merge preview, not a PR
+        if not is_merge_queue:
+            per_pr_exceeding = identify_gates_exceeding_pr_threshold(metric_handler)
+            if per_pr_exceeding:
+                threshold_str = byte_to_string(PER_PR_THRESHOLD)
+                print(
+                    color_message(
+                        f"Per-PR threshold ({threshold_str}) exceeded by: {', '.join(per_pr_exceeding)}",
+                        "red",
                     )
-                    gate_state["blocking"] = exception_checker.get() is None
+                )
+                for gate_state in gate_states:
+                    if gate_state["name"] in per_pr_exceeding and gate_state["state"] is True:
+                        delta = metric_handler.metrics.get(gate_state["name"], {}).get("relative_on_disk_size", 0)
+                        gate_state["state"] = False
+                        gate_state["error_type"] = "PerPRThresholdExceeded"
+                        gate_state["message"] = (
+                            f"On-disk size increase of {byte_to_string(delta)} exceeds the per-PR threshold of {threshold_str}"
+                        )
+                        gate_state["blocking"] = exception_checker.get() is None
 
     # Recompute final_state now that all post-processing is done (bypass logic and per-PR threshold
     # can both change gate states after the initial gate execution loop).

--- a/tasks/unit_tests/static_quality_gates_tests.py
+++ b/tasks/unit_tests/static_quality_gates_tests.py
@@ -702,6 +702,41 @@ class TestQualityGatesIntegration(unittest.TestCase):
                 parse_and_trigger_gates(ctx, "tasks/unit_tests/testdata/quality_gate_config_test.yml")
                 self.assertIn("Test infra error message", str(cm.exception))
 
+    @patch.dict(
+        'os.environ',
+        {
+            'CI_COMMIT_BRANCH': 'mq-working-branch-12345',
+            'CI_COMMIT_REF_SLUG': 'mq-working-branch-12345',
+            'BUCKET_BRANCH': 'main',
+            'CI_PIPELINE_ID': '71580015',
+            'CI_COMMIT_SHA': '1234567890abcdef',
+            'CI_COMMIT_SHORT_SHA': '1234567',
+        },
+    )
+    @patch(
+        "tasks.static_quality_gates.gates.PackageArtifactMeasurer._find_package_paths",
+        return_value={'primary': '/fake/path'},
+    )
+    @patch("tasks.static_quality_gates.gates.PackageArtifactMeasurer._calculate_package_sizes", return_value=(0, 0))
+    @patch("tasks.static_quality_gates.gates.DockerArtifactMeasurer._calculate_image_wire_size", return_value=0)
+    @patch("tasks.static_quality_gates.gates.DockerArtifactMeasurer._calculate_image_disk_size", return_value=0)
+    @patch("tasks.static_quality_gates.gates.GateMetricHandler.send_metrics_to_datadog", new=MagicMock())
+    @patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_relative_size", new=MagicMock())
+    @patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports", new=MagicMock())
+    @patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha")
+    @patch("tasks.quality_gates.get_commit_sha", return_value="current-sha")
+    @patch("tasks.quality_gates.identify_gates_exceeding_pr_threshold")
+    def test_per_pr_threshold_skipped_on_merge_queue(self, mock_identify, _mock_commit, _mock_ancestor, *_):
+        """Per-PR threshold check is not applied on merge queue branches."""
+        ctx = MockContext(
+            run={
+                "datadog-ci tag --level job --tags static_quality_gates:\"success\"": Result("Done"),
+                "datadog-ci tag --level job --tags static_quality_gates:\"failure\"": Result("Done"),
+            }
+        )
+        parse_and_trigger_gates(ctx, "tasks/unit_tests/testdata/quality_gate_config_test.yml")
+        mock_identify.assert_not_called()
+
 
 class TestQualityGatesConfigUpdate(unittest.TestCase):
     def test_one_gate_update(self):


### PR DESCRIPTION
### What does this PR do?

Stop running the SQG per-PR checks in the merge queue

### Motivation

There's no concept of a PR once we get into the MQ, these checks makes no sense there
Also, this will make Pierre happy and able to merge his PR

### Describe how you validated your changes

### Additional Notes
