### PR TITLE
[observer] Add log status detector component

### DIFF
--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -122,6 +122,13 @@ func defaultCatalog() *componentCatalog {
 				defaultEnabled: true,
 			},
 			{
+				name:           "log_stat_extractor",
+				displayName:    "Log Stat Extractor",
+				kind:           componentExtractor,
+				factory:        func(any) any { return NewLogStatExtractor() },
+				defaultEnabled: true,
+			},
+			{
 				name:           "log_pattern_extractor",
 				displayName:    "Log Pattern Extractor",
 				kind:           componentExtractor,

--- a/comp/observer/impl/log_stat_extractor.go
+++ b/comp/observer/impl/log_stat_extractor.go
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"strconv"
+	"strings"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+const logStatExtractorName = "log_stat_extractor"
+
+// logStatMetricPrefix is the shared prefix for all metrics emitted by LogStatExtractor.
+const logStatMetricPrefix = "log." + logStatExtractorName + ".status."
+
+// canonicalStatuses is the set of output status values after normalization.
+// emergency, alert → critical; notice → info; warning → warn.
+var canonicalStatuses = map[string]struct{}{
+	"critical": {},
+	"error":    {},
+	"warn":     {},
+	"info":     {},
+	"debug":    {},
+}
+
+// logStatMetricNames pre-computes the full metric name for each canonical status.
+var logStatMetricNames = map[string]string{
+	"critical": logStatMetricPrefix + "critical.count",
+	"error":    logStatMetricPrefix + "error.count",
+	"warn":     logStatMetricPrefix + "warn.count",
+	"info":     logStatMetricPrefix + "info.count",
+	"debug":    logStatMetricPrefix + "debug.count",
+}
+
+// normalizeStatus maps raw log status strings to a canonical value.
+// Groupings: emergency/alert/critical → "critical"; notice/info → "info";
+// warning → "warn". Anything else falls back to "info".
+func normalizeStatus(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "emergency", "alert", "critical":
+		return "critical"
+	case "error":
+		return "error"
+	case "warn", "warning":
+		return "warn"
+	case "notice", "info":
+		return "info"
+	case "debug":
+		return "debug"
+	default:
+		return "info"
+	}
+}
+
+// LogStatExtractor is a LogMetricsExtractor that counts logs per canonical
+// status, grouped by the same four tag dimensions as the log pattern extractor
+// (source, service, env, host).
+type LogStatExtractor struct {
+	contextByKey map[string]*observerdef.MetricContext
+}
+
+var _ observerdef.LogMetricsExtractor = (*LogStatExtractor)(nil)
+var _ observerdef.ContextProvider = (*LogStatExtractor)(nil)
+
+// NewLogStatExtractor creates a new LogStatExtractor.
+func NewLogStatExtractor() *LogStatExtractor {
+	return &LogStatExtractor{}
+}
+
+// Name returns "log_stat_extractor".
+func (e *LogStatExtractor) Name() string {
+	return logStatExtractorName
+}
+
+// ProcessLog normalizes the log status and emits a count metric per
+// (status, tag-group) pair. Unknown statuses are counted under "info".
+func (e *LogStatExtractor) ProcessLog(log observerdef.LogView) observerdef.LogMetricsExtractorOutput {
+	status := normalizeStatus(log.GetStatus())
+
+	groupTags := tagsForPatternGrouping(log.GetTags(), log.GetHostname())
+	group := extractTagGroupByKey(groupTags)
+	groupHash := tagGroupByKeyHash(group)
+
+	contextKey := "status:" + status + "|" + strconv.FormatUint(groupHash, 16)
+
+	if e.contextByKey == nil {
+		e.contextByKey = make(map[string]*observerdef.MetricContext)
+	}
+
+	ctx, exists := e.contextByKey[contextKey]
+	if !exists {
+		ctx = &observerdef.MetricContext{
+			Pattern:   status,
+			Source:    logStatExtractorName,
+			SplitTags: group.AsMap(),
+		}
+		e.contextByKey[contextKey] = ctx
+	}
+	ctx.Example = string(log.GetContent())
+
+	return observerdef.LogMetricsExtractorOutput{
+		Metrics: []observerdef.MetricOutput{
+			{
+				Name:       logStatMetricNames[status],
+				Value:      1.0,
+				Tags:       log.GetTags(),
+				ContextKey: contextKey,
+			},
+		},
+	}
+}
+
+// GetContextByKey implements observerdef.ContextProvider.
+func (e *LogStatExtractor) GetContextByKey(key string) (observerdef.MetricContext, bool) {
+	if e.contextByKey == nil {
+		return observerdef.MetricContext{}, false
+	}
+	ctx, ok := e.contextByKey[key]
+	if !ok {
+		return observerdef.MetricContext{}, false
+	}
+	return *ctx, true
+}

--- a/comp/observer/impl/log_stat_extractor_test.go
+++ b/comp/observer/impl/log_stat_extractor_test.go
@@ -1,0 +1,248 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// normalizeStatus
+
+func TestNormalizeStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// emergency/alert/critical → "critical"
+		{"emergency", "emergency", "critical"},
+		{"alert", "alert", "critical"},
+		{"critical", "critical", "critical"},
+		{"EMERGENCY", "EMERGENCY", "critical"},
+		{"ALERT", "ALERT", "critical"},
+		{"CRITICAL", "CRITICAL", "critical"},
+		// error
+		{"error", "error", "error"},
+		{"ERROR", "ERROR", "error"},
+		// warn/warning → "warn"
+		{"warn", "warn", "warn"},
+		{"warning", "warning", "warn"},
+		{"WARNING", "WARNING", "warn"},
+		{"Warning", "Warning", "warn"},
+		// notice/info → "info"
+		{"notice", "notice", "info"},
+		{"info", "info", "info"},
+		{"NOTICE", "NOTICE", "info"},
+		{"INFO", "INFO", "info"},
+		// debug
+		{"debug", "debug", "debug"},
+		{"DEBUG", "DEBUG", "debug"},
+		// Unknown → "info" fallback
+		{"trace", "trace", "info"},
+		{"verbose", "verbose", "info"},
+		{"fatal", "fatal", "info"},
+		{"ok", "ok", "info"},
+		{"empty", "", "info"},
+		{"punctuation", "???", "info"},
+		{"UNKNOWN", "UNKNOWN", "info"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeStatus(tc.input))
+		})
+	}
+}
+
+// ProcessLog core behavior
+
+func TestLogStatExtractor_EmitsMetricForKnownStatus(t *testing.T) {
+	e := NewLogStatExtractor()
+
+	log := &mockLogView{
+		content: []byte("user logged in"),
+		status:  "info",
+		tags:    []string{"service:web", "env:prod"},
+	}
+
+	res := e.ProcessLog(log)
+	require.Len(t, res.Metrics, 1)
+	assert.Equal(t, logStatMetricNames["info"], res.Metrics[0].Name)
+	assert.Equal(t, 1.0, res.Metrics[0].Value)
+}
+
+func TestLogStatExtractor_UnknownStatusCountedAsInfo(t *testing.T) {
+	e := NewLogStatExtractor()
+
+	log := &mockLogView{
+		content: []byte("some trace log"),
+		status:  "trace",
+		tags:    []string{"service:web"},
+	}
+
+	res := e.ProcessLog(log)
+	require.Len(t, res.Metrics, 1)
+	assert.Equal(t, logStatMetricNames["info"], res.Metrics[0].Name)
+}
+
+func TestLogStatExtractor_TagsAreForwardedAsIs(t *testing.T) {
+	e := NewLogStatExtractor()
+
+	tags := []string{"service:api", "env:staging", "version:1.2.3"}
+	log := &mockLogView{
+		content: []byte("starting up"),
+		status:  "info",
+		tags:    tags,
+	}
+
+	res := e.ProcessLog(log)
+	require.Len(t, res.Metrics, 1)
+	assert.Equal(t, tags, res.Metrics[0].Tags)
+}
+
+func TestLogStatExtractor_ContextKeyContainsStatus(t *testing.T) {
+	e := NewLogStatExtractor()
+
+	log := &mockLogView{
+		content: []byte("disk full"),
+		status:  "error",
+		tags:    []string{"service:storage"},
+	}
+
+	res := e.ProcessLog(log)
+	require.Len(t, res.Metrics, 1)
+	assert.True(t, strings.Contains(res.Metrics[0].ContextKey, "error"),
+		"context key %q should contain the status", res.Metrics[0].ContextKey)
+}
+
+func TestLogStatExtractor_GetContextByKeyReturnsPatternAndExample(t *testing.T) {
+	e := NewLogStatExtractor()
+
+	log := &mockLogView{
+		content: []byte("connection timeout"),
+		status:  "warn",
+		tags:    []string{"service:db"},
+	}
+
+	res := e.ProcessLog(log)
+	require.Len(t, res.Metrics, 1)
+
+	ctx, ok := e.GetContextByKey(res.Metrics[0].ContextKey)
+	require.True(t, ok)
+	assert.Equal(t, "warn", ctx.Pattern)
+	assert.Equal(t, "connection timeout", ctx.Example)
+	assert.Equal(t, logStatExtractorName, ctx.Source)
+}
+
+// Tag-group isolation
+
+func TestLogStatExtractor_SameStatusDifferentServiceProducesDifferentContextKey(t *testing.T) {
+	e := NewLogStatExtractor()
+
+	logA := &mockLogView{content: []byte("msg"), status: "info", tags: []string{"service:api"}}
+	logB := &mockLogView{content: []byte("msg"), status: "info", tags: []string{"service:worker"}}
+
+	resA := e.ProcessLog(logA)
+	resB := e.ProcessLog(logB)
+
+	require.Len(t, resA.Metrics, 1)
+	require.Len(t, resB.Metrics, 1)
+	assert.NotEqual(t, resA.Metrics[0].ContextKey, resB.Metrics[0].ContextKey)
+}
+
+func TestLogStatExtractor_SameStatusSameGroupProducesSameContextKey(t *testing.T) {
+	e := NewLogStatExtractor()
+
+	tags := []string{"service:api", "env:prod"}
+	logA := &mockLogView{content: []byte("first"), status: "info", tags: tags}
+	logB := &mockLogView{content: []byte("second"), status: "info", tags: tags}
+
+	resA := e.ProcessLog(logA)
+	resB := e.ProcessLog(logB)
+
+	require.Len(t, resA.Metrics, 1)
+	require.Len(t, resB.Metrics, 1)
+	assert.Equal(t, resA.Metrics[0].ContextKey, resB.Metrics[0].ContextKey)
+}
+
+func TestLogStatExtractor_HostnameInjectedIntoGroupingWhenNoHostTag(t *testing.T) {
+	e := NewLogStatExtractor()
+
+	tags := []string{"service:api", "env:prod"}
+	logA := &mockLogView{content: []byte("msg"), status: "info", tags: tags, hostname: "host-a"}
+	logB := &mockLogView{content: []byte("msg"), status: "info", tags: tags, hostname: "host-b"}
+
+	resA := e.ProcessLog(logA)
+	resB := e.ProcessLog(logB)
+
+	require.Len(t, resA.Metrics, 1)
+	require.Len(t, resB.Metrics, 1)
+	// Different hostnames → different group hash → different context keys.
+	assert.NotEqual(t, resA.Metrics[0].ContextKey, resB.Metrics[0].ContextKey)
+
+	ctxA, ok := e.GetContextByKey(resA.Metrics[0].ContextKey)
+	require.True(t, ok)
+	ctxB, ok := e.GetContextByKey(resB.Metrics[0].ContextKey)
+	require.True(t, ok)
+
+	// The grouping tag "host" should appear in SplitTags (from hostname injection),
+	// but the emitted metric tags should be the original tags without the injected host.
+	assert.Equal(t, "host-a", ctxA.SplitTags["host"])
+	assert.Equal(t, "host-b", ctxB.SplitTags["host"])
+	// Original tags are not enriched with the hostname.
+	assert.Equal(t, tags, resA.Metrics[0].Tags)
+	assert.Equal(t, tags, resB.Metrics[0].Tags)
+}
+
+func TestLogStatExtractor_SplitTagsReflectGroupDimensions(t *testing.T) {
+	e := NewLogStatExtractor()
+
+	log := &mockLogView{
+		content: []byte("request failed"),
+		status:  "error",
+		tags:    []string{"service:gateway", "env:prod", "version:2.0"},
+	}
+
+	res := e.ProcessLog(log)
+	require.Len(t, res.Metrics, 1)
+
+	ctx, ok := e.GetContextByKey(res.Metrics[0].ContextKey)
+	require.True(t, ok)
+	// SplitTags should only contain the grouping dimensions, not "version".
+	assert.Equal(t, map[string]string{"service": "gateway", "env": "prod"}, ctx.SplitTags)
+}
+
+// Catalog registration
+
+func TestLogStatExtractor_PresentInDefaultCatalog(t *testing.T) {
+	cat := defaultCatalog()
+	var found *componentEntry
+	for i := range cat.entries {
+		if cat.entries[i].name == logStatExtractorName {
+			found = &cat.entries[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "log_stat_extractor must be registered in defaultCatalog")
+	assert.True(t, found.defaultEnabled, "log_stat_extractor must be enabled by default")
+	assert.Equal(t, componentExtractor, found.kind)
+}
+
+func TestLogStatExtractor_InstantiateIncludesExtractor(t *testing.T) {
+	_, _, extractors, _ := defaultCatalog().Instantiate(ComponentSettings{})
+
+	var found bool
+	for _, ext := range extractors {
+		if ext.Name() == logStatExtractorName {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "log_stat_extractor must appear in the extractors slice from Instantiate")
+}

--- a/tasks/libs/q/eval.py
+++ b/tasks/libs/q/eval.py
@@ -41,6 +41,7 @@ EXTRACTORS = [
     "log_metrics_extractor",
     "connection_error_extractor",
     "log_pattern_extractor",
+    "log_stat_extractor",
 ]
 
 # Fixed anchor subsets used by eval_component to anchor the evaluation at known


### PR DESCRIPTION
### What does this PR do?

Add a new LogStatExtractor component that counts logs per canonical status (critical, error, warn, info, debug).

This counts logs per canonical status with grouping by source, service, env, and host

### Motivation

### Describe how you validated your changes

### Additional Notes