### PR TITLE
[k8s-latest] Only consider stable versions in latest k8s

### DIFF
--- a/tasks/k8s_versions.py
+++ b/tasks/k8s_versions.py
@@ -310,11 +310,11 @@ def _update_e2e_yaml_file(new_versions: dict[str, dict[str, str]]) -> tuple[bool
     version_items = []
     for version_str, data in new_versions.items():
         parsed = _parse_version(version_str)
-        if parsed:
+        if parsed and not parsed.prerelease:
             version_items.append((parsed, version_str, data))
 
     if not version_items:
-        print("No valid versions found")
+        print("No stable versions found")
         return False, []
 
     version_items.sort(key=lambda x: x[0], reverse=True)


### PR DESCRIPTION
### What does this PR do?
Filters out rcs when updating e2e yaml for latest k8s verison. 

### Motivation
https://github.com/DataDog/datadog-agent/pull/49083

### Describe how you validated your changes

### Additional Notes
