### PR TITLE
Disable Renovate updates for test/fakeintake/Dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -53,6 +53,11 @@
         "enabled": false
       },
       {
+        "matchManagers": ["dockerfile"],
+        "matchFileNames": ["test/fakeintake/Dockerfile"],
+        "enabled": false
+      },
+      {
         "matchManagers": ["cargo"],
         "labels": ["dependencies", "dependencies-cargo", "changelog/no-changelog", "qa/no-code-change"],
       },


### PR DESCRIPTION
### What does this PR do?
Disable Renovate dependency updates for `test/fakeintake/Dockerfile`.

### Motivation
Prevent unwanted automated bumps on this Dockerfile.

### Describe how you validated your changes
No code change — CI is sufficient.

### Additional Notes