### PR TITLE
Neutralize `rules_android` from `tools/bazel*` for the time being

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -408,8 +408,8 @@
         "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
         "recordedInputs": [
           "FILE:@@//.bazelversion 59b003a1f3465ae6084432329f8265e860cbaac0bd4a92a4f3ea6b979a6eed66",
-          "FILE:@@//tools/bazel dc2842f9517355471b221492ddbad546ab70c6b9b3f22e4a2e9c5480bcaed720",
-          "FILE:@@//tools/bazel.bat 8d4b069aa2d353f11b16903dc189623220bd747d4492357fd8a06fa712a964a6",
+          "FILE:@@//tools/bazel d41ee01add2b1855b32212c5f9fc6481336c132c39da8c56195dc21c2325e8b9",
+          "FILE:@@//tools/bazel.bat b016bc9a1d6cb93baa5a81eedc8710ea0170aec283bcb3ca176b06ee336f4be1",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],
         "generatedRepoSpecs": {}

--- a/tools/bazel
+++ b/tools/bazel
@@ -50,4 +50,6 @@ if [[ $# -gt 0 && ${#extra_args[@]} -gt 0 ]]; then
   set -- "${args[@]}"
 fi
 
+# Prevent rules_android from loading a system Android SDK - TODO(regis): replace with --experimental_strict_repo_env
+unset ANDROID_HOME
 exec "$BAZEL_REAL" "$@"

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -59,6 +59,8 @@ if not exist "!more_than_260_chars!" (
 
 set "args=%*"
 if defined args if defined extra_args call :insert_extra_args
+:: Prevent rules_android from loading a system Android SDK - TODO(regis): replace with --experimental_strict_repo_env
+set "ANDROID_HOME="
 "%BAZEL_REAL%" !bazel_home_startup_option! !args!
 exit /b !errorlevel!
 


### PR DESCRIPTION
### What does this PR do?
Unsets `ANDROID_HOME` in `tools/bazel*` hooks right before invoking `bazel`.

### Motivation
We transitively depend on `rules_android` 0.6.4 that looks for `$ANDROID_HOME` to locate an Android SDK.
GitHub Actions ubuntu-24.04 runners have one (partially?) installed, so the `android_sdk_repository_extension` generates a full `@androidsdk` repo that loads `helper.bzl`, which transitively references `CcInfo` as a `bazel` global.
That global was removed in `bazel` 9, causing analysis to fail at times with:
```
  The CcInfo symbol has been removed, add the following to your
  BUILD/bzl file: load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
```
(https://github.com/DataDog/datadog-agent/actions/runs/24135010393/job/70420742307#step:11:1684)

Unsetting `ANDROID_HOME` causes the extension to generate a stub repo instead, with no `CcInfo` reference.

### Describe how you validated your changes
Reproduced locally with:
```
  mkdir -p /tmp/fake-sdk/platforms/android-34
  ANDROID_HOME=/tmp/fake-sdk bazel run //bazel/tools:go_mod_tidy_all
```

Command fails without the fix, succeeds with it.

### Additional Notes
**The proper long-term fix is `--experimental_strict_repo_env`**, which will prevent repo rules from reading undeclared environment variables:
- #48713.