### PR TITLE
Bump default Go version for GPU K8s tests to 1.25

### DIFF
--- a/test/e2e-framework/components/kubernetes/nvidia/options.go
+++ b/test/e2e-framework/components/kubernetes/nvidia/options.go
@@ -14,7 +14,7 @@ const defaultNvkindVersion = "eeeb9ca30763177fbe7b4d10fb6b7e21725e2295"
 
 // defaultHostGoVersion is the default version of Go to install in the host. This version
 // must be compatible with the nvkind utility
-const defaultHostGoVersion = "1.23"
+const defaultHostGoVersion = "1.25"
 
 // defaultKindNodeImage is the default image to use for the kind nodes.
 const defaultKindNodeImage = "kindest/node"


### PR DESCRIPTION
### What does this PR do?
Bump the default Go version used to install `nvkind` on the GPU K8s E2E test host from `1.23` to `1.25`.

### Motivation
Go 1.23 is out of support (superseded by 1.24 and 1.25). The project itself already uses Go 1.25.7 (see `go.mod`), so aligning the E2E host toolchain avoids unnecessary drift. nvkind's `go.mod` requires `go 1.22.1` minimum, so 1.25 is fully compatible.

### Describe how you validated your changes
No agent code change, CI is sufficient.

### Additional Notes
Found while investigating a flaky E2E job failure (snap store 503) on job [1581177881](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1581177881).