### PR TITLE
rtloader: include Python.h before system headers

### DIFF
--- a/rtloader/common/stringutils.c
+++ b/rtloader/common/stringutils.c
@@ -2,11 +2,15 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-present Datadog, Inc.
+
+// stringutils.h includes Python.h which must come before system headers, see
+// https://docs.python.org/3/c-api/intro.html#include-files
+#include "stringutils.h"
+
 #include <stdlib.h>
 
 #include "rtloader_mem.h"
 #include "rtloader_types.h"
-#include "stringutils.h"
 
 
 PyObject * jloads = NULL;

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -6,13 +6,16 @@
 #ifndef DATADOG_AGENT_RTLOADER_THREE_H
 #define DATADOG_AGENT_RTLOADER_THREE_H
 
+// Python.h must be included before any system headers, see
+// https://docs.python.org/3/c-api/intro.html#include-files
+#include <Python.h>
+
 #include <atomic>
 #include <map>
 #include <mutex>
 #include <string>
 #include <vector>
 
-#include <Python.h>
 #include <rtloader.h>
 
 class Three : public RtLoader


### PR DESCRIPTION
### What does this PR do?
Move `#include <Python.h>` before system/stdlib headers in `rtloader/three/three.h` and `rtloader/common/stringutils.c`.

### Motivation
CPython requires `Python.h` to be included before any system headers ([docs](https://docs.python.org/3/c-api/intro.html#include-files)), as it may define preprocessor macros that affect how system headers behave on some platforms (including AIX).

### Describe how you validated your changes
No behavior change on existing platforms. CI is sufficient.

### Additional Notes