### PR TITLE
[observer/evals] Expand eval corpus to 12 scenarios

### DIFF
--- a/q_branch/gensim-eval-scenarios.json
+++ b/q_branch/gensim-eval-scenarios.json
@@ -1,14 +1,14 @@
 [
-  {"episode": "059_Fortnite_34M_CCU_Service_Outage",             "scenario": "memcached-saturation",          "sha": "395b848541436fa2d1947619d8c6542f84e562cf", "short": "059_fortnite"},
-  {"episode": "063_Twilio_Redis_Billing",                        "scenario": "redis-cascade-billing",         "sha": "3b369d10102839a1282e29e5dd4d9c019e513958", "short": "063_twilio"},
-  {"episode": "093_cloudflare_byzantine_failure",                "scenario": "byzantine-fault-cascade",       "sha": "54e27ec6cd6fa89a0a547f80a0f369fd3425dddb", "short": "093_cloudflare"},
-  {"episode": "211_DoorDash_June_2021_Outage",                   "scenario": "cascading-payment-failure",     "sha": "654ed430f82c9d5836f6a3f2266763ea1b6490c5", "short": "211_doordash"},
-  {"episode": "213_PagerDuty_June_2014_Outage",                  "scenario": "cassandra-repair-degradation",  "sha": "209ba5c62a4279a9913ca15f8b870ee9cc844b35", "short": "213_pagerduty"},
-  {"episode": "221_Base_September_2024_Outage",                  "scenario": "block-building-outage",         "sha": "fe29f66dc7fe5ef73f2c58a8ab954db58abd96c3", "short": "221_base"},
-  {"episode": "353_postmark_upstream_cloud_provider_outage",     "scenario": "dns-upstream-outage",           "sha": "f9bc9ca63cda0089334637cf9a2e86746ea860cb", "short": "353_postmark"},
-  {"episode": "546_cloudflare_october_2022_tiered_cache_outage", "scenario": "tiered-cache-header-corruption","sha": "3b490e26a0a626aa2acd9df691916af777f2ae8e", "short": "546_cloudflare"},
-  {"episode": "703_shopify_bfcm_incident",                       "scenario": "kafka-partition-saturation",    "sha": "0b1d495b0f308d913b461bc1117c8616f49645d2", "short": "703_shopify"},
-  {"episode": "casino-postgresql-lock-contention",               "scenario": "lock-contention",               "sha": "2c6a147b9e223f8df2553d1b559edb9200da9230", "short": "casino_postgresql"},
-  {"episode": "ehr-pgbouncer-pool-saturation",                   "scenario": "pool-saturation",               "sha": "62dfc29875afc61e8d0836015fa48009fca9e894", "short": "ehr_pgbouncer"},
-  {"episode": "food-delivery-redis-cpu-saturation",              "scenario": "redis-cpu-saturation",          "sha": "4c52202d84aa1949d591905b6aefa48f79f107a9", "short": "food_delivery_redis"}
+  {"episode": "059_Fortnite_34M_CCU_Service_Outage",             "scenario": "memcached-saturation",          "short": "059_fortnite",       "sha": "395b848541436fa2d1947619d8c6542f84e562cf"},
+  {"episode": "063_Twilio_Redis_Billing",                        "scenario": "redis-cascade-billing",         "short": "063_twilio",         "sha": "3b369d10102839a1282e29e5dd4d9c019e513958"},
+  {"episode": "093_cloudflare_byzantine_failure",                "scenario": "byzantine-fault-cascade",       "short": "093_cloudflare",     "sha": "54e27ec6cd6fa89a0a547f80a0f369fd3425dddb"},
+  {"episode": "211_DoorDash_June_2021_Outage",                   "scenario": "cascading-payment-failure",     "short": "211_doordash",       "sha": "654ed430f82c9d5836f6a3f2266763ea1b6490c5"},
+  {"episode": "213_PagerDuty_June_2014_Outage",                  "scenario": "cassandra-repair-degradation",  "short": "213_pagerduty",      "sha": "209ba5c62a4279a9913ca15f8b870ee9cc844b35"},
+  {"episode": "221_Base_September_2024_Outage",                  "scenario": "block-building-outage",         "short": "221_base",           "sha": "fe29f66dc7fe5ef73f2c58a8ab954db58abd96c3"},
+  {"episode": "353_postmark_upstream_cloud_provider_outage",     "scenario": "dns-upstream-outage",           "short": "353_postmark",       "sha": "f9bc9ca63cda0089334637cf9a2e86746ea860cb"},
+  {"episode": "546_cloudflare_october_2022_tiered_cache_outage", "scenario": "tiered-cache-header-corruption","short": "546_cloudflare",     "sha": "3b490e26a0a626aa2acd9df691916af777f2ae8e"},
+  {"episode": "703_shopify_bfcm_incident",                       "scenario": "kafka-partition-saturation",    "short": "703_shopify",        "sha": "0b1d495b0f308d913b461bc1117c8616f49645d2"},
+  {"episode": "casino-postgresql-lock-contention",               "scenario": "lock-contention",               "short": "casino_postgresql",  "sha": "2c6a147b9e223f8df2553d1b559edb9200da9230"},
+  {"episode": "ehr-pgbouncer-pool-saturation",                   "scenario": "pool-saturation",               "short": "ehr_pgbouncer",      "sha": "62dfc29875afc61e8d0836015fa48009fca9e894"},
+  {"episode": "food-delivery-redis-cpu-saturation",              "scenario": "redis-cpu-saturation",          "short": "food_delivery_redis", "sha": "4c52202d84aa1949d591905b6aefa48f79f107a9"}
 ]

--- a/q_branch/gensim-eval-scenarios.json
+++ b/q_branch/gensim-eval-scenarios.json
@@ -1,14 +1,14 @@
 [
-  {"episode": "059_Fortnite_34M_CCU_Service_Outage",             "scenario": "memcached-saturation",          "sha": "395b848541436fa2d1947619d8c6542f84e562cf"},
-  {"episode": "063_Twilio_Redis_Billing",                        "scenario": "redis-cascade-billing",         "sha": "3b369d10102839a1282e29e5dd4d9c019e513958"},
-  {"episode": "093_cloudflare_byzantine_failure",                "scenario": "byzantine-fault-cascade",       "sha": "54e27ec6cd6fa89a0a547f80a0f369fd3425dddb"},
-  {"episode": "211_DoorDash_June_2021_Outage",                   "scenario": "cascading-payment-failure",     "sha": "654ed430f82c9d5836f6a3f2266763ea1b6490c5"},
-  {"episode": "213_PagerDuty_June_2014_Outage",                  "scenario": "cassandra-repair-degradation",  "sha": "209ba5c62a4279a9913ca15f8b870ee9cc844b35"},
-  {"episode": "221_Base_September_2024_Outage",                  "scenario": "block-building-outage",         "sha": "fe29f66dc7fe5ef73f2c58a8ab954db58abd96c3"},
-  {"episode": "353_postmark_upstream_cloud_provider_outage",     "scenario": "dns-upstream-outage",           "sha": "f9bc9ca63cda0089334637cf9a2e86746ea860cb"},
-  {"episode": "546_cloudflare_october_2022_tiered_cache_outage", "scenario": "tiered-cache-header-corruption","sha": "3b490e26a0a626aa2acd9df691916af777f2ae8e"},
-  {"episode": "703_shopify_bfcm_incident",                       "scenario": "kafka-partition-saturation",    "sha": "0b1d495b0f308d913b461bc1117c8616f49645d2"},
-  {"episode": "casino-postgresql-lock-contention",               "scenario": "lock-contention",               "sha": "2c6a147b9e223f8df2553d1b559edb9200da9230"},
-  {"episode": "ehr-pgbouncer-pool-saturation",                   "scenario": "pool-saturation",               "sha": "62dfc29875afc61e8d0836015fa48009fca9e894"},
-  {"episode": "food-delivery-redis-cpu-saturation",              "scenario": "redis-cpu-saturation",          "sha": "4c52202d84aa1949d591905b6aefa48f79f107a9"}
+  {"episode": "059_Fortnite_34M_CCU_Service_Outage",             "scenario": "memcached-saturation",          "sha": "395b848541436fa2d1947619d8c6542f84e562cf", "short": "059_fortnite"},
+  {"episode": "063_Twilio_Redis_Billing",                        "scenario": "redis-cascade-billing",         "sha": "3b369d10102839a1282e29e5dd4d9c019e513958", "short": "063_twilio"},
+  {"episode": "093_cloudflare_byzantine_failure",                "scenario": "byzantine-fault-cascade",       "sha": "54e27ec6cd6fa89a0a547f80a0f369fd3425dddb", "short": "093_cloudflare"},
+  {"episode": "211_DoorDash_June_2021_Outage",                   "scenario": "cascading-payment-failure",     "sha": "654ed430f82c9d5836f6a3f2266763ea1b6490c5", "short": "211_doordash"},
+  {"episode": "213_PagerDuty_June_2014_Outage",                  "scenario": "cassandra-repair-degradation",  "sha": "209ba5c62a4279a9913ca15f8b870ee9cc844b35", "short": "213_pagerduty"},
+  {"episode": "221_Base_September_2024_Outage",                  "scenario": "block-building-outage",         "sha": "fe29f66dc7fe5ef73f2c58a8ab954db58abd96c3", "short": "221_base"},
+  {"episode": "353_postmark_upstream_cloud_provider_outage",     "scenario": "dns-upstream-outage",           "sha": "f9bc9ca63cda0089334637cf9a2e86746ea860cb", "short": "353_postmark"},
+  {"episode": "546_cloudflare_october_2022_tiered_cache_outage", "scenario": "tiered-cache-header-corruption","sha": "3b490e26a0a626aa2acd9df691916af777f2ae8e", "short": "546_cloudflare"},
+  {"episode": "703_shopify_bfcm_incident",                       "scenario": "kafka-partition-saturation",    "sha": "0b1d495b0f308d913b461bc1117c8616f49645d2", "short": "703_shopify"},
+  {"episode": "casino-postgresql-lock-contention",               "scenario": "lock-contention",               "sha": "2c6a147b9e223f8df2553d1b559edb9200da9230", "short": "casino_postgresql"},
+  {"episode": "ehr-pgbouncer-pool-saturation",                   "scenario": "pool-saturation",               "sha": "62dfc29875afc61e8d0836015fa48009fca9e894", "short": "ehr_pgbouncer"},
+  {"episode": "food-delivery-redis-cpu-saturation",              "scenario": "redis-cpu-saturation",          "sha": "4c52202d84aa1949d591905b6aefa48f79f107a9", "short": "food_delivery_redis"}
 ]

--- a/tasks/libs/q/eval.py
+++ b/tasks/libs/q/eval.py
@@ -448,17 +448,28 @@ def _resolve_zip_from_runs_jsonl(ctx, name):
         if not matches:
             return None
 
-        latest = matches[-1]
-        zip_key = latest.get("zip")
-        if zip_key:
+        # Walk newest-first, return the first zip that actually exists in S3.
+        for entry in reversed(matches):
+            zip_key = entry.get("zip")
+            if not zip_key:
+                continue
+            check = ctx.run(
+                f"aws-vault exec {AWS_PROFILE} -- aws s3api head-object --bucket {S3_BUCKET} --key {shlex.quote(zip_key)}",
+                warn=True,
+                hide=True,
+            )
+            if check is None or check.failed:
+                print(color_message(f"  '{zip_key}' not found in S3, trying previous run...", Color.BLUE))
+                continue
             print(
                 color_message(
                     f"Resolved '{name}' from runs.jsonl: {zip_key} "
-                    f"(image: {latest.get('image', '?')}, {latest.get('timestamp', '?')})",
+                    f"(image: {entry.get('image', '?')}, {entry.get('timestamp', '?')})",
                     Color.BLUE,
                 )
             )
-        return zip_key
+            return zip_key
+        return None
     except (OSError, json.JSONDecodeError):
         return None
     finally:

--- a/tasks/libs/q/eval.py
+++ b/tasks/libs/q/eval.py
@@ -17,14 +17,13 @@ from tasks.libs.common.color import Color, color_message
 
 # --- Constants ---
 
-SCENARIOS = ["213_pagerduty", "353_postmark", "food_delivery_redis"]
+_MANIFEST_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "..", "q_branch", "gensim-eval-scenarios.json")
+with open(_MANIFEST_PATH) as _f:
+    _EVAL_MANIFEST = json.load(_f)
 
-# Maps short scenario names to episode names used in runs.jsonl
-SCENARIO_EPISODE_NAMES = {
-    "213_pagerduty": "213_PagerDuty_June_2014_Outage",
-    "353_postmark": "353_postmark_upstream_cloud_provider_outage",
-    "food_delivery_redis": "food-delivery-redis-cpu-saturation",
-}
+# Short name → full episode name, loaded from the eval corpus manifest.
+SCENARIO_EPISODE_NAMES = {entry["short"]: entry["episode"] for entry in _EVAL_MANIFEST}
+SCENARIOS = list(SCENARIO_EPISODE_NAMES.keys())
 
 S3_BUCKET = "qbranch-gensim-recordings"
 AWS_PROFILE = "sso-agent-sandbox-account-admin"
@@ -441,8 +440,11 @@ def _resolve_zip_from_runs_jsonl(ctx, name):
                 except json.JSONDecodeError:
                     continue  # skip malformed records
 
-        # Find the latest entry matching this episode
-        matches = [entry for entry in lines if entry.get("episode") == episode_name]
+        # Find the latest successful entry matching this episode.
+        # parquet_count < 100 indicates a failed or incomplete run (empirically: 0 or 2).
+        matches = [
+            entry for entry in lines if entry.get("episode") == episode_name and entry.get("parquet_count", 0) >= 100
+        ]
         if not matches:
             return None
 


### PR DESCRIPTION
## Summary
- `SCENARIOS` and `SCENARIO_EPISODE_NAMES` in `tasks/libs/q/eval.py` now load dynamically from the manifest instead of being hardcoded
- Adds `"short"` key to `q_branch/gensim-eval-scenarios.json` as single source of truth for scenario short names
- `_resolve_zip_from_runs_jsonl` now filters out failed/incomplete runs using `parquet_count >= 100` (empirical split: bad runs are 0–2 parquets, good runs are 194+)

## Test plan
- [x] `dda inv q.download-scenarios` against S3 to verify all 12 scenarios resolve correctly
- [x] `dda inv q.eval-scenarios` to verify full corpus runs end-to-end