### PR TITLE
perf(discovery): remove UTF-8 conversion from injector maps check

### DIFF
--- a/pkg/discovery/module/rust/src/procfs/maps.rs
+++ b/pkg/discovery/module/rust/src/procfs/maps.rs
@@ -120,9 +120,6 @@ pub fn read_maps_info_from_reader<R: BufRead>(reader: R) -> MapsInfo {
 ///
 /// Matches paths like:
 ///   /opt/datadog-packages/datadog-apm-inject/<version>/inject/launcher.preload.so
-///
-/// Operates on raw bytes — no UTF-8 conversion needed since the matched path
-/// is pure ASCII.
 fn is_injector_line(line: &[u8]) -> bool {
     if !line.ends_with(INJECTOR_SUFFIX) {
         return false;

--- a/pkg/discovery/module/rust/src/procfs/maps.rs
+++ b/pkg/discovery/module/rust/src/procfs/maps.rs
@@ -28,6 +28,10 @@ static GPU_LIB_FINDERS: LazyLock<[Finder<'static>; 7]> = LazyLock::new(|| {
 
 static DDTRACE_FINDER: LazyLock<Finder<'static>> = LazyLock::new(|| Finder::new(b"/ddtrace/"));
 
+static INJECTOR_PREFIX_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(b"/opt/datadog-packages/datadog-apm-inject/"));
+const INJECTOR_SUFFIX: &[u8] = b"/inject/launcher.preload.so";
+
 /// Consolidated information extracted from a single scan of /proc/[pid]/maps.
 #[derive(Debug, Default)]
 pub struct MapsInfo {
@@ -116,32 +120,20 @@ pub fn read_maps_info_from_reader<R: BufRead>(reader: R) -> MapsInfo {
 ///
 /// Matches paths like:
 ///   /opt/datadog-packages/datadog-apm-inject/<version>/inject/launcher.preload.so
+///
+/// Operates on raw bytes — no UTF-8 conversion needed since the matched path
+/// is pure ASCII.
 fn is_injector_line(line: &[u8]) -> bool {
-    let Ok(line) = std::str::from_utf8(line) else {
-        return false;
-    };
-
-    let Some(filename) = line.split_whitespace().last() else {
-        return false;
-    };
-
-    let Some(after_prefix) = filename.strip_prefix("/opt/datadog-packages/datadog-apm-inject/")
-    else {
-        return false;
-    };
-
-    let Some(slash_pos) = after_prefix.find('/') else {
-        return false;
-    };
-
-    // Non-empty version component
-    if slash_pos == 0 {
+    if !line.ends_with(INJECTOR_SUFFIX) {
         return false;
     }
-
-    after_prefix
-        .get(slash_pos..)
-        .is_some_and(|remainder| remainder == "/inject/launcher.preload.so")
+    let Some(pos) = INJECTOR_PREFIX_FINDER.find(line) else {
+        return false;
+    };
+    let version_start = pos + INJECTOR_PREFIX_FINDER.needle().len();
+    let suffix_start = line.len() - INJECTOR_SUFFIX.len();
+    // Version component between prefix and suffix must be non-empty
+    suffix_start > version_start
 }
 
 #[cfg(test)]
@@ -493,5 +485,14 @@ ffffb7360000-ffffb74ec000 r-xp 00000000 00:22 13920  /opt/datadog-packages/datad
                 lib
             );
         }
+    }
+
+    #[test]
+    fn test_maps_info_apm_injector_empty_version() {
+        // Empty version component (consecutive slashes)
+        let info = maps_info_from(
+            "ffffb7360000-ffffb74ec000 r-xp 00000000 00:22 13920  /opt/datadog-packages/datadog-apm-inject//inject/launcher.preload.so\n",
+        );
+        assert!(!info.has_apm_injector);
     }
 }


### PR DESCRIPTION
### What does this PR do?

Replaces the `std::str::from_utf8` + string operations in `is_injector_line()` with byte-level `Finder` + `ends_with`, consistent with the other four signal checks in the consolidated maps scanner. The matched path (`/opt/datadog-packages/datadog-apm-inject/<version>/inject/launcher.preload.so`) is pure ASCII, so UTF-8 validation was unnecessary overhead.

Also adds a test for the empty-version edge case (consecutive slashes).

### Motivation

Follow-up to #49013 which consolidated `/proc/[pid]/maps` reads into a single scan and noted this optimization opportunity:

> "the injector check doesn't need UTF-8 conversion"

### Describe how you validated your changes

All 31 existing maps tests pass plus the new `test_maps_info_apm_injector_empty_version` test. `bazel build --config=lint //pkg/discovery/module/rust/...` passes.

Ad-hoc benchmark (1M iterations, `--release`):

| Input | Old (UTF-8) | New (bytes) | Speedup |
|-------|-------------|-------------|---------|
| Matching line | 210 ns | 79 ns | 2.7x |
| Non-matching line | 115 ns | 5 ns | 22x |

### Additional Notes

The prefix `/opt/datadog-packages/datadog-apm-inject/` cannot appear in the non-pathname columns of `/proc/[pid]/maps` (those contain hex addresses, permissions, offsets, device numbers, and inode numbers), so matching the prefix anywhere in the line is equivalent to matching only in the filename field.