### PR TITLE
[observer] Per-source attribution for late and dropped data points

### DIFF
--- a/comp/observer/impl/advance_log.go
+++ b/comp/observer/impl/advance_log.go
@@ -18,10 +18,12 @@ const advanceLogFileName = "advances.jsonl"
 // advanceEntry records a single advance call, including data ingestion counters
 // accumulated since the previous advance.
 type advanceEntry struct {
-	DataTime   int64  `json:"data_time"`
-	Reason     string `json:"reason"`
-	LatePoints int64  `json:"late_points,omitempty"` // points ingested after their timestamp was analyzed
-	DroppedObs int64  `json:"dropped_obs,omitempty"` // observations dropped due to full channel
+	DataTime           int64            `json:"data_time"`
+	Reason             string           `json:"reason"`
+	LatePoints         int64            `json:"late_points,omitempty"`            // points ingested after their timestamp was analyzed
+	LatePointsBySource map[string]int64 `json:"late_points_by_source,omitempty"` // per-source breakdown
+	DroppedObs         int64            `json:"dropped_obs,omitempty"`            // observations dropped due to full channel
+	DroppedBySource    map[string]int64 `json:"dropped_by_source,omitempty"`     // per-source breakdown
 }
 
 func advanceReasonString(r advanceReason) string {
@@ -70,12 +72,14 @@ func (r *advanceLogRecorder) close() error {
 
 // advanceLogComparator compares advance sequences between live and replay.
 type advanceLogComparator struct {
-	liveAdvances    map[int64]advanceEntry // dataTime → full entry
-	replayOnly      []advanceEntry
-	liveOnly        []advanceEntry
-	matched         int
-	totalLatePoints int64
-	totalDroppedObs int64
+	liveAdvances           map[int64]advanceEntry // dataTime → full entry
+	replayOnly             []advanceEntry
+	liveOnly               []advanceEntry
+	matched                int
+	totalLatePoints        int64
+	totalDroppedObs        int64
+	totalLateBySource      map[string]int64
+	totalDroppedBySource   map[string]int64
 }
 
 func newAdvanceLogComparator(path string) (*advanceLogComparator, error) {
@@ -87,6 +91,8 @@ func newAdvanceLogComparator(path string) (*advanceLogComparator, error) {
 
 	advances := make(map[int64]advanceEntry)
 	var totalLate, totalDropped int64
+	lateBySource := make(map[string]int64)
+	droppedBySource := make(map[string]int64)
 	dec := json.NewDecoder(f)
 	for dec.More() {
 		var e advanceEntry
@@ -96,12 +102,20 @@ func newAdvanceLogComparator(path string) (*advanceLogComparator, error) {
 		advances[e.DataTime] = e
 		totalLate += e.LatePoints
 		totalDropped += e.DroppedObs
+		for src, count := range e.LatePointsBySource {
+			lateBySource[src] += count
+		}
+		for src, count := range e.DroppedBySource {
+			droppedBySource[src] += count
+		}
 	}
 
 	return &advanceLogComparator{
-		liveAdvances:    advances,
-		totalLatePoints: totalLate,
-		totalDroppedObs: totalDropped,
+		liveAdvances:         advances,
+		totalLatePoints:      totalLate,
+		totalDroppedObs:      totalDropped,
+		totalLateBySource:    lateBySource,
+		totalDroppedBySource: droppedBySource,
 	}, nil
 }
 
@@ -131,6 +145,20 @@ func (c *advanceLogComparator) printSummary() {
 	if c.totalLatePoints > 0 || c.totalDroppedObs > 0 {
 		fmt.Printf("[testbench] Live ingestion anomalies: %d late points, %d dropped observations\n",
 			c.totalLatePoints, c.totalDroppedObs)
+		if len(c.totalLateBySource) > 0 {
+			fmt.Printf("[testbench] Late points by source:")
+			for src, count := range c.totalLateBySource {
+				fmt.Printf(" %s=%d", src, count)
+			}
+			fmt.Println()
+		}
+		if len(c.totalDroppedBySource) > 0 {
+			fmt.Printf("[testbench] Dropped observations by source:")
+			for src, count := range c.totalDroppedBySource {
+				fmt.Printf(" %s=%d", src, count)
+			}
+			fmt.Println()
+		}
 	}
 
 	if len(c.replayOnly) == 0 && len(c.liveOnly) == 0 {

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -103,8 +103,10 @@ type engine struct {
 	onAdvance      func(advanceEntry) // scheduler trace
 
 	// Counters for data ingestion anomalies, reset after each advance.
-	latePoints atomic.Int64 // points ingested after their timestamp was already analyzed
-	droppedObs atomic.Int64 // observations dropped due to full channel
+	latePoints         atomic.Int64      // points ingested after their timestamp was already analyzed
+	latePointsBySource map[string]int64  // per-source breakdown (single-goroutine access from run loop)
+	handles            []*handle         // registered handles for per-source drop collection
+	handlesMu          sync.Mutex        // protects handles slice
 }
 
 // engineConfig holds the parameters for constructing an engine.
@@ -197,6 +199,14 @@ func (e *engine) emit(evt engineEvent) {
 	}
 }
 
+// registerHandle adds a handle to the engine's handle list so that per-source
+// drop counts can be collected at advance time.
+func (e *engine) registerHandle(h *handle) {
+	e.handlesMu.Lock()
+	e.handles = append(e.handles, h)
+	e.handlesMu.Unlock()
+}
+
 // IngestMetric stores a metric observation and consults the scheduler policy
 // to determine whether detectors should advance. Returns advance requests
 // that the caller should execute via Advance.
@@ -206,6 +216,10 @@ func (e *engine) IngestMetric(source string, m *metricObs) []advanceRequest {
 	// These points are in storage but were invisible to detectors at analysis time.
 	if m.timestamp <= e.lastAnalyzedDataTime {
 		e.latePoints.Add(1)
+		if e.latePointsBySource == nil {
+			e.latePointsBySource = make(map[string]int64)
+		}
+		e.latePointsBySource[source]++
 	}
 	e.trackLatestDataTime(m.timestamp)
 	return e.scheduler.onObservation(m.timestamp, e.schedulerState())
@@ -339,11 +353,32 @@ func (e *engine) advanceWithReason(upToSec int64, reason advanceReason) advanceR
 	e.mu.Unlock()
 
 	if e.onAdvance != nil {
+		var lateBySource map[string]int64
+		if len(e.latePointsBySource) > 0 {
+			lateBySource = e.latePointsBySource
+			e.latePointsBySource = nil
+		}
+		var totalDrops int64
+		var dropsBySource map[string]int64
+		e.handlesMu.Lock()
+		for _, h := range e.handles {
+			n := h.dropCount.Swap(0)
+			if n > 0 {
+				totalDrops += n
+				if dropsBySource == nil {
+					dropsBySource = make(map[string]int64)
+				}
+				dropsBySource[h.source] += n
+			}
+		}
+		e.handlesMu.Unlock()
 		e.onAdvance(advanceEntry{
-			DataTime:   upToSec,
-			Reason:     advanceReasonString(reason),
-			LatePoints: e.latePoints.Swap(0),
-			DroppedObs: e.droppedObs.Swap(0),
+			DataTime:           upToSec,
+			Reason:             advanceReasonString(reason),
+			LatePoints:         e.latePoints.Swap(0),
+			LatePointsBySource: lateBySource,
+			DroppedObs:         totalDrops,
+			DroppedBySource:    dropsBySource,
 		})
 	}
 

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -718,7 +718,8 @@ func (o *observerImpl) GetHandle(name string) observerdef.Handle {
 // with hfFilteredHandle to suppress 15s samples for checks that have a 1s HF
 // counterpart active — the scorer should only see the higher-resolution stream.
 func (o *observerImpl) innerHandle(name string) observerdef.Handle {
-	h := &handle{ch: o.obsCh, source: name, dropCount: &o.engine.droppedObs, dropCounter: o.dropCounter}
+	h := &handle{ch: o.obsCh, source: name, dropCounter: o.dropCounter}
+	o.engine.registerHandle(h)
 	if len(o.hfFilterSources) > 0 && name == "all-metrics" {
 		return &hfFilteredHandle{inner: h, sources: o.hfFilterSources}
 	}
@@ -811,7 +812,7 @@ func (o *observerImpl) DumpMetrics(path string) error {
 type handle struct {
 	ch          chan<- observation
 	source      string
-	dropCount   *atomic.Int64     // shared with engine.droppedObs for parity debugging; may be nil
+	dropCount   atomic.Int64      // per-handle drop counter, collected by engine at advance time
 	dropCounter telemetry.Counter // tagged by source for Prometheus visibility; may be nil
 }
 
@@ -843,9 +844,7 @@ func (h *handle) ObserveMetric(sample observerdef.MetricView) {
 	select {
 	case h.ch <- obs:
 	default:
-		if h.dropCount != nil {
-			h.dropCount.Add(1)
-		}
+		h.dropCount.Add(1)
 		if h.dropCounter != nil {
 			h.dropCounter.Add(1, h.source)
 		}
@@ -872,9 +871,7 @@ func (h *handle) ObserveLog(msg observerdef.LogView) {
 	select {
 	case h.ch <- obs:
 	default:
-		if h.dropCount != nil {
-			h.dropCount.Add(1)
-		}
+		h.dropCount.Add(1)
 		if h.dropCounter != nil {
 			h.dropCounter.Add(1, h.source)
 		}
@@ -928,9 +925,7 @@ func (h *handle) ObserveTrace(trace observerdef.TraceView) {
 	select {
 	case h.ch <- obs:
 	default:
-		if h.dropCount != nil {
-			h.dropCount.Add(1)
-		}
+		h.dropCount.Add(1)
 		if h.dropCounter != nil {
 			h.dropCounter.Add(1, h.source)
 		}
@@ -970,9 +965,7 @@ func (h *handle) ObserveProfile(profile observerdef.ProfileView) {
 	select {
 	case h.ch <- obs:
 	default:
-		if h.dropCount != nil {
-			h.dropCount.Add(1)
-		}
+		h.dropCount.Add(1)
 		if h.dropCounter != nil {
 			h.dropCounter.Add(1, h.source)
 		}


### PR DESCRIPTION
## Summary

- Adds per-source breakdown (`late_points_by_source`, `dropped_by_source`) to the advance log alongside existing aggregate counters
- Drops are now tracked per-handle with individual atomic counters, collected by the engine at advance time
- The testbench comparator aggregates and displays per-source totals when parity data is available

## Motivation

We're investigating detection divergence between live mode and testbench replay. Parity instrumentation shows ~21-24s time-shifted anomaly detections and ~27K late points per run, but we currently can't attribute them to specific data sources. This makes it impossible to confirm whether the trace-agent concentrator delay is the dominant cause vs other sources contributing late data.

## Test plan

- [x] `go test ./comp/observer/impl/` passes
- [x] Testbench runs against existing scenario data (no per-source fields) without regression
- [ ] Next gensim-eks run will produce advance logs with per-source fields to confirm trace-agent attribution