### PR TITLE
docs(AGENTS.md): instruct AI agents to use dda inv instead of raw go commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,13 +47,13 @@ wrapper tasks (defined in `tasks/`) compute the right build tags automatically.
 
 **Never run these commands directly:**
 
-| Instead of              | Use                                           |
-|-------------------------|-----------------------------------------------|
-| `go build …`           | `dda inv agent.build`, `dda inv cluster-agent.build`, etc. |
-| `go test …`            | `dda inv test --targets=./pkg/…`              |
-| `go mod tidy`          | `dda inv tidy`                                |
-| `go vet …`             | `dda inv linter.go`                           |
-| `golangci-lint run …`  | `dda inv linter.go`                           |
+| Instead of | Use |
+|---|---|
+| `go build …` | `dda inv agent.build`, `dda inv cluster-agent.build`, etc. |
+| `go test …` | `dda inv test --targets=./pkg/…` |
+| `go mod tidy` | `dda inv tidy` |
+| `go vet …` | `dda inv linter.go` |
+| `golangci-lint run …` | `dda inv linter.go` |
 
 This also applies to indirect usage — do not shell out to `go build` or
 `go test` for compilation checks. If you need to verify that code compiles,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,26 @@ The Datadog Agent is a comprehensive monitoring and observability agent written 
 
 ## Development Workflow
 
+### Critical: Always use `dda inv`, never raw `go` commands
+
+This project uses extensive custom Go build tags. Most source files are ignored
+by the standard Go toolchain unless the correct tags are passed. The `dda inv`
+wrapper tasks (defined in `tasks/`) compute the right build tags automatically.
+
+**Never run these commands directly:**
+
+| Instead of              | Use                                           |
+|-------------------------|-----------------------------------------------|
+| `go build …`           | `dda inv agent.build`, `dda inv cluster-agent.build`, etc. |
+| `go test …`            | `dda inv test --targets=./pkg/…`              |
+| `go mod tidy`          | `dda inv tidy`                                |
+| `go vet …`             | `dda inv linter.go`                           |
+| `golangci-lint run …`  | `dda inv linter.go`                           |
+
+This also applies to indirect usage — do not shell out to `go build` or
+`go test` for compilation checks. If you need to verify that code compiles,
+build the relevant component with `dda inv *.build`.
+
 ### Common Commands
 
 #### Building
@@ -144,7 +164,7 @@ Key Bazel macros:
 ## Testing Strategy
 
 ### Unit Tests
-- Go tests using standard `go test`
+- Go tests run via `dda inv test` (not raw `go test`)
 - Python tests using pytest
 - Run with `dda inv test --targets=<package>`
 


### PR DESCRIPTION
### What does this PR do?

Adds an explicit rule in `AGENTS.md` instructing AI coding agents to always use
`dda inv` wrapper tasks instead of raw Go toolchain commands (`go build`,
`go test`, `go mod tidy`, `go vet`, `golangci-lint`). Includes a mapping table
of the most common replacements.

Also fixes a contradictory line in the "Unit Tests" section that still referred
to "standard `go test`".

### Motivation

AI agents working on this codebase repeatedly attempt to use standard Go
toolchain commands, which fail or produce unreliable results because this project
makes massive use of custom Go build tags. The `dda inv` tasks (defined in
`tasks/`) compute the correct build tags automatically.

This has been a recurring problem across multiple AI-assisted sessions. Codifying
the rule in `AGENTS.md` ensures **all** AI agents see it upfront, not just those
with session-specific memory.

### Describe how you validated your changes

- Read the full `AGENTS.md` to confirm internal consistency after the edit.
- Used Codex (via MCP) to independently review the diff for contradictions —
  none remain.

### Additional Notes

Only documentation changes — no Agent binary code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)