### PR TITLE
fix ebpf build modes not affecting config

### DIFF
--- a/pkg/ebpf/ebpftest/buildmode_linux.go
+++ b/pkg/ebpf/ebpftest/buildmode_linux.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/ebpf/rlimit"
 
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/prebuilt"
 	"github.com/DataDog/datadog-agent/pkg/util/funcs"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -59,6 +60,7 @@ func TestBuildMode(t *testing.T, mode BuildMode, name string, fn func(t *testing
 		for k, v := range mode.Env() {
 			t.Setenv(k, v)
 		}
+		_ = mock.NewSystemProbe(t)
 		if name != "" {
 			t.Run(name, fn)
 		} else {

--- a/pkg/ebpf/ebpftest/buildmode_test.go
+++ b/pkg/ebpf/ebpftest/buildmode_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestBuildModeConstants(t *testing.T) {
 	TestBuildMode(t, Prebuilt, "", func(t *testing.T) {
-		mock.NewSystemProbe(t)
 		cfg := ebpf.NewConfig()
 		assert.False(t, cfg.EnableRuntimeCompiler)
 		assert.False(t, cfg.EnableCORE)
@@ -32,7 +31,6 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.Equal(t, Prebuilt, GetBuildMode())
 	})
 	TestBuildMode(t, RuntimeCompiled, "", func(t *testing.T) {
-		mock.NewSystemProbe(t)
 		cfg := ebpf.NewConfig()
 		assert.True(t, cfg.EnableRuntimeCompiler)
 		assert.False(t, cfg.EnableCORE)
@@ -44,7 +42,6 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.Equal(t, RuntimeCompiled, GetBuildMode())
 	})
 	TestBuildMode(t, CORE, "", func(t *testing.T) {
-		mock.NewSystemProbe(t)
 		cfg := ebpf.NewConfig()
 		assert.False(t, cfg.EnableRuntimeCompiler)
 		assert.True(t, cfg.EnableCORE)
@@ -56,7 +53,6 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.Equal(t, CORE, GetBuildMode())
 	})
 	TestBuildMode(t, Fentry, "", func(t *testing.T) {
-		mock.NewSystemProbe(t)
 		cfg := ebpf.NewConfig()
 		assert.False(t, cfg.EnableRuntimeCompiler)
 		assert.True(t, cfg.EnableCORE)
@@ -68,7 +64,6 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.Equal(t, Fentry, GetBuildMode())
 	})
 	TestBuildMode(t, Ebpfless, "", func(t *testing.T) {
-		mock.NewSystemProbe(t)
 		cfg := ebpf.NewConfig()
 		assert.False(t, cfg.EnableRuntimeCompiler)
 		assert.False(t, cfg.EnableCORE)

--- a/pkg/ebpf/ebpftest/buildmode_test.go
+++ b/pkg/ebpf/ebpftest/buildmode_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 )
 


### PR DESCRIPTION
### What does this PR do?

Ensures a new system-probe config re-evaluates environment variables with using the `ebpftest.TestBuildMode(s)` helpers.

### Motivation

build modes have not been affecting the config object since at least #45367 

### Describe how you validated your changes

### Additional Notes
