### PR TITLE
use absolute path for kmt ssh key

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1623,7 +1623,7 @@ def ssh_config(
                 print(f"    HostName {domain.ip}")
                 if instance.arch != "local":
                     print(f"    ProxyJump kmt-{stack_name}-{instance.arch}")
-                print(f"    IdentityFile {ddvm_rsa}")
+                print(f"    IdentityFile {os.path.abspath(ddvm_rsa)}")
                 print("    IdentitiesOnly yes")
                 print("    User root")
 


### PR DESCRIPTION
### What does this PR do?

Uses an absolute path for the SSH config for KMT guests

### Motivation

ability to SSH from any directory, not just the `datadog-agent` repo.

### Describe how you validated your changes

### Additional Notes
