### PR TITLE
Run macos jobs less often, linter only on main now we cross lint

### DIFF
--- a/.gitlab/build/lint/macos.yml
+++ b/.gitlab/build/lint/macos.yml
@@ -7,7 +7,7 @@ include:
   extends: .macos_gitlab
   rules:
     - !reference [.except_mergequeue]
-    - when: on_success
+    - !reference [.on_main_or_release_branch]
   script:
     - dda inv -- -e linter.go --cpus 12 --debug --timeout 60
   retry: !reference [.retry_only_infra_failure, retry]

--- a/.gitlab/build/source_test/macos.yml
+++ b/.gitlab/build/source_test/macos.yml
@@ -38,6 +38,8 @@ include:
   retry: !reference [.retry_only_infra_failure, retry]
 
 tests_macos_gitlab_amd64:
+  rules:
+    - !reference [.on_main_or_release_branch]
   extends: .tests_macos_gitlab
   tags: ["macos:sonoma-amd64", "specific:true"]
 


### PR DESCRIPTION
### What does this PR do?

Run MacOS jobs less often.
MacOS linter will be ran only on main, now that we have cross linting (https://github.com/DataDog/datadog-agent/pull/46536), we keep them on main for now to make sure both linters behave the same
Remove `amd64` version of the tests on PR. It is very unlikely that code changes break the unit tests only on one architecture

### Motivation

### Describe how you validated your changes

### Additional Notes
