### PR TITLE
[procmgr] Implement Named Pipe transport for Windows

### DIFF
--- a/pkg/procmgr/rust/src/platform/windows.rs
+++ b/pkg/procmgr/rust/src/platform/windows.rs
@@ -14,7 +14,6 @@ use windows_sys::Win32::System::Threading::{
 /// Place the child in its own process group so `GenerateConsoleCtrlEvent`
 /// can target it without affecting the daemon.
 pub fn setup_process_group(cmd: &mut tokio::process::Command) {
-    use std::os::windows::process::CommandExt as _;
     cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
 }
 

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -16,6 +16,7 @@ use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOpti
 use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
 
 const DEFAULT_PIPE_PATH: &str = r"\\.\pipe\datadog-procmgrd";
+const DEFAULT_PIPE_INSTANCES: usize = 4;
 
 /// Placeholder URI for tonic Endpoint when connecting over Named Pipes.
 /// The actual address is irrelevant because `connect_with_connector` bypasses it.
@@ -97,7 +98,11 @@ where
 
     info!("gRPC server listening on {}", path.display());
 
-    let (tx, rx) = tokio::sync::mpsc::channel::<io::Result<NamedPipeIo>>(4);
+    let max_instances = std::env::var("DD_PM_PIPE_INSTANCES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_PIPE_INSTANCES);
+    let (tx, rx) = tokio::sync::mpsc::channel::<io::Result<NamedPipeIo>>(max_instances);
 
     let accept_handle = tokio::spawn(accept_loop(pipe_name, server, tx));
 

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -181,7 +181,10 @@ async fn open_pipe_with_retry(
     for attempt in 0..PIPE_BUSY_RETRIES {
         match ClientOptions::new().open(name) {
             Ok(client) => return Ok(hyper_util::rt::TokioIo::new(client)),
-            Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) && attempt + 1 < PIPE_BUSY_RETRIES => {
+            Err(e)
+                if e.raw_os_error() == Some(ERROR_PIPE_BUSY as i32)
+                    && attempt + 1 < PIPE_BUSY_RETRIES =>
+            {
                 tokio::time::sleep(std::time::Duration::from_millis(backoff)).await;
                 backoff *= 2;
             }

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -13,6 +13,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOptions};
+use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
 
 const DEFAULT_PIPE_PATH: &str = r"\\.\pipe\datadog-procmgrd";
 
@@ -152,12 +153,33 @@ pub async fn connect(path: &Path) -> Result<tonic::transport::Channel> {
     let channel = tonic::transport::Endpoint::from_static(DUMMY_ENDPOINT)
         .connect_with_connector(tower::service_fn(move |_| {
             let name = pipe_name.clone();
-            async move {
-                let client = ClientOptions::new().open(&name)?;
-                Ok::<_, io::Error>(hyper_util::rt::TokioIo::new(client))
-            }
+            async move { open_pipe_with_retry(&name).await }
         }))
         .await
         .context("failed to connect to named pipe")?;
     Ok(channel)
+}
+
+const PIPE_BUSY_RETRIES: u32 = 5;
+const PIPE_BUSY_BACKOFF_MS: u64 = 50;
+
+/// Open a named pipe client, retrying on `ERROR_PIPE_BUSY`.
+///
+/// All server instances may be occupied when the client calls `open()`.
+/// Windows named pipe clients are expected to wait and retry in this case.
+async fn open_pipe_with_retry(
+    name: &std::ffi::OsStr,
+) -> io::Result<hyper_util::rt::TokioIo<tokio::net::windows::named_pipe::NamedPipeClient>> {
+    let mut backoff = PIPE_BUSY_BACKOFF_MS;
+    for attempt in 0..PIPE_BUSY_RETRIES {
+        match ClientOptions::new().open(name) {
+            Ok(client) => return Ok(hyper_util::rt::TokioIo::new(client)),
+            Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) && attempt + 1 < PIPE_BUSY_RETRIES => {
+                tokio::time::sleep(std::time::Duration::from_millis(backoff)).await;
+                backoff *= 2;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    unreachable!()
 }

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -142,8 +142,13 @@ async fn accept_loop(
 ) -> Result<()> {
     loop {
         if let Err(e) = server.connect().await {
+            let msg = format!(
+                "named pipe accept failed on {}: {}",
+                pipe_name.to_string_lossy(),
+                e
+            );
             let _ = tx.send(Err(e)).await;
-            anyhow::bail!("named pipe accept failed");
+            anyhow::bail!(msg);
         }
 
         let connected = server;
@@ -171,7 +176,7 @@ pub async fn connect(path: &Path) -> Result<tonic::transport::Channel> {
             async move { open_pipe_with_retry(&name).await }
         }))
         .await
-        .context("failed to connect to named pipe")?;
+        .with_context(|| format!("failed to connect to named pipe {}", path.display()))?;
     Ok(channel)
 }
 

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -99,11 +99,7 @@ where
 
     let (tx, rx) = tokio::sync::mpsc::channel::<io::Result<NamedPipeIo>>(4);
 
-    let accept_handle = tokio::spawn(async move {
-        if let Err(e) = accept_loop(pipe_name, server, tx).await {
-            log::error!("named pipe accept loop error: {e}");
-        }
-    });
+    let accept_handle = tokio::spawn(accept_loop(pipe_name, server, tx));
 
     let incoming = tokio_stream::wrappers::ReceiverStream::new(rx);
 
@@ -113,6 +109,17 @@ where
         .context("gRPC server error")?;
 
     accept_handle.abort();
+
+    // If the accept loop finished before we aborted it (i.e. it hit a fatal
+    // error and dropped the sender, which ended the incoming stream), surface
+    // that error instead of returning Ok.
+    match accept_handle.await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => return Err(e).context("named pipe accept loop failed"),
+        Err(join_err) if join_err.is_cancelled() => {}
+        Err(join_err) => std::panic::resume_unwind(join_err.into_panic()),
+    }
+
     info!("gRPC server stopped");
     Ok(())
 }

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -89,12 +89,17 @@ where
     let path = ipc_path();
     let pipe_name = path.as_os_str().to_os_string();
 
+    let server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(&pipe_name)
+        .context("failed to create named pipe")?;
+
     info!("gRPC server listening on {}", path.display());
 
     let (tx, rx) = tokio::sync::mpsc::channel::<io::Result<NamedPipeIo>>(4);
 
     let accept_handle = tokio::spawn(async move {
-        if let Err(e) = accept_loop(pipe_name, tx).await {
+        if let Err(e) = accept_loop(pipe_name, server, tx).await {
             log::error!("named pipe accept loop error: {e}");
         }
     });
@@ -116,13 +121,9 @@ where
 /// so the next client can connect.
 async fn accept_loop(
     pipe_name: OsString,
+    mut server: NamedPipeServer,
     tx: tokio::sync::mpsc::Sender<io::Result<NamedPipeIo>>,
 ) -> Result<()> {
-    let mut server = ServerOptions::new()
-        .first_pipe_instance(true)
-        .create(&pipe_name)
-        .context("failed to create first named pipe instance")?;
-
     loop {
         if let Err(e) = server.connect().await {
             let _ = tx.send(Err(e)).await;

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -3,13 +3,21 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
+use log::info;
+use std::ffi::OsString;
 use std::future::Future;
+use std::io;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOptions};
 
 const DEFAULT_PIPE_PATH: &str = r"\\.\pipe\datadog-procmgrd";
 
 /// Placeholder URI for tonic Endpoint when connecting over Named Pipes.
+/// The actual address is irrelevant because `connect_with_connector` bypasses it.
 pub const DUMMY_ENDPOINT: &str = "http://[::]:50051";
 
 pub fn ipc_path() -> PathBuf {
@@ -18,21 +26,137 @@ pub fn ipc_path() -> PathBuf {
         .unwrap_or_else(|_| PathBuf::from(DEFAULT_PIPE_PATH))
 }
 
+/// Named pipes don't require filesystem preparation.
 pub fn prepare(_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Named pipe permissions are set via security descriptors at creation time.
 pub fn set_permissions(_path: &Path) {}
 
-pub async fn serve<F>(_router: tonic::transport::server::Router, _shutdown: F) -> Result<()>
+/// Named pipes are kernel objects; no filesystem cleanup needed.
+pub fn cleanup(_path: &Path) {}
+
+// ---------------------------------------------------------------------------
+// NamedPipeIo — wrapper for tonic's `Connected` trait
+// ---------------------------------------------------------------------------
+
+/// Newtype around [`NamedPipeServer`] that implements
+/// [`tonic::transport::server::Connected`] so tonic can serve over it.
+struct NamedPipeIo(NamedPipeServer);
+
+impl tonic::transport::server::Connected for NamedPipeIo {
+    type ConnectInfo = ();
+    fn connect_info(&self) -> Self::ConnectInfo {}
+}
+
+impl AsyncRead for NamedPipeIo {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for NamedPipeIo {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_shutdown(cx)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+pub async fn serve<F>(router: tonic::transport::server::Router, shutdown: F) -> Result<()>
 where
     F: Future<Output = ()>,
 {
-    anyhow::bail!("Named Pipe transport is not yet implemented on Windows")
+    let path = ipc_path();
+    let pipe_name = path.as_os_str().to_os_string();
+
+    info!("gRPC server listening on {}", path.display());
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<io::Result<NamedPipeIo>>(4);
+
+    let accept_handle = tokio::spawn(async move {
+        if let Err(e) = accept_loop(pipe_name, tx).await {
+            log::error!("named pipe accept loop error: {e}");
+        }
+    });
+
+    let incoming = tokio_stream::wrappers::ReceiverStream::new(rx);
+
+    router
+        .serve_with_incoming_shutdown(incoming, shutdown)
+        .await
+        .context("gRPC server error")?;
+
+    accept_handle.abort();
+    info!("gRPC server stopped");
+    Ok(())
 }
 
-pub async fn connect(_path: &Path) -> Result<tonic::transport::Channel> {
-    anyhow::bail!("Named Pipe client transport is not yet implemented on Windows")
+/// Accept connections on the named pipe, sending each connected instance
+/// through the channel. Creates a new pipe instance after each connection
+/// so the next client can connect.
+async fn accept_loop(
+    pipe_name: OsString,
+    tx: tokio::sync::mpsc::Sender<io::Result<NamedPipeIo>>,
+) -> Result<()> {
+    let mut server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(&pipe_name)
+        .context("failed to create first named pipe instance")?;
+
+    loop {
+        if let Err(e) = server.connect().await {
+            let _ = tx.send(Err(e)).await;
+            anyhow::bail!("named pipe accept failed");
+        }
+
+        let connected = server;
+        server = ServerOptions::new()
+            .create(&pipe_name)
+            .context("failed to create next named pipe instance")?;
+
+        if tx.send(Ok(NamedPipeIo(connected))).await.is_err() {
+            break;
+        }
+    }
+
+    Ok(())
 }
 
-pub fn cleanup(_path: &Path) {}
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+pub async fn connect(path: &Path) -> Result<tonic::transport::Channel> {
+    let pipe_name = path.as_os_str().to_os_string();
+    let channel = tonic::transport::Endpoint::from_static(DUMMY_ENDPOINT)
+        .connect_with_connector(tower::service_fn(move |_| {
+            let name = pipe_name.clone();
+            async move {
+                let client = ClientOptions::new().open(&name)?;
+                Ok::<_, io::Error>(hyper_util::rt::TokioIo::new(client))
+            }
+        }))
+        .await
+        .context("failed to connect to named pipe")?;
+    Ok(channel)
+}

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -103,16 +103,19 @@ where
 
     let incoming = tokio_stream::wrappers::ReceiverStream::new(rx);
 
-    router
+    let serve_result = router
         .serve_with_incoming_shutdown(incoming, shutdown)
         .await
-        .context("gRPC server error")?;
+        .context("gRPC server error");
 
+    // Always cancel the accept loop before returning — even on error — so we
+    // don't leak a background task blocked on server.connect().
     accept_handle.abort();
 
-    // If the accept loop finished before we aborted it (i.e. it hit a fatal
-    // error and dropped the sender, which ended the incoming stream), surface
-    // that error instead of returning Ok.
+    // Surface the accept-loop error when tonic returned successfully (e.g. the
+    // incoming stream ended because the accept loop hit a fatal error and
+    // dropped the sender).
+    serve_result?;
     match accept_handle.await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => return Err(e).context("named pipe accept loop failed"),

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -117,6 +117,9 @@ impl DaemonHandle {
     pub fn stop(&mut self) -> ExitStatus {
         #[cfg(unix)]
         self.send_signal(Signal::SIGTERM);
+        // TODO(S19): replace with GenerateConsoleCtrlEvent for graceful shutdown;
+        // child.kill() is a force-kill placeholder until the Windows platform
+        // module implements proper signal delivery.
         #[cfg(windows)]
         {
             use windows_sys::Win32::System::Console::{CTRL_BREAK_EVENT, GenerateConsoleCtrlEvent};


### PR DESCRIPTION
### What does this PR do?

Replaces the stub implementations in `transport/named_pipe.rs` with a real Windows Named Pipe server and client for tonic gRPC:

- **Server** (`serve`): spawns an accept loop that creates `NamedPipeServer` instances via `ServerOptions`, waits for client connections, and sends them through an mpsc channel as a `ReceiverStream`. A `NamedPipeIo` newtype wraps `NamedPipeServer` to implement tonic's `Connected` trait. The accept task is aborted on graceful shutdown.
- **Client** (`connect`): uses `connect_with_connector` with `ClientOptions::open()`, mirroring the UDS transport pattern.
- Removes an unused `CommandExt` import in `platform/windows.rs` caught by Windows-target clippy.

### Motivation

Completes the Windows transport layer. After this PR, both `dd-procmgrd` and `dd-procmgr` binaries have all platform-specific code implemented for Windows (process management, IPC transport, config paths).

### Describe how you validated your changes

- `cargo clippy --target x86_64-pc-windows-msvc -- -D warnings`
- `cargo check --target x86_64-pc-windows-msvc`
- `cargo clippy --all-targets --all-features`
- `cargo fmt -- --check`
- All existing transport unit tests pass (`cargo test --lib transport`)
- Code is `#[cfg(windows)]` only

### Additional Notes

- Bazel targets remain Linux-only because the prost toolchain does not yet support Windows. Enabling Bazel Windows builds is tracked as a separate step.
- Runtime validation on Windows will happen in future PR.