### PR TITLE
Remove debug eBPF object files from agent package

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -146,13 +146,14 @@ build do
             # Deepest paths first so nested tests/ trees are removed safely.
             command "find #{install_dir}/embedded/lib -path '*/site-packages/*' -depth -type d -name tests -exec rm -rf {} +"
 
-            # remove some debug ebpf object files to reduce the size of the package
-            delete "#{install_dir}/embedded/share/system-probe/ebpf/co-re/oom-kill-debug.o"
-            delete "#{install_dir}/embedded/share/system-probe/ebpf/co-re/tcp-queue-length-debug.o"
+            # Remove debug eBPF object files — they enable bpf_trace_printk logging
+            # and are only useful for local development, not deployed environments.
+            command "rm -f #{install_dir}/embedded/share/system-probe/ebpf/*-debug.o"
+            command "rm -f #{install_dir}/embedded/share/system-probe/ebpf/co-re/*-debug.o"
+
+            # Remove test-only eBPF object files
             delete "#{install_dir}/embedded/share/system-probe/ebpf/co-re/error_telemetry.o"
             delete "#{install_dir}/embedded/share/system-probe/ebpf/co-re/logdebug-test.o"
-            delete "#{install_dir}/embedded/share/system-probe/ebpf/co-re/shared-libraries-debug.o"
-            delete "#{install_dir}/embedded/share/system-probe/ebpf/shared-libraries-debug.o"
 
             # linux build will be stripped - but psycopg2 affected by bug in the way binutils
             # and patchelf work together:

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,9 +1,9 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 757.69 MiB
-  max_on_wire_size: 179.41 MiB
+  max_on_disk_size: 750.31 MiB
+  max_on_wire_size: 179.16 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 718.06 MiB
-  max_on_wire_size: 174.66 MiB
+  max_on_disk_size: 710.68 MiB
+  max_on_wire_size: 174.44 MiB
 static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 322.13 MiB
   max_on_wire_size: 80.31 MiB
@@ -11,41 +11,41 @@ static_quality_gate_agent_msi:
   max_on_disk_size: 656.11 MiB
   max_on_wire_size: 147.55 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 757.66 MiB
-  max_on_wire_size: 182.28 MiB
+  max_on_disk_size: 750.28 MiB
+  max_on_wire_size: 182.08 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 718.04 MiB
-  max_on_wire_size: 174.43 MiB
+  max_on_disk_size: 710.66 MiB
+  max_on_wire_size: 174.14 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 739.38 MiB
-  max_on_wire_size: 163.8 MiB
+  max_on_disk_size: 732.02 MiB
+  max_on_wire_size: 163.61 MiB
 static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 700.78 MiB
-  max_on_wire_size: 157.12 MiB
+  max_on_disk_size: 693.42 MiB
+  max_on_wire_size: 156.85 MiB
 static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 757.66 MiB
-  max_on_wire_size: 182.28 MiB
+  max_on_disk_size: 750.28 MiB
+  max_on_wire_size: 182.08 MiB
 static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 718.04 MiB
-  max_on_wire_size: 174.43 MiB
+  max_on_disk_size: 710.66 MiB
+  max_on_wire_size: 174.14 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 739.38 MiB
-  max_on_wire_size: 163.8 MiB
+  max_on_disk_size: 732.02 MiB
+  max_on_wire_size: 163.61 MiB
 static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 700.78 MiB
-  max_on_wire_size: 157.12 MiB
+  max_on_disk_size: 693.42 MiB
+  max_on_wire_size: 156.85 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 820.01 MiB
-  max_on_wire_size: 274.04 MiB
+  max_on_disk_size: 812.63 MiB
+  max_on_wire_size: 272.99 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 826.06 MiB
-  max_on_wire_size: 262.52 MiB
+  max_on_disk_size: 818.7 MiB
+  max_on_wire_size: 261.47 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 1010.89 MiB
-  max_on_wire_size: 342.66 MiB
+  max_on_disk_size: 1003.51 MiB
+  max_on_wire_size: 341.61 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 1005.66 MiB
-  max_on_wire_size: 327.1 MiB
+  max_on_disk_size: 998.3 MiB
+  max_on_wire_size: 326.05 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 207.6 MiB
   max_on_wire_size: 73.46 MiB


### PR DESCRIPTION
### What does this PR do?

1. Removes all `*-debug.o` eBPF object files from the shipped agent package by replacing 6 hand-picked `delete` calls in the omnibus finalize step with two glob-based `rm -f` commands covering both `ebpf/` and `ebpf/co-re/`.

2. Tightens static quality gates by 70% of the observed size improvement (~7.4 MiB on-disk, ~0.2-1.05 MiB on-wire depending on flavor), leaving 30% as headroom for future development.

The debug variants are still built by Bazel (`ebpf_program_suite`) and staged locally — they are only excluded from the final package.

### Motivation

Debug eBPF `.o` files are compiled with `-DDEBUG=1`, which enables `bpf_trace_printk` logging to `trace_pipe`. They add ~10 MB to the package but are not used in deployed environments — USM (the only team that considered
enabling them for customers) confirmed the log volume would be impractical and there is no built-in collection mechanism.

Removing them frees up ~10 MB of package headroom across all agent flavors.

### Describe how you validated your changes

Packaging-only change in omnibus finalize. The `rm -f` glob is safe (no error on zero matches). Verified the glob pattern `*-debug.o` matches exactly the set of files produced by `ebpf_program_suite` debug targets. SQG values computed from the size report on the first push of this PR.

### Additional Notes

- Local dev workflow is unaffected: `dda inv system-probe.build` still produces debug `.o` files in `pkg/ebpf/bytecode/build/<arch>/` and `system_probe_config.bpf_debug` still works when running from the build dir.
- Test-only artifacts (`error_telemetry.o`, `logdebug-test.o`) remain explicitly deleted as before — they don't match the `-debug.o` glob.