### PR TITLE
Add datadogpodautoscalerclusterprofiles in the orchestrator OOTB CR

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -527,6 +527,7 @@ func newBuiltinCRDConfigs() []builtinCRDConfig {
 		newBuiltinCRDConfig(datadogAPIGroup, "datadogmonitors", isOOTBCRDEnabled, "v1alpha1"),
 		newBuiltinCRDConfig(datadogAPIGroup, "datadogmetrics", isOOTBCRDEnabled, "v1alpha1"),
 		newBuiltinCRDConfig(datadogAPIGroup, "datadogpodautoscalers", isOOTBCRDEnabled, "v1alpha2"),
+		newBuiltinCRDConfig(datadogAPIGroup, "datadogpodautoscalerclusterprofiles", isOOTBCRDEnabled, "v1alpha2"),
 		newBuiltinCRDConfig(datadogAPIGroup, "datadogagents", isOOTBCRDEnabled, "v2alpha1"),
 
 		// Argo resources

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
@@ -400,6 +400,7 @@ func TestNewBuiltinCRDConfigs(t *testing.T) {
 	expectedConfigs := []string{
 		// Datadog resources
 		"datadoghq.com/v1alpha2/datadogpodautoscalers",
+		"datadoghq.com/v1alpha2/datadogpodautoscalerclusterprofiles",
 		"datadoghq.com/v2alpha1/datadogagents",
 		"datadoghq.com/v1alpha1/datadogslos",
 		"datadoghq.com/v1alpha1/datadogdashboards",


### PR DESCRIPTION
### What does this PR do?

Add datadogpodautoscalerclusterprofiles in the orchestrator OOTB CR collections config

to get automatically collected by the orchestrator check the CR `datadogpodautoscalerclusterprofiles` needs to be registered in the `builtinCRDConfig`

### Motivation

Make the autoscaling related resources collected OOTB to ease users onboarding

this new CRD was introduced in #48061 part of 7.78.0

### Describe how you validated your changes

* Unit-tests update
* Deployed a customer cluster-agent build in my local cluster

### Additional Notes
