### PR TITLE
fix(nfsiostat): correct typo of nfsiosat to nfsiostat (#49063)

### DIFF
--- a/deps/nfsiostat/BUILD.bazel
+++ b/deps/nfsiostat/BUILD.bazel
@@ -11,7 +11,7 @@ package(default_visibility = [
 genrule(
     name = "fix_shebang",
     srcs = ["@nfsiostat//:nfsiostat_py"],
-    outs = ["nfsiosat"],
+    outs = ["nfsiostat"],
     cmd = "sed 's@#!/usr/bin/python@#!/opt/datadog-agent/embedded/bin/python@' $(location  @nfsiostat//:nfsiostat_py) >$@",
 )
 


### PR DESCRIPTION
### What does this PR do?

Manual backport of https://github.com/DataDog/datadog-agent/pull/49063
