### PR TITLE
[procmgr] Add dd-procmgr-service binary for Windows installer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -566,6 +566,9 @@
 /pkg/pidfile/                           @DataDog/agent-runtimes
 /pkg/persistentcache/                   @DataDog/agent-runtimes
 /pkg/procmgr/                           @DataDog/agent-runtimes
+/pkg/procmgr/rust/src/platform/windows.rs          @DataDog/agent-runtimes @DataDog/windows-products
+/pkg/procmgr/rust/src/transport/named_pipe.rs       @DataDog/agent-runtimes @DataDog/windows-products
+/pkg/procmgr/rust/src/bins/dd-procmgr-service.rs    @DataDog/agent-runtimes @DataDog/windows-products
 /pkg/privateactionrunner/               @DataDog/action-platform
 /pkg/privateactionrunner/bundles/remoteaction/networks  @DataDog/action-platform @Datadog/network-path
 /pkg/proto/                             @DataDog/agent-runtimes

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -117,6 +117,25 @@ rust_binary(
     ],
 )
 
+# Windows service binary — functionally identical to dd-procmgrd, different
+# name for the Windows installer. Skipped until S22 enables the Windows prost
+# toolchain.
+rust_binary(
+    name = "dd-procmgr-service",
+    srcs = ["src/bins/dd-procmgr-service.rs"],
+    edition = "2024",
+    rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = ["@platforms//os:windows"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":dd-procmgrd-lib",
+        "//comp/core/log/rust:dd-agent-log",
+        "@crates//:anyhow",
+        "@crates//:log",
+        "@crates//:tokio",
+    ],
+)
+
 rust_binary(
     name = "dd-procmgr",
     srcs = ["src/bins/dd-procmgr.rs"],
@@ -137,6 +156,7 @@ pkg_files(
     name = "all_files",
     srcs = [
         ":dd-procmgr",
+        ":dd-procmgr-service",
         ":dd-procmgrd",
     ],
     attributes = pkg_attributes(
@@ -176,12 +196,14 @@ rust_test(
     crate_root = "tests/e2e.rs",
     data = [
         ":dd-procmgr",
+        ":dd-procmgr-service",
         ":dd-procmgrd",
         "//pkg/fleet/installer/packages/embedded:tmpl/datadog-agent-ddot.yaml.tmpl",
     ],
     edition = "2024",
     rustc_env = {
         "CARGO_BIN_EXE_dd-procmgr": "$(rootpath :dd-procmgr)",
+        "CARGO_BIN_EXE_dd-procmgr-service": "$(rootpath :dd-procmgr-service)",
         "CARGO_BIN_EXE_dd-procmgrd": "$(rootpath :dd-procmgrd)",
         "DDOT_TEMPLATE_PATH": "$(rootpath //pkg/fleet/installer/packages/embedded:tmpl/datadog-agent-ddot.yaml.tmpl)",
     },

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -156,9 +156,10 @@ pkg_files(
     name = "all_files",
     srcs = [
         ":dd-procmgr",
-        ":dd-procmgr-service",
-        ":dd-procmgrd",
-    ],
+    ] + select({
+        "@platforms//os:windows": [":dd-procmgr-service"],
+        "//conditions:default": [":dd-procmgrd"],
+    }),
     attributes = pkg_attributes(
         mode = "0755",
     ),
@@ -196,14 +197,12 @@ rust_test(
     crate_root = "tests/e2e.rs",
     data = [
         ":dd-procmgr",
-        ":dd-procmgr-service",
         ":dd-procmgrd",
         "//pkg/fleet/installer/packages/embedded:tmpl/datadog-agent-ddot.yaml.tmpl",
     ],
     edition = "2024",
     rustc_env = {
         "CARGO_BIN_EXE_dd-procmgr": "$(rootpath :dd-procmgr)",
-        "CARGO_BIN_EXE_dd-procmgr-service": "$(rootpath :dd-procmgr-service)",
         "CARGO_BIN_EXE_dd-procmgrd": "$(rootpath :dd-procmgrd)",
         "DDOT_TEMPLATE_PATH": "$(rootpath //pkg/fleet/installer/packages/embedded:tmpl/datadog-agent-ddot.yaml.tmpl)",
     },

--- a/pkg/procmgr/rust/Cargo.toml
+++ b/pkg/procmgr/rust/Cargo.toml
@@ -17,6 +17,13 @@ doctest = false
 name = "dd-procmgrd"
 path = "src/bins/dd-procmgrd.rs"
 
+# Windows service binary — functionally identical to dd-procmgrd, different
+# name for the Windows installer. Both always compile; packaging picks per
+# platform.
+[[bin]]
+name = "dd-procmgr-service"
+path = "src/bins/dd-procmgr-service.rs"
+
 [[bin]]
 name = "dd-procmgr"
 path = "src/bins/dd-procmgr.rs"

--- a/pkg/procmgr/rust/src/bins/dd-procmgr-service.rs
+++ b/pkg/procmgr/rust/src/bins/dd-procmgr-service.rs
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! Windows service entry point for dd-procmgrd.
+//!
+//! This binary is functionally identical to `dd-procmgrd` but is named
+//! `dd-procmgr-service` for the Windows installer. A separate source file
+//! avoids the Cargo warning about a shared source across multiple `[[bin]]`
+//! targets.
+
+use anyhow::Result;
+use dd_procmgrd::config::YamlConfigLoader;
+use dd_procmgrd::manager::ProcessManager;
+use dd_procmgrd::uuid_gen::V4UuidGenerator;
+use log::info;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dd_agent_log::init(dd_agent_log::LogConfig {
+        logger_name: "PROCMGR",
+        level: log::Level::Info,
+        log_file: None,
+    })?;
+    info!("dd-procmgr-service starting");
+
+    let loader = Arc::new(YamlConfigLoader::from_env());
+    let mgr = ProcessManager::new(loader, Arc::new(V4UuidGenerator));
+    mgr.run().await
+}

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -19,7 +19,7 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 // DaemonHandle
 // ---------------------------------------------------------------------------
 
-/// Handle to a running dd-procmgrd daemon process.
+/// Handle to a running dd-procmgrd (Unix) / dd-procmgr-service (Windows) daemon.
 pub struct DaemonHandle {
     child: Child,
     log_lines: Arc<Mutex<Vec<String>>>,
@@ -31,7 +31,11 @@ impl DaemonHandle {
     /// Start the daemon with the given config directory and socket path.
     /// Sets `DD_PM_CONFIG_DIR` and `DD_PM_SOCKET_PATH` environment variables.
     pub fn start(config_dir: &Path, socket_path: &Path) -> Self {
+        #[cfg(unix)]
         let bin = env!("CARGO_BIN_EXE_dd-procmgrd");
+        #[cfg(windows)]
+        let bin = env!("CARGO_BIN_EXE_dd-procmgr-service");
+
         let mut cmd = Command::new(bin);
         cmd.env("DD_PM_CONFIG_DIR", config_dir)
             .env("DD_PM_SOCKET_PATH", socket_path)
@@ -43,7 +47,7 @@ impl DaemonHandle {
             use windows_sys::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP;
             cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
         }
-        let mut child = cmd.spawn().expect("failed to start dd-procmgrd");
+        let mut child = cmd.spawn().expect("failed to start daemon");
 
         let stdout = child.stdout.take().expect("failed to capture stdout");
         let stderr = child.stderr.take().expect("failed to capture stderr");


### PR DESCRIPTION
### What does this PR do?

Adds a `dd-procmgr-service` binary that is functionally identical to `dd-procmgrd` but carries the name expected by the Windows MSI installer. Both binaries always compile via Cargo on all platforms; Bazel targets are platform-specific (`dd-procmgrd` for Linux, `dd-procmgr-service` for Windows).

- New `src/bins/dd-procmgr-service.rs` entry point
- `Cargo.toml`: new `[[bin]]` target
- `BUILD.bazel`: new `rust_binary` (Windows-only), added to `pkg_files` and `e2e_test` data
- Test helpers: `DaemonHandle` uses `dd-procmgr-service` on `#[cfg(windows)]`

### Motivation

Windows services use a different naming convention (`dd-procmgr-service.exe`) than the Unix daemon (`dd-procmgrd`). A separate binary name avoids confusion in the Windows Services console and aligns with the MSI packaging expectations.

### Describe how you validated your changes

- `cargo fmt --check`
- `cargo clippy --all-targets --features test-helpers`
- `cargo check` (Linux) 
- `cargo check --target x86_64-pc-windows-msvc`
- `cargo test --lib`

### Additional Notes

The Bazel `dd-procmgr-service` target is `target_compatible_with = ["@platforms//os:windows"]`, so it is currently skipped by Bazel (no Windows prost toolchain yet). It will start building automatically later when we enable the Windows Bazel toolchain.