### PR TITLE
[workloadmeta,tagger] Add completeness support for ECS

### DIFF
--- a/comp/core/autodiscovery/listeners/container.go
+++ b/comp/core/autodiscovery/listeners/container.go
@@ -59,7 +59,16 @@ func NewContainerListener(options ServiceListernerDeps) (ServiceListener, error)
 		return nil, errors.New("workloadmeta store is not initialized")
 	}
 	var err error
-	l.workloadmetaListener, err = newWorkloadmetaListener(name, filter, l.createContainerService, wmetaInstance, options.Telemetry)
+
+	l.workloadmetaListener, err = newWorkloadmetaListenerWithTagWait(
+		name,
+		filter,
+		l.createContainerService,
+		wmetaInstance,
+		options.Telemetry,
+		l.areTagsComplete,
+		time.Duration(pkgconfigsetup.Datadog().GetInt("ad_tag_completeness_max_wait"))*time.Second,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -201,4 +210,21 @@ func computeContainerServiceIDs(entity string, image string, labels map[string]s
 		ids = append(ids, short)
 	}
 	return ids
+}
+
+func (l *ContainerListener) areTagsComplete(entity workloadmeta.Entity) bool {
+	container, ok := entity.(*workloadmeta.Container)
+	if !ok {
+		log.Errorf("expected Container entity, got %T", entity)
+		return true
+	}
+
+	containerTaggerID := types.NewEntityID(types.ContainerID, container.ID)
+	_, complete, err := l.tagger.TagWithCompleteness(containerTaggerID, types.ChecksConfigCardinality)
+	if err != nil {
+		log.Debugf("error checking tag completeness for container %s: %s", container.ID, err)
+		return false
+	}
+
+	return complete
 }

--- a/comp/core/autodiscovery/listeners/container.go
+++ b/comp/core/autodiscovery/listeners/container.go
@@ -212,6 +212,14 @@ func computeContainerServiceIDs(entity string, image string, labels map[string]s
 	return ids
 }
 
+// areTagsComplete checks if the tags for a container are complete.
+// TODO: Completeness works by checking that all expected collectors have
+// reported tags for the container and its parent entity (Kubernetes pod, ECS
+// task). However, it does not account for collectors themselves reporting
+// partial data. This has been observed as with the ECS collector, where some
+// fields like "ecs_service" can be missing on the first pull. This happens
+// rarely. This is probably something that needs to be fixed in the collector
+// itself.
 func (l *ContainerListener) areTagsComplete(entity workloadmeta.Entity) bool {
 	container, ok := entity.(*workloadmeta.Container)
 	if !ok {

--- a/comp/core/autodiscovery/listeners/container_test.go
+++ b/comp/core/autodiscovery/listeners/container_test.go
@@ -16,6 +16,7 @@ import (
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -511,6 +512,75 @@ func TestComputeContainerServiceIDs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, computeContainerServiceIDs(tt.args.entity, tt.args.image, tt.args.labels))
+		})
+	}
+}
+
+func TestContainerAreTagsComplete(t *testing.T) {
+	containerEntityID := types.NewEntityID(types.ContainerID, containerID)
+
+	tests := []struct {
+		name      string
+		container *workloadmeta.Container
+		tagInfos  []*types.TagInfo
+		expected  bool
+	}{
+		{
+			name: "container complete",
+			container: &workloadmeta.Container{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   containerID,
+				},
+			},
+			tagInfos: []*types.TagInfo{
+				{
+					Source:      "source",
+					EntityID:    containerEntityID,
+					LowCardTags: []string{"container_name:agent"},
+					IsComplete:  true,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "container incomplete",
+			container: &workloadmeta.Container{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   containerID,
+				},
+			},
+			tagInfos: []*types.TagInfo{
+				{
+					Source:      "source",
+					EntityID:    containerEntityID,
+					LowCardTags: []string{"container_name:agent"},
+					IsComplete:  false,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "container not in tagger",
+			container: &workloadmeta.Container{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "unknown-container",
+				},
+			},
+			tagInfos: []*types.TagInfo{},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			taggerMock := taggerfxmock.SetupFakeTagger(t)
+			taggerMock.GetTagStore().ProcessTagInfo(test.tagInfos)
+			listener, _ := newContainerListener(t, taggerMock)
+
+			assert.Equal(t, test.expected, listener.areTagsComplete(test.container))
 		})
 	}
 }

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -538,6 +538,11 @@ func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*types.Ta
 func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.TagInfo {
 	task := ev.Entity.(*workloadmeta.ECSTask)
 
+	// ECS tasks are reported by a single collector (ECS), so they're always
+	// expected to be complete. We track this because we need it to determine
+	// if tags for the task's containers are complete.
+	c.entityCompleteness[task.EntityID] = ev.IsComplete
+
 	taskTags := taglist.NewTagList()
 
 	// as of Agent 7.33, tasks have a name internally, but before that
@@ -590,6 +595,8 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 
 		tagList.AddLow(tags.EcsContainerName, taskContainer.Name)
 
+		containerComplete := c.entityCompleteness[container.EntityID]
+
 		low, orch, high, standard := tagList.Compute()
 		tagInfos = append(tagInfos, &types.TagInfo{
 			// taskSource here is not a mistake. the source is
@@ -600,7 +607,7 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 			OrchestratorCardTags: orch,
 			LowCardTags:          append(low, clusterLow...),
 			StandardTags:         standard,
-			IsComplete:           ev.IsComplete,
+			IsComplete:           ev.IsComplete && containerComplete,
 		})
 	}
 
@@ -1004,14 +1011,23 @@ func (c *WorkloadMetaCollector) handleDelete(ev workloadmeta.Event) []*types.Tag
 	return tagInfos
 }
 
-// containerCompleteness computes the effective completeness for a container. In
-// Kubernetes, a container's tags also depend on its pod's data, so completeness
-// requires both the container and its pod to be complete.
+// containerCompleteness computes the effective completeness for a container.
+// Container tags depend on data from a parent entity (pod in Kubernetes, ECS
+// task in ECS), so completeness requires both the container and its parent to
+// be complete.
 func (c *WorkloadMetaCollector) containerCompleteness(containerID string, containerComplete bool) bool {
-	if !env.IsFeaturePresent(env.Kubernetes) {
-		return containerComplete
+	if env.IsFeaturePresent(env.Kubernetes) {
+		return c.containerCompletenessKubernetes(containerID, containerComplete)
 	}
 
+	if env.IsFeaturePresent(env.ECSEC2) || env.IsFeaturePresent(env.ECSManagedInstances) {
+		return c.containerCompletenessECS(containerID, containerComplete)
+	}
+
+	return containerComplete
+}
+
+func (c *WorkloadMetaCollector) containerCompletenessKubernetes(containerID string, containerComplete bool) bool {
 	if !containerComplete {
 		return false
 	}
@@ -1027,6 +1043,28 @@ func (c *WorkloadMetaCollector) containerCompleteness(containerID string, contai
 	}
 
 	return podComplete
+}
+
+func (c *WorkloadMetaCollector) containerCompletenessECS(containerID string, containerComplete bool) bool {
+	if !containerComplete {
+		return false
+	}
+
+	container, err := c.store.GetContainer(containerID)
+	if err != nil {
+		return false
+	}
+
+	if container.Owner == nil || container.Owner.Kind != workloadmeta.KindECSTask {
+		return false
+	}
+
+	taskComplete, ok := c.entityCompleteness[*container.Owner]
+	if !ok {
+		return false
+	}
+
+	return taskComplete
 }
 
 func (c *WorkloadMetaCollector) handleDeleteChildren(source string, children map[types.EntityID]struct{}) []*types.TagInfo {

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -2559,8 +2559,9 @@ func TestHandleContainer(t *testing.T) {
 
 func TestHandleContainer_IsComplete(t *testing.T) {
 	podID := "test-pod"
+	taskARN := "test-task-arn"
 
-	container := workloadmeta.Container{
+	kubeContainer := workloadmeta.Container{
 		EntityID: workloadmeta.EntityID{
 			Kind: workloadmeta.KindContainer,
 			ID:   "test-container",
@@ -2571,6 +2572,20 @@ func TestHandleContainer_IsComplete(t *testing.T) {
 		Owner: &workloadmeta.EntityID{
 			Kind: workloadmeta.KindKubernetesPod,
 			ID:   podID,
+		},
+	}
+
+	ecsContainer := workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainer,
+			ID:   "test-container",
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name: "agent",
+		},
+		Owner: &workloadmeta.EntityID{
+			Kind: workloadmeta.KindECSTask,
+			ID:   taskARN,
 		},
 	}
 
@@ -2585,54 +2600,106 @@ func TestHandleContainer_IsComplete(t *testing.T) {
 		},
 	}
 
+	ecsTask := &workloadmeta.ECSTask{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindECSTask,
+			ID:   taskARN,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name: "test-task",
+		},
+	}
+
 	tests := []struct {
 		name                string
-		isKubernetesEnv     bool
-		podInStore          bool
-		podIsComplete       bool
+		features            []env.Feature
+		container           workloadmeta.Container
+		parentInStore       bool // "parent" means pod or ECS task
+		parentIsComplete    bool
 		containerIsComplete bool
 		expectedIsComplete  bool
 	}{
 		{
-			name:                "non-Kubernetes: container complete",
-			isKubernetesEnv:     false,
+			name:                "no orchestrator: container complete",
+			features:            []env.Feature{}, // No kubernetes, no ECS
+			container:           kubeContainer,
 			containerIsComplete: true,
 			expectedIsComplete:  true,
 		},
 		{
-			name:                "non-Kubernetes: container incomplete",
-			isKubernetesEnv:     false,
+			name:                "no orchestrator: container incomplete",
+			features:            []env.Feature{}, // No kubernetes, no ECS
+			container:           kubeContainer,
 			containerIsComplete: false,
 			expectedIsComplete:  false,
 		},
 		{
 			name:                "kubernetes: container incomplete",
-			isKubernetesEnv:     true,
-			podInStore:          true,
-			podIsComplete:       true,
+			features:            []env.Feature{env.Kubernetes},
+			container:           kubeContainer,
+			parentInStore:       true,
+			parentIsComplete:    true,
 			containerIsComplete: false,
 			expectedIsComplete:  false,
 		},
 		{
 			name:                "kubernetes: container complete but pod incomplete",
-			isKubernetesEnv:     true,
-			podInStore:          true,
-			podIsComplete:       false,
+			features:            []env.Feature{env.Kubernetes},
+			container:           kubeContainer,
+			parentInStore:       true,
+			parentIsComplete:    false,
 			containerIsComplete: true,
 			expectedIsComplete:  false,
 		},
 		{
 			name:                "kubernetes: both container and pod complete",
-			isKubernetesEnv:     true,
-			podInStore:          true,
-			podIsComplete:       true,
+			features:            []env.Feature{env.Kubernetes},
+			container:           kubeContainer,
+			parentInStore:       true,
+			parentIsComplete:    true,
 			containerIsComplete: true,
 			expectedIsComplete:  true,
 		},
 		{
 			name:                "kubernetes: pod not found in store",
-			isKubernetesEnv:     true,
-			podInStore:          false,
+			features:            []env.Feature{env.Kubernetes},
+			container:           kubeContainer,
+			parentInStore:       false,
+			containerIsComplete: true,
+			expectedIsComplete:  false,
+		},
+		{
+			name:                "ECS EC2: container incomplete",
+			features:            []env.Feature{env.ECSEC2},
+			container:           ecsContainer,
+			parentInStore:       true,
+			parentIsComplete:    true,
+			containerIsComplete: false,
+			expectedIsComplete:  false,
+		},
+		{
+			name:                "ECS EC2: container complete but task incomplete",
+			features:            []env.Feature{env.ECSEC2},
+			container:           ecsContainer,
+			parentInStore:       true,
+			parentIsComplete:    false,
+			containerIsComplete: true,
+			expectedIsComplete:  false,
+		},
+		{
+			name:                "ECS EC2: both container and task complete",
+			features:            []env.Feature{env.ECSEC2},
+			container:           ecsContainer,
+			parentInStore:       true,
+			parentIsComplete:    true,
+			containerIsComplete: true,
+			expectedIsComplete:  true,
+		},
+		{
+			name:                "ECS EC2: task not found in store",
+			features:            []env.Feature{env.ECSEC2},
+			container:           ecsContainer,
+			parentInStore:       false,
 			containerIsComplete: true,
 			expectedIsComplete:  false,
 		},
@@ -2640,8 +2707,8 @@ func TestHandleContainer_IsComplete(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if test.isKubernetesEnv {
-				env.SetFeatures(t, env.Kubernetes)
+			if len(test.features) > 0 {
+				env.SetFeatures(t, test.features...)
 			}
 
 			cfg := configmock.New(t)
@@ -2652,25 +2719,32 @@ func TestHandleContainer_IsComplete(t *testing.T) {
 				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 			))
 
-			wmeta.Set(&container)
-
-			if test.isKubernetesEnv && test.podInStore {
-				wmeta.Set(pod)
-			}
+			wmeta.Set(&test.container)
 
 			collector := NewWorkloadMetaCollector(context.TODO(), cfg, wmeta, nil)
 
-			if test.isKubernetesEnv {
-				collector.handleKubePod(workloadmeta.Event{
-					Type:       workloadmeta.EventTypeSet,
-					Entity:     pod,
-					IsComplete: test.podIsComplete,
-				})
+			if test.container.Owner != nil && test.parentInStore {
+				switch test.container.Owner.Kind {
+				case workloadmeta.KindKubernetesPod:
+					wmeta.Set(pod)
+					collector.handleKubePod(workloadmeta.Event{
+						Type:       workloadmeta.EventTypeSet,
+						Entity:     pod,
+						IsComplete: test.parentIsComplete,
+					})
+				case workloadmeta.KindECSTask:
+					wmeta.Set(ecsTask)
+					collector.handleECSTask(workloadmeta.Event{
+						Type:       workloadmeta.EventTypeSet,
+						Entity:     ecsTask,
+						IsComplete: test.parentIsComplete,
+					})
+				}
 			}
 
 			actual := collector.handleContainer(workloadmeta.Event{
 				Type:       workloadmeta.EventTypeSet,
-				Entity:     &container,
+				Entity:     &test.container,
 				IsComplete: test.containerIsComplete,
 			})
 

--- a/comp/core/tagger/def/component.go
+++ b/comp/core/tagger/def/component.go
@@ -20,16 +20,13 @@ type Component interface {
 	Tag(entityID types.EntityID, cardinality types.TagCardinality) ([]string, error)
 	// TagWithCompleteness returns tags for an entity together with a boolean
 	// indicating whether the entity's data is complete. An entity is complete
-	// when all expected collectors have reported data for it. For containers in
-	// Kubernetes, completeness also considers the associated pod's
-	// completeness.
+	// when all expected collectors have reported data for it. For containers,
+	// completeness also considers the associated parent entity's completeness
+	// (pod in Kubernetes, ECS task in ECS).
 	//
-	// Important: completeness tracking is currently only supported for
-	// containers and pods when the agent runs on Kubernetes. For all other
-	// entity kinds the returned boolean is always true. Also note that tags may
-	// not be complete immediately after an entity is first seen, because the
-	// different workloadmeta collectors discover entity data at different
-	// speeds.
+	// Note: tags may not be complete immediately after an entity is first seen,
+	// because the different workloadmeta collectors discover entity data at
+	// different speeds.
 	TagWithCompleteness(entityID types.EntityID, cardinality types.TagCardinality) ([]string, bool, error)
 	GenerateContainerIDFromOriginInfo(originInfo origindetection.OriginInfo) (string, error)
 	Standard(entityID types.EntityID) ([]string, error)

--- a/comp/core/workloadmeta/impl/store_test.go
+++ b/comp/core/workloadmeta/impl/store_test.go
@@ -2352,3 +2352,197 @@ func TestIsComplete_KubernetesContainerRuntimeNotAccessible(t *testing.T) {
 
 	assert.Equal(t, expected, actual)
 }
+
+func TestIsComplete_ECSEC2(t *testing.T) {
+	env.SetFeatures(t, env.ECSEC2, env.Docker)
+
+	s := newWorkloadmetaObject(t)
+
+	container := &wmdef.Container{
+		EntityID: wmdef.EntityID{
+			Kind: wmdef.KindContainer,
+			ID:   "test-container",
+		},
+	}
+
+	ch := s.Subscribe(dummySubscriber, wmdef.NormalPriority, nil)
+	var actual []wmdef.EventBundle
+
+	doneCh := make(chan struct{})
+	go func() {
+		for bundle := range ch {
+			close(bundle.Ch)
+			actual = append(actual, wmdef.EventBundle{Events: bundle.Events})
+		}
+		close(doneCh)
+	}()
+
+	// Container reported by container runtime only (incomplete)
+	s.handleEvents([]wmdef.CollectorEvent{
+		{
+			Type:   wmdef.EventTypeSet,
+			Source: wmdef.SourceRuntime,
+			Entity: container,
+		},
+	})
+
+	// Container also reported by ECS collector (now complete)
+	s.handleEvents([]wmdef.CollectorEvent{
+		{
+			Type:   wmdef.EventTypeSet,
+			Source: wmdef.SourceNodeOrchestrator,
+			Entity: container,
+		},
+	})
+
+	s.Unsubscribe(ch)
+	<-doneCh
+
+	expected := []wmdef.EventBundle{
+		{}, // Initial empty bundle
+		{
+			Events: []wmdef.Event{
+				{
+					Type:       wmdef.EventTypeSet,
+					Entity:     container,
+					IsComplete: false, // Only Docker runtime reported, ECS collector not yet
+				},
+			},
+		},
+		{
+			Events: []wmdef.Event{
+				{
+					Type:       wmdef.EventTypeSet,
+					Entity:     container,
+					IsComplete: true, // Both Docker runtime and ECS collector reported
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestIsComplete_ECSManagedInstances(t *testing.T) {
+	env.SetFeatures(t, env.ECSManagedInstances, env.Containerd)
+
+	s := newWorkloadmetaObject(t)
+
+	container := &wmdef.Container{
+		EntityID: wmdef.EntityID{
+			Kind: wmdef.KindContainer,
+			ID:   "test-container",
+		},
+	}
+
+	ch := s.Subscribe(dummySubscriber, wmdef.NormalPriority, nil)
+	var actual []wmdef.EventBundle
+
+	doneCh := make(chan struct{})
+	go func() {
+		for bundle := range ch {
+			close(bundle.Ch)
+			actual = append(actual, wmdef.EventBundle{Events: bundle.Events})
+		}
+		close(doneCh)
+	}()
+
+	// Container reported by container runtime only (incomplete)
+	s.handleEvents([]wmdef.CollectorEvent{
+		{
+			Type:   wmdef.EventTypeSet,
+			Source: wmdef.SourceRuntime,
+			Entity: container,
+		},
+	})
+
+	// Container also reported by ECS collector (now complete)
+	s.handleEvents([]wmdef.CollectorEvent{
+		{
+			Type:   wmdef.EventTypeSet,
+			Source: wmdef.SourceNodeOrchestrator,
+			Entity: container,
+		},
+	})
+
+	s.Unsubscribe(ch)
+	<-doneCh
+
+	expected := []wmdef.EventBundle{
+		{}, // Initial empty bundle
+		{
+			Events: []wmdef.Event{
+				{
+					Type:       wmdef.EventTypeSet,
+					Entity:     container,
+					IsComplete: false, // Only containerd runtime reported, ECS collector not yet
+				},
+			},
+		},
+		{
+			Events: []wmdef.Event{
+				{
+					Type:       wmdef.EventTypeSet,
+					Entity:     container,
+					IsComplete: true, // Both containerd runtime and ECS collector reported
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestIsComplete_ECSFargate(t *testing.T) {
+	// In ECS Fargate, containers are reported by a single collector (ECS with
+	// SourceRuntime), so they're always complete.
+	env.SetFeatures(t, env.ECSFargate)
+
+	s := newWorkloadmetaObject(t)
+
+	container := &wmdef.Container{
+		EntityID: wmdef.EntityID{
+			Kind: wmdef.KindContainer,
+			ID:   "test-container",
+		},
+	}
+
+	ch := s.Subscribe(dummySubscriber, wmdef.NormalPriority, nil)
+	var actual []wmdef.EventBundle
+
+	doneCh := make(chan struct{})
+	go func() {
+		for bundle := range ch {
+			close(bundle.Ch)
+			actual = append(actual, wmdef.EventBundle{Events: bundle.Events})
+		}
+		close(doneCh)
+	}()
+
+	// Container reported by ECS collector
+	s.handleEvents([]wmdef.CollectorEvent{
+		{
+			Type:   wmdef.EventTypeSet,
+			Source: wmdef.SourceRuntime,
+			Entity: container,
+		},
+	})
+
+	s.Unsubscribe(ch)
+	<-doneCh
+
+	expected := []wmdef.EventBundle{
+		{}, // Initial empty bundle
+		{
+			Events: []wmdef.Event{
+				{
+					Type:       wmdef.EventTypeSet,
+					Entity:     container,
+					IsComplete: true, // Single collector, always complete
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, actual)
+}

--- a/comp/core/workloadmeta/impl/workloadmeta.go
+++ b/comp/core/workloadmeta/impl/workloadmeta.go
@@ -106,7 +106,7 @@ func NewWorkloadMeta(deps Dependencies) Provider {
 		eventCh:               make(chan []wmdef.CollectorEvent, eventChBufferSize),
 		pulls:                 make(map[string]*pullInfo),
 		collectorsInitialized: wmdef.CollectorsNotStarted,
-		expectedSources:       initExpectedSources(deps.Params.AgentType),
+		expectedSources:       initExpectedSources(deps.Params.AgentType, deps.Config),
 	}
 
 	deps.Lc.Append(compdef.Hook{OnStart: func(_ context.Context) error {
@@ -161,18 +161,11 @@ func (w *workloadmeta) writeResponse(writer http.ResponseWriter, r *http.Request
 // detected environment features. This determines which collectors are expected
 // to report data for each entity kind.
 //
-// For now, it only supports Kubernetes. Other cases with multiple collectors
-// reporting the same entity kind:
-// - ECS EC2: containers are reported by both the ECS and Docker collectors.
-// TODO: This will be handled later.
-// - Kubernetes Deployments: reported by the kubeapiserver collector and
-// language detection code. Completeness tracking is not needed for deployments.
-func initExpectedSources(agentType wmdef.AgentType) map[wmdef.Kind][]wmdef.Source {
+// Note: Kubernetes Deployments are also reported by multiple collectors
+// (kubeapiserver and language detection), but completeness tracking is not
+// needed for them.
+func initExpectedSources(agentType wmdef.AgentType, cfg config.Component) map[wmdef.Kind][]wmdef.Source {
 	expectedSources := make(map[wmdef.Kind][]wmdef.Source)
-
-	if !env.IsFeaturePresent(env.Kubernetes) {
-		return expectedSources
-	}
 
 	// Only the Node Agent runs multiple collectors that need to report
 	// for an entity to be complete
@@ -180,6 +173,22 @@ func initExpectedSources(agentType wmdef.AgentType) map[wmdef.Kind][]wmdef.Sourc
 		return expectedSources
 	}
 
+	if env.IsFeaturePresent(env.Kubernetes) {
+		initExpectedSourcesKubernetes(expectedSources)
+	}
+
+	// In ECS EC2 and ECS Managed (no sidecar), containers are reported by two
+	// collectors (ECS + container runtime). In sidecar mode (Fargate, or
+	// Managed Instances configured as sidecar), there's a single collector, so
+	// entities are always complete.
+	if env.IsFeaturePresent(env.ECSEC2) || (env.IsFeaturePresent(env.ECSManagedInstances) && !env.IsECSSidecarMode(cfg)) {
+		initExpectedSourcesECS(expectedSources)
+	}
+
+	return expectedSources
+}
+
+func initExpectedSourcesKubernetes(expectedSources map[wmdef.Kind][]wmdef.Source) {
 	// In Kubernetes, pods are reported by:
 	// - kubelet collector (SourceNodeOrchestrator)
 	// - kubemetadata collector (SourceClusterOrchestrator)
@@ -196,8 +205,17 @@ func initExpectedSources(agentType wmdef.AgentType) map[wmdef.Kind][]wmdef.Sourc
 		containerSources = append(containerSources, wmdef.SourceRuntime)
 	}
 	expectedSources[wmdef.KindContainer] = containerSources
+}
 
-	return expectedSources
+func initExpectedSourcesECS(expectedSources map[wmdef.Kind][]wmdef.Source) {
+	// In ECS EC2 and ECS Managed (no sidecar), containers are reported by:
+	// - ECS collector (SourceNodeOrchestrator)
+	// - container runtime collector (SourceRuntime)
+	containerSources := []wmdef.Source{wmdef.SourceNodeOrchestrator}
+	if containerRuntimeIsAccessible() {
+		containerSources = append(containerSources, wmdef.SourceRuntime)
+	}
+	expectedSources[wmdef.KindContainer] = containerSources
 }
 
 func containerRuntimeIsAccessible() bool {

--- a/comp/core/workloadmeta/impl/workloadmeta_test.go
+++ b/comp/core/workloadmeta/impl/workloadmeta_test.go
@@ -9,22 +9,26 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wmdef "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 func TestInitExpectedSources(t *testing.T) {
 	tests := []struct {
-		name      string
-		agentType wmdef.AgentType
-		features  []env.Feature
-		expected  map[wmdef.Kind][]wmdef.Source
+		name            string
+		agentType       wmdef.AgentType
+		features        []env.Feature
+		envVars         map[string]string
+		configOverrides map[string]interface{}
+		expected        map[wmdef.Kind][]wmdef.Source
 	}{
 		{
-			name:      "not kubernetes",
+			name:      "not kubernetes and not ECS",
 			agentType: wmdef.NodeAgent,
-			features:  nil, // No kubernetes
+			features:  nil, // No kubernetes and not ECS
 			expected:  map[wmdef.Kind][]wmdef.Source{},
 		},
 		{
@@ -67,6 +71,54 @@ func TestInitExpectedSources(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "ECS EC2 on node agent with Docker runtime",
+			agentType: wmdef.NodeAgent,
+			features: []env.Feature{
+				env.ECSEC2,
+				env.Docker,
+			},
+			expected: map[wmdef.Kind][]wmdef.Source{
+				wmdef.KindContainer: {
+					wmdef.SourceNodeOrchestrator,
+					wmdef.SourceRuntime,
+				},
+			},
+		},
+		{
+			name:      "ECS Managed on node agent with containerd runtime",
+			agentType: wmdef.NodeAgent,
+			features: []env.Feature{
+				env.ECSManagedInstances,
+				env.Containerd,
+			},
+			expected: map[wmdef.Kind][]wmdef.Source{
+				wmdef.KindContainer: {
+					wmdef.SourceNodeOrchestrator,
+					wmdef.SourceRuntime,
+				},
+			},
+		},
+		{
+			name:      "ECS Fargate has no expected sources (single collector, so always complete)",
+			agentType: wmdef.NodeAgent,
+			features:  []env.Feature{env.ECSFargate},
+			expected:  map[wmdef.Kind][]wmdef.Source{},
+		},
+		{
+			name:      "ECS Managed in sidecar mode has no expected sources (single collector)",
+			agentType: wmdef.NodeAgent,
+			features: []env.Feature{
+				env.ECSManagedInstances,
+			},
+			envVars: map[string]string{
+				"AWS_EXECUTION_ENV": "AWS_ECS_MANAGED_INSTANCES",
+			},
+			configOverrides: map[string]interface{}{
+				"ecs_deployment_mode": "sidecar",
+			},
+			expected: map[wmdef.Kind][]wmdef.Source{},
+		},
 	}
 
 	for _, test := range tests {
@@ -75,9 +127,18 @@ func TestInitExpectedSources(t *testing.T) {
 				env.SetFeatures(t, test.features...)
 			}
 
-			result := initExpectedSources(test.agentType)
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
 
-			assert.Equal(t, len(test.expected), len(result))
+			cfg := configmock.New(t)
+			for k, v := range test.configOverrides {
+				cfg.SetWithoutSource(k, v)
+			}
+
+			result := initExpectedSources(test.agentType, cfg)
+
+			require.Equal(t, len(test.expected), len(result))
 			for kind, expectedSources := range test.expected {
 				assert.ElementsMatch(t, expectedSources, result[kind])
 			}


### PR DESCRIPTION
### What does this PR do?

This PR is part of a series of PRs that address the missing tags issue in the agent.

What we have so far works on Kubernetes. The idea was to get one environment fully working first. This PR handles the other cases where multiple collectors can report the same entity: ECS EC2 and ECS Managed Instances.

### Describe how you validated your changes

New unit tests plus tests on an ECS EC2 cluster.

For ECS EC2, I first reproduced the missing tags problem. I deployed a redis container and checked that in some cases, metrics from the redisdb check (configured via autodiscovery) were missing tags. The missing tags were always ECS tags, never Docker tags, this is because AD doesn't schedule checks when only the Docker info is present.

Then I repeated the same tests with `ad_tag_completeness_max_wait` set to 15s. I expected no missing tags, since 15s is more than enough for ECS to report after Docker. This completely eliminated cases where Docker tags were present but all ECS tags were missing. However, there were still rare cases where Docker tags were present along with some ECS tags, but not all of them. This shows that the completeness mechanism works as intended. The remaining issue is that the ECS collector itself sometimes reports incomplete data on its first pull. I think this should be fixed separately in the ECS collector (needs more investigation to evaluate all consequences). I documented this edge case in the code.

