### PR TITLE
Ignore unified e2e output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,7 +159,7 @@ devenv/packer_cache
 test_output*.json
 module_test_output.json
 e2e_test_output.json
-e2e_test_output.json.*.part
+e2e_test_output*.json.*.part
 junit-out-AgentFlavor.base-*.xml
 
 # doxygen doc & error log


### PR DESCRIPTION
### What does this PR do?

This ignores files like `e2e_test_output_unified.json.0.part` produced by e2e tests.

### Motivation

### Describe how you validated your changes

### Additional Notes
