### PR TITLE
Update rules to trigger schema generation jobs

### DIFF
--- a/.gitlab/build/binary_build/schema_generation.yml
+++ b/.gitlab/build/binary_build/schema_generation.yml
@@ -3,10 +3,19 @@ include:
   - .gitlab/.pre/common/macos.yml
 
 
-generate_config_schema-linux:
+.generate_config_schema:
   stage: binary_build
   rules:
-    - when: on_success
+    - !reference [.except_mergequeue]
+    - !reference [.on_main_or_release_branch]
+    - changes:
+        paths:
+          - pkg/config/**/*
+          - tasks/schema/**/*
+        compare_to: $COMPARE_TO_BRANCH
+
+generate_config_schema-linux:
+  extends: .generate_config_schema
   variables:
     KUBERNETES_CPU_REQUEST: 16
     KUBERNETES_MEMORY_REQUEST: 16Gi
@@ -28,17 +37,15 @@ generate_config_schema-linux:
       - $CI_PROJECT_DIR/pkg/config/schema/system-probe_schema.yaml
 
 generate_config_schema-macos:
-  stage: binary_build
-  rules:
-    - when: on_success
+  extends:
+    - .generate_config_schema
+    - .bazel:defs:cache:macos
+    - .macos_gitlab
   variables:
     KUBERNETES_CPU_REQUEST: 16
     KUBERNETES_MEMORY_REQUEST: 16Gi
     KUBERNETES_MEMORY_LIMIT: 16Gi
     TEST_OUTPUT_FILE: test_output
-  extends:
-    - .bazel:defs:cache:macos
-    - .macos_gitlab
   tags: ["macos:sonoma-amd64", "specific:true"]
   needs: ["go_deps", "go_tools_deps"]
   script:
@@ -52,10 +59,9 @@ generate_config_schema-macos:
       - $CI_PROJECT_DIR/pkg/config/schema/system-probe_schema.yaml
 
 generate_config_schema-windows:
-  stage: binary_build
-  rules:
-    - when: on_success
-  extends: .windows_docker_default
+  extends:
+    - .generate_config_schema
+    - .windows_docker_default
   needs: ["go_deps", "go_tools_deps"]
   variables:
     ARCH: "x64"


### PR DESCRIPTION
⏺ What does this PR do?

  Adds path-based filtering to the generate_config_schema CI jobs (linux, macos, windows) so they only run when relevant files are modified, and skips them in merge queue pipelines.

  Introduces a shared .generate_config_schema template that all three jobs extend, consolidating the rules in one place.

  Motivation

  These jobs build the entire agent binary just to generate config schemas. Running them on every pipeline is wasteful when the schema-related code hasn't changed. Restricting them
  to pkg/config/**/* and tasks/schema/**/* changes reduces CI resource usage on unrelated PRs while still running unconditionally on main/release branches.
