### PR TITLE
[edge-only-processing] Add local_processing_only log routing rule

### DIFF
--- a/comp/logs/agent/config/processing_rules.go
+++ b/comp/logs/agent/config/processing_rules.go
@@ -8,17 +8,45 @@ package config
 import (
 	"errors"
 	"fmt"
+	"path"
 	"regexp"
 )
 
 // Processing rule types
 const (
-	ExcludeAtMatch   = "exclude_at_match"
-	IncludeAtMatch   = "include_at_match"
-	MaskSequences    = "mask_sequences"
-	MultiLine        = "multi_line"
-	ExcludeTruncated = "exclude_truncated"
+	ExcludeAtMatch      = "exclude_at_match"
+	IncludeAtMatch      = "include_at_match"
+	MaskSequences       = "mask_sequences"
+	MultiLine           = "multi_line"
+	ExcludeTruncated    = "exclude_truncated"
+	LocalProcessingOnly = "local_processing_only"
 )
+
+// RoutingMatch defines the matching criteria for routing rules (local_processing_only, remote_processing_only).
+// Values within services are OR'd. An empty list matches all.
+type RoutingMatch struct {
+	Services []string `mapstructure:"services" json:"services" yaml:"services"`
+}
+
+// CompiledRoutingMatch holds validated service glob patterns ready for runtime matching.
+// Glob syntax is validated at compile time; matching uses path.Match at runtime.
+type CompiledRoutingMatch struct {
+	ServiceGlobs []string
+}
+
+// Matches reports whether the given service satisfies the routing match.
+// An empty ServiceGlobs list means "match all".
+func (m *CompiledRoutingMatch) Matches(service string) bool {
+	if len(m.ServiceGlobs) == 0 {
+		return true
+	}
+	for _, g := range m.ServiceGlobs {
+		if matched, _ := path.Match(g, service); matched {
+			return true
+		}
+	}
+	return false
+}
 
 // ProcessingRule defines an exclusion or a masking rule to
 // be applied on log lines
@@ -29,6 +57,8 @@ type ProcessingRule struct {
 	Pattern            string
 	Regex              *regexp.Regexp
 	Placeholder        []byte
+	Match              *RoutingMatch         `mapstructure:"match" json:"match,omitempty" yaml:"match,omitempty"`
+	CompiledMatch      *CompiledRoutingMatch `mapstructure:"-" json:"-" yaml:"-"`
 }
 
 // ValidateProcessingRules validates the rules and raises an error if one is misconfigured.
@@ -53,6 +83,15 @@ func ValidateProcessingRules(rules []*ProcessingRule) error {
 			}
 		case ExcludeTruncated:
 			break
+		case LocalProcessingOnly:
+			if rule.Match == nil || len(rule.Match.Services) == 0 {
+				return fmt.Errorf("processing rule `%s` of type %s requires a non-empty match.services list", rule.Name, rule.Type)
+			}
+			for _, g := range rule.Match.Services {
+				if _, err := path.Match(g, ""); err != nil {
+					return fmt.Errorf("invalid services glob pattern %q in processing rule `%s`: %v", g, rule.Name, err)
+				}
+			}
 		case "":
 			return fmt.Errorf("type must be set for processing rule `%s`", rule.Name)
 		default:
@@ -65,7 +104,16 @@ func ValidateProcessingRules(rules []*ProcessingRule) error {
 // CompileProcessingRules compiles all processing rule regular expressions.
 func CompileProcessingRules(rules []*ProcessingRule) error {
 	for _, rule := range rules {
-		if rule.Type == ExcludeTruncated {
+		switch rule.Type {
+		case ExcludeTruncated:
+			continue
+		case LocalProcessingOnly:
+			if rule.Match == nil {
+				continue
+			}
+			rule.CompiledMatch = &CompiledRoutingMatch{
+				ServiceGlobs: rule.Match.Services,
+			}
 			continue
 		}
 		re, err := regexp.Compile(rule.Pattern)

--- a/comp/logs/agent/config/processing_rules_test.go
+++ b/comp/logs/agent/config/processing_rules_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompileShouldSucceedWithValidRules(t *testing.T) {
@@ -32,4 +33,90 @@ func TestCompileShouldFailWithInvalidRules(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Nil(t, rule.Regex)
 	}
+}
+
+// ---- LocalProcessingOnly / RemoteProcessingOnly validation ----
+
+func TestValidateLocalProcessingOnlyRequiresMatchBlock(t *testing.T) {
+	rule := &ProcessingRule{Name: "no-match", Type: LocalProcessingOnly}
+	err := ValidateProcessingRules([]*ProcessingRule{rule})
+	assert.Error(t, err)
+}
+
+func TestValidateLocalProcessingOnlyRequiresNonEmptyServices(t *testing.T) {
+	rule := &ProcessingRule{
+		Name:  "empty-services",
+		Type:  LocalProcessingOnly,
+		Match: &RoutingMatch{Services: []string{}},
+	}
+	err := ValidateProcessingRules([]*ProcessingRule{rule})
+	assert.Error(t, err)
+}
+
+func TestValidateLocalProcessingOnlyAcceptsValidRule(t *testing.T) {
+	rule := &ProcessingRule{
+		Name:  "valid",
+		Type:  LocalProcessingOnly,
+		Match: &RoutingMatch{Services: []string{"web-*", "api-*"}},
+	}
+	err := ValidateProcessingRules([]*ProcessingRule{rule})
+	assert.NoError(t, err)
+}
+
+func TestValidateLocalProcessingOnlyRejectsInvalidGlob(t *testing.T) {
+	rule := &ProcessingRule{
+		Name:  "bad-glob",
+		Type:  LocalProcessingOnly,
+		Match: &RoutingMatch{Services: []string{"[invalid"}},
+	}
+	err := ValidateProcessingRules([]*ProcessingRule{rule})
+	assert.Error(t, err)
+}
+
+// ---- CompileProcessingRules for routing rules ----
+
+func TestCompileLocalProcessingOnlyBuildsCompiledMatch(t *testing.T) {
+	rule := &ProcessingRule{
+		Name:  "compile-test",
+		Type:  LocalProcessingOnly,
+		Match: &RoutingMatch{Services: []string{"web-*"}},
+	}
+	err := CompileProcessingRules([]*ProcessingRule{rule})
+	require.NoError(t, err)
+	require.NotNil(t, rule.CompiledMatch)
+	assert.Equal(t, []string{"web-*"}, rule.CompiledMatch.ServiceGlobs)
+}
+
+func TestCompileLocalProcessingOnlyWithNilMatchIsNoop(t *testing.T) {
+	rule := &ProcessingRule{Name: "nil-match", Type: LocalProcessingOnly, Match: nil}
+	err := CompileProcessingRules([]*ProcessingRule{rule})
+	assert.NoError(t, err)
+	assert.Nil(t, rule.CompiledMatch)
+}
+
+// ---- CompiledRoutingMatch.Matches ----
+
+func TestMatchesServiceGlobOR(t *testing.T) {
+	m := &CompiledRoutingMatch{ServiceGlobs: []string{"web-*", "api-*"}}
+	assert.True(t, m.Matches("web-frontend"))
+	assert.True(t, m.Matches("api-gateway"))
+	assert.False(t, m.Matches("db-primary"))
+}
+
+func TestMatchesEmptyServiceGlobMatchesAll(t *testing.T) {
+	m := &CompiledRoutingMatch{ServiceGlobs: []string{}}
+	assert.True(t, m.Matches("anything"))
+	assert.True(t, m.Matches(""))
+}
+
+func TestMatchesWildcardServiceMatchesEmpty(t *testing.T) {
+	m := &CompiledRoutingMatch{ServiceGlobs: []string{"*"}}
+	assert.True(t, m.Matches(""))
+	assert.True(t, m.Matches("any-service"))
+}
+
+func TestMatchesNoOriginEmptyServiceDoesNotMatchPrefixGlob(t *testing.T) {
+	m := &CompiledRoutingMatch{ServiceGlobs: []string{"web-*"}}
+	// Empty service string does not match "web-*"
+	assert.False(t, m.Matches(""))
 }

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1114,13 +1114,23 @@ api_key:
 #   # @param processing_rules - list of custom objects - optional - default: []
 #   # @env DD_LOGS_CONFIG_PROCESSING_RULES - list of custom objects - optional - default: "[]"
 #   # Global processing rules that are applied to all logs. The available rules are
-#   # "exclude_at_match", "include_at_match" and "mask_sequences". More information in Datadog documentation:
+#   # "exclude_at_match", "include_at_match", "mask_sequences", "multi_line",
+#   # "exclude_truncated", and "local_processing_only". More information in Datadog documentation:
 #   # https://docs.datadoghq.com/agent/logs/advanced_log_collection/#global-processing-rules
 #
 #   processing_rules:
+#     # Pattern-based rules (exclude_at_match, include_at_match, mask_sequences, multi_line):
 #     - type: <RULE_TYPE>
 #       name: <RULE_NAME>
 #       pattern: <RULE_PATTERN>
+#
+#     # local_processing_only: logs from matching services are observed locally but
+#     # never forwarded to the Datadog backend.
+#     - type: local_processing_only
+#       name: <RULE_NAME>
+#       match:
+#         services:
+#           - <SERVICE_NAME>
 
 #   # @param auto_multi_line_detection - boolean - optional - default: false
 #   # @env DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION - boolean - optional - default: false

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -207,6 +207,9 @@ type ParsingExtra struct {
 	IsMultiLine bool
 	IsMRFAllow  bool
 	Tags        []string
+	// Set by a local_processing_only routing rule: the log is processed by the
+	// observer but must not be forwarded to the Datadog backend.
+	IsLocalProcessingOnly bool
 }
 
 // ServerlessExtra ships extra information from logs processing in serverless envs.

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -31,6 +32,9 @@ const (
 	configMRFFailoverLogs     = "multi_region_failover.failover_logs"
 	configMRFServiceAllowlist = "multi_region_failover.logs_service_allowlist"
 )
+
+var tlmLocalOnlyLogs = telemetry.NewCounter("logs_processor", "local_only_logs_total",
+	nil, "Number of logs suppressed from backend sending by a local_processing_only rule")
 
 type failoverConfig struct {
 	isFailoverActive         bool
@@ -212,6 +216,12 @@ func (p *Processor) processMessage(msg *message.Message) {
 			p.observerHandle.ObserveLog(msg)
 		}
 
+		// local_processing_only logs are observed but must not reach the backend
+		if msg.IsLocalProcessingOnly {
+			tlmLocalOnlyLogs.Inc()
+			return
+		}
+
 		if p.failoverConfig.isFailoverActive {
 			p.filterMRFMessages(msg)
 		}
@@ -253,6 +263,12 @@ func (p *Processor) filterMRFMessages(msg *message.Message) {
 func (p *Processor) applyRedactingRules(msg *message.Message) bool {
 	var content = msg.GetContent()
 
+	// Extract service once for use by LocalProcessingOnly / RemoteProcessingOnly rules.
+	var service string
+	if msg.Origin != nil {
+		service = msg.Origin.Service()
+	}
+
 	// Use the internal scrubbing implementation of the Agent
 	// ---------------------------
 
@@ -288,7 +304,10 @@ func (p *Processor) applyRedactingRules(msg *message.Message) bool {
 				msg.RecordProcessingRule(rule.Type, rule.Name)
 				return false
 			}
-
+		case config.LocalProcessingOnly:
+			if rule.CompiledMatch != nil && rule.CompiledMatch.Matches(service) {
+				msg.IsLocalProcessingOnly = true
+			}
 		}
 	}
 

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -13,9 +13,30 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
+
+// mockObserverHandle is a lightweight observer.Handle that records which logs it observed.
+type mockObserverHandle struct {
+	observed []observer.LogView
+}
+
+func (m *mockObserverHandle) ObserveMetric(observer.MetricView)         {}
+func (m *mockObserverHandle) ObserveTrace(observer.TraceView)           {}
+func (m *mockObserverHandle) ObserveTraceStats(observer.TraceStatsView) {}
+func (m *mockObserverHandle) ObserveProfile(observer.ProfileView)       {}
+func (m *mockObserverHandle) ObserveLog(msg observer.LogView) {
+	// Store status so tests can assert which messages were observed.
+	m.observed = append(m.observed, msg)
+}
+
+// mockDiagnosticReceiver satisfies diagnostic.MessageReceiver without any side effects.
+type mockDiagnosticReceiver struct{}
+
+func (m *mockDiagnosticReceiver) HandleMessage(*message.Message, []byte, string) {}
 
 type processorTestCase struct {
 	source        sources.LogSource
@@ -377,6 +398,109 @@ func newStructuredMessage(content []byte, source *sources.LogSource, status stri
 	msg := message.NewStructuredMessage(&structuredContent, message.NewOrigin(source), status, 0)
 	msg.SetContent(content)
 	return msg
+}
+
+// ---- LocalProcessingOnly routing tests ----
+
+// newProcessingRuleRouting creates a LocalProcessingOnly
+// rule with a pre-compiled CompiledRoutingMatch for the given service glob.
+func newProcessingRuleRouting(ruleType, serviceGlob string) *config.ProcessingRule {
+	return &config.ProcessingRule{
+		Name:          ruleName,
+		Type:          ruleType,
+		Match:         &config.RoutingMatch{Services: []string{serviceGlob}},
+		CompiledMatch: &config.CompiledRoutingMatch{ServiceGlobs: []string{serviceGlob}},
+	}
+}
+
+// newSourceWithService creates a LogSource whose Config has the given service set.
+func newSourceWithService(svc string) *sources.LogSource {
+	return sources.NewLogSource("", &config.LogsConfig{Service: svc})
+}
+
+func TestLocalProcessingOnlySetsFlag(t *testing.T) {
+	p := &Processor{
+		processingRules: []*config.ProcessingRule{
+			newProcessingRuleRouting(config.LocalProcessingOnly, "suppressed-svc"),
+		},
+	}
+	src := newSourceWithService("suppressed-svc")
+	msg := newMessage([]byte("hello"), src, "info")
+
+	shouldProcess := p.applyRedactingRules(msg)
+	assert.True(t, shouldProcess, "local_processing_only should not drop the message")
+	assert.True(t, msg.IsLocalProcessingOnly)
+}
+
+func TestLocalProcessingOnlyDoesNotMatchOtherService(t *testing.T) {
+	p := &Processor{
+		processingRules: []*config.ProcessingRule{
+			newProcessingRuleRouting(config.LocalProcessingOnly, "suppressed-svc"),
+		},
+	}
+	src := newSourceWithService("allowed-svc")
+	msg := newMessage([]byte("hello"), src, "info")
+
+	shouldProcess := p.applyRedactingRules(msg)
+	assert.True(t, shouldProcess)
+	assert.False(t, msg.IsLocalProcessingOnly)
+}
+
+// newTestProcessor creates a Processor wired up for processMessage testing.
+func newTestProcessor(
+	rules []*config.ProcessingRule,
+	inputChan, outputChan chan *message.Message,
+	obs *mockObserverHandle,
+) *Processor {
+	return &Processor{
+		processingRules:           rules,
+		inputChan:                 inputChan,
+		outputChan:                outputChan,
+		encoder:                   JSONEncoder,
+		diagnosticMessageReceiver: &mockDiagnosticReceiver{},
+		pipelineMonitor:           metrics.NewNoopPipelineMonitor("test"),
+		utilization:               metrics.NewNoopPipelineMonitor("test").MakeUtilizationMonitor("test", ""),
+		observerHandle:            obs,
+		done:                      make(chan struct{}),
+	}
+}
+
+func TestProcessMessageLocalProcessingOnlySkipsOutput(t *testing.T) {
+	inputChan := make(chan *message.Message, 1)
+	outputChan := make(chan *message.Message, 1)
+	obs := &mockObserverHandle{}
+
+	p := newTestProcessor(
+		[]*config.ProcessingRule{newProcessingRuleRouting(config.LocalProcessingOnly, "suppressed-svc")},
+		inputChan, outputChan, obs,
+	)
+
+	src := newSourceWithService("suppressed-svc")
+	msg := newMessage([]byte("hello"), src, "info")
+	p.processMessage(msg)
+
+	// The message must have been observed by the observer…
+	assert.Len(t, obs.observed, 1)
+	// …but must NOT have been sent to the output channel.
+	assert.Empty(t, outputChan)
+}
+
+func TestProcessMessageLocalProcessingOnlyAllowedServiceReachesOutput(t *testing.T) {
+	inputChan := make(chan *message.Message, 1)
+	outputChan := make(chan *message.Message, 1)
+	obs := &mockObserverHandle{}
+
+	p := newTestProcessor(
+		[]*config.ProcessingRule{newProcessingRuleRouting(config.LocalProcessingOnly, "suppressed-svc")},
+		inputChan, outputChan, obs,
+	)
+
+	src := newSourceWithService("allowed-svc")
+	msg := newMessage([]byte("hello"), src, "info")
+	p.processMessage(msg)
+
+	// Unmatched message should reach the output channel.
+	assert.Len(t, outputChan, 1)
 }
 
 func BenchmarkMaskSequences(b *testing.B) {

--- a/test/new-e2e/tests/agent-log-pipelines/linux-log/local-processing-only/config/agent_config.yaml
+++ b/test/new-e2e/tests/agent-log-pipelines/linux-log/local-processing-only/config/agent_config.yaml
@@ -1,0 +1,7 @@
+logs_config:
+  processing_rules:
+    - type: local_processing_only
+      name: suppress-svc
+      match:
+        services:
+          - suppressed-svc

--- a/test/new-e2e/tests/agent-log-pipelines/linux-log/local-processing-only/config/allowed-svc.yaml
+++ b/test/new-e2e/tests/agent-log-pipelines/linux-log/local-processing-only/config/allowed-svc.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: '/var/log/e2e_test_logs/allowed-svc.log'
+    service: allowed-svc
+    source: custom_log

--- a/test/new-e2e/tests/agent-log-pipelines/linux-log/local-processing-only/config/suppressed-svc.yaml
+++ b/test/new-e2e/tests/agent-log-pipelines/linux-log/local-processing-only/config/suppressed-svc.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: '/var/log/e2e_test_logs/suppressed-svc.log'
+    service: suppressed-svc
+    source: custom_log

--- a/test/new-e2e/tests/agent-log-pipelines/linux-log/local-processing-only/local_processing_only_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/linux-log/local-processing-only/local_processing_only_test.go
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package localprocessingonly tests that logs matching a local_processing_only rule
+// are not forwarded to the Datadog backend (fakeintake), while unmatched logs still arrive.
+package localprocessingonly
+
+import (
+	_ "embed"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/utils"
+)
+
+//go:embed config/agent_config.yaml
+var agentConfig string
+
+//go:embed config/suppressed-svc.yaml
+var suppressedSvcConfig string
+
+//go:embed config/allowed-svc.yaml
+var allowedSvcConfig string
+
+const (
+	suppressedLogFile = "suppressed-svc.log"
+	allowedLogFile    = "allowed-svc.log"
+)
+
+// LocalProcessingOnlySuite verifies the local_processing_only routing rule.
+type LocalProcessingOnlySuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+// TestLocalProcessingOnlySuite is the entry point for the E2E test suite.
+func TestLocalProcessingOnlySuite(t *testing.T) {
+	options := []e2e.SuiteOption{
+		e2e.WithProvisioner(
+			awshost.Provisioner(
+				awshost.WithRunOptions(
+					scenec2.WithAgentOptions(
+						agentparams.WithLogs(),
+						agentparams.WithAgentConfig(agentConfig),
+						agentparams.WithIntegration("suppressed_svc_logs.d", suppressedSvcConfig),
+						agentparams.WithIntegration("allowed_svc_logs.d", allowedSvcConfig),
+					)))),
+	}
+	t.Parallel()
+	e2e.Run(t, &LocalProcessingOnlySuite{}, options...)
+}
+
+func (s *LocalProcessingOnlySuite) BeforeTest(suiteName, testName string) {
+	s.BaseSuite.BeforeTest(suiteName, testName)
+	utils.CleanUp(s)
+
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		logs, err := s.Env().FakeIntake.Client().FilterLogs("suppressed-svc")
+		require.NoError(c, err)
+		assert.Empty(c, logs, "Found unexpected logs for suppressed-svc before test started")
+	}, 2*time.Minute, 10*time.Second)
+
+	s.Env().RemoteHost.MustExecute("sudo mkdir -p " + utils.LinuxLogsFolderPath)
+}
+
+func (s *LocalProcessingOnlySuite) TearDownSuite() {
+	utils.CleanUp(s)
+	s.BaseSuite.TearDownSuite()
+}
+
+// TestLocalProcessingOnlySuppressionByService verifies that:
+//   - Logs from "suppressed-svc" do NOT arrive at fakeintake.
+//   - Logs from "allowed-svc" DO arrive at fakeintake.
+func (s *LocalProcessingOnlySuite) TestLocalProcessingOnlySuppressionByService() {
+	// Generate logs for both services.
+	utils.AppendLog(s, allowedLogFile, "allowed-log-content", 1)
+	utils.AppendLog(s, suppressedLogFile, "suppressed-log-content", 1)
+
+	// First, wait until the allowed-svc logs arrive so we know the agent has
+	// processed the batch — then verify suppressed-svc logs are absent.
+	utils.CheckLogsExpected(s.T(), s.Env().FakeIntake, "allowed-svc", "allowed-log-content", []string{})
+
+	// Verify that suppressed-svc logs never reach fakeintake.
+	// We use a short fixed poll since we already confirmed the agent is processing.
+	s.T().Log("Verifying suppressed-svc logs are absent from fakeintake")
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		logs, err := s.Env().FakeIntake.Client().FilterLogs("suppressed-svc")
+		assert.NoError(c, err, "Error querying fakeintake for suppressed-svc")
+		assert.Empty(c, logs, "suppressed-svc logs must not reach fakeintake")
+	}, 30*time.Second, 5*time.Second)
+}


### PR DESCRIPTION
### What does this PR do?

> 1/N PR to process logs only locally and not send them to the backend.

Adds `local_processing_only` rule type to `logs_config.processing_rules`: logs from
matched services are observed locally but never forwarded to the Datadog backend.

This also adds `datadog.agent.logs_processor.local_only_logs_total` internal telemetry to know the number of skipped logs.

### Motivation

### Describe how you validated your changes

### Additional Notes

Here is an example to process appgate logs but not send them:

```yaml
logs_config:
  processing_rules:
    - type: local_processing_only
      name: "appgate-logs-only-at-the-edge"
      match:
        services:
          - appgate*
```