### PR TITLE
[procmgr] Enable Bazel Rust Windows builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -64,6 +64,9 @@ common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 # Force the x86_64-pc-windows-gnu Rust toolchain (compact name for rust_windows_gnu_x86_64)
 # to take priority over the default MSVC toolchain, since the CI cc_toolchain is MinGW/GCC.
 common:windows --extra_toolchains=@rust_toolchains//:rw-2070622084
+# The GNU Rust toolchain needs dlltool (from MinGW binutils) to create import libraries.
+# Bazel's default action PATH omits mingw64/bin, so pass through the host PATH.
+common:windows --action_env=PATH
 
 # Remote cache config --------------------------------------------------------------------------------------------------
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).

--- a/.bazelrc
+++ b/.bazelrc
@@ -51,6 +51,10 @@ common:macos --strategy=sandboxed
 # Windows config -------------------------------------------------------------------------------------------------------
 common:windows --credential_helper=*.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper.bat
 common:windows --strategy=standalone # Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]
+# The Windows CI uses MinGW (GNU ld) as its C++ toolchain. rules_rust defaults
+# to MSVC-style stdlib link flags (advapi32.lib, ws2_32.lib, ...) which GNU ld
+# cannot resolve. Override them with GNU-style -l flags.
+common:windows --repo_env=BAZEL_RUST_STDLIB_LINKFLAGS=-ladvapi32:-lws2_32:-luserenv:-lbcrypt
 # rules_python 1.9.0 transitions enable_runfiles to `true` for every py_ target on Windows. Pre-setting it here makes
 # that transition a no-op, so Bazel deduplicates python_win and avoids 2 concurrent MSBuild racing on shared resources.
 common:windows --enable_runfiles

--- a/.bazelrc
+++ b/.bazelrc
@@ -51,10 +51,6 @@ common:macos --strategy=sandboxed
 # Windows config -------------------------------------------------------------------------------------------------------
 common:windows --credential_helper=*.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper.bat
 common:windows --strategy=standalone # Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]
-# The Windows CI uses MinGW (GNU ld) as its C++ toolchain. rules_rust defaults
-# to MSVC-style stdlib link flags (advapi32.lib, ws2_32.lib, ...) which GNU ld
-# cannot resolve. Override them with GNU-style -l flags.
-common:windows --repo_env=BAZEL_RUST_STDLIB_LINKFLAGS=-ladvapi32:-lws2_32:-luserenv:-lbcrypt
 # rules_python 1.9.0 transitions enable_runfiles to `true` for every py_ target on Windows. Pre-setting it here makes
 # that transition a no-op, so Bazel deduplicates python_win and avoids 2 concurrent MSBuild racing on shared resources.
 common:windows --enable_runfiles

--- a/.bazelrc
+++ b/.bazelrc
@@ -66,7 +66,9 @@ common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 common:windows --extra_toolchains=@rust_toolchains//:rw-2070622084
 # The GNU Rust toolchain needs dlltool (from MinGW binutils) to create import libraries.
 # Bazel's default action PATH omits mingw64/bin, so pass through the host PATH.
+# --action_env covers target-config actions; --host_action_env covers exec-config (tool) actions.
 common:windows --action_env=PATH
+common:windows --host_action_env=PATH
 
 # Remote cache config --------------------------------------------------------------------------------------------------
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).

--- a/.bazelrc
+++ b/.bazelrc
@@ -61,6 +61,9 @@ common:windows --repo_env=SYSTEMROOT # used by COM to load system DLLs, needed b
 common:windows --repo_env=USERPROFILE # used by MSYS2 bash to emulate HOME, needed by git to fetch repositories
 common:windows --repo_env=VSTUDIO_ROOT # visual_studio(path_variable) in MODULE.bazel
 common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
+# Force the x86_64-pc-windows-gnu Rust toolchain (compact name for rust_windows_gnu_x86_64)
+# to take priority over the default MSVC toolchain, since the CI cc_toolchain is MinGW/GCC.
+common:windows --extra_toolchains=@rust_toolchains//:rw-2070622084
 
 # Remote cache config --------------------------------------------------------------------------------------------------
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).

--- a/.bazelrc
+++ b/.bazelrc
@@ -64,11 +64,6 @@ common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 # Force the x86_64-pc-windows-gnu Rust toolchain (compact name for rust_windows_gnu_x86_64)
 # to take priority over the default MSVC toolchain, since the CI cc_toolchain is MinGW/GCC.
 common:windows --extra_toolchains=@rust_toolchains//:rw-2070622084
-# The GNU Rust toolchain needs dlltool (from MinGW binutils) to create import libraries.
-# Bazel's default action PATH omits mingw64/bin, so pass through the host PATH.
-# --action_env covers target-config actions; --host_action_env covers exec-config (tool) actions.
-common:windows --action_env=PATH
-common:windows --host_action_env=PATH
 
 # Remote cache config --------------------------------------------------------------------------------------------------
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -28,8 +28,8 @@ bazel:test:windows-amd64:
   variables:
     POWERSHELL_SCRIPT: >-
       bazel test --keep_going
-      "--action_env=PATH=C:/tools/msys64/mingw64/bin;C:/tools/msys64/usr/bin;C:/Windows/system32;C:/Windows"
-      "--host_action_env=PATH=C:/tools/msys64/mingw64/bin;C:/tools/msys64/usr/bin;C:/Windows/system32;C:/Windows"
+      "--action_env=PATH=C:/tools/msys64/mingw64/bin;C:/tools/msys64/usr/bin;C:/Windows/System32/WindowsPowerShell/v1.0;C:/Windows/system32;C:/Windows"
+      "--host_action_env=PATH=C:/tools/msys64/mingw64/bin;C:/tools/msys64/usr/bin;C:/Windows/System32/WindowsPowerShell/v1.0;C:/Windows/system32;C:/Windows"
       //... --
       -//bazel/rules/dd_packaging/...
       -//packages/agent/linux/...

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -27,6 +27,9 @@ bazel:test:windows-amd64:
   extends: [ .bazel:test, .bazel:runner:windows-amd64 ]
   variables:
     POWERSHELL_SCRIPT: >-
-      bazel test --keep_going //... --
+      bazel test --keep_going
+      "--action_env=PATH=C:/tools/msys64/mingw64/bin;C:/tools/msys64/usr/bin;C:/Windows/system32;C:/Windows"
+      "--host_action_env=PATH=C:/tools/msys64/mingw64/bin;C:/tools/msys64/usr/bin;C:/Windows/system32;C:/Windows"
+      //... --
       -//bazel/rules/dd_packaging/...
       -//packages/agent/linux/...

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -264,19 +264,6 @@ rust.toolchain(
     edition = "2024",
     versions = ["1.92.0"],
 )
-
-# The Windows Bazel CI uses MinGW as its C++ toolchain. The default rules_rust
-# toolchain targets x86_64-pc-windows-msvc, whose MSVC linker flags (/NOLOGO,
-# kernel32.lib, etc.) are incompatible with MinGW's GNU ld. Override the
-# Windows x86_64 repository set to target x86_64-pc-windows-gnu instead, which
-# produces GNU-style link commands that MinGW understands.
-rust.repository_set(
-    name = "rust_windows_x86_64",
-    edition = "2024",
-    exec_triple = "x86_64-pc-windows-msvc",
-    target_triple = "x86_64-pc-windows-gnu",
-    versions = ["1.92.0"],
-)
 use_repo(rust, "rust_toolchains")
 
 register_toolchains("@rust_toolchains//:all")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -286,6 +286,14 @@ rust.repository_set(
     name = "rust_windows_gnu_x86_64",
     edition = "2024",
     exec_triple = "x86_64-pc-windows-gnu",
+    extra_exec_rustc_flags = [
+        "-Clinker=C:/tools/msys64/mingw64/bin/gcc.exe",
+        "-Cdlltool=C:/tools/msys64/mingw64/bin/dlltool.exe",
+    ],
+    extra_rustc_flags = [
+        "-Clinker=C:/tools/msys64/mingw64/bin/gcc.exe",
+        "-Cdlltool=C:/tools/msys64/mingw64/bin/dlltool.exe",
+    ],
     target_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -286,11 +286,11 @@ rust.repository_set(
     name = "rust_windows_gnu_x86_64",
     edition = "2024",
     exec_triple = "x86_64-pc-windows-gnu",
-    target_triple = "x86_64-pc-windows-gnu",
     target_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",
     ],
+    target_triple = "x86_64-pc-windows-gnu",
     versions = ["1.92.0"],
 )
 rust.toolchain(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -93,6 +93,22 @@ git_override(
     remote = "https://github.com/bazelbuild/rules_pkg.git",
 )
 
+# Temporary until rules_rust > 0.69.0 ships with Windows GNU ABI support (PR #3940).
+# The CI runner uses MinGW as its cc_toolchain; rules_rust 0.69.0 defaults to
+# x86_64-pc-windows-msvc whose linker flags are incompatible with MinGW's g++.
+git_override(
+    module_name = "rules_rust",
+    commit = "82506df3f31240f97194b2e9453022125eaa07f4",  # main as of April 21, 2026
+    remote = "https://github.com/bazelbuild/rules_rust.git",
+)
+
+git_override(
+    module_name = "rules_rust_prost",
+    commit = "82506df3f31240f97194b2e9453022125eaa07f4",
+    remote = "https://github.com/bazelbuild/rules_rust.git",
+    strip_prefix = "extensions/prost",
+)
+
 #########################
 ## Prebuilt binaries   ##
 #########################
@@ -260,6 +276,23 @@ register_toolchains("@pythons_hub//:all")
 #######################
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+
+# Register a GNU-ABI Rust toolchain for Windows so that rustc generates
+# GNU-style linker flags (-lkernel32, -o, etc.) compatible with the MinGW
+# cc_toolchain used on the Windows CI runner.  Processed before the default
+# toolchains, so Bazel's toolchain resolution picks it over the auto-registered
+# x86_64-pc-windows-msvc toolchain.
+rust.repository_set(
+    name = "rust_windows_gnu_x86_64",
+    edition = "2024",
+    exec_triple = "x86_64-pc-windows-gnu",
+    target_triple = "x86_64-pc-windows-gnu",
+    target_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    versions = ["1.92.0"],
+)
 rust.toolchain(
     edition = "2024",
     versions = ["1.92.0"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -264,6 +264,19 @@ rust.toolchain(
     edition = "2024",
     versions = ["1.92.0"],
 )
+
+# The Windows Bazel CI uses MinGW as its C++ toolchain. The default rules_rust
+# toolchain targets x86_64-pc-windows-msvc, whose MSVC linker flags (/NOLOGO,
+# kernel32.lib, etc.) are incompatible with MinGW's GNU ld. Override the
+# Windows x86_64 repository set to target x86_64-pc-windows-gnu instead, which
+# produces GNU-style link commands that MinGW understands.
+rust.repository_set(
+    name = "rust_windows_x86_64",
+    edition = "2024",
+    exec_triple = "x86_64-pc-windows-msvc",
+    target_triple = "x86_64-pc-windows-gnu",
+    versions = ["1.92.0"],
+)
 use_repo(rust, "rust_toolchains")
 
 register_toolchains("@rust_toolchains//:all")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -593,7 +593,7 @@
     },
     "@@gcc_toolchain+//:internal.bzl%non_bazel_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "hFH1yCyp2ucrdzlOqIFdIbU/GWFQzeimvYsGRrX66Jo=",
+        "bzlTransitiveDigest": "1Tl8gNDYKNLwM1L435EfTXDlrC2wLwGKvKHwUAGvOnI=",
         "usagesDigest": "sWe6gvmFpdWalNUJUWNZF23cgclfU+ijKXCf9JEbTjs=",
         "recordedInputs": [
           "REPO_MAPPING:gcc_toolchain+,bazel_tools bazel_tools",
@@ -650,7 +650,7 @@
     },
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "06cynZ1bCvvy8zHPrrDlXq+Z68xmjctHpfFxi+zEpJY=",
+        "bzlTransitiveDigest": "b+RP7Sgl8KN0VHamrgTqzGLuYPcQ/Mo4ptNkkHUIIlA=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedInputs": [
           "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
@@ -672,7 +672,7 @@
     },
     "@@rules_android+//bzlmod_extensions:apksig.bzl%apksig_extension": {
       "general": {
-        "bzlTransitiveDigest": "KrgiB8lWxqVdbipL9YIYOuGjS80xlZIM/EBvUg8SVd0=",
+        "bzlTransitiveDigest": "IiT2UgJGnHaKiyP2A1yh3U/QWN4W9g/Byolrm78hC/s=",
         "usagesDigest": "0FXD4PX+vQ/jVne2oV4v3Cw5Mc9DZQ4yTcoRkAjj/X4=",
         "recordedInputs": [
           "REPO_MAPPING:rules_android+,bazel_tools bazel_tools"
@@ -804,7 +804,7 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
       "general": {
-        "bzlTransitiveDigest": "TX+DvaYHvaXw5UbPnkep+t+mYO6w5d8y58mDOb0kh1U=",
+        "bzlTransitiveDigest": "rivoEqALgqTCLGdvXm7GtzsuPBvJm7npjQjhTrarAQo=",
         "usagesDigest": "qhmy4zrnFb6knNQRx2XBCVfHObom0vnflm+sibd7SA0=",
         "recordedInputs": [
           "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -18,30 +18,21 @@
     "https://bcr.bazel.build/modules/abseil-py/2.1.0/MODULE.bazel": "5ebe5bf853769c65707e5c28f216798f7a4b1042015e6a36e6d03094d94bec8a",
     "https://bcr.bazel.build/modules/abseil-py/2.1.0/source.json": "0e8fc4f088ce07099c1cd6594c20c7ddbb48b4b3c0849b7d94ba94be88ff042b",
     "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
-    "https://bcr.bazel.build/modules/apple_support/1.13.0/MODULE.bazel": "7c8cdea7e031b7f9f67f0b497adf6d2c6a2675e9304ca93a9af6ed84eef5a524",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.16.0/MODULE.bazel": "e785295d21ccab339c3af131752bfbe50fc33dd8215b357492d05bfad0232400",
     "https://bcr.bazel.build/modules/apple_support/1.21.0/MODULE.bazel": "ac1824ed5edf17dee2fdd4927ada30c9f8c3b520be1b5fd02a5da15bc10bff3e",
     "https://bcr.bazel.build/modules/apple_support/1.21.1/MODULE.bazel": "5809fa3efab15d1f3c3c635af6974044bac8a4919c62238cce06acee8a8c11f1",
-    "https://bcr.bazel.build/modules/apple_support/1.23.0/MODULE.bazel": "317d47e3f65b580e7fb4221c160797fda48e32f07d2dfff63d754ef2316dcd25",
     "https://bcr.bazel.build/modules/apple_support/1.24.1/MODULE.bazel": "f46e8ddad60aef170ee92b2f3d00ef66c147ceafea68b6877cb45bd91737f5f8",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
     "https://bcr.bazel.build/modules/apple_support/2.3.0/MODULE.bazel": "d48f824ae8eeea5f837eb3038cef3615075d996d3e82eb9187192c2820605a81",
     "https://bcr.bazel.build/modules/apple_support/2.3.0/source.json": "d99b0a50918c4484856d773026b2fd60a694668c70fc0e19d592786dc7e5e469",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "7bee702b4862612f29333590f4b658a5832d433d6f8e4395f090e8f4e85d442f",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/MODULE.bazel": "668e6bcb4d957fc0e284316dba546b705c8d43c857f87119619ee83c4555b859",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.3/MODULE.bazel": "253d739ba126f62a5767d832765b12b59e9f8d2bc88cc1572f4a73e46eb298ca",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.5/MODULE.bazel": "004ba890363d05372a97248c37205ae64b6fa31047629cd2c0895a9d0c7779e8",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.5/source.json": "ac2c3213df8f985785f1d0aeb7f0f73d5324e6e67d593d9b9470fb74a25d4a9b",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
-    "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
-    "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/MODULE.bazel": "aece421d479e3c31dc3e5f6d49a12acc2700457c03c556650ec7a0ff23fc0d95",
-    "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/MODULE.bazel": "e767c5dbfeb254ec03275a7701b5cfde2c4d2873676804bc7cb27ddff3728fed",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.2/MODULE.bazel": "598e7fe3b54f5fa64fdbeead1027653963a359cc23561d43680006f3b463d5a4",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.2/source.json": "c6f5c39e6f32eb395f8fdaea63031a233bbe96d49a3bfb9f75f6fce9b74bec6c",
-    "https://bcr.bazel.build/modules/bazel_features/0.1.0/MODULE.bazel": "47011d645b0f949f42ee67f2e8775188a9cf4a0a1528aa2fa4952f2fd00906fd",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
@@ -71,7 +62,6 @@
     "https://bcr.bazel.build/modules/bazel_lib/3.2.2/MODULE.bazel": "e2c890c8a515d6bca9c66d47718aa9e44b458fde64ec7204b8030bf2d349058c",
     "https://bcr.bazel.build/modules/bazel_lib/3.2.2/source.json": "9e84e115c20e14652c5c21401ae85ff4daa8702e265b5c0b3bf89353f17aa212",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
     "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
     "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
@@ -175,7 +165,6 @@
     "https://bcr.bazel.build/modules/rules_android/0.6.4/source.json": "95d3c233c81005ad95eadc9382fde7dc6bd2c61752361e463264ee8349c071fb",
     "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
     "https://bcr.bazel.build/modules/rules_apple/4.1.0/MODULE.bazel": "76e10fd4a48038d3fc7c5dc6e63b7063bbf5304a2e3bd42edda6ec660eebea68",
-    "https://bcr.bazel.build/modules/rules_buf/0.1.1/MODULE.bazel": "6189aec18a4f7caff599ad41b851ab7645d4f1e114aa6431acf9b0666eb92162",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
@@ -219,8 +208,8 @@
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
     "https://bcr.bazel.build/modules/rules_java/8.6.3/MODULE.bazel": "e90505b7a931d194245ffcfb6ff4ca8ef9d46b4e830d12e64817752e0198e2ed",
     "https://bcr.bazel.build/modules/rules_java/8.9.0/MODULE.bazel": "e17c876cb53dcd817b7b7f0d2985b710610169729e8c371b2221cacdcd3dce4a",
-    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
-    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
+    "https://bcr.bazel.build/modules/rules_java/9.0.3/MODULE.bazel": "1f98ed015f7e744a745e0df6e898a7c5e83562d6b759dfd475c76456dda5ccea",
+    "https://bcr.bazel.build/modules/rules_java/9.0.3/source.json": "b038c0c07e12e658135bbc32cc1a2ded6e33785105c9d41958014c592de4593e",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -241,7 +230,6 @@
     "https://bcr.bazel.build/modules/rules_m4/0.3.bcr.1/source.json": "0f3dffd7c11d8ae41eaf65ebcca59df6ed0b6cc44bd323129f1070ded71160f5",
     "https://bcr.bazel.build/modules/rules_multitool/1.11.1/MODULE.bazel": "f826d2d394e8d964e44ebb4a75ebcfe4e9cd4eb150e2ddcd60398ffeb939696a",
     "https://bcr.bazel.build/modules/rules_multitool/1.11.1/source.json": "201f43de1d35bd17f25a4fed3ba5a2ec500ef5e08b7d4b341bb9fd39cef0cbc6",
-    "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/MODULE.bazel": "6bc03c8f37f69401b888023bf511cb6ee4781433b0cb56236b2e55a21e3a026a",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
@@ -269,16 +257,9 @@
     "https://bcr.bazel.build/modules/rules_robolectric/4.14.1.2/source.json": "37c10335f2361c337c5c1f34ed36d2da70534c23088062b33a8bdaab68aa9dea",
     "https://bcr.bazel.build/modules/rules_rs/0.0.27/MODULE.bazel": "772d7c7dad91f3a6a1b95762362c93146fa53718ef3617a00c199624f50715d2",
     "https://bcr.bazel.build/modules/rules_rs/0.0.27/source.json": "ce3422d9111f3e5f70deaeafc90233ca8efd4cf3c2b7da883f7ad382634f2ecf",
-    "https://bcr.bazel.build/modules/rules_rust/0.45.1/MODULE.bazel": "a69d0db3a958fab2c6520961e1b2287afcc8b36690fd31bbc4f6f7391397150d",
-    "https://bcr.bazel.build/modules/rules_rust/0.66.0/MODULE.bazel": "86ef763a582f4739a27029bdcc6c562258ed0ea6f8d58294b049e215ceb251b3",
-    "https://bcr.bazel.build/modules/rules_rust/0.69.0/MODULE.bazel": "4326fec48f2fef0d514de46346f7f77e200c82936dd08b91c9ef039fbdad5c10",
-    "https://bcr.bazel.build/modules/rules_rust/0.69.0/source.json": "0d094307d690cc18b3ab003998697be8070a206f65592c5c8476999796f11c4b",
-    "https://bcr.bazel.build/modules/rules_rust_prost/0.69.0/MODULE.bazel": "39a13caf15be32bdfab87c14ae290cba5aa72be2eab93ae90cf7b7d8c18ae26d",
-    "https://bcr.bazel.build/modules/rules_rust_prost/0.69.0/source.json": "6297b96dbd3c404cbc83e851e2befc0706795239b16e089890d88ebc8cda66df",
     "https://bcr.bazel.build/modules/rules_shell/0.1.2/MODULE.bazel": "66e4ca3ce084b04af0b9ff05ff14cab4e5df7503973818bb91cbc6cda08d32fc",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
-    "https://bcr.bazel.build/modules/rules_shell/0.4.0/MODULE.bazel": "0f8f11bb3cd11755f0b48c1de0bbcf62b4b34421023aa41a2fc74ef68d9584f0",
     "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
     "https://bcr.bazel.build/modules/rules_shell/0.7.1/MODULE.bazel": "257dd8d667371de804918dfceb86f6ddd2e1b5e025f5d9322878d4a73dc8aa58",
@@ -289,10 +270,8 @@
     "https://bcr.bazel.build/modules/rules_swift/3.1.2/MODULE.bazel": "72c8f5cf9d26427cee6c76c8e3853eb46ce6b0412a081b2b6db6e8ad56267400",
     "https://bcr.bazel.build/modules/rules_testing/0.9.0/MODULE.bazel": "d4d9a7367978b5c589437f01dba1dc80ac6f389e9991e1c1edb3c8207526ca83",
     "https://bcr.bazel.build/modules/rules_testing/0.9.0/source.json": "2a943853f3480f42a9a5205cc4881a147fecdcf7c8ee87750bbeffff9c9a1877",
-    "https://bcr.bazel.build/modules/stardoc/0.5.0/MODULE.bazel": "f9f1f46ba8d9c3362648eea571c6f9100680efc44913618811b58cc9c02cd678",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
-    "https://bcr.bazel.build/modules/stardoc/0.5.4/MODULE.bazel": "6569966df04610b8520957cb8e97cf2e9faac2c0309657c537ab51c16c18a2a4",
     "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
     "https://bcr.bazel.build/modules/stardoc/0.6.2/MODULE.bazel": "7060193196395f5dd668eda046ccbeacebfd98efc77fed418dbe2b82ffaa39fd",
     "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
@@ -407,7 +386,7 @@
         "bzlTransitiveDigest": "vIQYQXzy/Q+owB/yz0XcUOwOyn9G0aQIpTxYlBfiCcQ=",
         "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
         "recordedInputs": [
-          "FILE:@@//.bazelversion 077ee5b3a3a7fc2622ceff6466fea0c28f3fb08b24653dcc7f4baab29b9aef36",
+          "FILE:@@//.bazelversion 59b003a1f3465ae6084432329f8265e860cbaac0bd4a92a4f3ea6b979a6eed66",
           "FILE:@@//tools/bazel 1dae499bda6b507adc6a400d1118c997b363267f2b697bb16452e87023d95f55",
           "FILE:@@//tools/bazel.bat 24c80eecf763cf0f70ef5919413247b8e3dbc9eecd41dd63bc21f7c461b8a010",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
@@ -486,7 +465,7 @@
     },
     "@@buildifier_prebuilt+//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
-        "bzlTransitiveDigest": "3SXpv/oaemUJfW9RAoTqenEgHJE2pkdbrrkPif6Vk00=",
+        "bzlTransitiveDigest": "u/i9PP+maGNppkHd1aTBEeOD4bynGUlbF5u5OLG5M64=",
         "usagesDigest": "eWMDBEn8E8CrwAPXrlrjIap2pseSMhxDyDdrntHBOOE=",
         "recordedInputs": [
           "REPO_MAPPING:buildifier_prebuilt+,bazel_skylib bazel_skylib+",
@@ -614,7 +593,7 @@
     },
     "@@gcc_toolchain+//:internal.bzl%non_bazel_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "1Tl8gNDYKNLwM1L435EfTXDlrC2wLwGKvKHwUAGvOnI=",
+        "bzlTransitiveDigest": "hFH1yCyp2ucrdzlOqIFdIbU/GWFQzeimvYsGRrX66Jo=",
         "usagesDigest": "sWe6gvmFpdWalNUJUWNZF23cgclfU+ijKXCf9JEbTjs=",
         "recordedInputs": [
           "REPO_MAPPING:gcc_toolchain+,bazel_tools bazel_tools",
@@ -671,7 +650,7 @@
     },
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "b+RP7Sgl8KN0VHamrgTqzGLuYPcQ/Mo4ptNkkHUIIlA=",
+        "bzlTransitiveDigest": "06cynZ1bCvvy8zHPrrDlXq+Z68xmjctHpfFxi+zEpJY=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedInputs": [
           "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
@@ -693,7 +672,7 @@
     },
     "@@rules_android+//bzlmod_extensions:apksig.bzl%apksig_extension": {
       "general": {
-        "bzlTransitiveDigest": "IiT2UgJGnHaKiyP2A1yh3U/QWN4W9g/Byolrm78hC/s=",
+        "bzlTransitiveDigest": "KrgiB8lWxqVdbipL9YIYOuGjS80xlZIM/EBvUg8SVd0=",
         "usagesDigest": "0FXD4PX+vQ/jVne2oV4v3Cw5Mc9DZQ4yTcoRkAjj/X4=",
         "recordedInputs": [
           "REPO_MAPPING:rules_android+,bazel_tools bazel_tools"
@@ -825,8 +804,8 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
       "general": {
-        "bzlTransitiveDigest": "Ge+KjZy8QMnoPMgIt4mv81panpzekkGwL/0JbLaYjGY=",
-        "usagesDigest": "tG3p3Nb5XxC7vWY/bcKdb//g0HoAxpxxH3F5/jBVlk4=",
+        "bzlTransitiveDigest": "TX+DvaYHvaXw5UbPnkep+t+mYO6w5d8y58mDOb0kh1U=",
+        "usagesDigest": "qhmy4zrnFb6knNQRx2XBCVfHObom0vnflm+sibd7SA0=",
         "recordedInputs": [
           "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",
           "REPO_MAPPING:bazel_features+,bazel_features_version bazel_features++version_extension+bazel_features_version",
@@ -839,6 +818,7 @@
           "REPO_MAPPING:rules_rust+,bazel_features bazel_features+",
           "REPO_MAPPING:rules_rust+,bazel_skylib bazel_skylib+",
           "REPO_MAPPING:rules_rust+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_rust+,cargo_bazel_bootstrap rules_rust++cu_nr+cargo_bazel_bootstrap",
           "REPO_MAPPING:rules_rust+,cui rules_rust++cu+cui",
           "REPO_MAPPING:rules_rust+,rrc rules_rust++i2+rrc",
           "REPO_MAPPING:rules_rust+,rules_cc rules_cc+",
@@ -904,7 +884,7 @@
               "binary": "cargo-bazel",
               "cargo_lockfile": "@@rules_rust+//crate_universe:Cargo.lock",
               "cargo_toml": "@@rules_rust+//crate_universe:Cargo.toml",
-              "version": "1.93.1",
+              "version": "1.95.0",
               "timeout": 900,
               "rust_toolchain_cargo_template": "@rust_host_tools//:bin/{tool}",
               "rust_toolchain_rustc_template": "@rust_host_tools//:bin/{tool}",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -208,8 +208,8 @@
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
     "https://bcr.bazel.build/modules/rules_java/8.6.3/MODULE.bazel": "e90505b7a931d194245ffcfb6ff4ca8ef9d46b4e830d12e64817752e0198e2ed",
     "https://bcr.bazel.build/modules/rules_java/8.9.0/MODULE.bazel": "e17c876cb53dcd817b7b7f0d2985b710610169729e8c371b2221cacdcd3dce4a",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/MODULE.bazel": "1f98ed015f7e744a745e0df6e898a7c5e83562d6b759dfd475c76456dda5ccea",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/source.json": "b038c0c07e12e658135bbc32cc1a2ded6e33785105c9d41958014c592de4593e",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -386,7 +386,7 @@
         "bzlTransitiveDigest": "vIQYQXzy/Q+owB/yz0XcUOwOyn9G0aQIpTxYlBfiCcQ=",
         "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
         "recordedInputs": [
-          "FILE:@@//.bazelversion 59b003a1f3465ae6084432329f8265e860cbaac0bd4a92a4f3ea6b979a6eed66",
+          "FILE:@@//.bazelversion 077ee5b3a3a7fc2622ceff6466fea0c28f3fb08b24653dcc7f4baab29b9aef36",
           "FILE:@@//tools/bazel 1dae499bda6b507adc6a400d1118c997b363267f2b697bb16452e87023d95f55",
           "FILE:@@//tools/bazel.bat 24c80eecf763cf0f70ef5919413247b8e3dbc9eecd41dd63bc21f7c461b8a010",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
@@ -465,7 +465,7 @@
     },
     "@@buildifier_prebuilt+//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
-        "bzlTransitiveDigest": "u/i9PP+maGNppkHd1aTBEeOD4bynGUlbF5u5OLG5M64=",
+        "bzlTransitiveDigest": "3SXpv/oaemUJfW9RAoTqenEgHJE2pkdbrrkPif6Vk00=",
         "usagesDigest": "eWMDBEn8E8CrwAPXrlrjIap2pseSMhxDyDdrntHBOOE=",
         "recordedInputs": [
           "REPO_MAPPING:buildifier_prebuilt+,bazel_skylib bazel_skylib+",

--- a/deps/crates.MODULE.bazel
+++ b/deps/crates.MODULE.bazel
@@ -5,6 +5,7 @@ crate.from_cargo(
     cargo_toml = "//:Cargo.toml",
     platform_triples = [
         "aarch64-unknown-linux-gnu",
+        "x86_64-pc-windows-msvc",
         "x86_64-unknown-linux-gnu",
     ],
     validate_lockfile = True,

--- a/deps/crates.MODULE.bazel
+++ b/deps/crates.MODULE.bazel
@@ -5,7 +5,6 @@ crate.from_cargo(
     cargo_toml = "//:Cargo.toml",
     platform_triples = [
         "aarch64-unknown-linux-gnu",
-        "x86_64-pc-windows-gnu",
         "x86_64-pc-windows-msvc",
         "x86_64-unknown-linux-gnu",
     ],

--- a/deps/crates.MODULE.bazel
+++ b/deps/crates.MODULE.bazel
@@ -5,6 +5,7 @@ crate.from_cargo(
     cargo_toml = "//:Cargo.toml",
     platform_triples = [
         "aarch64-unknown-linux-gnu",
+        "x86_64-pc-windows-gnu",
         "x86_64-pc-windows-msvc",
         "x86_64-unknown-linux-gnu",
     ],

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -5,6 +5,14 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("@rules_rust_prost//:defs.bzl", "rust_prost_library")
 
+# The prost toolchain is not configured for macOS (the prost_toolchain_impl
+# target does not provide ToolchainInfo on darwin). Exclude procmgr targets
+# from macOS — we only need Linux and Windows.
+_NOT_MACOS = select({
+    "@platforms//os:macos": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
+
 # ============================================================================
 # Protobuf / gRPC
 # ============================================================================
@@ -17,6 +25,7 @@ proto_library(
 rust_prost_library(
     name = "process_manager_rust_proto",
     proto = ":process_manager_proto",
+    target_compatible_with = _NOT_MACOS,
     visibility = ["//visibility:public"],
 )
 
@@ -58,9 +67,6 @@ _LIB_DEPS = [
     "@platforms//os:linux": [
         "@crates//:nix",
     ],
-    "@platforms//os:macos": [
-        "@crates//:nix",
-    ],
     "@platforms//os:windows": [
         "@crates//:windows-sys",
     ],
@@ -73,6 +79,7 @@ rust_library(
     crate_name = "dd_procmgrd",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = _NOT_MACOS,
     visibility = ["//visibility:public"],
     deps = _LIB_DEPS,
 )
@@ -85,6 +92,7 @@ rust_library(
     crate_name = "dd_procmgrd",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = _NOT_MACOS,
     deps = _LIB_DEPS,
 )
 
@@ -97,6 +105,7 @@ rust_binary(
     srcs = ["src/bins/dd-procmgrd.rs"],
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = _NOT_MACOS,
     visibility = ["//visibility:public"],
     deps = [
         ":dd-procmgrd-lib",
@@ -130,6 +139,7 @@ rust_binary(
     srcs = ["src/bins/dd-procmgr.rs"],
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = _NOT_MACOS,
     visibility = ["//visibility:public"],
     deps = [
         ":dd-procmgrd-lib",
@@ -152,12 +162,14 @@ pkg_files(
         mode = "0755",
     ),
     prefix = "embedded/bin",
+    target_compatible_with = _NOT_MACOS,
     visibility = ["//packages:__subpackages__"],
 )
 
 pkg_install(
     name = "install",
     srcs = [":all_files"],
+    target_compatible_with = _NOT_MACOS,
 )
 
 # ============================================================================
@@ -169,6 +181,7 @@ rust_test(
     crate = ":dd-procmgrd-lib",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = _NOT_MACOS,
     deps = [
         "@crates//:hyper-util",
         "@crates//:tempfile",

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -5,12 +5,15 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("@rules_rust_prost//:defs.bzl", "rust_prost_library")
 
-# The prost toolchain is not configured for macOS (the prost_toolchain_impl
-# target does not provide ToolchainInfo on darwin). Exclude procmgr targets
-# from macOS — we only need Linux and Windows.
-_NOT_MACOS = select({
-    "@platforms//os:macos": ["@platforms//:incompatible"],
-    "//conditions:default": [],
+# Gate procmgr Rust targets to Linux only for now:
+# - macOS: the prost toolchain does not provide ToolchainInfo on darwin.
+# - Windows: the Bazel CI runner uses MinGW (g++) as its C++ toolchain but
+#   rules_rust targets x86_64-pc-windows-msvc, whose MSVC linker flags
+#   (/NOLOGO, kernel32.lib, etc.) are incompatible with GNU ld. No Rust target
+#   can be built until the CI has MSVC link.exe or rules_rust supports MinGW.
+_LINUX_ONLY = select({
+    "@platforms//os:linux": [],
+    "//conditions:default": ["@platforms//:incompatible"],
 })
 
 # ============================================================================
@@ -25,14 +28,13 @@ proto_library(
 rust_prost_library(
     name = "process_manager_rust_proto",
     proto = ":process_manager_proto",
-    target_compatible_with = _NOT_MACOS,
+    target_compatible_with = _LINUX_ONLY,
     visibility = ["//visibility:public"],
 )
 
 # rust_prost_library propagates CcInfo from proto_library, which transitively
 # includes abseil-cpp (C++). The Rust linker does not add libstdc++ by default,
-# so we provide it explicitly via -lstdc++ (works for both Unix and Windows GNU
-# toolchains).
+# so we provide it explicitly via -lstdc++.
 cc_library(
     name = "cpp_stdlib",
     linkopts = ["-lstdc++"],
@@ -79,7 +81,7 @@ rust_library(
     crate_name = "dd_procmgrd",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = _NOT_MACOS,
+    target_compatible_with = _LINUX_ONLY,
     visibility = ["//visibility:public"],
     deps = _LIB_DEPS,
 )
@@ -92,7 +94,7 @@ rust_library(
     crate_name = "dd_procmgrd",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = _NOT_MACOS,
+    target_compatible_with = _LINUX_ONLY,
     deps = _LIB_DEPS,
 )
 
@@ -105,7 +107,7 @@ rust_binary(
     srcs = ["src/bins/dd-procmgrd.rs"],
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = _NOT_MACOS,
+    target_compatible_with = _LINUX_ONLY,
     visibility = ["//visibility:public"],
     deps = [
         ":dd-procmgrd-lib",
@@ -139,7 +141,7 @@ rust_binary(
     srcs = ["src/bins/dd-procmgr.rs"],
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = _NOT_MACOS,
+    target_compatible_with = _LINUX_ONLY,
     visibility = ["//visibility:public"],
     deps = [
         ":dd-procmgrd-lib",
@@ -154,22 +156,20 @@ pkg_files(
     name = "all_files",
     srcs = [
         ":dd-procmgr",
-    ] + select({
-        "@platforms//os:windows": [":dd-procmgr-service"],
-        "//conditions:default": [":dd-procmgrd"],
-    }),
+        ":dd-procmgrd",
+    ],
     attributes = pkg_attributes(
         mode = "0755",
     ),
     prefix = "embedded/bin",
-    target_compatible_with = _NOT_MACOS,
+    target_compatible_with = _LINUX_ONLY,
     visibility = ["//packages:__subpackages__"],
 )
 
 pkg_install(
     name = "install",
     srcs = [":all_files"],
-    target_compatible_with = _NOT_MACOS,
+    target_compatible_with = _LINUX_ONLY,
 )
 
 # ============================================================================
@@ -181,7 +181,7 @@ rust_test(
     crate = ":dd-procmgrd-lib",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = _NOT_MACOS,
+    target_compatible_with = _LINUX_ONLY,
     deps = [
         "@crates//:hyper-util",
         "@crates//:tempfile",

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -197,12 +197,14 @@ rust_test(
     crate_root = "tests/e2e.rs",
     data = [
         ":dd-procmgr",
+        ":dd-procmgr-service",
         ":dd-procmgrd",
         "//pkg/fleet/installer/packages/embedded:tmpl/datadog-agent-ddot.yaml.tmpl",
     ],
     edition = "2024",
     rustc_env = {
         "CARGO_BIN_EXE_dd-procmgr": "$(rootpath :dd-procmgr)",
+        "CARGO_BIN_EXE_dd-procmgr-service": "$(rootpath :dd-procmgr-service)",
         "CARGO_BIN_EXE_dd-procmgrd": "$(rootpath :dd-procmgrd)",
         "DDOT_TEMPLATE_PATH": "$(rootpath //pkg/fleet/installer/packages/embedded:tmpl/datadog-agent-ddot.yaml.tmpl)",
     },

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -17,9 +17,6 @@ proto_library(
 rust_prost_library(
     name = "process_manager_rust_proto",
     proto = ":process_manager_proto",
-    # Keep Linux-only: rust_prost_library requires a prost toolchain that
-    # is only configured for Linux. Widen when a Windows toolchain exists.
-    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
 )
 
@@ -38,10 +35,6 @@ cc_library(
 # ============================================================================
 # Library
 # ============================================================================
-
-# The Rust source is cross-platform, but Bazel targets remain Linux-only
-# because :process_manager_rust_proto requires a prost toolchain that only
-# exists for Linux. Widen to Linux+Windows when the toolchain is ported.
 
 _LIB_SRCS = glob(
     ["src/**/*.rs"],
@@ -80,7 +73,6 @@ rust_library(
     crate_name = "dd_procmgrd",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
     deps = _LIB_DEPS,
 )
@@ -93,7 +85,6 @@ rust_library(
     crate_name = "dd_procmgrd",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = ["@platforms//os:linux"],
     deps = _LIB_DEPS,
 )
 
@@ -106,7 +97,6 @@ rust_binary(
     srcs = ["src/bins/dd-procmgrd.rs"],
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
     deps = [
         ":dd-procmgrd-lib",
@@ -118,8 +108,7 @@ rust_binary(
 )
 
 # Windows service binary — functionally identical to dd-procmgrd, different
-# name for the Windows installer. Skipped until S22 enables the Windows prost
-# toolchain.
+# name for the Windows installer.
 rust_binary(
     name = "dd-procmgr-service",
     srcs = ["src/bins/dd-procmgr-service.rs"],
@@ -141,7 +130,6 @@ rust_binary(
     srcs = ["src/bins/dd-procmgr.rs"],
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
     deps = [
         ":dd-procmgrd-lib",
@@ -206,7 +194,7 @@ rust_test(
         "CARGO_BIN_EXE_dd-procmgrd": "$(rootpath :dd-procmgrd)",
         "DDOT_TEMPLATE_PATH": "$(rootpath //pkg/fleet/installer/packages/embedded:tmpl/datadog-agent-ddot.yaml.tmpl)",
     },
-    # Keep Linux-only until transport/named_pipe.rs is implemented
+    # E2E tests use UDS for transport and spawn the Linux daemon binary.
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
         ":dd-procmgrd-lib-testhelpers",

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -197,14 +197,12 @@ rust_test(
     crate_root = "tests/e2e.rs",
     data = [
         ":dd-procmgr",
-        ":dd-procmgr-service",
         ":dd-procmgrd",
         "//pkg/fleet/installer/packages/embedded:tmpl/datadog-agent-ddot.yaml.tmpl",
     ],
     edition = "2024",
     rustc_env = {
         "CARGO_BIN_EXE_dd-procmgr": "$(rootpath :dd-procmgr)",
-        "CARGO_BIN_EXE_dd-procmgr-service": "$(rootpath :dd-procmgr-service)",
         "CARGO_BIN_EXE_dd-procmgrd": "$(rootpath :dd-procmgrd)",
         "DDOT_TEMPLATE_PATH": "$(rootpath //pkg/fleet/installer/packages/embedded:tmpl/datadog-agent-ddot.yaml.tmpl)",
     },

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -14,16 +14,16 @@ proto_library(
     srcs = ["proto/process_manager.proto"],
 )
 
+_LINUX_OR_WINDOWS = select({
+    "@platforms//os:linux": [],
+    "@platforms//os:windows": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})
+
 rust_prost_library(
     name = "process_manager_rust_proto",
     proto = ":process_manager_proto",
-    # Keep off macOS: the prost toolchain requires a proto toolchain that
-    # is not configured for darwin.
-    target_compatible_with = select({
-        "@platforms//os:linux": [],
-        "@platforms//os:windows": [],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
+    target_compatible_with = _LINUX_OR_WINDOWS,
     visibility = ["//visibility:public"],
 )
 
@@ -80,6 +80,7 @@ rust_library(
     crate_name = "dd_procmgrd",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = _LINUX_OR_WINDOWS,
     visibility = ["//visibility:public"],
     deps = _LIB_DEPS,
 )
@@ -92,6 +93,7 @@ rust_library(
     crate_name = "dd_procmgrd",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = _LINUX_OR_WINDOWS,
     deps = _LIB_DEPS,
 )
 
@@ -138,6 +140,7 @@ rust_binary(
     srcs = ["src/bins/dd-procmgr.rs"],
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = _LINUX_OR_WINDOWS,
     visibility = ["//visibility:public"],
     deps = [
         ":dd-procmgrd-lib",
@@ -177,6 +180,7 @@ rust_test(
     crate = ":dd-procmgrd-lib",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = _LINUX_OR_WINDOWS,
     deps = [
         "@crates//:hyper-util",
         "@crates//:tempfile",

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -5,17 +5,6 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("@rules_rust_prost//:defs.bzl", "rust_prost_library")
 
-# Gate procmgr Rust targets to Linux only for now:
-# - macOS: the prost toolchain does not provide ToolchainInfo on darwin.
-# - Windows: the Bazel CI runner uses MinGW (g++) as its C++ toolchain but
-#   rules_rust targets x86_64-pc-windows-msvc, whose MSVC linker flags
-#   (/NOLOGO, kernel32.lib, etc.) are incompatible with GNU ld. No Rust target
-#   can be built until the CI has MSVC link.exe or rules_rust supports MinGW.
-_LINUX_ONLY = select({
-    "@platforms//os:linux": [],
-    "//conditions:default": ["@platforms//:incompatible"],
-})
-
 # ============================================================================
 # Protobuf / gRPC
 # ============================================================================
@@ -28,16 +17,26 @@ proto_library(
 rust_prost_library(
     name = "process_manager_rust_proto",
     proto = ":process_manager_proto",
-    target_compatible_with = _LINUX_ONLY,
+    # Keep off macOS: the prost toolchain requires a proto toolchain that
+    # is not configured for darwin.
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "@platforms//os:windows": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     visibility = ["//visibility:public"],
 )
 
 # rust_prost_library propagates CcInfo from proto_library, which transitively
 # includes abseil-cpp (C++). The Rust linker does not add libstdc++ by default,
-# so we provide it explicitly via -lstdc++.
+# so we provide it explicitly. On Windows the MinGW toolchain links C++ runtime
+# automatically.
 cc_library(
     name = "cpp_stdlib",
-    linkopts = ["-lstdc++"],
+    linkopts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-lstdc++"],
+    }),
 )
 
 # ============================================================================
@@ -81,7 +80,6 @@ rust_library(
     crate_name = "dd_procmgrd",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = _LINUX_ONLY,
     visibility = ["//visibility:public"],
     deps = _LIB_DEPS,
 )
@@ -94,7 +92,6 @@ rust_library(
     crate_name = "dd_procmgrd",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = _LINUX_ONLY,
     deps = _LIB_DEPS,
 )
 
@@ -107,7 +104,7 @@ rust_binary(
     srcs = ["src/bins/dd-procmgrd.rs"],
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = _LINUX_ONLY,
+    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
     deps = [
         ":dd-procmgrd-lib",
@@ -141,7 +138,6 @@ rust_binary(
     srcs = ["src/bins/dd-procmgr.rs"],
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = _LINUX_ONLY,
     visibility = ["//visibility:public"],
     deps = [
         ":dd-procmgrd-lib",
@@ -162,14 +158,14 @@ pkg_files(
         mode = "0755",
     ),
     prefix = "embedded/bin",
-    target_compatible_with = _LINUX_ONLY,
+    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//packages:__subpackages__"],
 )
 
 pkg_install(
     name = "install",
     srcs = [":all_files"],
-    target_compatible_with = _LINUX_ONLY,
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 # ============================================================================
@@ -181,7 +177,6 @@ rust_test(
     crate = ":dd-procmgrd-lib",
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
-    target_compatible_with = _LINUX_ONLY,
     deps = [
         "@crates//:hyper-util",
         "@crates//:tempfile",

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -61,6 +61,9 @@ _LIB_DEPS = [
     "@platforms//os:linux": [
         "@crates//:nix",
     ],
+    "@platforms//os:macos": [
+        "@crates//:nix",
+    ],
     "@platforms//os:windows": [
         "@crates//:windows-sys",
     ],

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -52,6 +52,7 @@ _LIB_DEPS = [
     "@crates//:serde_json",
     "@crates//:serde_yaml",
     "@crates//:tokio",
+    "@crates//:tokio-stream",
     "@crates//:tonic",
     "@crates//:tonic-reflection",
     "@crates//:tower",
@@ -59,7 +60,6 @@ _LIB_DEPS = [
 ] + select({
     "@platforms//os:linux": [
         "@crates//:nix",
-        "@crates//:tokio-stream",
     ],
     "@platforms//os:windows": [
         "@crates//:windows-sys",

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -22,14 +22,11 @@ rust_prost_library(
 
 # rust_prost_library propagates CcInfo from proto_library, which transitively
 # includes abseil-cpp (C++). The Rust linker does not add libstdc++ by default,
-# so we provide it explicitly. On Windows the MSVC toolchain links the C++
-# runtime automatically.
+# so we provide it explicitly via -lstdc++ (works for both Unix and Windows GNU
+# toolchains).
 cc_library(
     name = "cpp_stdlib",
-    linkopts = select({
-        "@platforms//os:windows": [],
-        "//conditions:default": ["-lstdc++"],
-    }),
+    linkopts = ["-lstdc++"],
 )
 
 # ============================================================================


### PR DESCRIPTION
### What does this PR do?

Enables procmgr Rust targets to build and pass unit tests on the Windows Bazel CI runner (`bazel:test:windows-amd64`). Also fixes sandbox PATH issues affecting non-procmgr Windows tests (`filesystem_test`, `secrets/impl_test`).

Key changes:

- **GNU Rust toolchain**: Upgrades `rules_rust` and `rules_rust_prost` via `git_override` to a commit with Windows GNU ABI support. Registers a `x86_64-pc-windows-gnu` toolchain in `MODULE.bazel` and selects it via `--extra_toolchains` in `.bazelrc`, matching the MinGW C++ toolchain on CI.
- **Windows CI PATH**: Sets a fixed, deterministic `PATH` via `--action_env` and `--host_action_env` in `.gitlab/build/bazel/test.yml` (not `.bazelrc`, to avoid poisoning remote cache keys). Includes MinGW, PowerShell, and system32 directories needed by Rust (`dlltool`), Go (`powershell.exe`), and Python test actions.
- **Cross-platform procmgr targets**: Removes `target_compatible_with` from cross-platform Rust targets so they build on both Linux and Windows. `dd-procmgr-service` stays Windows-only, `e2e_test` stays Linux-only.

### Motivation

All procmgr Rust Bazel targets were previously restricted to Linux. The Windows CI runner skipped them entirely, and other Windows tests intermittently failed due to incomplete sandbox PATH. This PR enables Rust compilation and unit testing on Windows, and fixes the PATH for all Bazel test actions on Windows CI.

### Describe how you validated your changes

- `bazel:test:windows-amd64` CI job: 322 tests pass, 57 skipped, 0 failures
- Verified `dd-procmgrd_test` (procmgr unit tests) passes on Windows
- Verified `filesystem_test` and `secrets/impl_test` (previously broken by missing PowerShell) now pass

### Additional Notes