### PR TITLE
Fix build tag filtering for GOOS-based cross-compilation

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -368,6 +368,18 @@ _GOOS_TO_SYS_PLATFORM = {
 }
 
 
+def _resolve_platform(platform=None):
+    """Return the effective target platform as a sys.platform-style string.
+
+    If platform is explicitly provided, normalize it from GOOS format to
+    sys.platform format (e.g. "windows" -> "win32"). Otherwise fall back to
+    the GOOS env var, then sys.platform.
+    """
+    if platform is None:
+        platform = os.getenv("GOOS") or sys.platform
+    return _GOOS_TO_SYS_PLATFORM.get(platform, platform)
+
+
 def compute_build_tags_for_flavor(
     build: str,
     build_include: str | None,
@@ -384,10 +396,7 @@ def compute_build_tags_for_flavor(
 
     Then, remove from these the provided list of tags to exclude.
     """
-    # Normalize GOOS values (e.g. "windows") to sys.platform values (e.g. "win32")
-    # so that downstream functions like filter_incompatible_tags work correctly.
-    if platform is not None:
-        platform = _GOOS_TO_SYS_PLATFORM.get(platform, platform)
+    platform = _resolve_platform(platform)
 
     build_include = (
         get_default_build_tags(build=build, flavor=flavor, platform=platform)
@@ -429,7 +438,7 @@ def get_default_build_tags(build="agent", flavor=AgentFlavor.base, platform: str
     The container integrations are currently only supported on Linux, disabling on
     the Windows and Darwin builds.
     """
-    platform = platform or sys.platform
+    platform = _resolve_platform(platform)
     include = build_tags[flavor].get(build)
     if include is None:
         print("Warning: unrecognized build type, no build tags included.", file=sys.stderr)
@@ -439,16 +448,17 @@ def get_default_build_tags(build="agent", flavor=AgentFlavor.base, platform: str
     return sorted(filter_incompatible_tags(include, platform=platform))
 
 
-def filter_incompatible_tags(include, platform=sys.platform):
+def filter_incompatible_tags(include, platform=None):
     """
     Filter out tags incompatible with the platform.
     include can be a list or a set.
     """
+    platform = _resolve_platform(platform)
     exclude = set()
     if not platform.startswith("linux"):
         exclude = exclude.union(LINUX_ONLY_TAGS)
 
-    if platform == "win32" or os.getenv("GOOS") == "windows":
+    if platform == "win32":
         include = include.union(["wmi"])
         exclude = exclude.union(WINDOWS_EXCLUDE_TAGS)
 


### PR DESCRIPTION
### What does this PR do?

When cross-compiling on a Linux host with `GOOS=windows` (or another target), `filter_incompatible_tags` was using `sys.platform` (the host platform) instead of the intended target platform, so Linux-only tags were not filtered out and Windows-specific tags were not added.

Introduce a `_resolve_platform` helper that normalizes the platform value from GOOS format to `sys.platform` format (e.g. `"windows"` -> `"win32"`), falling back to the `GOOS` env var when no explicit platform is provided, then to `sys.platform`. Call it at the top of `filter_incompatible_tags`, `get_default_build_tags`, and `compute_build_tags_for_flavor` so each function behaves correctly independently.

### Motivation

`compute_build_tags_for_flavor` (used by `agent.build`, `dogstatsd.build`, etc.) passes no `platform` argument when called without one, so cross-compilation via `GOOS=windows` on a Linux host would produce the wrong set of build tags.

### Describe how you validated your changes

Only invoke task code, no agent code changed. CI is sufficient.

### Additional Notes

Identified while working on DataDog/datadog-agent#49105.