### PR TITLE
move do_query_actions scheduling to postgres check

### DIFF
--- a/comp/dataobs/queryactions/def/component.go
+++ b/comp/dataobs/queryactions/def/component.go
@@ -11,6 +11,6 @@ package queryactions
 // Component is the Data Observability query actions component interface.
 // This component subscribes to RC DO_QUERY_ACTIONS product to receive declarative query configs,
 // each containing the full set of active monitor queries for a DB instance.
-// It schedules long-lived checks that manage query scheduling internally.
-// Gated by the data_observability.query_actions.enabled configuration.
+// It injects data_observability config into matching postgres check instances.
+// Activates when a postgres instance with data_observability.enabled: true is detected.
 type Component interface{}

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -16,10 +16,10 @@ import (
 )
 
 // activeConfigEntry stores the scheduled check config alongside the base postgres config
-// metadata and parsed instance, so that collectDisable can rebuild a "disable" config.
+// metadata and parsed instance, so that disabling can restore the original config.
 type activeConfigEntry struct {
 	checkConfig integration.Config
-	baseCfg     *integration.Config // Provider, NodeName from the matched postgres config
+	baseCfg     *integration.Config // the original matched postgres config for restoration
 	instance    map[string]any      // full parsed postgres instance for rebuilding
 }
 
@@ -94,8 +94,11 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 			continue
 		}
 
-		// Disable previous version before scheduling updated config
-		c.collectDisable(configID, &changes)
+		// Remove previous DO config version if this config_id was already active.
+		c.removeActiveConfig(configID, &changes)
+		// Unschedule the base file-provider config to prevent duplicate check execution.
+		// No-op in autodiscovery if the base config was already unscheduled by a prior update.
+		changes.Unschedule = append(changes.Unschedule, *baseCfg)
 
 		c.activeConfigsMu.Lock()
 		c.activeConfigs[configID] = activeConfigEntry{
@@ -127,59 +130,42 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 	return changes
 }
 
-// collectDisable removes a config from activeConfigs and replaces it with a disable
-// config that turns off data_observability on the postgres instance. The previous
-// enabled config is unscheduled so autodiscovery removes the old YAML variant, and
-// a new config with data_observability.enabled: false is scheduled in its place.
-// It is a no-op if configID is not currently active.
-func (c *component) collectDisable(configID string, changes *integration.ConfigChanges) {
+// removeActiveConfig removes a config from activeConfigs and adds the previous DO check
+// config to changes.Unschedule. Used before scheduling an updated DO config (where the
+// base config should NOT be restored). It is a no-op if configID is not currently active.
+func (c *component) removeActiveConfig(configID string, changes *integration.ConfigChanges) {
 	c.activeConfigsMu.Lock()
 	prev, existed := c.activeConfigs[configID]
+	if existed {
+		delete(c.activeConfigs, configID)
+	}
 	c.activeConfigsMu.Unlock()
 
 	if !existed {
 		return
 	}
 
-	disableCfg, err := c.buildDisableConfig(prev.baseCfg, prev.instance)
-	if err != nil {
-		// Don't delete from activeConfigs — the old config stays tracked so a
-		// future reconciliation can retry the disable.
-		c.log.Errorf("Failed to build disable config for %s: %v", configID, err)
+	changes.Unschedule = append(changes.Unschedule, prev.checkConfig)
+}
+
+// collectDisable removes a config from activeConfigs, unschedules the DO check config,
+// and re-schedules the original base postgres config to restore normal check behavior.
+// It is a no-op if configID is not currently active.
+func (c *component) collectDisable(configID string, changes *integration.ConfigChanges) {
+	c.activeConfigsMu.Lock()
+	prev, existed := c.activeConfigs[configID]
+	if existed {
+		delete(c.activeConfigs, configID)
+	}
+	c.activeConfigsMu.Unlock()
+
+	if !existed {
 		return
 	}
 
-	// Only delete after successfully building the disable config.
-	c.activeConfigsMu.Lock()
-	delete(c.activeConfigs, configID)
-	c.activeConfigsMu.Unlock()
-
-	// Unschedule the previous enabled config so autodiscovery removes the old
-	// YAML variant (different FastDigest), then schedule the disable config.
 	changes.Unschedule = append(changes.Unschedule, prev.checkConfig)
-	changes.Schedule = append(changes.Schedule, disableCfg)
+	changes.Schedule = append(changes.Schedule, *prev.baseCfg)
 	c.log.Infof("Disabled Data Observability query actions for config: %s", configID)
-}
-
-// buildDisableConfig creates a postgres config with data_observability.enabled: false.
-func (c *component) buildDisableConfig(baseCfg *integration.Config, instance map[string]any) (integration.Config, error) {
-	instanceFields := maps.Clone(instance)
-	instanceFields["data_observability"] = map[string]any{
-		"enabled": false,
-	}
-
-	instanceYAML, err := yaml.Marshal(instanceFields)
-	if err != nil {
-		return integration.Config{}, fmt.Errorf("failed to marshal disable instance: %w", err)
-	}
-
-	return integration.Config{
-		Name:      "postgres",
-		Source:    c.String(),
-		Provider:  baseCfg.Provider,
-		NodeName:  baseCfg.NodeName,
-		Instances: []integration.Data{instanceYAML},
-	}, nil
 }
 
 // findPostgresConfig finds a postgres config that matches the given identifier and has

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -211,25 +211,18 @@ func (c *component) findPostgresConfig(dbID *DBIdentifier) (*integration.Config,
 
 	if lastParseErr != nil {
 		// Surface the parse error so operators debug the postgres config YAML, not the RC identifier.
-		return nil, nil, fmt.Errorf("no postgres config found for identifier: type=%s, host=%s, dbname=%s; at least one postgres instance had a YAML parse error: %w",
-			dbID.Type, dbID.Host, dbID.DBName, lastParseErr)
+		return nil, nil, fmt.Errorf("no postgres config found for identifier: type=%s, host=%s; at least one postgres instance had a YAML parse error: %w",
+			dbID.Type, dbID.Host, lastParseErr)
 	}
-	return nil, nil, fmt.Errorf("no postgres config found for identifier: type=%s, host=%s, dbname=%s",
-		dbID.Type, dbID.Host, dbID.DBName)
-}
-
-// matchesDBName checks if an instance's dbname matches the RC identifier's dbname exactly.
-// Both must be equal; an empty RC dbname only matches instances that also have no dbname configured.
-func matchesDBName(instance map[string]any, dbID *DBIdentifier) bool {
-	instanceDBName, _ := instance["dbname"].(string)
-	return instanceDBName == dbID.DBName
+	return nil, nil, fmt.Errorf("no postgres config found for identifier: type=%s, host=%s",
+		dbID.Type, dbID.Host)
 }
 
 // matchesIdentifier checks if an instance matches the given DB identifier.
-// Matching is by host and dbname, regardless of hosting type.
+// Matching is by host only — per-query dbname fields handle database routing.
 func matchesIdentifier(instance map[string]any, dbID *DBIdentifier) bool {
 	host, _ := instance["host"].(string)
-	return host == dbID.Host && matchesDBName(instance, dbID)
+	return host == dbID.Host
 }
 
 // buildCheckConfig creates a postgres check config with data_observability queries injected.
@@ -239,6 +232,7 @@ func (c *component) buildCheckConfig(payload *DOQueryPayload, baseCfg *integrati
 	queries := make([]map[string]any, 0, len(payload.Queries))
 	for _, q := range payload.Queries {
 		qm := map[string]any{
+			"dbname":           q.DBName,
 			"monitor_id":       q.MonitorID,
 			"type":             q.Type,
 			"query":            q.Query,

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -15,21 +15,28 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// dbCredentialAllowList defines the connection and authentication fields to copy
-// from an existing postgres instance config into a Data Observability query actions check.
-// This list must never include "remote_config_id", "db_type", "db_identifier", or "queries" —
-// those keys are set programmatically and auth fields copied via maps.Copy
-// would silently overwrite them.
-var dbCredentialAllowList = []string{
-	"host", "port", "username", "password", "dbname",
-	"ssl", "ssl_mode", "ssl_cert", "ssl_key", "ssl_root_cert",
-	"tls", "tls_verify", "tls_cert", "tls_key", "tls_ca_cert",
-	"aws", "managed_authentication",
+// activeConfigEntry stores the scheduled check config alongside the base postgres config
+// metadata and parsed instance, so that collectDisable can rebuild a "disable" config.
+type activeConfigEntry struct {
+	checkConfig integration.Config
+	baseCfg     *integration.Config // Provider, NodeName from the matched postgres config
+	instance    map[string]any      // full parsed postgres instance for rebuilding
 }
 
-// isPostgresIntegration reports whether name is "postgres". Only postgres is currently supported.
-func isPostgresIntegration(name string) bool {
+// isSupportedIntegration reports whether name is a supported DB integration.
+// Currently only postgres is supported; mysql may be added in the future.
+func isSupportedIntegration(name string) bool {
 	return name == "postgres"
+}
+
+// instanceHasDOEnabled checks whether a parsed instance map has data_observability.enabled: true.
+func instanceHasDOEnabled(instance map[string]any) bool {
+	doSection, ok := instance["data_observability"].(map[string]any)
+	if !ok {
+		return false
+	}
+	enabled, _ := doSection["enabled"].(bool)
+	return enabled
 }
 
 // onRCUpdate handles DO_QUERY_ACTIONS RC product updates with a declarative config model.
@@ -61,7 +68,7 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 
 		// Empty queries list signals all queries for this config should be removed
 		if len(payload.Queries) == 0 {
-			c.collectUnschedule(configID, &changes)
+			c.collectDisable(configID, &changes)
 			applyStatus(path, state.ApplyStatus{State: state.ApplyStateAcknowledged})
 			continue
 		}
@@ -70,7 +77,7 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 		if err != nil {
 			c.log.Warnf("No matching postgres config for %s: %v", configID, err)
 			applyStatus(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
-			c.collectUnschedule(configID, &changes)
+			c.collectDisable(configID, &changes)
 			continue
 		}
 
@@ -83,15 +90,19 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 		if err != nil {
 			c.log.Errorf("Failed to build check config for %s: %v", configID, err)
 			applyStatus(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
-			c.collectUnschedule(configID, &changes)
+			c.collectDisable(configID, &changes)
 			continue
 		}
 
-		// Unschedule previous version before scheduling updated config
-		c.collectUnschedule(configID, &changes)
+		// Disable previous version before scheduling updated config
+		c.collectDisable(configID, &changes)
 
 		c.activeConfigsMu.Lock()
-		c.activeConfigs[configID] = checkConfig
+		c.activeConfigs[configID] = activeConfigEntry{
+			checkConfig: checkConfig,
+			baseCfg:     baseCfg,
+			instance:    instance,
+		}
 		c.activeConfigsMu.Unlock()
 		changes.Schedule = append(changes.Schedule, checkConfig)
 		c.log.Infof("Scheduled Data Observability query action check: %s (%d queries)", configID, len(payload.Queries))
@@ -109,16 +120,18 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 	c.activeConfigsMu.Unlock()
 
 	for _, configID := range toUnschedule {
-		c.log.Infof("Config %s absent from RC snapshot, unscheduling", configID)
-		c.collectUnschedule(configID, &changes)
+		c.log.Infof("Config %s absent from RC snapshot, disabling", configID)
+		c.collectDisable(configID, &changes)
 	}
 
 	return changes
 }
 
-// collectUnschedule removes a config from activeConfigs and appends it to changes.Unschedule.
+// collectDisable removes a config from activeConfigs and schedules an update that
+// disables data_observability on the postgres instance. Unlike unscheduling, this
+// does not remove the postgres check — it only turns off the DO query execution.
 // It is a no-op if configID is not currently active.
-func (c *component) collectUnschedule(configID string, changes *integration.ConfigChanges) {
+func (c *component) collectDisable(configID string, changes *integration.ConfigChanges) {
 	c.activeConfigsMu.Lock()
 	prev, existed := c.activeConfigs[configID]
 	if existed {
@@ -130,19 +143,46 @@ func (c *component) collectUnschedule(configID string, changes *integration.Conf
 		return
 	}
 
-	changes.Unschedule = append(changes.Unschedule, prev)
-	c.log.Infof("Unscheduled Data Observability query action check: %s", configID)
+	disableCfg, err := c.buildDisableConfig(prev.baseCfg, prev.instance)
+	if err != nil {
+		c.log.Errorf("Failed to build disable config for %s: %v", configID, err)
+		return
+	}
+	changes.Schedule = append(changes.Schedule, disableCfg)
+	c.log.Infof("Disabled Data Observability query actions for config: %s", configID)
 }
 
-// findPostgresConfig finds a postgres config that matches the given identifier.
-// Returns the matching config and the already-parsed instance map to avoid re-parsing YAML in callers.
+// buildDisableConfig creates a postgres config with data_observability.enabled: false.
+func (c *component) buildDisableConfig(baseCfg *integration.Config, instance map[string]any) (integration.Config, error) {
+	instanceFields := maps.Clone(instance)
+	instanceFields["data_observability"] = map[string]any{
+		"enabled": false,
+	}
+
+	instanceYAML, err := yaml.Marshal(instanceFields)
+	if err != nil {
+		return integration.Config{}, fmt.Errorf("failed to marshal disable instance: %w", err)
+	}
+
+	return integration.Config{
+		Name:      "postgres",
+		Source:    c.String(),
+		Provider:  baseCfg.Provider,
+		NodeName:  baseCfg.NodeName,
+		Instances: []integration.Data{instanceYAML},
+	}, nil
+}
+
+// findPostgresConfig finds a postgres config that matches the given identifier and has
+// data_observability.enabled: true. Returns the matching config and the already-parsed
+// instance map to avoid re-parsing YAML in callers.
 func (c *component) findPostgresConfig(dbID *DBIdentifier) (*integration.Config, map[string]any, error) {
 	cfgs := c.ac.GetUnresolvedConfigs()
 
 	var lastParseErr error
 	for cfgIdx := range cfgs {
 		cfg := cfgs[cfgIdx]
-		if !isPostgresIntegration(cfg.Name) {
+		if !isSupportedIntegration(cfg.Name) {
 			continue
 		}
 
@@ -154,7 +194,7 @@ func (c *component) findPostgresConfig(dbID *DBIdentifier) (*integration.Config,
 				continue
 			}
 
-			if matchesIdentifier(instance, dbID) {
+			if matchesIdentifier(instance, dbID) && instanceHasDOEnabled(instance) {
 				return &cfg, instance, nil
 			}
 		}
@@ -183,24 +223,10 @@ func matchesIdentifier(instance map[string]any, dbID *DBIdentifier) bool {
 	return host == dbID.Host && matchesDBName(instance, dbID)
 }
 
-// extractDBAuthFromInstance extracts credential fields from a parsed instance map using an allowlist.
-// The instance map comes from findPostgresConfig, which already parsed the YAML.
-func extractDBAuthFromInstance(instance map[string]any) map[string]any {
-	out := make(map[string]any)
-	for _, k := range dbCredentialAllowList {
-		if v, ok := instance[k]; ok {
-			out[k] = v
-		}
-	}
-	return out
-}
-
-// buildCheckConfig creates a check config for the do_query_actions check.
-// Returns an error if auth extraction or instance YAML serialization fails;
-// callers must report ApplyStateError to RC rather than scheduling the broken config.
+// buildCheckConfig creates a postgres check config with data_observability queries injected.
+// It clones the full matched postgres instance and adds the data_observability section.
+// Returns an error if YAML serialization fails; callers must report ApplyStateError to RC.
 func (c *component) buildCheckConfig(payload *DOQueryPayload, baseCfg *integration.Config, instance map[string]any, remoteConfigID string) (integration.Config, error) {
-	auth := extractDBAuthFromInstance(instance)
-
 	queries := make([]map[string]any, 0, len(payload.Queries))
 	for _, q := range payload.Queries {
 		qm := map[string]any{
@@ -226,20 +252,13 @@ func (c *component) buildCheckConfig(payload *DOQueryPayload, baseCfg *integrati
 		queries = append(queries, qm)
 	}
 
-	instanceFields := map[string]any{
-		"remote_config_id": remoteConfigID,
-		"db_type":          baseCfg.Name,
-		"db_identifier": map[string]any{
-			"host":   payload.DBIdentifier.Host,
-			"dbname": payload.DBIdentifier.DBName,
-		},
-		"queries": queries,
+	instanceFields := maps.Clone(instance)
+	instanceFields["data_observability"] = map[string]any{
+		"enabled":             true,
+		"collection_interval": 10,
+		"config_id":           remoteConfigID,
+		"queries":             queries,
 	}
-
-	// Copy auth fields into instance config. Auth fields from dbCredentialAllowList
-	// will overwrite any matching keys already set (none currently overlap).
-	// dbCredentialAllowList must not include "remote_config_id", "db_type", "db_identifier", or "queries".
-	maps.Copy(instanceFields, auth)
 
 	instanceYAML, err := yaml.Marshal(instanceFields)
 	if err != nil {
@@ -247,7 +266,7 @@ func (c *component) buildCheckConfig(payload *DOQueryPayload, baseCfg *integrati
 	}
 
 	return integration.Config{
-		Name:      "do_query_actions",
+		Name:      "postgres",
 		Source:    c.String(),
 		Provider:  baseCfg.Provider,
 		NodeName:  baseCfg.NodeName,

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -127,16 +127,14 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 	return changes
 }
 
-// collectDisable removes a config from activeConfigs and schedules an update that
-// disables data_observability on the postgres instance. Unlike unscheduling, this
-// does not remove the postgres check — it only turns off the DO query execution.
+// collectDisable removes a config from activeConfigs and replaces it with a disable
+// config that turns off data_observability on the postgres instance. The previous
+// enabled config is unscheduled so autodiscovery removes the old YAML variant, and
+// a new config with data_observability.enabled: false is scheduled in its place.
 // It is a no-op if configID is not currently active.
 func (c *component) collectDisable(configID string, changes *integration.ConfigChanges) {
 	c.activeConfigsMu.Lock()
 	prev, existed := c.activeConfigs[configID]
-	if existed {
-		delete(c.activeConfigs, configID)
-	}
 	c.activeConfigsMu.Unlock()
 
 	if !existed {
@@ -145,9 +143,20 @@ func (c *component) collectDisable(configID string, changes *integration.ConfigC
 
 	disableCfg, err := c.buildDisableConfig(prev.baseCfg, prev.instance)
 	if err != nil {
+		// Don't delete from activeConfigs — the old config stays tracked so a
+		// future reconciliation can retry the disable.
 		c.log.Errorf("Failed to build disable config for %s: %v", configID, err)
 		return
 	}
+
+	// Only delete after successfully building the disable config.
+	c.activeConfigsMu.Lock()
+	delete(c.activeConfigs, configID)
+	c.activeConfigsMu.Unlock()
+
+	// Unschedule the previous enabled config so autodiscovery removes the old
+	// YAML variant (different FastDigest), then schedule the disable config.
+	changes.Unschedule = append(changes.Unschedule, prev.checkConfig)
 	changes.Schedule = append(changes.Schedule, disableCfg)
 	c.log.Infof("Disabled Data Observability query actions for config: %s", configID)
 }

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -379,7 +379,7 @@ func TestOnRCUpdate_EmptyQueriesDisables(t *testing.T) {
 
 	assert.Equal(t, state.ApplyStateAcknowledged, statuses["path/config"].State)
 	assert.Empty(t, c.activeConfigs)
-	assert.Empty(t, changes.Unschedule, "should not unschedule postgres check")
+	require.Len(t, changes.Unschedule, 1, "should unschedule previous enabled config")
 	require.Len(t, changes.Schedule, 1, "should schedule disable config")
 	assert.Equal(t, "postgres", changes.Schedule[0].Name)
 
@@ -409,7 +409,7 @@ func TestOnRCUpdate_ReconcileDisablesStaleConfigs(t *testing.T) {
 	_, changes := collectStatuses(c, updates)
 
 	assert.Empty(t, c.activeConfigs)
-	assert.Empty(t, changes.Unschedule, "should not unschedule postgres check")
+	require.Len(t, changes.Unschedule, 1, "should unschedule previous enabled config")
 	require.Len(t, changes.Schedule, 1, "should schedule disable config")
 }
 
@@ -438,7 +438,8 @@ func TestCollectDisable_Found(t *testing.T) {
 	c.collectDisable("my-config", &changes)
 
 	assert.Empty(t, c.activeConfigs)
-	assert.Empty(t, changes.Unschedule, "should not unschedule postgres check")
+	require.Len(t, changes.Unschedule, 1, "should unschedule previous enabled config")
+	assert.Equal(t, "postgres", changes.Unschedule[0].Name)
 	require.Len(t, changes.Schedule, 1, "should schedule disable config")
 	assert.Equal(t, "postgres", changes.Schedule[0].Name)
 
@@ -539,13 +540,13 @@ func TestOnRCUpdate_UpdateReplacesExistingCheck(t *testing.T) {
 	require.Len(t, changes1.Schedule, 1, "first update should schedule the check")
 	require.Contains(t, c.activeConfigs, "cfg-update")
 
-	// Second update: same config_id, different query. Should disable the old and schedule the new.
+	// Second update: same config_id, different query. Should unschedule old, disable, and schedule new.
 	_, changes2 := collectStatuses(c, map[string]state.RawConfig{
 		"path/cfg": {Config: mkPayload("SELECT 2")},
 	})
+	require.Len(t, changes2.Unschedule, 1, "should unschedule the previous enabled config")
 	// Expect 2 Schedule entries: disable old + schedule new
 	require.Len(t, changes2.Schedule, 2, "second update should disable old + schedule new")
-	assert.Empty(t, changes2.Unschedule, "should not unschedule postgres check")
 
 	// The last scheduled config should have the updated query.
 	var instance map[string]any

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -63,65 +63,16 @@ func TestInstanceHasDOEnabled(t *testing.T) {
 	assert.True(t, instanceHasDOEnabled(map[string]any{"data_observability": map[string]any{"enabled": true}}))
 }
 
-func TestMatchesDBName(t *testing.T) {
-	t.Run("empty RC dbname matches empty instance dbname", func(t *testing.T) {
-		instance := map[string]any{}
-		dbID := &DBIdentifier{DBName: ""}
-		assert.True(t, matchesDBName(instance, dbID))
-	})
+func TestMatchesIdentifier_HostOnly(t *testing.T) {
+	instance := map[string]any{"host": "localhost", "dbname": "production"}
 
-	t.Run("empty RC dbname does not match instance with dbname", func(t *testing.T) {
-		instance := map[string]any{"dbname": "mydb"}
-		dbID := &DBIdentifier{DBName: ""}
-		assert.False(t, matchesDBName(instance, dbID))
-	})
-
-	t.Run("empty instance dbname does not match specific RC dbname", func(t *testing.T) {
-		instance := map[string]any{}
-		dbID := &DBIdentifier{DBName: "mydb"}
-		assert.False(t, matchesDBName(instance, dbID))
-	})
-
-	t.Run("matching dbnames", func(t *testing.T) {
-		instance := map[string]any{"dbname": "mydb"}
-		dbID := &DBIdentifier{DBName: "mydb"}
-		assert.True(t, matchesDBName(instance, dbID))
-	})
-
-	t.Run("mismatching dbnames", func(t *testing.T) {
-		instance := map[string]any{"dbname": "otherdb"}
-		dbID := &DBIdentifier{DBName: "mydb"}
-		assert.False(t, matchesDBName(instance, dbID))
-	})
-}
-
-func TestMatchesIdentifier_SelfHosted(t *testing.T) {
-	instance := map[string]any{"host": "localhost"}
-	dbID := &DBIdentifier{Type: "self-hosted", Host: "localhost"}
-	assert.True(t, matchesIdentifier(instance, dbID))
-
-	dbID = &DBIdentifier{Type: "self-hosted", Host: "otherhost"}
-	assert.False(t, matchesIdentifier(instance, dbID))
-}
-
-func TestMatchesIdentifier_SelfHosted_WithDBName(t *testing.T) {
-	instance := map[string]any{
-		"host":   "localhost",
-		"dbname": "production",
-	}
-
-	t.Run("matching dbname", func(t *testing.T) {
-		dbID := &DBIdentifier{Type: "self-hosted", Host: "localhost", DBName: "production"}
+	t.Run("matching host", func(t *testing.T) {
+		dbID := &DBIdentifier{Type: "self-hosted", Host: "localhost"}
 		assert.True(t, matchesIdentifier(instance, dbID))
 	})
 
-	t.Run("mismatching dbname", func(t *testing.T) {
-		dbID := &DBIdentifier{Type: "self-hosted", Host: "localhost", DBName: "staging"}
-		assert.False(t, matchesIdentifier(instance, dbID))
-	})
-
-	t.Run("empty RC dbname does not match instance with dbname", func(t *testing.T) {
-		dbID := &DBIdentifier{Type: "self-hosted", Host: "localhost"}
+	t.Run("mismatching host", func(t *testing.T) {
+		dbID := &DBIdentifier{Type: "self-hosted", Host: "otherhost"}
 		assert.False(t, matchesIdentifier(instance, dbID))
 	})
 }
@@ -142,7 +93,7 @@ func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 
 	payload := &DOQueryPayload{
 		ConfigID:     "test-config-1",
-		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost", DBName: "testdb"},
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
 		Queries: []QuerySpec{
 			{
 				MonitorID:       100,
@@ -467,7 +418,7 @@ func TestOnRCUpdate_ValidConfig_SchedulesCheck(t *testing.T) {
 
 	payload := DOQueryPayload{
 		ConfigID:     "cfg-happy",
-		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost", DBName: "mydb"},
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
 		Queries: []QuerySpec{
 			{
 				MonitorID:       42,
@@ -526,7 +477,7 @@ func TestOnRCUpdate_UpdateReplacesExistingCheck(t *testing.T) {
 	mkPayload := func(query string) []byte {
 		b, err := json.Marshal(DOQueryPayload{
 			ConfigID:     "cfg-update",
-			DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost", DBName: "mydb"},
+			DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
 			Queries:      []QuerySpec{{Type: "run_query", Query: query, IntervalSeconds: 60, TimeoutSeconds: 10}},
 		})
 		require.NoError(t, err)
@@ -566,7 +517,7 @@ func TestOnRCUpdate_NoMatchingPostgres_ReportsError(t *testing.T) {
 
 	payload := DOQueryPayload{
 		ConfigID:     "cfg-nomatch",
-		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "notfound.example.com", DBName: "mydb"},
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "notfound.example.com"},
 		Queries:      []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
 	}
 	payloadJSON, err := json.Marshal(payload)
@@ -582,6 +533,94 @@ func TestOnRCUpdate_NoMatchingPostgres_ReportsError(t *testing.T) {
 	assert.Empty(t, c.activeConfigs)
 }
 
+// TestOnRCUpdate_HostOnlyMatching verifies that a config matches a postgres instance
+// by host only, with per-query dbname routing to different databases.
+func TestOnRCUpdate_HostOnlyMatching(t *testing.T) {
+	postgresCfg := integration.Config{
+		Name:      "postgres",
+		Provider:  "file",
+		Instances: []integration.Data{integration.Data("host: localhost\ndbname: testdb\ndata_observability:\n  enabled: true\n")},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-hostonly",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
+		Queries: []QuerySpec{
+			{
+				DBName:          "analyticsdb",
+				Type:            "run_query",
+				Query:           "SELECT count(*) AS dd_value FROM events.page_views",
+				IntervalSeconds: 60,
+				TimeoutSeconds:  10,
+			},
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-hostonly": {Config: payloadJSON},
+	})
+
+	assert.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-hostonly"].State)
+	require.Len(t, changes.Schedule, 1)
+	require.Contains(t, c.activeConfigs, "cfg-hostonly")
+}
+
+// TestBuildCheckConfig_PerQueryDBName verifies that the dbname field from each QuerySpec
+// appears in the YAML output for each query entry.
+func TestBuildCheckConfig_PerQueryDBName(t *testing.T) {
+	c := &component{log: logmock.New(t)}
+
+	payload := &DOQueryPayload{
+		ConfigID: "cfg-multidb",
+		Queries: []QuerySpec{
+			{
+				DBName:          "testdb",
+				MonitorID:       100,
+				Type:            "run_query",
+				Query:           "SELECT count(*) AS dd_value FROM shop.orders",
+				IntervalSeconds: 60,
+				TimeoutSeconds:  10,
+				Entity:          EntityMetadata{Platform: "postgres", Database: "testdb", Schema: "shop", Table: "orders"},
+			},
+			{
+				DBName:          "analyticsdb",
+				MonitorID:       200,
+				Type:            "run_query",
+				Query:           "SELECT count(*) AS dd_value FROM events.clicks",
+				IntervalSeconds: 60,
+				TimeoutSeconds:  10,
+				Entity:          EntityMetadata{Platform: "postgres", Database: "analyticsdb", Schema: "events", Table: "clicks"},
+			},
+		},
+	}
+
+	baseCfg := &integration.Config{Name: "postgres"}
+	pgInstance := map[string]any{"host": "localhost", "dbname": "testdb", "data_observability": map[string]any{"enabled": true}}
+
+	checkCfg, err := c.buildCheckConfig(payload, baseCfg, pgInstance, "rc-multidb")
+	require.NoError(t, err)
+
+	var instance map[string]any
+	require.NoError(t, yaml.Unmarshal(checkCfg.Instances[0], &instance))
+
+	doConfig, ok := instance["data_observability"].(map[string]any)
+	require.True(t, ok)
+	queries, ok := doConfig["queries"].([]any)
+	require.True(t, ok)
+	require.Len(t, queries, 2)
+
+	q1 := queries[0].(map[string]any)
+	assert.Equal(t, "testdb", q1["dbname"])
+	assert.Equal(t, 100, q1["monitor_id"])
+
+	q2 := queries[1].(map[string]any)
+	assert.Equal(t, "analyticsdb", q2["dbname"])
+	assert.Equal(t, 200, q2["monitor_id"])
+}
+
 // TestOnRCUpdate_MalformedPostgresYAML_SurfacesParseError verifies that when a postgres
 // instance's YAML is malformed, the error message from findPostgresConfig mentions the
 // parse failure, not just "identifier not found".
@@ -594,7 +633,7 @@ func TestOnRCUpdate_MalformedPostgresYAML_SurfacesParseError(t *testing.T) {
 
 	payload := DOQueryPayload{
 		ConfigID:     "cfg-badyaml",
-		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost", DBName: "mydb"},
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
 		Queries:      []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
 	}
 	payloadJSON, err := json.Marshal(payload)

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -330,16 +330,9 @@ func TestOnRCUpdate_EmptyQueriesDisables(t *testing.T) {
 
 	assert.Equal(t, state.ApplyStateAcknowledged, statuses["path/config"].State)
 	assert.Empty(t, c.activeConfigs)
-	require.Len(t, changes.Unschedule, 1, "should unschedule previous enabled config")
-	require.Len(t, changes.Schedule, 1, "should schedule disable config")
-	assert.Equal(t, "postgres", changes.Schedule[0].Name)
-
-	// Verify the disable config has data_observability.enabled: false
-	var instance map[string]any
-	require.NoError(t, yaml.Unmarshal(changes.Schedule[0].Instances[0], &instance))
-	doConfig, ok := instance["data_observability"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, false, doConfig["enabled"])
+	require.Len(t, changes.Unschedule, 1, "should unschedule previous DO config")
+	require.Len(t, changes.Schedule, 1, "should re-schedule original base config")
+	assert.Equal(t, *baseCfg, changes.Schedule[0], "scheduled config should be the original base config")
 }
 
 func TestOnRCUpdate_ReconcileDisablesStaleConfigs(t *testing.T) {
@@ -360,8 +353,9 @@ func TestOnRCUpdate_ReconcileDisablesStaleConfigs(t *testing.T) {
 	_, changes := collectStatuses(c, updates)
 
 	assert.Empty(t, c.activeConfigs)
-	require.Len(t, changes.Unschedule, 1, "should unschedule previous enabled config")
-	require.Len(t, changes.Schedule, 1, "should schedule disable config")
+	require.Len(t, changes.Unschedule, 1, "should unschedule previous DO config")
+	require.Len(t, changes.Schedule, 1, "should re-schedule original base config")
+	assert.Equal(t, *baseCfg, changes.Schedule[0])
 }
 
 // --- collectDisable tests ---
@@ -378,9 +372,10 @@ func TestCollectDisable_NotFound(t *testing.T) {
 func TestCollectDisable_Found(t *testing.T) {
 	baseCfg := &integration.Config{Name: "postgres", Provider: "file"}
 	pgInstance := map[string]any{"host": "localhost", "dbname": "mydb", "data_observability": map[string]any{"enabled": true}}
+	doCheckConfig := integration.Config{Name: "postgres", Provider: "do_query_actions"}
 	c := newTestComponent(t)
 	c.activeConfigs["my-config"] = activeConfigEntry{
-		checkConfig: integration.Config{Name: "postgres"},
+		checkConfig: doCheckConfig,
 		baseCfg:     baseCfg,
 		instance:    pgInstance,
 	}
@@ -389,16 +384,39 @@ func TestCollectDisable_Found(t *testing.T) {
 	c.collectDisable("my-config", &changes)
 
 	assert.Empty(t, c.activeConfigs)
-	require.Len(t, changes.Unschedule, 1, "should unschedule previous enabled config")
-	assert.Equal(t, "postgres", changes.Unschedule[0].Name)
-	require.Len(t, changes.Schedule, 1, "should schedule disable config")
-	assert.Equal(t, "postgres", changes.Schedule[0].Name)
+	require.Len(t, changes.Unschedule, 1, "should unschedule previous DO config")
+	assert.Equal(t, doCheckConfig, changes.Unschedule[0])
+	require.Len(t, changes.Schedule, 1, "should re-schedule original base config")
+	assert.Equal(t, *baseCfg, changes.Schedule[0])
+}
 
-	var instance map[string]any
-	require.NoError(t, yaml.Unmarshal(changes.Schedule[0].Instances[0], &instance))
-	doConfig, ok := instance["data_observability"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, false, doConfig["enabled"])
+// --- removeActiveConfig tests ---
+
+func TestRemoveActiveConfig_NotFound(t *testing.T) {
+	c := newTestComponent(t)
+	changes := integration.ConfigChanges{}
+	c.removeActiveConfig("nonexistent", &changes)
+	assert.Empty(t, changes.Schedule)
+	assert.Empty(t, changes.Unschedule)
+}
+
+func TestRemoveActiveConfig_Found(t *testing.T) {
+	baseCfg := &integration.Config{Name: "postgres", Provider: "file"}
+	doCheckConfig := integration.Config{Name: "postgres", Provider: "do_query_actions"}
+	c := newTestComponent(t)
+	c.activeConfigs["my-config"] = activeConfigEntry{
+		checkConfig: doCheckConfig,
+		baseCfg:     baseCfg,
+		instance:    map[string]any{"host": "localhost"},
+	}
+	changes := integration.ConfigChanges{}
+
+	c.removeActiveConfig("my-config", &changes)
+
+	assert.Empty(t, c.activeConfigs, "config should be removed from activeConfigs")
+	require.Len(t, changes.Unschedule, 1, "should unschedule previous DO config")
+	assert.Equal(t, doCheckConfig, changes.Unschedule[0])
+	assert.Empty(t, changes.Schedule, "removeActiveConfig should NOT re-schedule base config")
 }
 
 // --- Happy-path integration tests (require mocked autodiscovery) ---
@@ -439,8 +457,8 @@ func TestOnRCUpdate_ValidConfig_SchedulesCheck(t *testing.T) {
 	statuses, changes := collectStatuses(c, updates)
 
 	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-happy"].State)
-	require.Len(t, changes.Schedule, 1, "expected one scheduled check")
-	assert.Empty(t, changes.Unschedule)
+	require.Len(t, changes.Schedule, 1, "expected one scheduled DO check")
+	require.Len(t, changes.Unschedule, 1, "should unschedule base file-provider config to prevent duplicate")
 	assert.Equal(t, "postgres", changes.Schedule[0].Name)
 	assert.Equal(t, "file", changes.Schedule[0].Provider)
 	assert.Equal(t, "node1", changes.Schedule[0].NodeName)
@@ -484,24 +502,24 @@ func TestOnRCUpdate_UpdateReplacesExistingCheck(t *testing.T) {
 		return b
 	}
 
-	// First update: schedule initial version.
+	// First update: schedule initial version. Unschedules the base file-provider config.
 	_, changes1 := collectStatuses(c, map[string]state.RawConfig{
 		"path/cfg": {Config: mkPayload("SELECT 1")},
 	})
-	require.Len(t, changes1.Schedule, 1, "first update should schedule the check")
+	require.Len(t, changes1.Schedule, 1, "first update should schedule the DO check")
+	require.Len(t, changes1.Unschedule, 1, "first update should unschedule base config")
 	require.Contains(t, c.activeConfigs, "cfg-update")
 
-	// Second update: same config_id, different query. Should unschedule old, disable, and schedule new.
+	// Second update: same config_id, different query. Unschedules previous DO config + base config,
+	// schedules only the new DO config.
 	_, changes2 := collectStatuses(c, map[string]state.RawConfig{
 		"path/cfg": {Config: mkPayload("SELECT 2")},
 	})
-	require.Len(t, changes2.Unschedule, 1, "should unschedule the previous enabled config")
-	// Expect 2 Schedule entries: disable old + schedule new
-	require.Len(t, changes2.Schedule, 2, "second update should disable old + schedule new")
+	require.Len(t, changes2.Unschedule, 2, "should unschedule previous DO config + base config")
+	require.Len(t, changes2.Schedule, 1, "should schedule only the new DO check")
 
-	// The last scheduled config should have the updated query.
 	var instance map[string]any
-	require.NoError(t, yaml.Unmarshal(changes2.Schedule[1].Instances[0], &instance))
+	require.NoError(t, yaml.Unmarshal(changes2.Schedule[0].Instances[0], &instance))
 	doConfig, ok := instance["data_observability"].(map[string]any)
 	require.True(t, ok)
 	queries, ok := doConfig["queries"].([]any)
@@ -564,7 +582,8 @@ func TestOnRCUpdate_HostOnlyMatching(t *testing.T) {
 	})
 
 	assert.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-hostonly"].State)
-	require.Len(t, changes.Schedule, 1)
+	require.Len(t, changes.Schedule, 1, "should schedule the DO check")
+	require.Len(t, changes.Unschedule, 1, "should unschedule base file-provider config")
 	require.Contains(t, c.activeConfigs, "cfg-hostonly")
 }
 

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -44,15 +44,23 @@ func newTestComponentWithAC(t *testing.T, configs []integration.Config) *compone
 	return &component{
 		log:           logmock.New(t),
 		ac:            newMockAutodiscovery(t, configs),
-		activeConfigs: make(map[string]integration.Config),
+		activeConfigs: make(map[string]activeConfigEntry),
 	}
 }
 
-func TestIsPostgresIntegration(t *testing.T) {
-	assert.True(t, isPostgresIntegration("postgres"))
-	assert.False(t, isPostgresIntegration("mysql"))
-	assert.False(t, isPostgresIntegration("redis"))
-	assert.False(t, isPostgresIntegration(""))
+func TestIsSupportedIntegration(t *testing.T) {
+	assert.True(t, isSupportedIntegration("postgres"))
+	assert.False(t, isSupportedIntegration("mysql"))
+	assert.False(t, isSupportedIntegration("redis"))
+	assert.False(t, isSupportedIntegration(""))
+}
+
+func TestInstanceHasDOEnabled(t *testing.T) {
+	assert.False(t, instanceHasDOEnabled(map[string]any{}))
+	assert.False(t, instanceHasDOEnabled(map[string]any{"data_observability": "not-a-map"}))
+	assert.False(t, instanceHasDOEnabled(map[string]any{"data_observability": map[string]any{}}))
+	assert.False(t, instanceHasDOEnabled(map[string]any{"data_observability": map[string]any{"enabled": false}}))
+	assert.True(t, instanceHasDOEnabled(map[string]any{"data_observability": map[string]any{"enabled": true}}))
 }
 
 func TestMatchesDBName(t *testing.T) {
@@ -127,69 +135,6 @@ func TestMatchesIdentifier_RDS(t *testing.T) {
 	assert.False(t, matchesIdentifier(instance, dbID))
 }
 
-func TestExtractDBAuthFromInstance(t *testing.T) {
-	instance := map[string]any{
-		"host":        "localhost",
-		"port":        5432,
-		"username":    "datadog",
-		"password":    "secret",
-		"dbname":      "testdb",
-		"ssl_mode":    "require",
-		"extra_field": "should_not_appear",
-	}
-	auth := extractDBAuthFromInstance(instance)
-
-	require.Equal(t, "localhost", auth["host"])
-	require.Equal(t, 5432, auth["port"])
-	require.Equal(t, "datadog", auth["username"])
-	require.Equal(t, "secret", auth["password"])
-	require.Equal(t, "testdb", auth["dbname"])
-	require.Equal(t, "require", auth["ssl_mode"])
-	_, ok := auth["extra_field"]
-	assert.False(t, ok, "extra_field should not be in allowlist output")
-}
-
-func TestExtractDBAuthFromInstance_NestedMap(t *testing.T) {
-	instance := map[string]any{
-		"host":     "mydb.rds.amazonaws.com",
-		"port":     5432,
-		"username": "datadog",
-		"password": "secret",
-		"aws": map[string]any{
-			"instance_endpoint": "my-rds-instance",
-			"region":            "us-east-1",
-		},
-	}
-	auth := extractDBAuthFromInstance(instance)
-
-	require.Equal(t, "mydb.rds.amazonaws.com", auth["host"])
-	awsMap, ok := auth["aws"].(map[string]any)
-	require.True(t, ok, "aws should be a map[string]any")
-	assert.Equal(t, "my-rds-instance", awsMap["instance_endpoint"])
-	assert.Equal(t, "us-east-1", awsMap["region"])
-}
-
-func TestDBCredentialAllowList_ExcludesReservedKeys(t *testing.T) {
-	instance := map[string]any{
-		"host":             "localhost",
-		"port":             5432,
-		"remote_config_id": "should-not-appear",
-		"db_type":          "should-not-appear",
-		"db_identifier":    "should-not-appear",
-		"queries":          []any{"should-not-appear"},
-	}
-	auth := extractDBAuthFromInstance(instance)
-
-	_, hasRemoteConfigID := auth["remote_config_id"]
-	assert.False(t, hasRemoteConfigID, "remote_config_id must not be in the allowlist")
-	_, hasDBType := auth["db_type"]
-	assert.False(t, hasDBType, "db_type must not be in the allowlist")
-	_, hasDBIdentifier := auth["db_identifier"]
-	assert.False(t, hasDBIdentifier, "db_identifier must not be in the allowlist")
-	_, hasQueries := auth["queries"]
-	assert.False(t, hasQueries, "queries must not be in the allowlist")
-}
-
 func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 	c := &component{
 		log: logmock.New(t),
@@ -241,12 +186,15 @@ func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 		"port":     5432,
 		"username": "datadog",
 		"password": "secret",
+		"data_observability": map[string]any{
+			"enabled": true,
+		},
 	}
 
 	checkCfg, err := c.buildCheckConfig(payload, baseCfg, pgInstance, "rc-id-1")
 	require.NoError(t, err)
 
-	assert.Equal(t, "do_query_actions", checkCfg.Name)
+	assert.Equal(t, "postgres", checkCfg.Name)
 	assert.Equal(t, "file", checkCfg.Provider)
 	assert.Equal(t, "node1", checkCfg.NodeName)
 	require.Len(t, checkCfg.Instances, 1)
@@ -255,24 +203,24 @@ func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 	err = yaml.Unmarshal(checkCfg.Instances[0], &instance)
 	require.NoError(t, err)
 
-	assert.Equal(t, "rc-id-1", instance["remote_config_id"])
-	assert.Equal(t, "postgres", instance["db_type"])
-
-	dbID, ok := instance["db_identifier"].(map[string]interface{})
-	require.True(t, ok, "db_identifier should be a map")
-	assert.Equal(t, "localhost", dbID["host"])
-	assert.Equal(t, "testdb", dbID["dbname"])
-
+	// Verify full postgres instance fields are preserved
 	assert.Equal(t, "localhost", instance["host"])
 	assert.Equal(t, 5432, instance["port"])
 	assert.Equal(t, "datadog", instance["username"])
 	assert.Equal(t, "secret", instance["password"])
 
-	queries, ok := instance["queries"].([]interface{})
+	// Verify data_observability section
+	doConfig, ok := instance["data_observability"].(map[string]any)
+	require.True(t, ok, "data_observability should be a map")
+	assert.Equal(t, true, doConfig["enabled"])
+	assert.Equal(t, "rc-id-1", doConfig["config_id"])
+	assert.Equal(t, 10, doConfig["collection_interval"])
+
+	queries, ok := doConfig["queries"].([]any)
 	require.True(t, ok, "queries should be a list")
 	require.Len(t, queries, 2)
 
-	q1, ok := queries[0].(map[string]interface{})
+	q1, ok := queries[0].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, 100, q1["monitor_id"])
 	assert.Equal(t, "run_query", q1["type"])
@@ -280,7 +228,7 @@ func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 	assert.Equal(t, 60, q1["interval_seconds"])
 	assert.Equal(t, 10, q1["timeout_seconds"])
 
-	entity1, ok := q1["entity"].(map[string]interface{})
+	entity1, ok := q1["entity"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "postgres", entity1["platform"])
 	assert.Equal(t, "my-account", entity1["account"])
@@ -288,14 +236,10 @@ func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 	assert.Equal(t, "public", entity1["schema"])
 	assert.Equal(t, "orders", entity1["table"])
 
-	q2, ok := queries[1].(map[string]interface{})
+	q2, ok := queries[1].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, 200, q2["monitor_id"])
 	assert.Equal(t, "SELECT avg(price) FROM products", q2["query"])
-
-	// Verify run_once is NOT present
-	_, hasRunOnce := instance["run_once"]
-	assert.False(t, hasRunOnce, "run_once should not be present in declarative model")
 }
 
 func TestBuildCheckConfig_CustomSQLSelectFields(t *testing.T) {
@@ -319,7 +263,7 @@ func TestBuildCheckConfig_CustomSQLSelectFields(t *testing.T) {
 	}
 
 	baseCfg := &integration.Config{Name: "postgres"}
-	pgInstance := map[string]any{"host": "localhost", "port": 5432}
+	pgInstance := map[string]any{"host": "localhost", "port": 5432, "data_observability": map[string]any{"enabled": true}}
 
 	checkCfg, err := c.buildCheckConfig(payload, baseCfg, pgInstance, "rc-id-custom")
 	require.NoError(t, err)
@@ -327,14 +271,16 @@ func TestBuildCheckConfig_CustomSQLSelectFields(t *testing.T) {
 	var instance map[string]any
 	require.NoError(t, yaml.Unmarshal(checkCfg.Instances[0], &instance))
 
-	queries, ok := instance["queries"].([]interface{})
+	doConfig, ok := instance["data_observability"].(map[string]any)
+	require.True(t, ok)
+	queries, ok := doConfig["queries"].([]any)
 	require.True(t, ok)
 	require.Len(t, queries, 1)
 
-	q, ok := queries[0].(map[string]interface{})
+	q, ok := queries[0].(map[string]any)
 	require.True(t, ok)
 
-	csf, ok := q["custom_sql_select_fields"].(map[string]interface{})
+	csf, ok := q["custom_sql_select_fields"].(map[string]any)
 	require.True(t, ok, "custom_sql_select_fields should be present")
 	assert.Equal(t, 42, csf["metric_config_id"])
 	assert.Equal(t, "entity-abc", csf["entity_id"])
@@ -357,7 +303,7 @@ func TestBuildCheckConfig_NoCustomSQLSelectFields(t *testing.T) {
 	}
 
 	baseCfg := &integration.Config{Name: "postgres"}
-	pgInstance := map[string]any{"host": "localhost", "port": 5432}
+	pgInstance := map[string]any{"host": "localhost", "port": 5432, "data_observability": map[string]any{"enabled": true}}
 
 	checkCfg, err := c.buildCheckConfig(payload, baseCfg, pgInstance, "rc-id")
 	require.NoError(t, err)
@@ -365,9 +311,11 @@ func TestBuildCheckConfig_NoCustomSQLSelectFields(t *testing.T) {
 	var instance map[string]any
 	require.NoError(t, yaml.Unmarshal(checkCfg.Instances[0], &instance))
 
-	queries, ok := instance["queries"].([]interface{})
+	doConfig, ok := instance["data_observability"].(map[string]any)
 	require.True(t, ok)
-	q, ok := queries[0].(map[string]interface{})
+	queries, ok := doConfig["queries"].([]any)
+	require.True(t, ok)
+	q, ok := queries[0].(map[string]any)
 	require.True(t, ok)
 
 	_, hasCsf := q["custom_sql_select_fields"]
@@ -380,7 +328,7 @@ func newTestComponent(t *testing.T) *component {
 	t.Helper()
 	return &component{
 		log:           logmock.New(t),
-		activeConfigs: make(map[string]integration.Config),
+		activeConfigs: make(map[string]activeConfigEntry),
 	}
 }
 
@@ -413,8 +361,14 @@ func TestOnRCUpdate_EmptyConfigID(t *testing.T) {
 	assert.Empty(t, c.activeConfigs)
 }
 
-func TestOnRCUpdate_EmptyQueriesUnschedules(t *testing.T) {
-	existing := integration.Config{Name: "do_query_actions"}
+func TestOnRCUpdate_EmptyQueriesDisables(t *testing.T) {
+	baseCfg := &integration.Config{Name: "postgres", Provider: "file", NodeName: "node1"}
+	pgInstance := map[string]any{"host": "localhost", "dbname": "mydb", "data_observability": map[string]any{"enabled": true}}
+	existing := activeConfigEntry{
+		checkConfig: integration.Config{Name: "postgres"},
+		baseCfg:     baseCfg,
+		instance:    pgInstance,
+	}
 	c := newTestComponent(t)
 	c.activeConfigs["cfg-1"] = existing
 
@@ -425,45 +379,74 @@ func TestOnRCUpdate_EmptyQueriesUnschedules(t *testing.T) {
 
 	assert.Equal(t, state.ApplyStateAcknowledged, statuses["path/config"].State)
 	assert.Empty(t, c.activeConfigs)
-	require.Len(t, changes.Unschedule, 1)
-	assert.Equal(t, "do_query_actions", changes.Unschedule[0].Name)
+	assert.Empty(t, changes.Unschedule, "should not unschedule postgres check")
+	require.Len(t, changes.Schedule, 1, "should schedule disable config")
+	assert.Equal(t, "postgres", changes.Schedule[0].Name)
+
+	// Verify the disable config has data_observability.enabled: false
+	var instance map[string]any
+	require.NoError(t, yaml.Unmarshal(changes.Schedule[0].Instances[0], &instance))
+	doConfig, ok := instance["data_observability"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, doConfig["enabled"])
 }
 
-func TestOnRCUpdate_ReconcileRemovesStaleConfigs(t *testing.T) {
-	existing := integration.Config{Name: "do_query_actions"}
+func TestOnRCUpdate_ReconcileDisablesStaleConfigs(t *testing.T) {
+	baseCfg := &integration.Config{Name: "postgres", Provider: "file"}
+	pgInstance := map[string]any{"host": "localhost", "dbname": "mydb", "data_observability": map[string]any{"enabled": true}}
+	existing := activeConfigEntry{
+		checkConfig: integration.Config{Name: "postgres"},
+		baseCfg:     baseCfg,
+		instance:    pgInstance,
+	}
 	c := newTestComponent(t)
 	c.activeConfigs["stale-config"] = existing
 
-	// Update snapshot contains only a config without config_id — stale-config should be unscheduled
+	// Update snapshot contains only a config without config_id — stale-config should be disabled
 	updates := map[string]state.RawConfig{
 		"path/other": {Config: []byte(`{"some_field": true}`)},
 	}
 	_, changes := collectStatuses(c, updates)
 
 	assert.Empty(t, c.activeConfigs)
-	require.Len(t, changes.Unschedule, 1)
+	assert.Empty(t, changes.Unschedule, "should not unschedule postgres check")
+	require.Len(t, changes.Schedule, 1, "should schedule disable config")
 }
 
-// --- collectUnschedule tests ---
+// --- collectDisable tests ---
 
-func TestCollectUnschedule_NotFound(t *testing.T) {
+func TestCollectDisable_NotFound(t *testing.T) {
 	c := newTestComponent(t)
 	changes := integration.ConfigChanges{}
-	c.collectUnschedule("nonexistent", &changes)
+	c.collectDisable("nonexistent", &changes)
+	assert.Empty(t, changes.Schedule)
 	assert.Empty(t, changes.Unschedule)
 	assert.Empty(t, c.activeConfigs)
 }
 
-func TestCollectUnschedule_Found(t *testing.T) {
+func TestCollectDisable_Found(t *testing.T) {
+	baseCfg := &integration.Config{Name: "postgres", Provider: "file"}
+	pgInstance := map[string]any{"host": "localhost", "dbname": "mydb", "data_observability": map[string]any{"enabled": true}}
 	c := newTestComponent(t)
-	c.activeConfigs["my-config"] = integration.Config{Name: "do_query_actions"}
+	c.activeConfigs["my-config"] = activeConfigEntry{
+		checkConfig: integration.Config{Name: "postgres"},
+		baseCfg:     baseCfg,
+		instance:    pgInstance,
+	}
 	changes := integration.ConfigChanges{}
 
-	c.collectUnschedule("my-config", &changes)
+	c.collectDisable("my-config", &changes)
 
 	assert.Empty(t, c.activeConfigs)
-	require.Len(t, changes.Unschedule, 1)
-	assert.Equal(t, "do_query_actions", changes.Unschedule[0].Name)
+	assert.Empty(t, changes.Unschedule, "should not unschedule postgres check")
+	require.Len(t, changes.Schedule, 1, "should schedule disable config")
+	assert.Equal(t, "postgres", changes.Schedule[0].Name)
+
+	var instance map[string]any
+	require.NoError(t, yaml.Unmarshal(changes.Schedule[0].Instances[0], &instance))
+	doConfig, ok := instance["data_observability"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, doConfig["enabled"])
 }
 
 // --- Happy-path integration tests (require mocked autodiscovery) ---
@@ -476,7 +459,7 @@ func TestOnRCUpdate_ValidConfig_SchedulesCheck(t *testing.T) {
 		Provider: "file",
 		NodeName: "node1",
 		Instances: []integration.Data{
-			integration.Data("host: localhost\nport: 5432\nusername: datadog\npassword: secret\ndbname: mydb\n"),
+			integration.Data("host: localhost\nport: 5432\nusername: datadog\npassword: secret\ndbname: mydb\ndata_observability:\n  enabled: true\n"),
 		},
 	}
 	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
@@ -506,22 +489,25 @@ func TestOnRCUpdate_ValidConfig_SchedulesCheck(t *testing.T) {
 	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-happy"].State)
 	require.Len(t, changes.Schedule, 1, "expected one scheduled check")
 	assert.Empty(t, changes.Unschedule)
-	assert.Equal(t, "do_query_actions", changes.Schedule[0].Name)
+	assert.Equal(t, "postgres", changes.Schedule[0].Name)
 	assert.Equal(t, "file", changes.Schedule[0].Provider)
 	assert.Equal(t, "node1", changes.Schedule[0].NodeName)
 
 	require.Len(t, changes.Schedule[0].Instances, 1)
 	var instance map[string]any
 	require.NoError(t, yaml.Unmarshal(changes.Schedule[0].Instances[0], &instance))
-	assert.Equal(t, "rc-id-happy", instance["remote_config_id"])
-	assert.Equal(t, "postgres", instance["db_type"])
 	assert.Equal(t, "localhost", instance["host"])
 	assert.Equal(t, "datadog", instance["username"])
 
-	queries, ok := instance["queries"].([]interface{})
+	doConfig, ok := instance["data_observability"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, doConfig["enabled"])
+	assert.Equal(t, "rc-id-happy", doConfig["config_id"])
+
+	queries, ok := doConfig["queries"].([]any)
 	require.True(t, ok)
 	require.Len(t, queries, 1)
-	q := queries[0].(map[string]interface{})
+	q := queries[0].(map[string]any)
 	assert.Equal(t, "SELECT count(*) FROM orders", q["query"])
 
 	require.Contains(t, c.activeConfigs, "cfg-happy")
@@ -532,7 +518,7 @@ func TestOnRCUpdate_ValidConfig_SchedulesCheck(t *testing.T) {
 func TestOnRCUpdate_UpdateReplacesExistingCheck(t *testing.T) {
 	postgresCfg := integration.Config{
 		Name:      "postgres",
-		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\n")},
+		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\ndata_observability:\n  enabled: true\n")},
 	}
 	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
 
@@ -551,26 +537,25 @@ func TestOnRCUpdate_UpdateReplacesExistingCheck(t *testing.T) {
 		"path/cfg": {Config: mkPayload("SELECT 1")},
 	})
 	require.Len(t, changes1.Schedule, 1, "first update should schedule the check")
-	assert.Empty(t, changes1.Unschedule, "first update should not unschedule anything")
 	require.Contains(t, c.activeConfigs, "cfg-update")
 
-	firstCfg := changes1.Schedule[0]
-
-	// Second update: same config_id, different query. Should unschedule the old and schedule the new.
+	// Second update: same config_id, different query. Should disable the old and schedule the new.
 	_, changes2 := collectStatuses(c, map[string]state.RawConfig{
 		"path/cfg": {Config: mkPayload("SELECT 2")},
 	})
-	require.Len(t, changes2.Schedule, 1, "second update should schedule the updated check")
-	require.Len(t, changes2.Unschedule, 1, "second update should unschedule the previous check")
-	assert.Equal(t, firstCfg, changes2.Unschedule[0], "unscheduled config should be the previous version")
+	// Expect 2 Schedule entries: disable old + schedule new
+	require.Len(t, changes2.Schedule, 2, "second update should disable old + schedule new")
+	assert.Empty(t, changes2.Unschedule, "should not unschedule postgres check")
 
-	// Verify the new instance has the updated query.
+	// The last scheduled config should have the updated query.
 	var instance map[string]any
-	require.NoError(t, yaml.Unmarshal(changes2.Schedule[0].Instances[0], &instance))
-	queries, ok := instance["queries"].([]interface{})
+	require.NoError(t, yaml.Unmarshal(changes2.Schedule[1].Instances[0], &instance))
+	doConfig, ok := instance["data_observability"].(map[string]any)
+	require.True(t, ok)
+	queries, ok := doConfig["queries"].([]any)
 	require.True(t, ok)
 	require.Len(t, queries, 1)
-	assert.Equal(t, "SELECT 2", queries[0].(map[string]interface{})["query"])
+	assert.Equal(t, "SELECT 2", queries[0].(map[string]any)["query"])
 }
 
 // TestOnRCUpdate_NoMatchingPostgres_ReportsError verifies that when no postgres instance

--- a/comp/dataobs/queryactions/impl/queryactions.go
+++ b/comp/dataobs/queryactions/impl/queryactions.go
@@ -15,19 +15,18 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	doqueryactions "github.com/DataDog/datadog-agent/comp/dataobs/queryactions/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"gopkg.in/yaml.v3"
 )
 
 // Requires defines the dependencies for the Data Observability query actions component
 type Requires struct {
 	Lc       compdef.Lifecycle
-	Config   config.Component
 	Log      log.Component
 	RcClient rcclient.Component
 	Ac       autodiscovery.Component
@@ -43,21 +42,17 @@ type component struct {
 	log             log.Component
 	ac              autodiscovery.Component
 	rcclient        rcclient.Component
-	enabled         bool
-	activeConfigs   map[string]integration.Config
+	activeConfigs   map[string]activeConfigEntry
 	activeConfigsMu sync.Mutex
 }
 
 // NewComponent creates a new Data Observability query actions component
 func NewComponent(reqs Requires) (Provides, error) {
-	enabled := reqs.Config.GetBool("data_observability.query_actions.enabled")
-
 	c := &component{
 		log:           reqs.Log,
 		ac:            reqs.Ac,
 		rcclient:      reqs.RcClient,
-		enabled:       enabled,
-		activeConfigs: make(map[string]integration.Config),
+		activeConfigs: make(map[string]activeConfigEntry),
 	}
 
 	reqs.Lc.Append(compdef.Hook{
@@ -68,10 +63,6 @@ func NewComponent(reqs Requires) (Provides, error) {
 }
 
 func (c *component) start(_ context.Context) error {
-	if !c.enabled {
-		c.log.Info("Data Observability query actions component disabled (data_observability.query_actions.enabled)")
-		return nil
-	}
 	c.ac.AddConfigProvider(c, false, 0)
 	c.log.Info("Data Observability query actions component started")
 	return nil
@@ -129,6 +120,7 @@ func (c *component) Stream(ctx context.Context) <-chan integration.ConfigChanges
 			case dropped = <-outCh:
 			default:
 			}
+			changes.Schedule = append(dropped.Schedule, changes.Schedule...)
 			changes.Unschedule = append(dropped.Unschedule, changes.Unschedule...)
 			outCh <- changes // safe: mu held, closed=false, channel was just drained
 		}
@@ -158,7 +150,7 @@ func (c *component) Stream(ctx context.Context) <-chan integration.ConfigChanges
 
 		// Check immediately: the file config provider runs before this one in LoadAndRun,
 		// so postgres is typically already available when Stream() is called.
-		if c.hasPostgresIntegration() {
+		if c.hasSupportedIntegration() {
 			subscribeAndWait()
 			return
 		}
@@ -170,7 +162,7 @@ func (c *component) Stream(ctx context.Context) <-chan integration.ConfigChanges
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if c.hasPostgresIntegration() {
+				if c.hasSupportedIntegration() {
 					subscribeAndWait()
 					return
 				}
@@ -181,11 +173,21 @@ func (c *component) Stream(ctx context.Context) <-chan integration.ConfigChanges
 	return outCh
 }
 
-// hasPostgresIntegration checks if any postgres integration is configured in autodiscovery
-func (c *component) hasPostgresIntegration() bool {
+// hasSupportedIntegration checks if any supported DB integration with
+// data_observability.enabled: true is configured in autodiscovery.
+func (c *component) hasSupportedIntegration() bool {
 	for _, cfg := range c.ac.GetUnresolvedConfigs() {
-		if isPostgresIntegration(cfg.Name) {
-			return true
+		if !isSupportedIntegration(cfg.Name) {
+			continue
+		}
+		for _, instanceData := range cfg.Instances {
+			var instance map[string]any
+			if err := yaml.Unmarshal(instanceData, &instance); err != nil {
+				continue
+			}
+			if instanceHasDOEnabled(instance) {
+				return true
+			}
 		}
 	}
 	return false

--- a/comp/dataobs/queryactions/impl/queryactions.go
+++ b/comp/dataobs/queryactions/impl/queryactions.go
@@ -111,16 +111,16 @@ func (c *component) Stream(ctx context.Context) <-chan integration.ConfigChanges
 		select {
 		case outCh <- changes:
 		default:
-			// Channel full: drain old entry, preserving its Unschedule events so that
-			// checks already in autodiscovery are not orphaned.
-			// The drain is non-blocking because config_poller may have already read the
-			// buffer between the default branch firing and this point.
+			// Channel full: drain old entry. Only preserve Unschedule events from the
+			// dropped update so checks already in autodiscovery are not orphaned.
+			// dropped.Schedule is NOT preserved: the latest RC snapshot is authoritative,
+			// and re-adding stale Schedule entries would resurrect configs that the new
+			// snapshot intentionally removed.
 			var dropped integration.ConfigChanges
 			select {
 			case dropped = <-outCh:
 			default:
 			}
-			changes.Schedule = append(dropped.Schedule, changes.Schedule...)
 			changes.Unschedule = append(dropped.Unschedule, changes.Unschedule...)
 			outCh <- changes // safe: mu held, closed=false, channel was just drained
 		}

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -219,11 +219,12 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	payload3 := buildPayloadJSON(t, "cfg-B", "localhost", "db-b", singleQuery)
 	triggerRC(map[string]state.RawConfig{"path/cfg-B": {Config: payload3}}, noStatus)
 
-	// The merged result must contain cfg-B's Schedule AND cfg-A's disable Schedule.
+	// The merged result must contain cfg-B's Schedule + cfg-A's disable Schedule,
+	// and cfg-A's Unschedule (the old enabled config).
 	select {
 	case changes := <-outCh:
 		require.Len(t, changes.Schedule, 2, "should contain cfg-A disable + cfg-B schedule")
-		assert.Empty(t, changes.Unschedule, "no Unschedule entries expected with disable semantics")
+		require.Len(t, changes.Unschedule, 1, "cfg-A Unschedule must not be lost in the channel replace")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for merged ConfigChanges")
 	}

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -64,11 +64,11 @@ func newStreamComponent(t *testing.T, postgresConfigs []integration.Config) (*co
 }
 
 // buildPayloadJSON marshals a DOQueryPayload with the given parameters.
-func buildPayloadJSON(t *testing.T, configID, host, dbname string, queries []QuerySpec) []byte {
+func buildPayloadJSON(t *testing.T, configID, host string, queries []QuerySpec) []byte {
 	t.Helper()
 	b, err := json.Marshal(DOQueryPayload{
 		ConfigID:     configID,
-		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: host, DBName: dbname},
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: host},
 		Queries:      queries,
 	})
 	require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestStream_RCCallback_DeliverChangesToChannel(t *testing.T) {
 
 	triggerRC := waitSubscribe(t, rc)
 
-	payload := buildPayloadJSON(t, "cfg-1", "localhost", "mydb", singleQuery)
+	payload := buildPayloadJSON(t, "cfg-1", "localhost", singleQuery)
 	triggerRC(
 		map[string]state.RawConfig{"path/cfg-1": {Config: payload, Metadata: state.Metadata{ID: "rc-id-1"}}},
 		func(string, state.ApplyStatus) {},
@@ -203,7 +203,7 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 
 	// Update 1: schedule cfg-A. Drain it to simulate autodiscovery processing it —
 	// cfg-A is now "in autodiscovery".
-	payload1 := buildPayloadJSON(t, "cfg-A", "localhost", "db-a", singleQuery)
+	payload1 := buildPayloadJSON(t, "cfg-A", "localhost", singleQuery)
 	triggerRC(map[string]state.RawConfig{"path/cfg-A": {Config: payload1}}, noStatus)
 	update1 := <-outCh
 	require.Len(t, update1.Schedule, 1, "update 1 should schedule cfg-A")
@@ -216,7 +216,7 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 
 	// Update 3: schedule cfg-B. Channel is FULL with update 2.
 	// sendChanges must drain the full channel and merge update 2's Unschedule into update 3.
-	payload3 := buildPayloadJSON(t, "cfg-B", "localhost", "db-b", singleQuery)
+	payload3 := buildPayloadJSON(t, "cfg-B", "localhost", singleQuery)
 	triggerRC(map[string]state.RawConfig{"path/cfg-B": {Config: payload3}}, noStatus)
 
 	// The merged result must contain cfg-B's Schedule + cfg-A's disable Schedule,
@@ -253,7 +253,7 @@ func TestStream_NoPanicAfterContextCancel(t *testing.T) {
 
 	// Trigger RC callback after shutdown — must not panic (write to closed channel).
 	assert.NotPanics(t, func() {
-		payload := buildPayloadJSON(t, "cfg-post-cancel", "localhost", "mydb", singleQuery)
+		payload := buildPayloadJSON(t, "cfg-post-cancel", "localhost", singleQuery)
 		triggerRC(
 			map[string]state.RawConfig{"path/cfg-post-cancel": {Config: payload}},
 			func(string, state.ApplyStatus) {},

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -180,8 +180,9 @@ func TestStream_RCCallback_DeliverChangesToChannel(t *testing.T) {
 // arrives while the previous update is still buffered in outCh (unread by autodiscovery),
 // the dropped update's Unschedule entries are merged into the new update.
 //
-// Without the merge, the Unschedule is silently dropped, leaving the check permanently
-// scheduled in autodiscovery (a check leak).
+// Only Unschedule entries are preserved from the dropped update — dropped Schedule entries
+// are discarded because the latest RC snapshot is authoritative. This prevents stale
+// Schedule entries from resurrecting configs that the new snapshot intentionally removed.
 func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	// Two separate postgres instances so each RC config can match a distinct one.
 	postgresCfg := integration.Config{
@@ -209,22 +210,22 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	require.Len(t, update1.Schedule, 1, "update 1 should schedule cfg-A")
 
 	// Update 2: remove cfg-A (empty queries = disable). Channel is now empty — writes directly.
-	// With the new semantics, disabling schedules a config with data_observability.enabled: false.
+	// Disabling produces: Unschedule=[cfg-A DO config], Schedule=[base config restoration].
 	removeA, _ := json.Marshal(DOQueryPayload{ConfigID: "cfg-A"})
 	triggerRC(map[string]state.RawConfig{"path/cfg-A": {Config: removeA}}, noStatus)
-	// DON'T read outCh — leave update 2 ({Schedule: [cfg-A-disable]}) buffered.
+	// DON'T read outCh — leave update 2 buffered.
 
 	// Update 3: schedule cfg-B. Channel is FULL with update 2.
 	// sendChanges must drain the full channel and merge update 2's Unschedule into update 3.
+	// Only Unschedule from the dropped update is preserved; dropped Schedule (base config
+	// restoration) is discarded since the new snapshot is authoritative.
 	payload3 := buildPayloadJSON(t, "cfg-B", "localhost", singleQuery)
 	triggerRC(map[string]state.RawConfig{"path/cfg-B": {Config: payload3}}, noStatus)
 
-	// The merged result must contain cfg-B's Schedule + cfg-A's disable Schedule,
-	// and cfg-A's Unschedule (the old enabled config).
 	select {
 	case changes := <-outCh:
-		require.Len(t, changes.Schedule, 2, "should contain cfg-A disable + cfg-B schedule")
-		require.Len(t, changes.Unschedule, 1, "cfg-A Unschedule must not be lost in the channel replace")
+		require.Len(t, changes.Schedule, 1, "should contain only cfg-B schedule (dropped base restoration is discarded)")
+		require.Len(t, changes.Unschedule, 2, "should contain cfg-A Unschedule from dropped + cfg-B's base config Unschedule")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for merged ConfigChanges")
 	}

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -58,7 +58,7 @@ func newStreamComponent(t *testing.T, postgresConfigs []integration.Config) (*co
 		log:           logmock.New(t),
 		ac:            newMockAutodiscovery(t, postgresConfigs),
 		rcclient:      rc,
-		activeConfigs: make(map[string]integration.Config),
+		activeConfigs: make(map[string]activeConfigEntry),
 	}
 	return c, rc
 }
@@ -113,11 +113,11 @@ func TestStream_ContextCancel_ClosesChannel(t *testing.T) {
 }
 
 func TestStream_SubscribesImmediatelyWhenPostgresAvailable(t *testing.T) {
-	// When postgres is already configured, Stream() must subscribe to RC without waiting
-	// for the 10-second polling ticker.
+	// When postgres is already configured with data_observability.enabled, Stream() must
+	// subscribe to RC without waiting for the 10-second polling ticker.
 	postgresCfg := integration.Config{
 		Name:      "postgres",
-		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\n")},
+		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\ndata_observability:\n  enabled: true\n")},
 	}
 	c, rc := newStreamComponent(t, []integration.Config{postgresCfg})
 	ctx, cancel := context.WithCancel(context.Background())
@@ -150,7 +150,7 @@ func TestStream_NoPostgresAvailable_DoesNotSubscribeImmediately(t *testing.T) {
 func TestStream_RCCallback_DeliverChangesToChannel(t *testing.T) {
 	postgresCfg := integration.Config{
 		Name:      "postgres",
-		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\n")},
+		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\ndata_observability:\n  enabled: true\n")},
 	}
 	c, rc := newStreamComponent(t, []integration.Config{postgresCfg})
 	ctx, cancel := context.WithCancel(context.Background())
@@ -170,7 +170,7 @@ func TestStream_RCCallback_DeliverChangesToChannel(t *testing.T) {
 	select {
 	case changes := <-outCh:
 		require.Len(t, changes.Schedule, 1)
-		assert.Equal(t, "do_query_actions", changes.Schedule[0].Name)
+		assert.Equal(t, "postgres", changes.Schedule[0].Name)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for ConfigChanges from RC callback")
 	}
@@ -187,8 +187,8 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	postgresCfg := integration.Config{
 		Name: "postgres",
 		Instances: []integration.Data{
-			integration.Data("host: localhost\ndbname: db-a\n"),
-			integration.Data("host: localhost\ndbname: db-b\n"),
+			integration.Data("host: localhost\ndbname: db-a\ndata_observability:\n  enabled: true\n"),
+			integration.Data("host: localhost\ndbname: db-b\ndata_observability:\n  enabled: true\n"),
 		},
 	}
 	c, rc := newStreamComponent(t, []integration.Config{postgresCfg})
@@ -208,24 +208,22 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	update1 := <-outCh
 	require.Len(t, update1.Schedule, 1, "update 1 should schedule cfg-A")
 
-	// Update 2: remove cfg-A (empty queries = unschedule). Channel is now empty — writes directly.
+	// Update 2: remove cfg-A (empty queries = disable). Channel is now empty — writes directly.
+	// With the new semantics, disabling schedules a config with data_observability.enabled: false.
 	removeA, _ := json.Marshal(DOQueryPayload{ConfigID: "cfg-A"})
 	triggerRC(map[string]state.RawConfig{"path/cfg-A": {Config: removeA}}, noStatus)
-	// DON'T read outCh — leave update 2 ({Unschedule: [cfg-A]}) buffered.
+	// DON'T read outCh — leave update 2 ({Schedule: [cfg-A-disable]}) buffered.
 
 	// Update 3: schedule cfg-B. Channel is FULL with update 2.
 	// sendChanges must drain the full channel and merge update 2's Unschedule into update 3.
 	payload3 := buildPayloadJSON(t, "cfg-B", "localhost", "db-b", singleQuery)
 	triggerRC(map[string]state.RawConfig{"path/cfg-B": {Config: payload3}}, noStatus)
 
-	// The merged result must contain cfg-B's Schedule AND cfg-A's Unschedule.
-	// Without the merge, the Unschedule(cfg-A) would be silently dropped and cfg-A
-	// would remain scheduled in autodiscovery forever.
+	// The merged result must contain cfg-B's Schedule AND cfg-A's disable Schedule.
 	select {
 	case changes := <-outCh:
-		require.Len(t, changes.Schedule, 1, "cfg-B should be scheduled")
-		assert.Equal(t, "do_query_actions", changes.Schedule[0].Name)
-		require.Len(t, changes.Unschedule, 1, "cfg-A Unschedule must not be lost in the channel replace")
+		require.Len(t, changes.Schedule, 2, "should contain cfg-A disable + cfg-B schedule")
+		assert.Empty(t, changes.Unschedule, "no Unschedule entries expected with disable semantics")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for merged ConfigChanges")
 	}
@@ -236,7 +234,7 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 func TestStream_NoPanicAfterContextCancel(t *testing.T) {
 	postgresCfg := integration.Config{
 		Name:      "postgres",
-		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\n")},
+		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\ndata_observability:\n  enabled: true\n")},
 	}
 	c, rc := newStreamComponent(t, []integration.Config{postgresCfg})
 	ctx, cancel := context.WithCancel(context.Background())

--- a/comp/dataobs/queryactions/impl/types.go
+++ b/comp/dataobs/queryactions/impl/types.go
@@ -5,31 +5,26 @@
 
 package queryactionsimpl
 
-// DOQueryPayload represents the RC config payload for a single DB instance.
-// Each config contains the full set of active monitor queries for that instance.
+// DOQueryPayload represents the RC config payload for a database cluster.
+// Each config groups all active monitor queries for a single host, with per-query dbname routing.
 type DOQueryPayload struct {
 	ConfigID     string       `json:"config_id"`
 	DBIdentifier DBIdentifier `json:"db_identifier"`
 	Queries      []QuerySpec  `json:"queries"`
 }
 
-// DBIdentifier identifies a database instance to target.
-// Type describes the hosting kind (e.g. "self-hosted", "rds"). It is stored
-// for informational purposes; instance matching is by host and dbname only.
+// DBIdentifier identifies a database cluster to target.
+// Type describes the hosting kind (e.g. "self-hosted", "rds"). Instance matching
+// is by host only; per-query dbname fields handle database routing.
 type DBIdentifier struct {
-	Type   string `json:"type"`
-	Host   string `json:"host"`
-	DBName string `json:"dbname"`
-	// AgentHostname is deserialized from RC but is not currently used for filtering.
-	// The RC backend is expected to route each config only to the agent whose hostname matches.
-	// TODO: If RC delivery becomes broadcast (all agents receive all configs), filter here by
-	// comparing AgentHostname against the current agent's hostname to prevent duplicate checks
-	// in multi-agent deployments where multiple agents monitor the same postgres host.
+	Type string `json:"type"`
+	Host string `json:"host"`
 	AgentHostname string `json:"agent_hostname"`
 }
 
 // QuerySpec defines a single monitor query to schedule.
 type QuerySpec struct {
+	DBName                string                 `json:"dbname,omitempty"`
 	MonitorID             int64                  `json:"monitor_id,omitempty"`
 	Type                  string                 `json:"type"`
 	Query                 string                 `json:"query"`

--- a/comp/dataobs/queryactions/impl/types.go
+++ b/comp/dataobs/queryactions/impl/types.go
@@ -17,8 +17,8 @@ type DOQueryPayload struct {
 // Type describes the hosting kind (e.g. "self-hosted", "rds"). Instance matching
 // is by host only; per-query dbname fields handle database routing.
 type DBIdentifier struct {
-	Type string `json:"type"`
-	Host string `json:"host"`
+	Type          string `json:"type"`
+	Host          string `json:"host"`
 	AgentHostname string `json:"agent_hostname"`
 }
 

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -990,7 +990,6 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("djm_config.enabled", false)
 
 	// Data Observability
-	config.BindEnvAndSetDefault("data_observability.query_actions.enabled", false)
 	bindEnvAndSetLogsConfigKeys(config, "data_observability.forwarder.")
 
 	// Reverse DNS Enrichment

--- a/releasenotes/notes/do-queryactions-postgres-migration-dd207c7418b56c7c.yaml
+++ b/releasenotes/notes/do-queryactions-postgres-migration-dd207c7418b56c7c.yaml
@@ -1,0 +1,40 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    List upgrade notes here, or remove this section.
+    Upgrade notes should be rare: only list known/potential breaking changes,
+    or major behaviorial changes that require user action before the upgrade.
+    Notes here must include steps that users can follow to 1. know if they're
+    affected and 2. handle the change gracefully on their end.
+features:
+  - |
+    List new features here, or remove this section.
+enhancements:
+  - |
+    List enhancements (new behavior that is too small to be
+    considered a new feature), or remove this section.
+issues:
+  - |
+    List known issues here, or remove this section.
+deprecations:
+  - |
+    List deprecations notes here, or remove this section.
+security:
+  - |
+    Include security notes here, or remove this section if none. Specific CVEs are handled automatically and should not be mentioned directly in the changelog.
+    For instance, if you bumped a lib to fix a CVE, just mention the bump.
+fixes:
+  - |
+    Add normal bug fixes here, or remove this section.
+other:
+  - |
+    Add here every other information you want in the CHANGELOG that
+    don't fit in any other section. This section should rarely be
+    used.


### PR DESCRIPTION
### What does this PR do?

Migrates the Data Observability query actions Go handler from scheduling a standalone `do_query_actions` Python check to injecting a `data_observability` config section into the existing Postgres check. The handler now clones the full matched Postgres instance from autodiscovery and injects the `data_observability` section with queries received from Remote Config, allowing DO queries to run inside the Postgres check's existing connection pool.

### Motivation

The standalone `do_query_actions` check duplicated credential management and connection handling that the Postgres check already provides. By running DO queries inside the Postgres check's `DBMAsyncJob`, we align the DO feature as a native capability of the Postgres integration rather than a separate check, and are able to reuse multiple components DBM team has build over years.

The agent-level `data_observability.query_actions.enabled` config flag is replaced by a per-instance opt-in (`data_observability.enabled: true` on the Postgres instance config), making it possible to enable DO selectively per database and extensible to other integrations (e.g. MySQL) in the future.

### Describe how you validated your changes

- End-to-end validation using Podman-based test environment: built custom agent binary, installed Postgres check from `integrations-core` branch `mobuchowski/do-in-postgres-check`, confirmed RC config delivery, config injection into autodiscovery, and successful query execution against a local Postgres database with results sent to `data-obs-intake.datad0g.com`
