### PR TITLE
Fail fast when `cgo -godefs` fails in `cgo_godefs` rule

### DIFF
--- a/bazel/rules/ebpf/cgo_godefs.bzl
+++ b/bazel/rules/ebpf/cgo_godefs.bzl
@@ -79,7 +79,7 @@ def _cgo_godefs_impl(ctx):
     cc_prefix = "CC=clang " if platform == "linux" else ""
 
     cmd = (
-        "ROOT=$PWD && cd {src_dir} && " +
+        "set -euo pipefail && ROOT=$PWD && cd {src_dir} && " +
         "GOROOT=$ROOT/{goroot} {cc_prefix}$ROOT/{go} tool cgo -godefs -- {includes} -fsigned-char {src_file} | " +
         "$ROOT/{genpost} {genpost_args} > $ROOT/{out}"
     ).format(


### PR DESCRIPTION
### What does this PR do?
Adds `set -euo pipefail` to the shell command in `_cgo_godefs_impl`. Previously, a `cgo -godefs` failure (e.g. missing CC compiler) was silently swallowed by the pipe: the pipeline exited 0 with empty output, which Bazel cached as a successful action.

### Motivation
PR #48994 fixed the `diff_test` self-comparison bug in `cgo_godefs`, exposing this silent failure: the committed file differed from the empty generated file, producing a confusing `diff-test` failure instead of a clear build error.
With `-o pipefail`, Bazel now reports the real cause (e.g. `cgo: C compiler "clang" not found`).

### Describe how you validated your changes
```
bazel test //...
...
cgo: C compiler "clang" not found: exec: "clang": executable file not found in $PATH
```
### Additional Notes
We of course plan to hermetize the clang toolchain as well.