### PR TITLE
feat(ci): pass GITLAB_USER_LOGIN to images child pipeline for OCI label

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -36,7 +36,7 @@
         TMPL_SRC_REPO="${TMPL_SRC_REPO}-nightly"
       fi
     - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${BASE_RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}${RELEASE_TAG_SUFFIX}${RELEASE_TAG_COMPRESSION_SUFFIX}"; fi
-    - "dda inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master --timeout 3600 --variable IMAGE_VERSION --variable IMAGE_NAME --variable RELEASE_TAG --variable TMPL_SRC_IMAGE --variable TMPL_SRC_REPO --variable TMPL_ADP_VERSION --variable RELEASE_STAGING --variable RELEASE_PROD --variable DYNAMIC_BUILD_RENDER_RULES --variable APPS --variable BAZEL_TARGET --variable DDR --variable DDR_WORKFLOW_ID --variable TARGET_ENV --variable DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS"
+    - "dda inv pipeline.trigger-child-pipeline --project-name DataDog/images --git-ref master --timeout 3600 --variable IMAGE_VERSION --variable IMAGE_NAME --variable RELEASE_TAG --variable TMPL_SRC_IMAGE --variable TMPL_SRC_REPO --variable TMPL_ADP_VERSION --variable RELEASE_STAGING --variable RELEASE_PROD --variable DYNAMIC_BUILD_RENDER_RULES --variable APPS --variable BAZEL_TARGET --variable DDR --variable DDR_WORKFLOW_ID --variable TARGET_ENV --variable DYNAMIC_BUILD_RENDER_TARGET_FORWARD_PARAMETERS --variable GITLAB_USER_LOGIN"
   retry: 2
 
 # -- binary specific variables --

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical.go
@@ -205,7 +205,10 @@ func (u *verticalController) syncInternal(
 					patchForbidden = true
 				}
 				log.Warnf("failed to patch pod %s/%s in place: %v", cp.pod.Namespace, cp.pod.Name, err)
+				autoscalerInternal.InPlacePatchErrorInc()
 				toEvictOnPatchFailure = append(toEvictOnPatchFailure, cp)
+			} else {
+				autoscalerInternal.InPlacePatchSuccessInc()
 			}
 		}
 	}
@@ -232,6 +235,7 @@ func (u *verticalController) syncInternal(
 		} else {
 			log.Infof("In-place resize fallback: pods stuck too long, triggering rollout for autoscaler %s", autoscalerInternal.ID())
 		}
+		autoscalerInternal.InPlaceRolloutFallbackInc()
 		return u.triggerRollout(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID)
 	}
 
@@ -247,6 +251,7 @@ func (u *verticalController) syncInternal(
 			} else {
 				log.Warnf("error while evicting pod %s/%s: %v", cp.pod.Namespace, cp.pod.Name, err)
 				failedEvictions++
+				autoscalerInternal.InPlaceEvictionErrorInc()
 				autoscalerInternal.UpdateFromVerticalAction(nil,
 					autoscaling.NewConditionError(autoscaling.ConditionReasonFailedToEvict,
 						fmt.Errorf("error while evicting pod %s/%s: %w", cp.pod.Namespace, cp.pod.Name, err)))
@@ -255,9 +260,11 @@ func (u *verticalController) syncInternal(
 		}
 		if result == evictor.Evicted {
 			evictedThisSync++
+			autoscalerInternal.InPlaceEvictionSuccessInc()
 		}
 		if result == evictor.PDBLockedOrThrottle || result == evictor.Skipped {
 			pdbBlocked = true
+			autoscalerInternal.InPlacePDBBlockedInc()
 			break
 		}
 	}
@@ -296,6 +303,7 @@ func (u *verticalController) syncInternal(
 			lastAction.Type == datadoghqcommon.DatadogPodAutoscalerResizeTriggeredVerticalActionType {
 			u.eventRecorder.Eventf(podAutoscaler, corev1.EventTypeNormal, model.ResizeSuccessfulEventReason,
 				"All %d pods resized successfully for autoscaler %s/%s", totalActive, podAutoscaler.Namespace, podAutoscaler.Name)
+			autoscalerInternal.InPlaceResizeCompletedInc()
 			autoscalerInternal.UpdateFromVerticalAction(&datadoghqcommon.DatadogPodAutoscalerVerticalAction{
 				Time:    metav1.NewTime(u.clock.Now()),
 				Version: recommendationID,

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator.go
@@ -258,7 +258,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		Tags:  baseWithVerticalSourceTags,
 	})
 
-	// 7a. Vertical scaled/evicted replica gauges
+	// 8. Vertical scaled/evicted replica gauges
 	if scaledReplicas := internal.ScaledReplicas(); scaledReplicas != nil {
 		metrics = append(metrics, metricsstore.StructuredMetric{
 			Name:  metricPrefix + ".status.vertical.scaled_replicas",

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator.go
@@ -210,7 +210,73 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		Tags:  append(baseWithVerticalSourceTags, "status:ok"),
 	})
 
-	// 7. Local recommender horizontal metrics
+	// 7. In-place vertical scaling action metrics
+	metrics = append(metrics, metricsstore.StructuredMetric{
+		Name:  metricPrefix + ".vertical_inplace.patch",
+		Type:  metricsstore.MetricTypeMonotonicCount,
+		Value: float64(internal.InPlacePatchSuccessCount()),
+		Tags:  append(baseWithVerticalSourceTags, "status:ok"),
+	})
+	metrics = append(metrics, metricsstore.StructuredMetric{
+		Name:  metricPrefix + ".vertical_inplace.patch",
+		Type:  metricsstore.MetricTypeMonotonicCount,
+		Value: float64(internal.InPlacePatchErrorCount()),
+		Tags:  append(baseWithVerticalSourceTags, "status:error"),
+	})
+
+	metrics = append(metrics, metricsstore.StructuredMetric{
+		Name:  metricPrefix + ".vertical_inplace.eviction",
+		Type:  metricsstore.MetricTypeMonotonicCount,
+		Value: float64(internal.InPlaceEvictionSuccessCount()),
+		Tags:  append(baseWithVerticalSourceTags, "status:ok"),
+	})
+	metrics = append(metrics, metricsstore.StructuredMetric{
+		Name:  metricPrefix + ".vertical_inplace.eviction",
+		Type:  metricsstore.MetricTypeMonotonicCount,
+		Value: float64(internal.InPlaceEvictionErrorCount()),
+		Tags:  append(baseWithVerticalSourceTags, "status:error"),
+	})
+
+	metrics = append(metrics, metricsstore.StructuredMetric{
+		Name:  metricPrefix + ".vertical_inplace.rollout_fallback",
+		Type:  metricsstore.MetricTypeMonotonicCount,
+		Value: float64(internal.InPlaceRolloutFallbackCount()),
+		Tags:  baseWithVerticalSourceTags,
+	})
+
+	metrics = append(metrics, metricsstore.StructuredMetric{
+		Name:  metricPrefix + ".vertical_inplace.pdb_blocked",
+		Type:  metricsstore.MetricTypeMonotonicCount,
+		Value: float64(internal.InPlacePDBBlockedCount()),
+		Tags:  baseWithVerticalSourceTags,
+	})
+
+	metrics = append(metrics, metricsstore.StructuredMetric{
+		Name:  metricPrefix + ".vertical_inplace.resize_completed",
+		Type:  metricsstore.MetricTypeMonotonicCount,
+		Value: float64(internal.InPlaceResizeCompletedCount()),
+		Tags:  baseWithVerticalSourceTags,
+	})
+
+	// 7a. Vertical scaled/evicted replica gauges
+	if scaledReplicas := internal.ScaledReplicas(); scaledReplicas != nil {
+		metrics = append(metrics, metricsstore.StructuredMetric{
+			Name:  metricPrefix + ".status.vertical.scaled_replicas",
+			Type:  metricsstore.MetricTypeGauge,
+			Value: float64(*scaledReplicas),
+			Tags:  baseTags,
+		})
+	}
+	if evictedReplicas := internal.EvictedReplicas(); evictedReplicas != nil {
+		metrics = append(metrics, metricsstore.StructuredMetric{
+			Name:  metricPrefix + ".status.vertical.evicted_replicas",
+			Type:  metricsstore.MetricTypeGauge,
+			Value: float64(*evictedReplicas),
+			Tags:  baseTags,
+		})
+	}
+
+	// 9. Local recommender horizontal metrics
 	if fallbackHorizontal := internal.FallbackScalingValues().Horizontal; fallbackHorizontal != nil {
 		localSourceTags := append(baseTags, "source:"+string(fallbackHorizontal.Source))
 		metrics = append(metrics, metricsstore.StructuredMetric{
@@ -229,7 +295,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		}
 	}
 
-	// 8. Horizontal scaling constraints
+	// 10. Horizontal scaling constraints
 	if spec := internal.Spec(); spec != nil && spec.Constraints != nil {
 		if spec.Constraints.MaxReplicas != nil {
 			metrics = append(metrics, metricsstore.StructuredMetric{
@@ -248,7 +314,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 			})
 		}
 
-		// 9. Vertical scaling container constraints (per container, CPU in millicores, memory in bytes)
+		// 11. Vertical scaling container constraints (per container, CPU in millicores, memory in bytes)
 		// Mirror the resolveMinMaxBounds fallback from controller_vertical_helpers.go:
 		// prefer top-level MinAllowed/MaxAllowed; fall back to deprecated Requests field.
 		for _, container := range spec.Constraints.Containers {
@@ -298,9 +364,9 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 		}
 	}
 
-	// 10. Status metrics and autoscaler conditions (from upstream CR)
+	// 12. Status metrics and autoscaler conditions (from upstream CR)
 	if podAutoscaler := internal.UpstreamCR(); podAutoscaler != nil {
-		// 10a. Horizontal desired replicas from status
+		// 12a. Horizontal desired replicas from status
 		if horizontal := podAutoscaler.Status.Horizontal; horizontal != nil && horizontal.Target != nil {
 			metrics = append(metrics, metricsstore.StructuredMetric{
 				Name:  metricPrefix + ".status.desired.replicas",
@@ -310,7 +376,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 			})
 		}
 
-		// 10b. Vertical desired resources from status (per container, CPU in millicores, memory in bytes)
+		// 12b. Vertical desired resources from status (per container, CPU in millicores, memory in bytes)
 		if vertical := podAutoscaler.Status.Vertical; vertical != nil && vertical.Target != nil {
 			for _, container := range vertical.Target.DesiredResources {
 				containerTags := append(baseTags, "kube_container_name:"+container.Name)
@@ -349,7 +415,7 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 			}
 		}
 
-		// 10c. Autoscaler conditions
+		// 12c. Autoscaler conditions
 		for _, condition := range podAutoscaler.Status.Conditions {
 			value := 0.0
 			if condition.Status == corev1.ConditionTrue {

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
@@ -989,13 +989,13 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 					value float64
 					found bool
 				}{
-					"patch_ok":          {tag: "status:ok", value: 5},
-					"patch_error":       {tag: "status:error", value: 2},
-					"eviction_ok":       {tag: "status:ok", value: 3},
-					"eviction_error":    {tag: "status:error", value: 1},
-					"rollout_fallback":  {value: 1},
-					"pdb_blocked":       {value: 2},
-					"resize_completed":  {value: 4},
+					"patch_ok":         {tag: "status:ok", value: 5},
+					"patch_error":      {tag: "status:error", value: 2},
+					"eviction_ok":      {tag: "status:ok", value: 3},
+					"eviction_error":   {tag: "status:error", value: 1},
+					"rollout_fallback": {value: 1},
+					"pdb_blocked":      {value: 2},
+					"resize_completed": {value: 4},
 				}
 				for _, m := range metrics {
 					switch m.Name {

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
@@ -104,7 +104,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 6, // horizontal_scaling_received_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 13, // horizontal_scaling_received_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(patch,eviction,rollout_fallback,pdb_blocked,resize_completed)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var found bool
 				for _, m := range metrics {
@@ -154,7 +154,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 9, // 2 requests + 2 limits + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 16, // 2 requests + 2 limits + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var requestsCount, limitsCount int
 				for _, m := range metrics {
@@ -204,7 +204,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 5, // horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 12, // horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				for _, m := range metrics {
 					assert.Contains(t, m.Tags, "team:autoscaling", "annotation tag should be in metric %s", m.Name)
@@ -245,7 +245,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 7, // 2 conditions + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 14, // 2 conditions + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var activeFound, readyFound bool
 				for _, m := range metrics {
@@ -287,7 +287,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 6, // horizontal_scaling_applied_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 13, // horizontal_scaling_applied_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var appliedFound, actionsFound bool
 				for _, m := range metrics {
@@ -323,7 +323,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 5, // horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 12, // horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var actionsFound bool
 				for _, m := range metrics {
@@ -357,7 +357,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 6, // horizontal_scaling_applied_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 13, // horizontal_scaling_applied_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				for _, m := range metrics {
 					if m.Name == metricPrefix+".horizontal_scaling_applied_replicas" {
@@ -386,7 +386,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 6, // horizontal_scaling_applied_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 13, // horizontal_scaling_applied_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var appliedFound, okFound, errorFound bool
 				for _, m := range metrics {
@@ -425,7 +425,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 5, // vertical_rollout_triggered(error,ok) + horizontal_scaling_actions(error,ok) + local_fallback_enabled
+			expectedCount: 12, // vertical_rollout_triggered(error,ok) + horizontal_scaling_actions(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var found bool
 				for _, m := range metrics {
@@ -453,7 +453,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 5, // vertical_rollout_triggered(error,ok) + horizontal_scaling_actions(error,ok) + local_fallback_enabled
+			expectedCount: 12, // vertical_rollout_triggered(error,ok) + horizontal_scaling_actions(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var found bool
 				for _, m := range metrics {
@@ -482,7 +482,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 5, // vertical_rollout_triggered(error,ok) + horizontal_scaling_actions(error,ok) + local_fallback_enabled
+			expectedCount: 12, // vertical_rollout_triggered(error,ok) + horizontal_scaling_actions(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var foundOk, foundError bool
 				for _, m := range metrics {
@@ -523,7 +523,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 7, // local_horizontal_scaling_recommended_replicas + local_horizontal_utilization_pct + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 14, // local_horizontal_scaling_recommended_replicas + local_horizontal_utilization_pct + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var replicasFound, utilizationFound bool
 				for _, m := range metrics {
@@ -564,7 +564,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 6, // local_horizontal_scaling_recommended_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 13, // local_horizontal_scaling_recommended_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var replicasFound bool
 				for _, m := range metrics {
@@ -596,7 +596,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 7, // horizontal_scaling.constraints.{max,min}_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 14, // horizontal_scaling.constraints.{max,min}_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var maxFound, minFound bool
 				for _, m := range metrics {
@@ -635,7 +635,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 6, // horizontal_scaling.constraints.max_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 13, // horizontal_scaling.constraints.max_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var maxFound bool
 				for _, m := range metrics {
@@ -678,7 +678,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 9, // 4 container constraints + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 16, // 4 container constraints + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var cpuMinFound, memMinFound, cpuMaxFound, memMaxFound bool
 				for _, m := range metrics {
@@ -730,7 +730,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 6, // 1 constraint metric + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 13, // 1 constraint metric + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var cpuMinFound bool
 				for _, m := range metrics {
@@ -779,7 +779,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 9, // 4 container constraints + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 16, // 4 container constraints + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var cpuMinFound, memMinFound, cpuMaxFound, memMaxFound bool
 				for _, m := range metrics {
@@ -833,7 +833,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 6, // status.desired.replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 13, // status.desired.replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var found bool
 				for _, m := range metrics {
@@ -889,7 +889,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 9, // 4 vertical desired resources + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 16, // 4 vertical desired resources + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var cpuReqFound, memReqFound, cpuLimFound, memLimFound bool
 				for _, m := range metrics {
@@ -944,7 +944,7 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				}.Build()
 				return &internal
 			},
-			expectedCount: 6, // horizontal_scaling_received_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled
+			expectedCount: 13, // horizontal_scaling_received_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
 			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
 				var found bool
 				for _, m := range metrics {

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
@@ -956,6 +956,144 @@ func TestGeneratePodAutoscalerMetrics(t *testing.T) {
 				assert.True(t, found, "local_fallback_enabled metric not found")
 			},
 		},
+		{
+			name: "in-place vertical scaling action counters",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+					},
+					MainScalingValues: model.ScalingValues{
+						Vertical: &model.VerticalScalingValues{
+							Source: datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+						},
+					},
+					InPlacePatchSuccessCount:    5,
+					InPlacePatchErrorCount:      2,
+					InPlaceEvictionSuccessCount: 3,
+					InPlaceEvictionErrorCount:   1,
+					InPlaceRolloutFallbackCount: 1,
+					InPlacePDBBlockedCount:      2,
+					InPlaceResizeCompletedCount: 4,
+				}.Build()
+				return &internal
+			},
+			expectedCount: 12, // horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				checks := map[string]struct {
+					tag   string
+					value float64
+					found bool
+				}{
+					"patch_ok":          {tag: "status:ok", value: 5},
+					"patch_error":       {tag: "status:error", value: 2},
+					"eviction_ok":       {tag: "status:ok", value: 3},
+					"eviction_error":    {tag: "status:error", value: 1},
+					"rollout_fallback":  {value: 1},
+					"pdb_blocked":       {value: 2},
+					"resize_completed":  {value: 4},
+				}
+				for _, m := range metrics {
+					switch m.Name {
+					case metricPrefix + ".vertical_inplace.patch":
+						assert.Equal(t, metricsstore.MetricTypeMonotonicCount, m.Type)
+						assert.Contains(t, m.Tags, "source:Autoscaling")
+						if slices.Contains(m.Tags, "status:ok") {
+							assert.Equal(t, 5.0, m.Value, "patch ok count")
+							c := checks["patch_ok"]
+							c.found = true
+							checks["patch_ok"] = c
+						} else if slices.Contains(m.Tags, "status:error") {
+							assert.Equal(t, 2.0, m.Value, "patch error count")
+							c := checks["patch_error"]
+							c.found = true
+							checks["patch_error"] = c
+						}
+					case metricPrefix + ".vertical_inplace.eviction":
+						assert.Equal(t, metricsstore.MetricTypeMonotonicCount, m.Type)
+						assert.Contains(t, m.Tags, "source:Autoscaling")
+						if slices.Contains(m.Tags, "status:ok") {
+							assert.Equal(t, 3.0, m.Value, "eviction ok count")
+							c := checks["eviction_ok"]
+							c.found = true
+							checks["eviction_ok"] = c
+						} else if slices.Contains(m.Tags, "status:error") {
+							assert.Equal(t, 1.0, m.Value, "eviction error count")
+							c := checks["eviction_error"]
+							c.found = true
+							checks["eviction_error"] = c
+						}
+					case metricPrefix + ".vertical_inplace.rollout_fallback":
+						assert.Equal(t, metricsstore.MetricTypeMonotonicCount, m.Type)
+						assert.Equal(t, 1.0, m.Value, "rollout fallback count")
+						assert.Contains(t, m.Tags, "source:Autoscaling")
+						c := checks["rollout_fallback"]
+						c.found = true
+						checks["rollout_fallback"] = c
+					case metricPrefix + ".vertical_inplace.pdb_blocked":
+						assert.Equal(t, metricsstore.MetricTypeMonotonicCount, m.Type)
+						assert.Equal(t, 2.0, m.Value, "pdb blocked count")
+						assert.Contains(t, m.Tags, "source:Autoscaling")
+						c := checks["pdb_blocked"]
+						c.found = true
+						checks["pdb_blocked"] = c
+					case metricPrefix + ".vertical_inplace.resize_completed":
+						assert.Equal(t, metricsstore.MetricTypeMonotonicCount, m.Type)
+						assert.Equal(t, 4.0, m.Value, "resize completed count")
+						assert.Contains(t, m.Tags, "source:Autoscaling")
+						c := checks["resize_completed"]
+						c.found = true
+						checks["resize_completed"] = c
+					}
+				}
+				for key, c := range checks {
+					assert.True(t, c.found, "metric not found for key %s", key)
+				}
+			},
+		},
+		{
+			name: "vertical scaled and evicted replica gauges",
+			setupFunc: func() *model.PodAutoscalerInternal {
+				internal := model.FakePodAutoscalerInternal{
+					Namespace: "test-ns",
+					Name:      "test-dpa",
+					Spec: &datadoghq.DatadogPodAutoscalerSpec{
+						TargetRef: v2.CrossVersionObjectReference{
+							Name: "test-deployment",
+						},
+					},
+					ScaledReplicas:  pointer.Ptr(int32(6)),
+					EvictedReplicas: pointer.Ptr(int32(2)),
+				}.Build()
+				return &internal
+			},
+			expectedCount: 14, // status.vertical.scaled_replicas + status.vertical.evicted_replicas + horizontal_scaling_actions(error,ok) + vertical_rollout_triggered(error,ok) + local_fallback_enabled + vertical_inplace(7)
+			validateMetric: func(t *testing.T, metrics metricsstore.StructuredMetrics) {
+				var scaledFound, evictedFound bool
+				for _, m := range metrics {
+					switch m.Name {
+					case metricPrefix + ".status.vertical.scaled_replicas":
+						scaledFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, 6.0, m.Value)
+						assert.Contains(t, m.Tags, "namespace:test-ns")
+						assert.Contains(t, m.Tags, "autoscaler_name:test-dpa")
+					case metricPrefix + ".status.vertical.evicted_replicas":
+						evictedFound = true
+						assert.Equal(t, metricsstore.MetricTypeGauge, m.Type)
+						assert.Equal(t, 2.0, m.Value)
+						assert.Contains(t, m.Tags, "namespace:test-ns")
+						assert.Contains(t, m.Tags, "autoscaler_name:test-dpa")
+					}
+				}
+				assert.True(t, scaledFound, "status.vertical.scaled_replicas metric not found")
+				assert.True(t, evictedFound, "status.vertical.evicted_replicas metric not found")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
@@ -123,6 +123,27 @@ type PodAutoscalerInternal struct {
 	// verticalActionSuccessCount is the number of successful vertical actions
 	verticalActionSuccessCount uint
 
+	// inPlacePatchSuccessCount is the number of pods successfully patched in-place
+	inPlacePatchSuccessCount uint
+
+	// inPlacePatchErrorCount is the number of pods that failed in-place patching
+	inPlacePatchErrorCount uint
+
+	// inPlaceEvictionSuccessCount is the number of pods successfully evicted during in-place resize
+	inPlaceEvictionSuccessCount uint
+
+	// inPlaceEvictionErrorCount is the number of pods that failed eviction during in-place resize
+	inPlaceEvictionErrorCount uint
+
+	// inPlaceRolloutFallbackCount is the number of times in-place resize fell back to a rollout
+	inPlaceRolloutFallbackCount uint
+
+	// inPlacePDBBlockedCount is the number of times eviction was blocked by a PodDisruptionBudget
+	inPlacePDBBlockedCount uint
+
+	// inPlaceResizeCompletedCount is the number of times all pods in a resize cycle completed successfully
+	inPlaceResizeCompletedCount uint
+
 	// verticalLastLimitReason is the reason vertical scaling was limited by min/max constraints.
 	// When non-nil, it carries a ConditionError so that both Reason and Message are preserved.
 	verticalLastLimitReason error
@@ -694,6 +715,76 @@ func (p *PodAutoscalerInternal) VerticalActionSuccessCount() uint {
 // VerticalActionSuccessInc increment the number of vertical actions that triggered as success
 func (p *PodAutoscalerInternal) VerticalActionSuccessInc() {
 	p.verticalActionSuccessCount++
+}
+
+// InPlacePatchSuccessCount returns the number of pods successfully patched in-place
+func (p *PodAutoscalerInternal) InPlacePatchSuccessCount() uint {
+	return p.inPlacePatchSuccessCount
+}
+
+// InPlacePatchSuccessInc increments the in-place patch success counter
+func (p *PodAutoscalerInternal) InPlacePatchSuccessInc() {
+	p.inPlacePatchSuccessCount++
+}
+
+// InPlacePatchErrorCount returns the number of pods that failed in-place patching
+func (p *PodAutoscalerInternal) InPlacePatchErrorCount() uint {
+	return p.inPlacePatchErrorCount
+}
+
+// InPlacePatchErrorInc increments the in-place patch error counter
+func (p *PodAutoscalerInternal) InPlacePatchErrorInc() {
+	p.inPlacePatchErrorCount++
+}
+
+// InPlaceEvictionSuccessCount returns the number of pods successfully evicted during in-place resize
+func (p *PodAutoscalerInternal) InPlaceEvictionSuccessCount() uint {
+	return p.inPlaceEvictionSuccessCount
+}
+
+// InPlaceEvictionSuccessInc increments the in-place eviction success counter
+func (p *PodAutoscalerInternal) InPlaceEvictionSuccessInc() {
+	p.inPlaceEvictionSuccessCount++
+}
+
+// InPlaceEvictionErrorCount returns the number of pods that failed eviction during in-place resize
+func (p *PodAutoscalerInternal) InPlaceEvictionErrorCount() uint {
+	return p.inPlaceEvictionErrorCount
+}
+
+// InPlaceEvictionErrorInc increments the in-place eviction error counter
+func (p *PodAutoscalerInternal) InPlaceEvictionErrorInc() {
+	p.inPlaceEvictionErrorCount++
+}
+
+// InPlaceRolloutFallbackCount returns the number of times in-place resize fell back to a rollout
+func (p *PodAutoscalerInternal) InPlaceRolloutFallbackCount() uint {
+	return p.inPlaceRolloutFallbackCount
+}
+
+// InPlaceRolloutFallbackInc increments the rollout fallback counter
+func (p *PodAutoscalerInternal) InPlaceRolloutFallbackInc() {
+	p.inPlaceRolloutFallbackCount++
+}
+
+// InPlacePDBBlockedCount returns the number of times eviction was blocked by a PodDisruptionBudget
+func (p *PodAutoscalerInternal) InPlacePDBBlockedCount() uint {
+	return p.inPlacePDBBlockedCount
+}
+
+// InPlacePDBBlockedInc increments the PDB blocked counter
+func (p *PodAutoscalerInternal) InPlacePDBBlockedInc() {
+	p.inPlacePDBBlockedCount++
+}
+
+// InPlaceResizeCompletedCount returns the number of times all pods completed an in-place resize cycle
+func (p *PodAutoscalerInternal) InPlaceResizeCompletedCount() uint {
+	return p.inPlaceResizeCompletedCount
+}
+
+// InPlaceResizeCompletedInc increments the resize completed counter
+func (p *PodAutoscalerInternal) InPlaceResizeCompletedInc() {
+	p.inPlaceResizeCompletedCount++
 }
 
 // CurrentReplicas returns the current number of PODs for the targetRef

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
@@ -53,6 +53,13 @@ type FakePodAutoscalerInternal struct {
 	VerticalLastLimitReason            error
 	VerticalActionErrorCount           uint
 	VerticalActionSuccessCount         uint
+	InPlacePatchSuccessCount           uint
+	InPlacePatchErrorCount             uint
+	InPlaceEvictionSuccessCount        uint
+	InPlaceEvictionErrorCount          uint
+	InPlaceRolloutFallbackCount        uint
+	InPlacePDBBlockedCount             uint
+	InPlaceResizeCompletedCount        uint
 	CurrentReplicas                    *int32
 	ScaledReplicas                     *int32
 	EvictedReplicas                    *int32
@@ -102,6 +109,13 @@ func (f FakePodAutoscalerInternal) Build() PodAutoscalerInternal {
 		verticalLastLimitReason:            f.VerticalLastLimitReason,
 		verticalActionErrorCount:           f.VerticalActionErrorCount,
 		verticalActionSuccessCount:         f.VerticalActionSuccessCount,
+		inPlacePatchSuccessCount:           f.InPlacePatchSuccessCount,
+		inPlacePatchErrorCount:             f.InPlacePatchErrorCount,
+		inPlaceEvictionSuccessCount:        f.InPlaceEvictionSuccessCount,
+		inPlaceEvictionErrorCount:          f.InPlaceEvictionErrorCount,
+		inPlaceRolloutFallbackCount:        f.InPlaceRolloutFallbackCount,
+		inPlacePDBBlockedCount:             f.InPlacePDBBlockedCount,
+		inPlaceResizeCompletedCount:        f.InPlaceResizeCompletedCount,
 		currentReplicas:                    f.CurrentReplicas,
 		scaledReplicas:                     f.ScaledReplicas,
 		evictedReplicas:                    f.EvictedReplicas,


### PR DESCRIPTION
## Summary

- Appends `--variable GITLAB_USER_LOGIN` to the `dda inv pipeline.trigger-child-pipeline` call in `.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml`.
- `GITLAB_USER_LOGIN` is a GitLab predefined variable automatically set to the username of whoever triggered the pipeline — no additional configuration required.

## Why

The companion change in DataDog/images ([PR #9421](https://github.com/DataDog/images/pull/9421)) embeds the builder's GitLab username as the `com.datadoghq.ci.gitlab.user` OCI label on internal agent images. That label is only set when the variable is non-empty, so the images-side change is safe to merge independently.

Passing the variable from this side closes the loop: cluster availability tooling can then read image metadata directly to identify who built a given custom image, without needing to chase pipeline IDs in GitLab.

## Test plan

- [ ] Merge DataDog/images PR #9421 first (or at the same time).
- [ ] Trigger an `internal_image_deploy` job on a feature branch.
- [ ] Inspect the resulting image: `crane config <image>:<tag> | jq '.config.Labels["com.datadoghq.ci.gitlab.user"]'` — should return your GitLab username.

🤖 Generated with [Claude Code](https://claude.com/claude-code)