### PR TITLE
[SNMP] Show YAML unmarhsalling errors in Agent status for profiles

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig.go
@@ -6,6 +6,8 @@
 package profile
 
 import (
+	"expvar"
+
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -20,6 +22,10 @@ func loadInitConfigProfiles(rawInitConfigProfiles ProfileConfigMap) (ProfileConf
 			haveLegacyInitConfigProfile = haveLegacyInitConfigProfile || isLegacyInitConfigProfile
 			if err != nil {
 				log.Warnf("unable to load profile %q: %s", name, err)
+				errMsg := err.Error()
+				profileExpVar.Set(name, expvar.Func(func() interface{} {
+					return errMsg
+				}))
 				continue
 			}
 			profConfig.Definition = *profDefinition

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig_test.go
@@ -6,9 +6,11 @@
 package profile
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 )
@@ -118,4 +120,20 @@ func Test_loadInitConfigProfiles_legacyProfiles(t *testing.T) {
 			assert.Equal(t, tt.expectedHaveLegacyProfile, haveLegacyProfile)
 		})
 	}
+}
+
+func Test_loadInitConfigProfiles_invalidDefinitionFile(t *testing.T) {
+	SetConfdPathAndCleanProfiles()
+
+	invalidFile, _ := filepath.Abs(filepath.Join("..", "test", "test_profiles", "invalid_yaml_file.yaml"))
+	_, _, err := loadInitConfigProfiles(ProfileConfigMap{
+		"bad-profile": {
+			DefinitionFile: invalidFile,
+		},
+	})
+	require.NoError(t, err)
+
+	expVarEntry := profileExpVar.Get("bad-profile")
+	require.NotNil(t, expVarEntry, "expected bad-profile error in snmpProfileErrors expvar")
+	assert.Contains(t, expVarEntry.String(), "parse error")
 }

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
@@ -40,6 +40,10 @@ func normalizeProfiles(pConfig ProfileConfigMap, defaultProfiles ProfileConfigMa
 		err := recursivelyExpandBaseProfiles(name, &newProfileConfig.Definition, newProfileConfig.Definition.Extends, []string{}, pConfig, defaultProfiles)
 		if err != nil {
 			log.Warnf("failed to expand profile %q: %v", name, err)
+			errMsg := err.Error()
+			profileExpVar.Set(name, expvar.Func(func() interface{} {
+				return errMsg
+			}))
 			continue
 		}
 		profiledefinition.NormalizeMetrics(newProfileConfig.Definition.Metrics)

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_yaml.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_yaml.go
@@ -7,6 +7,7 @@ package profile
 
 import (
 	"errors"
+	"expvar"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -79,6 +80,10 @@ func getProfileDefinitions(profilesFolder string, isUserProfile bool) (ProfileCo
 		haveLegacyProfile = haveLegacyProfile || isLegacyProfile
 		if err != nil {
 			log.Warnf("cannot load profile %q: %v", profileName, err)
+			errMsg := err.Error()
+			profileExpVar.Set(profileName, expvar.Func(func() interface{} {
+				return errMsg
+			}))
 			continue
 		}
 		if definition.Name == "" {

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_yaml_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_yaml_test.go
@@ -137,6 +137,10 @@ func Test_loadYamlProfiles_invalidExtendProfile(t *testing.T) {
 	logs.AssertPresent(t, "failed to expand profile \"f5-big-ip\"")
 	assert.Equal(t, ProfileConfigMap{}, defaultProfiles)
 	assert.False(t, haveLegacyProfile)
+
+	expVarEntry := profileExpVar.Get("f5-big-ip")
+	require.NotNil(t, expVarEntry, "expected f5-big-ip error in snmpProfileErrors expvar")
+	assert.Contains(t, expVarEntry.String(), "extend does not exist")
 }
 
 func Test_loadYamlProfiles_userAndDefaultProfileFolderDoesNotExist(t *testing.T) {
@@ -180,6 +184,10 @@ func Test_loadYamlProfiles_validAndInvalidProfiles(t *testing.T) {
 	assert.Contains(t, defaultProfiles, "f5-big-ip")
 	assert.NotContains(t, defaultProfiles, "f5-invalid")
 	assert.True(t, haveLegacyProfile)
+
+	expVarEntry := profileExpVar.Get("f5-invalid")
+	require.NotNil(t, expVarEntry, "expected f5-invalid error in snmpProfileErrors expvar")
+	assert.Contains(t, expVarEntry.String(), "parse error")
 }
 
 func Test_getProfileDefinitions_legacyProfiles(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Currently when there are YAML parse errors in profiles, we don't show them in the Agent status command (and also in the `status.log` file in flares), this PR adds showing the errors.

https://datadoghq.atlassian.net/browse/NDMC-233

<img width="1512" height="327" alt="image" src="https://github.com/user-attachments/assets/07359fa8-3237-4e08-81b0-63aec4dee46e" />

### Motivation

### Describe how you validated your changes

### Additional Notes
