### PR TITLE
Remove verbose log from eBPF `include_headers` flattener

### DIFF
--- a/pkg/ebpf/include_headers.go
+++ b/pkg/ebpf/include_headers.go
@@ -55,11 +55,9 @@ func main() {
 		log.Fatalf("unable to resolve path to %s: %s", args[1], err)
 	}
 
-	err = runProcessing(root, inputFile, outputFile, args[2:])
-	if err != nil {
+	if err := runProcessing(root, inputFile, outputFile, args[2:]); err != nil {
 		log.Fatalf("error including headers: %s", err)
 	}
-	fmt.Printf("successfully included headers from %s => %s\n", inputFile, outputFile)
 }
 
 func resolvePath(root, path string) (string, error) {
@@ -142,7 +140,6 @@ func processIncludes(path string, out io.Writer, ps *pathSearcher, includedFiles
 		return nil
 	}
 	includedFiles[path] = struct{}{}
-	log.Printf("included %s\n", path)
 
 	sourceReader, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?
Removes two unconditional log statements from `include_headers.go`:
- `log.Printf("included %s\n", path)`, fired once per header visited by `processIncludes`, and kind of flooding the build output with absolute paths (e.g. `2026/03/25 16:10:15 included .../pkg/ebpf/c/bpf_metadata.h`),
- `fmt.Printf("successfully included headers from %s => %s\n", ...)`, fired once per `run_binary` invocation (e.g. `successfully included headers from .../probe.c => .../runtime-security.c`).

### Motivation
Same as #47930:
> Received feedback from users indicating that Bazel's console output was excessively verbose, hindering their ability to follow progress and diagnose potential issues.

Example:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1585802813#L158

### Additional Notes
In this case, both statements look like transitional/debug aids that could be safely removed since the `.d` dependency file written by the same function already captures the full include graph.