### PR TITLE
Remove macOS <12.0 leftovers

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -36,7 +36,7 @@ common:linux --strategy=sandboxed
 
 # macOS config ---------------------------------------------------------------------------------------------------------
 common:macos --features=-macos_default_link_flags # https://github.com/bazelbuild/bazel/issues/23312
-common:macos --macos_minimum_os=11.0 # Keep in sync with https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
+common:macos --macos_minimum_os=12.0 # Keep in sync with https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
 common:macos --strategy=sandboxed
 
 # Windows config -------------------------------------------------------------------------------------------------------

--- a/comp/core/gui/guiimpl/systray/Package.swift
+++ b/comp/core/gui/guiimpl/systray/Package.swift
@@ -1,9 +1,10 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 
 import PackageDescription
 
 let package = Package(
     name: "dd-agent-gui",
+    platforms: [.macOS(.v12)], // Keep in sync with https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
     targets: [
         .target(name: "dd-agent-gui", path: "./Sources")
     ]

--- a/comp/core/gui/guiimpl/systray/Sources/WiFiDataProvider.swift
+++ b/comp/core/gui/guiimpl/systray/Sources/WiFiDataProvider.swift
@@ -376,11 +376,7 @@ class WiFiDataProvider: NSObject, CLLocationManagerDelegate {
 
     // Authorization Status Helper
     private func getAuthorizationStatus() -> CLAuthorizationStatus {
-        if #available(macOS 11.0, *) {
-            return locationManager.authorizationStatus
-        } else {
-            return CLLocationManager.authorizationStatus()
-        }
+        return locationManager.authorizationStatus
     }
 
     // Helper Methods

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -271,7 +271,7 @@ build do
     mkdir "#{app_temp_dir}/MacOS"
     systray_build_dir = "#{project_dir}/comp/core/gui/guiimpl/systray"
     # Add @executable_path/../Frameworks to rpath to find the swift libs in the Frameworks folder.
-    target = "#{arm_target? ? 'arm64' : 'x86_64'}-apple-macos11.0" # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
+    target = "#{arm_target? ? 'arm64' : 'x86_64'}-apple-macos12.0" # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
     command "swiftc -O -swift-version \"5\" -target \"#{target}\" -Xlinker '-rpath' -Xlinker '@executable_path/../Frameworks' Sources/*.swift -o gui", cwd: systray_build_dir
     copy "#{systray_build_dir}/gui", "#{app_temp_dir}/MacOS/"
     copy "#{systray_build_dir}/agent.png", "#{app_temp_dir}/MacOS/"

--- a/pkg/logonduration/timestamps_darwin.go
+++ b/pkg/logonduration/timestamps_darwin.go
@@ -8,7 +8,8 @@
 package logonduration
 
 /*
-#cgo CFLAGS: -x objective-c -mmacosx-version-min=10.15
+// Keep in sync with https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
+#cgo CFLAGS: -x objective-c -mmacosx-version-min=12.0
 #cgo LDFLAGS: -framework Foundation -framework OSLog
 
 #include <stdlib.h>


### PR DESCRIPTION
### What does this PR do?
- `.bazelrc`: `--macos_minimum_os=11.0` -> `12.0`,
- `omnibus/config/software/datadog-agent.rb`: Swift compiler target `macos11.0` -> `macos12.0`,
- `pkg/logonduration/timestamps_darwin.go`: CGo flag `-mmacosx-version-min=10.15` -> `12.0`,
- `comp/core/gui/guiimpl/systray/Sources/WiFiDataProvider.swift`: remove dead `#available(macOS 11.0, *)` guard,
- `comp/core/gui/guiimpl/systray/Package.swift`: declare `.macOS(.v12)` minimum platform ([credits](https://github.com/DataDog/datadog-agent/pull/49191#discussion_r3065388568) to @codex), which in turn [mandates to bump](https://github.com/DataDog/datadog-agent/pull/49191#discussion_r3065811837) `swift-tools-version:5.1` -> `5.5`.

### Motivation
Following PRs partially bumped the macOS minimum to 12.0:
- DataDog/integrations-core#22898
- #47811

The changelog **already** mentions it:
- #47818

The present change therefore address what was left behind.

### Describe how you validated your changes
Mechanical change, no logic altered.

### Additional Notes
See:
- https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
- https://github.com/DataDog/datadog-agent/releases/tag/7.75.0 (`Deprecation Notes`)
- https://datadoghq.atlassian.net/wiki/spaces/ASC1/blog/6539805218/February+-+March+2026+-+Agent+Supply+Chain+Monthly+Update#macOS-12.0-Minimum
- Homebrew/homebrew-cask#258631