### PR TITLE
dyninst/irgen: adjust memory limit for memory test

### DIFF
--- a/pkg/dyninst/irgen/irgen_memory_use_test.go
+++ b/pkg/dyninst/irgen/irgen_memory_use_test.go
@@ -59,7 +59,7 @@ func TestIrgenMemoryUse(t *testing.T) {
 	require.NoError(t, err)
 
 	scanner := bufio.NewScanner(stderrFile)
-	const maxMemLimitMB = uint64(5)
+	const maxMemLimitMB = uint64(7)
 	for scanner.Scan() {
 		line := scanner.Text()
 		match := gcTraceRegexp.FindStringSubmatch(line)


### PR DESCRIPTION
### What does this PR do?

This test is to make sure we don't accidentally load the whole dwarf or lots of symbols but it's a bit crude. Something in the dependencies we touch has started to use more heap space so let's up the limit.

### Motivation

See [this test](https://app.datadoghq.com/ci/test/AwAAAZ14G22Sbek1VQAAABhBWjE0RzIyU0FBQ25iNGROYjZZTGk1Tk0AAAAkZjE5ZDc4MWMtNjFhNS00MWIzLTkwZjEtN2MxZTk3MjRlNzkyAAAF5Q?colorByAttr=service&currentTab=overview&env=prod)


### Describe how you validated your changes

Testing only

Fix DD_2BKJ4H