### PR TITLE
fix(ebpf): replace direct kernel struct field accesses with dynamic offsets

### DIFF
--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -26,6 +26,15 @@ static __attribute__((always_inline)) struct inode* get_dentry_inode(struct dent
     return inode;
 }
 
+static struct dentry *__attribute__((always_inline)) get_dentry_parent(struct dentry *dentry) {
+    u64 offset;
+    LOAD_CONSTANT("dentry_d_parent_offset", offset);
+
+    struct dentry *parent;
+    bpf_probe_read(&parent, sizeof(parent), (void *)dentry + offset);
+    return parent;
+}
+
 static dev_t __attribute__((always_inline)) get_sb_dev(struct super_block *sb) {
     u64 sb_dev_offset;
     LOAD_CONSTANT("sb_dev_offset", sb_dev_offset);

--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -296,12 +296,17 @@ static unsigned long __attribute__((always_inline)) get_path_ino(struct path *pa
     return get_dentry_ino(dentry);
 }
 
-static void __attribute__((always_inline)) get_dentry_name(struct dentry *dentry, void *buffer, size_t n) {
+static struct qstr __attribute__((always_inline)) get_dentry_qstr(struct dentry *dentry) {
 	u64 dentry_d_name_offset;
 	LOAD_CONSTANT("dentry_d_name_offset", dentry_d_name_offset);
 
     struct qstr qstr;
     bpf_probe_read(&qstr, sizeof(qstr), (void *)dentry + dentry_d_name_offset);
+    return qstr;
+}
+
+static void __attribute__((always_inline)) get_dentry_name(struct dentry *dentry, void *buffer, size_t n) {
+    struct qstr qstr = get_dentry_qstr(dentry);
     bpf_probe_read_str(buffer, n, (void *)qstr.name);
 }
 

--- a/pkg/security/ebpf/c/include/constants/offsets/netns.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/netns.h
@@ -78,6 +78,12 @@ __attribute__((always_inline)) u32 get_netns_from_socket(struct socket *socket) 
     return get_netns_from_sock(sk);
 }
 
+__attribute__((always_inline)) u64 get_nf_conn_tuplehash_offset(void) {
+    u64 nf_conn_tuplehash_offset;
+    LOAD_CONSTANT("nf_conn_tuplehash_offset", nf_conn_tuplehash_offset);
+    return nf_conn_tuplehash_offset;
+}
+
 __attribute__((always_inline)) u32 get_netns_from_nf_conn(struct nf_conn *ct) {
     u64 nf_conn_ct_net_offset;
     LOAD_CONSTANT("nf_conn_ct_net_offset", nf_conn_ct_net_offset);

--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -89,11 +89,15 @@ static __attribute__((always_inline)) void fill_file(struct dentry *dentry, stru
       file->metadata.nlink = nlink;
     }
 
+    u64 inode_mode_offset;
+    LOAD_CONSTANT("inode_mode_offset", inode_mode_offset);
+    u64 inode_uid_offset;
+    LOAD_CONSTANT("inode_uid_offset", inode_uid_offset);
     u64 inode_gid_offset;
     LOAD_CONSTANT("inode_gid_offset", inode_gid_offset);
 
-    bpf_probe_read(&file->metadata.mode, sizeof(file->metadata.mode), &d_inode->i_mode);
-    bpf_probe_read(&file->metadata.uid, sizeof(file->metadata.uid), &d_inode->i_uid);
+    bpf_probe_read(&file->metadata.mode, sizeof(file->metadata.mode), (void *)d_inode + inode_mode_offset);
+    bpf_probe_read(&file->metadata.uid, sizeof(file->metadata.uid), (void *)d_inode + inode_uid_offset);
     bpf_probe_read(&file->metadata.gid, sizeof(file->metadata.gid), (void *)d_inode + inode_gid_offset);
 
     u64 inode_ctime_sec_offset;

--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -111,14 +111,11 @@ static __attribute__((always_inline)) void fill_file(struct dentry *dentry, stru
 		bpf_probe_read(&nsec, sizeof(nsec), (void *)d_inode + inode_ctime_nsec_offset);
 		file->metadata.ctime.tv_nsec = nsec;
 	} else {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
     u64 inode_ctime_offset;
     LOAD_CONSTANT("inode_ctime_offset", inode_ctime_offset);
-    bpf_probe_read(&file->metadata.ctime, sizeof(file->metadata.ctime), (void *)d_inode + inode_ctime_offset);
-#else
-    bpf_probe_read(&file->metadata.ctime.tv_sec, sizeof(file->metadata.ctime.tv_sec), &d_inode->i_ctime_sec);
-    bpf_probe_read(&file->metadata.ctime.tv_nsec, sizeof(file->metadata.ctime.tv_nsec), &d_inode->i_ctime_nsec);
-#endif
+    if (inode_ctime_offset) {
+        bpf_probe_read(&file->metadata.ctime, sizeof(file->metadata.ctime), (void *)d_inode + inode_ctime_offset);
+    }
 	}
 
     u64 inode_mtime_sec_offset;
@@ -132,14 +129,11 @@ static __attribute__((always_inline)) void fill_file(struct dentry *dentry, stru
 		bpf_probe_read(&nsec, sizeof(nsec), (void *)d_inode + inode_mtime_nsec_offset);
 		file->metadata.mtime.tv_nsec = nsec;
 	} else {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
     u64 inode_mtime_offset;
     LOAD_CONSTANT("inode_mtime_offset", inode_mtime_offset);
-    bpf_probe_read(&file->metadata.mtime, sizeof(file->metadata.mtime), (void *)d_inode + inode_mtime_offset);
-#else
-    bpf_probe_read(&file->metadata.mtime.tv_sec, sizeof(file->metadata.mtime.tv_sec), &d_inode->i_mtime_sec);
-    bpf_probe_read(&file->metadata.mtime.tv_nsec, sizeof(file->metadata.mtime.tv_nsec), &d_inode->i_mtime_nsec);
-#endif
+    if (inode_mtime_offset) {
+        bpf_probe_read(&file->metadata.mtime, sizeof(file->metadata.mtime), (void *)d_inode + inode_mtime_offset);
+    }
 	}
 
     // set again the layer here as after update a file will be moved to the upper layer

--- a/pkg/security/ebpf/c/include/hooks/cgroup.h
+++ b/pkg/security/ebpf/c/include/hooks/cgroup.h
@@ -93,7 +93,7 @@ static __attribute__((always_inline)) int trace__cgroup_write(ctx_t *ctx) {
         // The last dentry in the cgroup path should be `cgroup.procs`, thus the container ID should be its parent.
         container_d = get_dentry_parent(dentry);
 #ifdef DEBUG_CGROUP
-        bpf_probe_read(&container_qstr, sizeof(container_qstr), &container_d->d_name);
+        container_qstr = get_dentry_qstr(container_d);
         container_id = (void *)container_qstr.name;
 #endif
 
@@ -107,7 +107,7 @@ static __attribute__((always_inline)) int trace__cgroup_write(ctx_t *ctx) {
         bpf_probe_read(&container_d, sizeof(container_d), cgroup + 72); // offsetof(struct cgroup, dentry)
 
 #ifdef DEBUG_CGROUP
-        bpf_probe_read(&container_qstr, sizeof(container_qstr), &container_d->d_name);
+        container_qstr = get_dentry_qstr(container_d);
         container_id = (void *)container_qstr.name;
 #endif
 

--- a/pkg/security/ebpf/c/include/hooks/cgroup.h
+++ b/pkg/security/ebpf/c/include/hooks/cgroup.h
@@ -86,8 +86,10 @@ static __attribute__((always_inline)) int trace__cgroup_write(ctx_t *ctx) {
     case CGROUP_DEFAULT: {
         // Retrieve the container ID from the cgroup path.
         struct kernfs_open_file *kern_f = (struct kernfs_open_file *)CTX_PARM1(ctx);
+        u64 kernfs_open_file_file_offset;
+        LOAD_CONSTANT("kernfs_open_file_file_offset", kernfs_open_file_file_offset);
         struct file *f;
-        bpf_probe_read(&f, sizeof(f), &kern_f->file);
+        bpf_probe_read(&f, sizeof(f), (void *)kern_f + kernfs_open_file_file_offset);
         struct dentry *dentry = get_file_dentry(f);
 
         // The last dentry in the cgroup path should be `cgroup.procs`, thus the container ID should be its parent.

--- a/pkg/security/ebpf/c/include/hooks/cgroup.h
+++ b/pkg/security/ebpf/c/include/hooks/cgroup.h
@@ -91,7 +91,7 @@ static __attribute__((always_inline)) int trace__cgroup_write(ctx_t *ctx) {
         struct dentry *dentry = get_file_dentry(f);
 
         // The last dentry in the cgroup path should be `cgroup.procs`, thus the container ID should be its parent.
-        bpf_probe_read(&container_d, sizeof(container_d), &dentry->d_parent);
+        container_d = get_dentry_parent(dentry);
 #ifdef DEBUG_CGROUP
         bpf_probe_read(&container_qstr, sizeof(container_qstr), &container_d->d_name);
         container_id = (void *)container_qstr.name;
@@ -225,8 +225,7 @@ static __attribute__((always_inline)) int trace__cgroup_open(ctx_t *ctx) {
 
     cache_file(dentry, mount_id);
 
-    struct dentry *d_parent;
-    bpf_probe_read(&d_parent, sizeof(d_parent), &dentry->d_parent);
+    struct dentry *d_parent = get_dentry_parent(dentry);
     cache_file(d_parent, mount_id);
 
     return 0;

--- a/pkg/security/ebpf/c/include/hooks/cgroup.h
+++ b/pkg/security/ebpf/c/include/hooks/cgroup.h
@@ -106,7 +106,9 @@ static __attribute__((always_inline)) int trace__cgroup_write(ctx_t *ctx) {
     }
     case CGROUP_CENTOS_7: {
         void *cgroup = (void *)CTX_PARM1(ctx);
-        bpf_probe_read(&container_d, sizeof(container_d), cgroup + 72); // offsetof(struct cgroup, dentry)
+        u64 cgroup_dentry_offset;
+        LOAD_CONSTANT("cgroup_dentry_offset", cgroup_dentry_offset);
+        bpf_probe_read(&container_d, sizeof(container_d), cgroup + cgroup_dentry_offset);
 
 #ifdef DEBUG_CGROUP
         container_qstr = get_dentry_qstr(container_d);

--- a/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
@@ -58,7 +58,7 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(void *ctx, struct de
             }
         }
 
-        bpf_probe_read(&qstr, sizeof(qstr), &dentry->d_name);
+        qstr = get_dentry_qstr(dentry);
 
         long len = bpf_probe_read_str(&map_value.name, sizeof(map_value.name), (void *)qstr.name);
         if (len < 0) {

--- a/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
@@ -33,7 +33,7 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(void *ctx, struct de
 #pragma unroll
 #endif
     for (int i = 0; i < DR_MAX_ITERATION_DEPTH; i++) {
-        bpf_probe_read(&d_parent, sizeof(d_parent), &dentry->d_parent);
+        d_parent = get_dentry_parent(dentry);
 
         key = next_key;
         ino_parent = get_dentry_ino(d_parent);
@@ -77,8 +77,7 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(void *ctx, struct de
         if (key.ino == ino_parent && dentry != d_parent) {
             // It's not expected to have 2 different dentries with the same inode in the same mount
             // In case of btrfs, it might be the root of the subvolume
-            struct dentry *d_parent_parent = NULL;
-            bpf_probe_read(&d_parent_parent, sizeof(d_parent_parent), &d_parent->d_parent);
+            struct dentry *d_parent_parent = get_dentry_parent(d_parent);
             if (d_parent == d_parent_parent) {
                 update = 0;
             }

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -664,11 +664,16 @@ int __attribute__((always_inline)) fetch_interpreter(void *ctx, struct linux_bin
 
     bpf_printk("interpreter file: %llx", interpreter);
 
+    u64 binprm_filename_offset;
+    LOAD_CONSTANT("linux_binprm_filename_offset", binprm_filename_offset);
+    u64 binprm_interp_offset;
+    LOAD_CONSTANT("linux_binprm_interp_offset", binprm_interp_offset);
+
     const char *s;
-    bpf_probe_read(&s, sizeof(s), &bprm->filename);
+    bpf_probe_read(&s, sizeof(s), (char *)bprm + binprm_filename_offset);
     bpf_printk("*filename from binprm: %s", s);
 
-    bpf_probe_read(&s, sizeof(s), &bprm->interp);
+    bpf_probe_read(&s, sizeof(s), (char *)bprm + binprm_interp_offset);
     bpf_printk("*interp from binprm: %s", s);
 #endif
 

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -65,7 +65,9 @@ int __attribute__((always_inline)) fetch_mod_name_common(struct module *m) {
         return 0;
     }
 
-    bpf_probe_read_str(&syscall->init_module.name, sizeof(syscall->init_module.name), &m->name);
+    u64 module_name_offset;
+    LOAD_CONSTANT("module_name_offset", module_name_offset);
+    bpf_probe_read_str(&syscall->init_module.name, sizeof(syscall->init_module.name), (void *)m + module_name_offset);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/mprotect.h
+++ b/pkg/security/ebpf/c/include/hooks/mprotect.h
@@ -30,12 +30,16 @@ int hook_security_file_mprotect(ctx_t *ctx) {
 
     u64 flags_offset;
     LOAD_CONSTANT("vm_area_struct_flags_offset", flags_offset);
+    u64 vm_start_offset;
+    LOAD_CONSTANT("vm_area_struct_vm_start_offset", vm_start_offset);
+    u64 vm_end_offset;
+    LOAD_CONSTANT("vm_area_struct_vm_end_offset", vm_end_offset);
 
     // Retrieve vma information
     struct vm_area_struct *vma = (struct vm_area_struct *)CTX_PARM1(ctx);
     bpf_probe_read(&syscall->mprotect.vm_protection, sizeof(syscall->mprotect.vm_protection), (char *)vma + flags_offset);
-    bpf_probe_read(&syscall->mprotect.vm_start, sizeof(syscall->mprotect.vm_start), &vma->vm_start);
-    bpf_probe_read(&syscall->mprotect.vm_end, sizeof(syscall->mprotect.vm_end), &vma->vm_end);
+    bpf_probe_read(&syscall->mprotect.vm_start, sizeof(syscall->mprotect.vm_start), (char *)vma + vm_start_offset);
+    bpf_probe_read(&syscall->mprotect.vm_end, sizeof(syscall->mprotect.vm_end), (char *)vma + vm_end_offset);
     syscall->mprotect.req_protection = (u64)CTX_PARM2(ctx);
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/namespaces.h
+++ b/pkg/security/ebpf/c/include/hooks/namespaces.h
@@ -11,8 +11,11 @@ int hook_switch_task_namespaces(ctx_t *ctx) {
         return 0;
     }
 
+    u64 nsproxy_mnt_ns_offset;
+    LOAD_CONSTANT("nsproxy_mnt_ns_offset", nsproxy_mnt_ns_offset);
+
     void *mnt_ns;
-    bpf_probe_read(&mnt_ns, sizeof(mnt_ns), &new_ns->mnt_ns);
+    bpf_probe_read(&mnt_ns, sizeof(mnt_ns), (void *)new_ns + nsproxy_mnt_ns_offset);
     if (mnt_ns != NULL) {
         u32 inum = 0;
         bpf_probe_read(&inum, sizeof(inum), (void *)mnt_ns + get_mount_offset_of_nscommon_inum());
@@ -21,8 +24,11 @@ int hook_switch_task_namespaces(ctx_t *ctx) {
         bpf_map_update_elem(&mntns_cache, &pid, &inum, BPF_ANY);
     }
 
+    u64 nsproxy_net_ns_offset;
+    LOAD_CONSTANT("nsproxy_net_ns_offset", nsproxy_net_ns_offset);
+
     struct net *net;
-    bpf_probe_read(&net, sizeof(net), &new_ns->net_ns);
+    bpf_probe_read(&net, sizeof(net), (void *)new_ns + nsproxy_net_ns_offset);
     if (net == NULL) {
         return 0;
     }

--- a/pkg/security/ebpf/c/include/hooks/network/flow.h
+++ b/pkg/security/ebpf/c/include/hooks/network/flow.h
@@ -160,7 +160,7 @@ __attribute__((always_inline)) int trace_nat_manip_pkt(struct nf_conn *ct) {
     u32 netns = get_netns_from_nf_conn(ct);
 
     struct nf_conntrack_tuple_hash tuplehash[IP_CT_DIR_MAX];
-    bpf_probe_read(&tuplehash, sizeof(tuplehash), &ct->tuplehash);
+    bpf_probe_read(&tuplehash, sizeof(tuplehash), (void *)ct + get_nf_conn_tuplehash_offset());
 
     struct nf_conntrack_tuple *orig_tuple = &tuplehash[IP_CT_DIR_ORIGINAL].tuple;
     struct nf_conntrack_tuple *reply_tuple = &tuplehash[IP_CT_DIR_REPLY].tuple;
@@ -221,7 +221,7 @@ int hook_nf_ct_delete(ctx_t *ctx) {
     u32 netns = get_netns_from_nf_conn(ct);
 
     struct nf_conntrack_tuple_hash tuplehash[IP_CT_DIR_MAX];
-    bpf_probe_read(&tuplehash, sizeof(tuplehash), &ct->tuplehash);
+    bpf_probe_read(&tuplehash, sizeof(tuplehash), (void *)ct + get_nf_conn_tuplehash_offset());
     struct nf_conntrack_tuple *orig_tuple = &tuplehash[IP_CT_DIR_ORIGINAL].tuple;
     struct nf_conntrack_tuple *reply_tuple = &tuplehash[IP_CT_DIR_REPLY].tuple;
 

--- a/pkg/security/ebpf/c/include/hooks/procfs.h
+++ b/pkg/security/ebpf/c/include/hooks/procfs.h
@@ -183,7 +183,7 @@ int hook_proc_fd_link(ctx_t *ctx) {
     struct basename_t basename = {};
 
     get_dentry_name(d, &basename, sizeof(basename)); // this is the file descriptor number
-    bpf_probe_read(&d_parent, sizeof(d_parent), &d->d_parent);
+    d_parent = get_dentry_parent(d);
     d = d_parent;
 
     get_dentry_name(d, &basename, sizeof(basename)); // this should be 'fd'
@@ -191,7 +191,7 @@ int hook_proc_fd_link(ctx_t *ctx) {
         return 0;
     }
 
-    bpf_probe_read(&d_parent, sizeof(d_parent), &d->d_parent);
+    d_parent = get_dentry_parent(d);
     d = d_parent;
     get_dentry_name(d, &basename, sizeof(basename)); // this should be the pid of the procfs path
     u32 pid = atoi(&basename.value[0]);

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -135,6 +135,9 @@ const (
 	// Interpreter constants
 	OffsetNameLinuxBinprmStructFile = "binprm_file_offset"
 
+	// cgroup constants
+	OffsetNameCgroupDentry = "cgroup_dentry_offset"
+
 	// kernfs constants
 	OffsetNameKernfsOpenFileFile = "kernfs_open_file_file_offset"
 

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -135,6 +135,9 @@ const (
 	// Interpreter constants
 	OffsetNameLinuxBinprmStructFile = "binprm_file_offset"
 
+	// kernfs constants
+	OffsetNameKernfsOpenFileFile = "kernfs_open_file_file_offset"
+
 	// module constants
 	OffsetNameModuleName = "module_name_offset"
 

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -113,6 +113,7 @@ const (
 	OffsetNameSockCommonStructSKCNet    = "sock_common_skc_net_offset"
 	OffsetNameSocketStructSK            = "socket_sock_offset"
 	OffsetNameNFConnStructCTNet         = "nf_conn_ct_net_offset"
+	OffsetNameNFConnStructTuplehash     = "nf_conn_tuplehash_offset"
 	OffsetNameSockCommonStructSKCFamily = "sock_common_skc_family_offset"
 	OffsetNameSockCommonStructSKCNum    = "sock_common_skc_num_offset"
 	OffsetNameFlowI4StructSADDR         = "flowi4_saddr_offset"

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -54,6 +54,8 @@ const (
 	// inode
 	OffsetInodeIno   = "inode_ino_offset"
 	OffsetInodeNlink = "inode_nlink_offset"
+	OffsetInodeMode  = "inode_mode_offset"
+	OffsetInodeUid   = "inode_uid_offset"
 	OffsetInodeGid   = "inode_gid_offset"
 	OffsetInodeMtime = "inode_mtime_offset"
 	OffsetInodeCtime = "inode_ctime_offset"

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -125,6 +125,10 @@ const (
 	OffsetNameFlowI6StructProto = "flowi6_proto_offset"
 	OffsetNameRtnlLinkOpsKind   = "rtnl_link_ops_kind_offset"
 
+	// nsproxy offsets
+	OffsetNameNsproxyMntNs = "nsproxy_mnt_ns_offset"
+	OffsetNameNsproxyNetNs = "nsproxy_net_ns_offset"
+
 	// Interpreter constants
 	OffsetNameLinuxBinprmStructFile = "binprm_file_offset"
 

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -133,7 +133,9 @@ const (
 	OffsetNameNsproxyNetNs = "nsproxy_net_ns_offset"
 
 	// Interpreter constants
-	OffsetNameLinuxBinprmStructFile = "binprm_file_offset"
+	OffsetNameLinuxBinprmStructFile     = "binprm_file_offset"
+	OffsetNameLinuxBinprmStructFilename = "linux_binprm_filename_offset"
+	OffsetNameLinuxBinprmStructInterp   = "linux_binprm_interp_offset"
 
 	// cgroup constants
 	OffsetNameCgroupDentry = "cgroup_dentry_offset"

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -49,6 +49,7 @@ const (
 	OffsetNameVfsmountMntSb             = "vfsmount_mnt_sb_offset"
 	OffsetNameSuperblockSType           = "super_block_s_type_offset"
 	OffsetNameDentryDName               = "dentry_d_name_offset"
+	OffsetNameDentryDParent             = "dentry_d_parent_offset"
 
 	// inode
 	OffsetInodeIno   = "inode_ino_offset"

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -26,6 +26,8 @@ const (
 	OffsetNameLinuxBinprmArgc           = "linux_binprm_argc_offset"
 	OffsetNameLinuxBinprmEnvc           = "linux_binprm_envc_offset"
 	OffsetNameVMAreaStructFlags         = "vm_area_struct_flags_offset"
+	OffsetNameVMAreaStructVMStart       = "vm_area_struct_vm_start_offset"
+	OffsetNameVMAreaStructVMEnd         = "vm_area_struct_vm_end_offset"
 	OffsetNameKernelCloneArgsExitSignal = "kernel_clone_args_exit_signal_offset"
 	OffsetNameFileFinode                = "file_f_inode_offset"
 	OffsetNameFileFpath                 = "file_f_path_offset"

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -135,6 +135,9 @@ const (
 	// Interpreter constants
 	OffsetNameLinuxBinprmStructFile = "binprm_file_offset"
 
+	// module constants
+	OffsetNameModuleName = "module_name_offset"
+
 	// iouring constants
 	OffsetNameIoKiocbStructCtx = "iokiocb_ctx_offset"
 )

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -57,7 +57,7 @@ const (
 	OffsetInodeIno   = "inode_ino_offset"
 	OffsetInodeNlink = "inode_nlink_offset"
 	OffsetInodeMode  = "inode_mode_offset"
-	OffsetInodeUid   = "inode_uid_offset"
+	OffsetInodeUID   = "inode_uid_offset"
 	OffsetInodeGid   = "inode_gid_offset"
 	OffsetInodeMtime = "inode_mtime_offset"
 	OffsetInodeCtime = "inode_ctime_offset"

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -61,6 +61,8 @@ func computeRawsTable() map[string]uint64 {
 		OffsetNameSockCommonStructSKCFamily:       16,
 		OffsetNameDentryDSb:                       104,
 		OffsetNameNetDeviceStructName:             0,
+		OffsetNameVMAreaStructVMStart:             0,
+		OffsetNameVMAreaStructVMEnd:               8,
 		OffsetNameRenameStructOldDentry:           16,
 		OffsetNameRenameStructNewDentry:           40,
 		OffsetNameSbDev:                           16,

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -73,6 +73,7 @@ func computeRawsTable() map[string]uint64 {
 		OffsetNameSuperblockSType:                 40,
 		OffsetNameVfsmountMntRoot:                 0,
 		OffsetNameDentryDName:                     32,
+		OffsetNameDentryDParent:                   24,
 		OffsetNameVfsmountMntSb:                   8,
 		OffsetNameSockCommonStructSKCNum:          14,
 		SizeOfPipeBuffer:                          40,

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -46,7 +46,7 @@ func computeRawsTable() map[string]uint64 {
 	return map[string]uint64{
 		OffsetInodeIno:                            64,
 		OffsetInodeMode:                           0,
-		OffsetInodeUid:                            4,
+		OffsetInodeUID:                            4,
 		OffsetInodeGid:                            8,
 		OffsetInodeNlink:                          72,
 		OffsetInodeMtime:                          104,

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -83,6 +83,8 @@ func computeRawsTable() map[string]uint64 {
 		OffsetNameRtnlLinkOpsKind:                 16,
 		OffsetNameMntNamespaceNs:                  8,
 		OffsetNameNsCommonInum:                    16,
+		OffsetNameNsproxyMntNs:                    0,
+		OffsetNameNsproxyNetNs:                    32,
 	}
 }
 

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -82,6 +82,7 @@ func computeRawsTable() map[string]uint64 {
 		OffsetNameSockCommonStructSKCNum:          14,
 		SizeOfPipeBuffer:                          40,
 		OffsetNamePipeBufferStructFlags:           24,
+		OffsetNameKernfsOpenFileFile:              24,
 		OffsetNameModuleName:                      24,
 		OffsetNameRtnlLinkOpsKind:                 16,
 		OffsetNameMntNamespaceNs:                  8,

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -82,6 +82,7 @@ func computeRawsTable() map[string]uint64 {
 		OffsetNameSockCommonStructSKCNum:          14,
 		SizeOfPipeBuffer:                          40,
 		OffsetNamePipeBufferStructFlags:           24,
+		OffsetNameCgroupDentry:                    72,
 		OffsetNameKernfsOpenFileFile:              24,
 		OffsetNameModuleName:                      24,
 		OffsetNameRtnlLinkOpsKind:                 16,

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -45,6 +45,8 @@ func (f *FallbackConstantFetcher) String() string {
 func computeRawsTable() map[string]uint64 {
 	return map[string]uint64{
 		OffsetInodeIno:                            64,
+		OffsetInodeMode:                           0,
+		OffsetInodeUid:                            4,
 		OffsetInodeGid:                            8,
 		OffsetInodeNlink:                          72,
 		OffsetInodeMtime:                          104,

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -82,6 +82,7 @@ func computeRawsTable() map[string]uint64 {
 		OffsetNameSockCommonStructSKCNum:          14,
 		SizeOfPipeBuffer:                          40,
 		OffsetNamePipeBufferStructFlags:           24,
+		OffsetNameModuleName:                      24,
 		OffsetNameRtnlLinkOpsKind:                 16,
 		OffsetNameMntNamespaceNs:                  8,
 		OffsetNameNsCommonInum:                    16,

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3494,6 +3494,7 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntRoot, "struct vfsmount", "mnt_root")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntSb, "struct vfsmount", "mnt_sb")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameRtnlLinkOpsKind, "struct rtnl_link_ops", "kind")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameCgroupDentry, "struct cgroup", "dentry")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameKernfsOpenFileFile, "struct kernfs_open_file", "file")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameModuleName, "struct module", "name")
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3446,6 +3446,8 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 
 	// inode
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeIno, "struct inode", "i_ino")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeMode, "struct inode", "i_mode")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeUid, "struct inode", "i_uid")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeGid, "struct inode", "i_gid")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeNlink, "struct inode", "i_nlink")
 	constantFetcher.AppendOffsetofRequestWithFallbacks(

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3310,6 +3310,8 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameLinuxBinprmArgc, "struct linux_binprm", "argc")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameLinuxBinprmEnvc, "struct linux_binprm", "envc")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVMAreaStructFlags, "struct vm_area_struct", "vm_flags")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVMAreaStructVMStart, "struct vm_area_struct", "vm_start")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVMAreaStructVMEnd, "struct vm_area_struct", "vm_end")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameFileFinode, "struct file", "f_inode")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameFileFpath, "struct file", "f_path")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameDentryDSb, "struct dentry", "d_sb")

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3309,6 +3309,8 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameLinuxBinprmP, "struct linux_binprm", "p")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameLinuxBinprmArgc, "struct linux_binprm", "argc")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameLinuxBinprmEnvc, "struct linux_binprm", "envc")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameLinuxBinprmStructFilename, "struct linux_binprm", "filename")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameLinuxBinprmStructInterp, "struct linux_binprm", "interp")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVMAreaStructFlags, "struct vm_area_struct", "vm_flags")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVMAreaStructVMStart, "struct vm_area_struct", "vm_start")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVMAreaStructVMEnd, "struct vm_area_struct", "vm_end")

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3476,6 +3476,7 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameSuperblockSType, "struct super_block", "s_type")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameDentryDInode, "struct dentry", "d_inode")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameDentryDName, "struct dentry", "d_name")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameDentryDParent, "struct dentry", "d_parent")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNamePathDentry, "struct path", "dentry")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNamePathMnt, "struct path", "mnt")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameInodeSuperblock, "struct inode", "i_sb")

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3494,6 +3494,7 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntRoot, "struct vfsmount", "mnt_root")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntSb, "struct vfsmount", "mnt_sb")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameRtnlLinkOpsKind, "struct rtnl_link_ops", "kind")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameModuleName, "struct module", "name")
 }
 
 // HandleActions handles the rule actions

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3323,6 +3323,9 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 		appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameNsCommonInum, "struct ns_common", "inum")
 	}
 
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameNsproxyMntNs, "struct nsproxy", "mnt_ns")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameNsproxyNetNs, "struct nsproxy", "net_ns")
+
 	if kv.Code >= kernel.Kernel6_8 {
 		appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMountMntIDUnique, "struct mount", "mnt_id_unique")
 	}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3494,6 +3494,7 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntRoot, "struct vfsmount", "mnt_root")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameVfsmountMntSb, "struct vfsmount", "mnt_sb")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameRtnlLinkOpsKind, "struct rtnl_link_ops", "kind")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameKernfsOpenFileFile, "struct kernfs_open_file", "file")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameModuleName, "struct module", "name")
 }
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3455,7 +3455,7 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	// inode
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeIno, "struct inode", "i_ino")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeMode, "struct inode", "i_mode")
-	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeUid, "struct inode", "i_uid")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeUID, "struct inode", "i_uid")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeGid, "struct inode", "i_gid")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetInodeNlink, "struct inode", "i_nlink")
 	constantFetcher.AppendOffsetofRequestWithFallbacks(

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3434,6 +3434,7 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 
 	if !kv.IsRH7Kernel() {
 		appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameNFConnStructCTNet, "struct nf_conn", "ct_net")
+		appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameNFConnStructTuplehash, "struct nf_conn", "tuplehash")
 	}
 
 	if getNetStructType(kv) == netStructHasProcINum {


### PR DESCRIPTION
### What does this PR do?

Replaces direct kernel struct field accesses (`&ptr->field`) in eBPF programs with `LOAD_CONSTANT` + `bpf_probe_read` using dynamically resolved offsets.

### Motivation

Direct field access relies on compile-time struct layout from the kernel headers the program was built against. When the running kernel has a different layout (different version, different `CONFIG_` options), the read silently targets the wrong memory location, causing corrupt security events. The `LOAD_CONSTANT` mechanism resolves offsets at eBPF load time via BTF, making the programs portable across kernel versions.

Affected structs: `dentry` (d_parent, d_name), `inode` (i_mode, i_uid, ctime/mtime fallback), `nsproxy` (mnt_ns, net_ns), `nf_conn` (tuplehash), `vm_area_struct` (vm_start, vm_end), `module` (name), `kernfs_open_file` (file), `cgroup` (dentry, was hardcoded offset 72), `linux_binprm` (filename, interp — debug only).

### Describe how you validated your changes

- KMT security agent tests are passing (no regressions)

### Additional Notes

UAPI structs (`sockaddr`, `sockaddr_in`, `sockaddr_in6`) and BPF context structs (`__sk_buff`) were intentionally left unchanged as they have a stable ABI.