### PR TITLE
[backport 7.78.x] Add datadogpodautoscalerclusterprofiles in the orchestrator OOTB CR

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -505,6 +505,7 @@ func newBuiltinCRDConfigs() []builtinCRDConfig {
 		newBuiltinCRDConfig(datadogAPIGroup, "datadogmonitors", isOOTBCRDEnabled, "v1alpha1"),
 		newBuiltinCRDConfig(datadogAPIGroup, "datadogmetrics", isOOTBCRDEnabled, "v1alpha1"),
 		newBuiltinCRDConfig(datadogAPIGroup, "datadogpodautoscalers", isOOTBCRDEnabled, "v1alpha2"),
+		newBuiltinCRDConfig(datadogAPIGroup, "datadogpodautoscalerclusterprofiles", isOOTBCRDEnabled, "v1alpha2"),
 		newBuiltinCRDConfig(datadogAPIGroup, "datadogagents", isOOTBCRDEnabled, "v2alpha1"),
 
 		// Argo resources

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
@@ -401,6 +401,7 @@ func TestNewBuiltinCRDConfigs(t *testing.T) {
 	expectedConfigs := []string{
 		// Datadog resources
 		"datadoghq.com/v1alpha2/datadogpodautoscalers",
+		"datadoghq.com/v1alpha2/datadogpodautoscalerclusterprofiles",
 		"datadoghq.com/v2alpha1/datadogagents",
 		"datadoghq.com/v1alpha1/datadogslos",
 		"datadoghq.com/v1alpha1/datadogdashboards",


### PR DESCRIPTION
## Backport

This is a backport of #49167 to `7.78.x`.

## What does this PR do?

Add `datadogpodautoscalerclusterprofiles` in the orchestrator OOTB CR collections config.

To get automatically collected by the orchestrator check the CR `datadogpodautoscalerclusterprofiles` needs to be registered in the `builtinCRDConfig`.

## Motivation

Make the autoscaling related resources collected OOTB to ease users onboarding. This new CRD was introduced in #48061 as part of 7.78.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)