### PR TITLE
APM: Add org prop guard support (APMSP-2807)

### DIFF
--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -98,6 +98,7 @@ type component struct {
 	*pkgagent.Agent
 
 	cancel             context.CancelFunc
+	ctx                context.Context
 	config             traceconfigdef.Component
 	secrets            secrets.Component
 	params             *Params
@@ -121,6 +122,7 @@ func NewAgent(deps dependencies) (traceagent.Component, error) {
 	ctx, cancel := context.WithCancel(deps.Context) // Several related non-components require a shared context to gracefully stop.
 	c = component{
 		cancel:             cancel,
+		ctx:                ctx,
 		config:             deps.Config,
 		secrets:            deps.Secrets,
 		params:             deps.Params,

--- a/comp/trace/agent/impl/run.go
+++ b/comp/trace/agent/impl/run.go
@@ -39,6 +39,7 @@ func runAgentSidekicks(ag component) error {
 	if err != nil {
 		return err
 	}
+	ag.Agent.Receiver.StartOPMFetch(ag.ctx, time.Second)
 
 	defer watchdog.LogOnPanic(ag.Statsd)
 

--- a/comp/trace/config/impl/setup.go
+++ b/comp/trace/config/impl/setup.go
@@ -140,6 +140,12 @@ func prepareConfig(c corecompcfg.Component, tagger tagger.Component, ipc ipc.Com
 	cfg.HTTPTransportFunc = func() *http.Transport {
 		return httputils.CreateHTTPTransport(coreConfigObject)
 	}
+	cfg.EnableOPMFetch = true
+	cfg.OPMValidateURL = utils.GetMainEndpoint(
+		pkgconfigsetup.Datadog(),
+		"https://api.",
+		"apm_config.opm_dd_url",
+	) + "/api/v2/validate"
 
 	return cfg, nil
 }

--- a/comp/trace/config/impl/setup.go
+++ b/comp/trace/config/impl/setup.go
@@ -144,7 +144,7 @@ func prepareConfig(c corecompcfg.Component, tagger tagger.Component, ipc ipc.Com
 	cfg.OPMValidateURL = utils.GetMainEndpoint(
 		pkgconfigsetup.Datadog(),
 		"https://api.",
-		"apm_config.opm_dd_url",
+		"dd_url",
 	) + "/api/v2/validate"
 
 	return cfg, nil

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -136,16 +136,13 @@ type HTTPReceiver struct {
 	// payload in makeInfoHandler and updated when orgPropMarker is set.
 	agentState atomic.String
 
-	// computeStateHashMu protects computeStateHash and computeInfoResponse.
-	computeStateHashMu sync.Mutex
+	// computeInfoAndHashMu protects computeInfoAndHash.
+	computeInfoAndHashMu sync.Mutex
 
-	// computeStateHash is set by makeInfoHandler. Given an OPM value (may be
-	// empty), it returns the SHA-256 hex hash of the full /info payload.
-	computeStateHash func(opm string) string
-
-	// computeInfoResponse is set by makeInfoHandler. Given an OPM value (may be
-	// empty), it returns the pre-serialised JSON body for GET /info.
-	computeInfoResponse func(opm string) []byte
+	// computeInfoAndHash is set by makeInfoHandler. Given an OPM value (may be
+	// empty), it returns the pre-serialised JSON body for GET /info and its
+	// SHA-256 hex hash (the Datadog-Agent-State header value).
+	computeInfoAndHash func(opm string) (body []byte, hash string)
 
 	// cachedInfoResponse holds the pre-serialised JSON body for GET /info.
 	// Value type: []byte. Initialised by makeInfoHandler and updated by

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -136,12 +136,21 @@ type HTTPReceiver struct {
 	// payload in makeInfoHandler and updated when orgPropMarker is set.
 	agentState atomic.String
 
-	// computeStateHashMu protects computeStateHash.
+	// computeStateHashMu protects computeStateHash and computeInfoResponse.
 	computeStateHashMu sync.Mutex
 
 	// computeStateHash is set by makeInfoHandler. Given an OPM value (may be
 	// empty), it returns the SHA-256 hex hash of the full /info payload.
 	computeStateHash func(opm string) string
+
+	// computeInfoResponse is set by makeInfoHandler. Given an OPM value (may be
+	// empty), it returns the pre-serialised JSON body for GET /info.
+	computeInfoResponse func(opm string) []byte
+
+	// cachedInfoResponse holds the pre-serialised JSON body for GET /info.
+	// Value type: []byte. Initialised by makeInfoHandler and updated by
+	// setOrgPropMarker so the handler never needs to marshal on the hot path.
+	cachedInfoResponse atomic.Value
 
 	statsd   statsd.ClientInterface
 	timing   timing.Reporter

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -127,6 +127,22 @@ type HTTPReceiver struct {
 	// outOfCPUCounter is counter to throttle the out of cpu warning log
 	outOfCPUCounter *atomic.Uint32
 
+	// orgPropMarker holds the Org Propagation Marker once the background fetch
+	// succeeds. An empty string means the marker is not yet available.
+	orgPropMarker atomic.String
+
+	// agentState is the Datadog-Agent-State hash served on all endpoints via
+	// the Datadog-Agent-State response header. Initialised from the static /info
+	// payload in makeInfoHandler and updated when orgPropMarker is set.
+	agentState atomic.String
+
+	// computeStateHashMu protects computeStateHash.
+	computeStateHashMu sync.Mutex
+
+	// computeStateHash is set by makeInfoHandler. Given an OPM value (may be
+	// empty), it returns the SHA-256 hex hash of the full /info payload.
+	computeStateHash func(opm string) string
+
 	statsd   statsd.ClientInterface
 	timing   timing.Reporter
 	info     *watchdog.CurrentInfo
@@ -208,7 +224,7 @@ func (r *HTTPReceiver) buildMux() *http.ServeMux {
 
 	defaultTimeout := getConfiguredRequestTimeoutDuration(r.conf)
 
-	hash, infoHandler := r.makeInfoHandler()
+	_, infoHandler := r.makeInfoHandler()
 	for _, e := range endpoints {
 		if e.IsEnabled != nil && !e.IsEnabled(r.conf) {
 			continue
@@ -217,7 +233,7 @@ func (r *HTTPReceiver) buildMux() *http.ServeMux {
 		if e.TimeoutOverride != nil {
 			timeout = e.TimeoutOverride(r.conf)
 		}
-		h := replyWithVersion(hash, r.conf.AgentVersion, timeoutMiddleware(timeout, e.Handler(r)))
+		h := replyWithVersion(r.agentState.Load, r.conf.AgentVersion, timeoutMiddleware(timeout, e.Handler(r)))
 		r.Handlers[e.Pattern] = h
 		mux.Handle(e.Pattern, h)
 	}
@@ -228,11 +244,13 @@ func (r *HTTPReceiver) buildMux() *http.ServeMux {
 }
 
 // replyWithVersion returns an http.Handler which calls h with an addition of some
-// HTTP headers containing version and state information.
-func replyWithVersion(hash string, version string, h http.Handler) http.Handler {
+// HTTP headers containing version and state information. stateGetter is called on
+// every request so that the Datadog-Agent-State header always reflects the latest
+// agent state (which may change when the Org Propagation Marker is fetched).
+func replyWithVersion(stateGetter func() string, version string, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Datadog-Agent-Version", version)
-		w.Header().Set("Datadog-Agent-State", hash)
+		w.Header().Set("Datadog-Agent-State", stateGetter())
 		h.ServeHTTP(w, r)
 	})
 }

--- a/pkg/trace/api/info.go
+++ b/pkg/trace/api/info.go
@@ -218,14 +218,15 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		return hex.EncodeToString(h[:])
 	}
 
+	// Hold the mutex across the entire assignment + read + store so that
+	// setOrgPropMarker cannot interleave. Without this, setOrgPropMarker could
+	// write the correct OPM-based agentState between our unlock and our Store,
+	// and our Store would then revert it to the stale pre-OPM hash.
 	r.computeStateHashMu.Lock()
 	r.computeStateHash = computeStateHashFn
-	r.computeStateHashMu.Unlock()
-
-	// Initialise agentState using the OPM that may have already been stored by
-	// startOPMFetch (possible when the fetch completes before buildMux runs).
-	initialHash := computeStateHashFn(r.OrgPropMarker())
+	initialHash := computeStateHashFn(r.orgPropMarker.Load())
 	r.agentState.Store(initialHash)
+	r.computeStateHashMu.Unlock()
 
 	return initialHash, func(w http.ResponseWriter, req *http.Request) {
 		opm := r.OrgPropMarker()

--- a/pkg/trace/api/info.go
+++ b/pkg/trace/api/info.go
@@ -19,6 +19,27 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 )
 
+// infoPayload is the JSON structure served by the /info endpoint.
+type infoPayload struct {
+	Version                string        `json:"version"`
+	GitCommit              string        `json:"git_commit"`
+	Endpoints              []string      `json:"endpoints"`
+	FeatureFlags           []string      `json:"feature_flags,omitempty"`
+	ClientDropP0s          bool          `json:"client_drop_p0s"`
+	SpanMetaStructs        bool          `json:"span_meta_structs"`
+	LongRunningSpans       bool          `json:"long_running_spans"`
+	SpanEvents             bool          `json:"span_events"`
+	EvpProxyAllowedHeaders []string      `json:"evp_proxy_allowed_headers"`
+	Config                 reducedConfig `json:"config"`
+	PeerTags               []string      `json:"peer_tags"`
+	SpanKindsStatsComputed []string      `json:"span_kinds_stats_computed"`
+	ObfuscationVersion     int           `json:"obfuscation_version"`
+	FilterTags             *filterTags   `json:"filter_tags,omitempty"`
+	FilterTagsRegex        *filterTags   `json:"filter_tags_regex,omitempty"`
+	IgnoreResources        []string      `json:"ignore_resources,omitempty"`
+	OrgPropMarker          string        `json:"org_prop_marker,omitempty"`
+}
+
 const (
 	containerTagsHashHeader = "Datadog-Container-Tags-Hash"
 )
@@ -71,6 +92,9 @@ type filterTags struct {
 }
 
 // makeInfoHandler returns a new handler for handling the discovery endpoint.
+// As a side effect it initialises r.computeStateHash and r.agentState so that
+// the Datadog-Agent-State header reflects the current /info payload (including
+// any already-fetched Org Propagation Marker).
 func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc) {
 	var all []string
 	for _, e := range endpoints {
@@ -149,24 +173,8 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		ignoreResources = patterns
 	}
 
-	txt, err := json.MarshalIndent(struct {
-		Version                string        `json:"version"`
-		GitCommit              string        `json:"git_commit"`
-		Endpoints              []string      `json:"endpoints"`
-		FeatureFlags           []string      `json:"feature_flags,omitempty"`
-		ClientDropP0s          bool          `json:"client_drop_p0s"`
-		SpanMetaStructs        bool          `json:"span_meta_structs"`
-		LongRunningSpans       bool          `json:"long_running_spans"`
-		SpanEvents             bool          `json:"span_events"`
-		EvpProxyAllowedHeaders []string      `json:"evp_proxy_allowed_headers"`
-		Config                 reducedConfig `json:"config"`
-		PeerTags               []string      `json:"peer_tags"`
-		SpanKindsStatsComputed []string      `json:"span_kinds_stats_computed"`
-		ObfuscationVersion     int           `json:"obfuscation_version"`
-		FilterTags             *filterTags   `json:"filter_tags,omitempty"`
-		FilterTagsRegex        *filterTags   `json:"filter_tags_regex,omitempty"`
-		IgnoreResources        []string      `json:"ignore_resources,omitempty"`
-	}{
+	// staticPayload holds every field that does not change after startup.
+	staticPayload := infoPayload{
 		Version:                r.conf.AgentVersion,
 		GitCommit:              r.conf.GitCommit,
 		Endpoints:              all,
@@ -197,18 +205,44 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 			Obfuscation:            oconf,
 		},
 		PeerTags: r.conf.ConfiguredPeerTags(),
-	}, "", "\t")
-	if err != nil {
-		panic(fmt.Errorf("Error making /info handler: %v", err))
 	}
-	h := sha256.Sum256(txt)
-	return hex.EncodeToString(h[:]), func(w http.ResponseWriter, req *http.Request) {
+
+	// computeStateHash produces the Datadog-Agent-State hash for a given OPM.
+	// Stored on the receiver so setOrgPropMarker can reuse it without re-parsing
+	// the configuration.
+	computeStateHashFn := func(opm string) string {
+		p := staticPayload
+		p.OrgPropMarker = opm
+		b, _ := json.Marshal(p)
+		h := sha256.Sum256(b)
+		return hex.EncodeToString(h[:])
+	}
+
+	r.computeStateHashMu.Lock()
+	r.computeStateHash = computeStateHashFn
+	r.computeStateHashMu.Unlock()
+
+	// Initialise agentState using the OPM that may have already been stored by
+	// startOPMFetch (possible when the fetch completes before buildMux runs).
+	initialHash := computeStateHashFn(r.OrgPropMarker())
+	r.agentState.Store(initialHash)
+
+	return initialHash, func(w http.ResponseWriter, req *http.Request) {
+		opm := r.OrgPropMarker()
+		payload := staticPayload
+		payload.OrgPropMarker = opm
+
 		containerID := r.containerIDProvider.GetContainerID(req.Context(), req.Header)
 		if containerTags, err := r.conf.ContainerTags(containerID); err == nil {
-			hash := computeContainerTagsHash(containerTags)
-			w.Header().Add(containerTagsHashHeader, hash)
+			w.Header().Add(containerTagsHashHeader, computeContainerTagsHash(containerTags))
 		}
-		fmt.Fprintf(w, "%s", txt)
+
+		txt, err := json.MarshalIndent(payload, "", "\t")
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Write(txt) //nolint:errcheck
 	}
 }
 

--- a/pkg/trace/api/info.go
+++ b/pkg/trace/api/info.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
@@ -207,7 +208,7 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		PeerTags: r.conf.ConfiguredPeerTags(),
 	}
 
-	// computeStateHash produces the Datadog-Agent-State hash for a given OPM.
+	// computeStateHashFn produces the Datadog-Agent-State hash for a given OPM.
 	// Stored on the receiver so setOrgPropMarker can reuse it without re-parsing
 	// the configuration.
 	computeStateHashFn := func(opm string) string {
@@ -218,32 +219,38 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		return hex.EncodeToString(h[:])
 	}
 
+	// computeInfoResponseFn produces the full pre-serialised JSON body for a
+	// given OPM. Stored on the receiver so setOrgPropMarker can refresh the
+	// cache without re-parsing the configuration.
+	computeInfoResponseFn := func(opm string) []byte {
+		p := staticPayload
+		p.OrgPropMarker = opm
+		b, _ := json.MarshalIndent(p, "", "\t")
+		return b
+	}
+
 	// Hold the mutex across the entire assignment + read + store so that
 	// setOrgPropMarker cannot interleave. Without this, setOrgPropMarker could
 	// write the correct OPM-based agentState between our unlock and our Store,
 	// and our Store would then revert it to the stale pre-OPM hash.
 	r.computeStateHashMu.Lock()
 	r.computeStateHash = computeStateHashFn
-	initialHash := computeStateHashFn(r.orgPropMarker.Load())
+	r.computeInfoResponse = computeInfoResponseFn
+	opm := r.orgPropMarker.Load()
+	initialHash := computeStateHashFn(opm)
 	r.agentState.Store(initialHash)
+	r.cachedInfoResponse.Store(computeInfoResponseFn(opm))
 	r.computeStateHashMu.Unlock()
 
 	return initialHash, func(w http.ResponseWriter, req *http.Request) {
-		opm := r.OrgPropMarker()
-		payload := staticPayload
-		payload.OrgPropMarker = opm
-
 		containerID := r.containerIDProvider.GetContainerID(req.Context(), req.Header)
 		if containerTags, err := r.conf.ContainerTags(containerID); err == nil {
 			w.Header().Add(containerTagsHashHeader, computeContainerTagsHash(containerTags))
 		}
 
-		txt, err := json.MarshalIndent(payload, "", "\t")
-		if err != nil {
-			http.Error(w, "internal error", http.StatusInternalServerError)
-			return
-		}
-		w.Write(txt) //nolint:errcheck
+		body := r.cachedInfoResponse.Load().([]byte)
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.Write(body) //nolint:errcheck
 	}
 }
 

--- a/pkg/trace/api/info.go
+++ b/pkg/trace/api/info.go
@@ -93,7 +93,7 @@ type filterTags struct {
 }
 
 // makeInfoHandler returns a new handler for handling the discovery endpoint.
-// As a side effect it initialises r.computeStateHash and r.agentState so that
+// As a side effect it initialises r.computeInfoAndHash and r.agentState so that
 // the Datadog-Agent-State header reflects the current /info payload (including
 // any already-fetched Org Propagation Marker).
 func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc) {
@@ -208,39 +208,28 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		PeerTags: r.conf.ConfiguredPeerTags(),
 	}
 
-	// computeStateHashFn produces the Datadog-Agent-State hash for a given OPM.
-	// Stored on the receiver so setOrgPropMarker can reuse it without re-parsing
-	// the configuration.
-	computeStateHashFn := func(opm string) string {
+	// computeInfoAndHashFn serialises the payload for a given OPM and returns
+	// both the response body and its SHA-256 hash (the Datadog-Agent-State
+	// header value), so the two are always derived from identical bytes.
+	computeInfoAndHashFn := func(opm string) ([]byte, string) {
 		p := staticPayload
 		p.OrgPropMarker = opm
-		b, _ := json.Marshal(p)
-		h := sha256.Sum256(b)
-		return hex.EncodeToString(h[:])
-	}
-
-	// computeInfoResponseFn produces the full pre-serialised JSON body for a
-	// given OPM. Stored on the receiver so setOrgPropMarker can refresh the
-	// cache without re-parsing the configuration.
-	computeInfoResponseFn := func(opm string) []byte {
-		p := staticPayload
-		p.OrgPropMarker = opm
-		b, _ := json.MarshalIndent(p, "", "\t")
-		return b
+		body, _ := json.MarshalIndent(p, "", "\t")
+		h := sha256.Sum256(body)
+		return body, hex.EncodeToString(h[:])
 	}
 
 	// Hold the mutex across the entire assignment + read + store so that
 	// setOrgPropMarker cannot interleave. Without this, setOrgPropMarker could
 	// write the correct OPM-based agentState between our unlock and our Store,
 	// and our Store would then revert it to the stale pre-OPM hash.
-	r.computeStateHashMu.Lock()
-	r.computeStateHash = computeStateHashFn
-	r.computeInfoResponse = computeInfoResponseFn
+	r.computeInfoAndHashMu.Lock()
+	r.computeInfoAndHash = computeInfoAndHashFn
 	opm := r.orgPropMarker.Load()
-	initialHash := computeStateHashFn(opm)
+	initialBody, initialHash := computeInfoAndHashFn(opm)
+	r.cachedInfoResponse.Store(initialBody)
 	r.agentState.Store(initialHash)
-	r.cachedInfoResponse.Store(computeInfoResponseFn(opm))
-	r.computeStateHashMu.Unlock()
+	r.computeInfoAndHashMu.Unlock()
 
 	return initialHash, func(w http.ResponseWriter, req *http.Request) {
 		containerID := r.containerIDProvider.GetContainerID(req.Context(), req.Header)

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -10,10 +10,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -372,6 +374,97 @@ func TestInfoHandler(t *testing.T) {
 	assert.NoError(t, ensureKeys(expectedKeys, m, ""))
 	expectedContainerHash := fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join([]string{"kube_cluster_name:clusterA", "kube_namespace:namespace1"}, ","))))
 	assert.Equal(t, expectedContainerHash, rec.Header().Get(containerTagsHashHeader))
+}
+
+func TestInfoHandler_OPMAbsent(t *testing.T) {
+	conf := config.New()
+	conf.Endpoints = []*config.Endpoint{{Host: "http://localhost:8126", APIKey: "test"}}
+	rcv := newTestReceiverFromConfig(conf)
+
+	_, h := rcv.makeInfoHandler()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/info", nil)
+	h.ServeHTTP(rec, req)
+
+	var m map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&m))
+	_, hasOPM := m["org_prop_marker"]
+	assert.False(t, hasOPM, "org_prop_marker must be absent from /info when OPM is not set")
+}
+
+func TestInfoHandler_OPMPresent(t *testing.T) {
+	conf := config.New()
+	conf.Endpoints = []*config.Endpoint{{Host: "http://localhost:8126", APIKey: "test"}}
+	rcv := newTestReceiverFromConfig(conf)
+
+	_, h := rcv.makeInfoHandler()
+	rcv.setOrgPropMarker("testOPM123")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/info", nil)
+	h.ServeHTTP(rec, req)
+
+	var m map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&m))
+	opm, ok := m["org_prop_marker"]
+	assert.True(t, ok, "org_prop_marker should be present in /info when OPM is set")
+	assert.Equal(t, "testOPM123", opm)
+}
+
+func TestInfoHandler_AgentStateHashChanges(t *testing.T) {
+	conf := config.New()
+	conf.Endpoints = []*config.Endpoint{{Host: "http://localhost:8126", APIKey: "test"}}
+	rcv := newTestReceiverFromConfig(conf)
+
+	_, _ = rcv.makeInfoHandler()
+	hashBefore := rcv.agentState.Load()
+
+	rcv.setOrgPropMarker("newOPMValue")
+	hashAfter := rcv.agentState.Load()
+
+	assert.NotEmpty(t, hashBefore)
+	assert.NotEmpty(t, hashAfter)
+	assert.NotEqual(t, hashBefore, hashAfter, "Datadog-Agent-State hash must change when OPM is set")
+
+	// Verify the post-OPM hash matches what computeStateHash produces
+	rcv.computeStateHashMu.Lock()
+	fn := rcv.computeStateHash
+	rcv.computeStateHashMu.Unlock()
+	require.NotNil(t, fn)
+	assert.Equal(t, fn("newOPMValue"), hashAfter)
+}
+
+func TestInfoHandler_OPMConcurrent(t *testing.T) {
+	conf := config.New()
+	conf.Endpoints = []*config.Endpoint{{Host: "http://localhost:8126", APIKey: "test"}}
+	rcv := newTestReceiverFromConfig(conf)
+
+	_, h := rcv.makeInfoHandler()
+
+	done := make(chan struct{})
+	// Writer goroutine: repeatedly update the OPM
+	go func() {
+		defer close(done)
+		for i := 0; i < 100; i++ {
+			rcv.setOrgPropMarker("opm-concurrent")
+			time.Sleep(time.Microsecond)
+		}
+	}()
+
+	// 50 reader goroutines hit /info concurrently
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/info", nil)
+			h.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusOK, rec.Code)
+		}()
+	}
+	wg.Wait()
+	<-done
 }
 
 func TestInfoHandlerFilterTags(t *testing.T) {

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -537,4 +538,47 @@ func TestInfoHandlerFilterTags(t *testing.T) {
 	assert.Len(t, ignoreResources, 2)
 	assert.Contains(t, ignoreResources, "(GET|POST) /healthcheck")
 	assert.Contains(t, ignoreResources, "GET /ping")
+}
+
+// TestInfoHandler_CachedResponseBytes verifies that the pre-serialised response
+// cache is populated by makeInfoHandler and updated by setOrgPropMarker, and
+// that the /info handler serves exactly those bytes.
+func TestInfoHandler_CachedResponseBytes(t *testing.T) {
+	conf := config.New()
+	conf.Endpoints = []*config.Endpoint{{Host: "http://localhost:8126", APIKey: "test"}}
+	rcv := newTestReceiverFromConfig(conf)
+
+	_, h := rcv.makeInfoHandler()
+
+	// After makeInfoHandler, the cache should be populated with valid JSON.
+	initialBytes, ok := rcv.cachedInfoResponse.Load().([]byte)
+	require.True(t, ok, "cachedInfoResponse should be []byte after makeInfoHandler")
+	require.NotEmpty(t, initialBytes)
+
+	var initialPayload map[string]any
+	require.NoError(t, json.Unmarshal(initialBytes, &initialPayload))
+	_, hasOPM := initialPayload["org_prop_marker"]
+	assert.False(t, hasOPM, "org_prop_marker should be absent from cached bytes before OPM is set")
+
+	// After setOrgPropMarker, the cache should be refreshed with the OPM included.
+	rcv.setOrgPropMarker("cached-opm-value")
+
+	updatedBytes, ok := rcv.cachedInfoResponse.Load().([]byte)
+	require.True(t, ok, "cachedInfoResponse should still be []byte after setOrgPropMarker")
+	require.NotEmpty(t, updatedBytes)
+	assert.NotEqual(t, initialBytes, updatedBytes, "cached bytes should change when OPM is set")
+
+	var updatedPayload map[string]any
+	require.NoError(t, json.Unmarshal(updatedBytes, &updatedPayload))
+	opm, hasOPM := updatedPayload["org_prop_marker"]
+	assert.True(t, hasOPM, "org_prop_marker should be present in cached bytes after OPM is set")
+	assert.Equal(t, "cached-opm-value", opm)
+
+	// The handler should serve the same bytes as what is in the cache.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/info", nil)
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, string(updatedBytes), rec.Body.String(), "handler response body must match cached bytes")
+	assert.Equal(t, strconv.Itoa(len(updatedBytes)), rec.Header().Get("Content-Length"))
 }

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -427,12 +427,13 @@ func TestInfoHandler_AgentStateHashChanges(t *testing.T) {
 	assert.NotEmpty(t, hashAfter)
 	assert.NotEqual(t, hashBefore, hashAfter, "Datadog-Agent-State hash must change when OPM is set")
 
-	// Verify the post-OPM hash matches what computeStateHash produces
-	rcv.computeStateHashMu.Lock()
-	fn := rcv.computeStateHash
-	rcv.computeStateHashMu.Unlock()
+	// Verify the post-OPM hash is consistent with the combined compute function.
+	rcv.computeInfoAndHashMu.Lock()
+	fn := rcv.computeInfoAndHash
+	rcv.computeInfoAndHashMu.Unlock()
 	require.NotNil(t, fn)
-	assert.Equal(t, fn("newOPMValue"), hashAfter)
+	_, expectedHash := fn("newOPMValue")
+	assert.Equal(t, expectedHash, hashAfter)
 }
 
 func TestInfoHandler_OPMConcurrent(t *testing.T) {
@@ -560,6 +561,11 @@ func TestInfoHandler_CachedResponseBytes(t *testing.T) {
 	_, hasOPM := initialPayload["org_prop_marker"]
 	assert.False(t, hasOPM, "org_prop_marker should be absent from cached bytes before OPM is set")
 
+	// Datadog-Agent-State must equal SHA-256 of the response body.
+	initialHash := rcv.agentState.Load()
+	assert.Equal(t, fmt.Sprintf("%x", sha256.Sum256(initialBytes)), initialHash,
+		"agentState must be SHA-256 of the cached response body")
+
 	// After setOrgPropMarker, the cache should be refreshed with the OPM included.
 	rcv.setOrgPropMarker("cached-opm-value")
 
@@ -573,6 +579,11 @@ func TestInfoHandler_CachedResponseBytes(t *testing.T) {
 	opm, hasOPM := updatedPayload["org_prop_marker"]
 	assert.True(t, hasOPM, "org_prop_marker should be present in cached bytes after OPM is set")
 	assert.Equal(t, "cached-opm-value", opm)
+
+	// After OPM update, agentState must still equal SHA-256 of the (now-updated) body.
+	updatedHash := rcv.agentState.Load()
+	assert.Equal(t, fmt.Sprintf("%x", sha256.Sum256(updatedBytes)), updatedHash,
+		"agentState must be SHA-256 of the updated response body after OPM is set")
 
 	// The handler should serve the same bytes as what is in the cache.
 	rec := httptest.NewRecorder()

--- a/pkg/trace/api/opm.go
+++ b/pkg/trace/api/opm.go
@@ -80,9 +80,11 @@ func fetchOPM(ctx context.Context, client *config.ResetClient, cfg *config.Agent
 func (r *HTTPReceiver) setOrgPropMarker(opm string) {
 	r.orgPropMarker.Store(opm)
 	r.computeStateHashMu.Lock()
-	fn := r.computeStateHash
-	if fn != nil {
+	if fn := r.computeStateHash; fn != nil {
 		r.agentState.Store(fn(opm))
+	}
+	if fn := r.computeInfoResponse; fn != nil {
+		r.cachedInfoResponse.Store(fn(opm))
 	}
 	r.computeStateHashMu.Unlock()
 }

--- a/pkg/trace/api/opm.go
+++ b/pkg/trace/api/opm.go
@@ -1,0 +1,130 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
+)
+
+// validateResponse is the subset of the /api/v2/validate response we care about.
+type validateResponse struct {
+	Data struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+// computeOPM derives the Org Propagation Marker from an org UUID string.
+//
+// OPM = base64url( Trunc60( SHA-256(orgUUID) ) )
+//
+// SHA-256 produces a 32-byte digest. Trunc60 keeps the first 60 bits:
+// the first 7 bytes plus the high nibble of byte 7 (mask byte 7 with 0xF0).
+func computeOPM(orgUUID string) string {
+	digest := sha256.Sum256([]byte(orgUUID))
+	trunc := make([]byte, 8)
+	copy(trunc, digest[:8])
+	trunc[7] &= 0xF0
+	return base64.RawURLEncoding.EncodeToString(trunc)
+}
+
+// fetchOPM performs a single GET to cfg.OPMValidateURL, decodes the org UUID,
+// and returns the computed OPM. The request uses cfg.APIKey() for authentication
+// and is made through the configured HTTP client (proxy-aware).
+func fetchOPM(ctx context.Context, client *config.ResetClient, cfg *config.AgentConfig) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.OPMValidateURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("DD-API-KEY", cfg.APIKey())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var vr validateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&vr); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+	if vr.Data.ID == "" {
+		return "", errors.New("empty org UUID in validate response")
+	}
+	return computeOPM(vr.Data.ID), nil
+}
+
+// setOrgPropMarker stores opm atomically and updates the agentState hash.
+// If computeStateHash has not yet been set by makeInfoHandler (possible when
+// the OPM arrives very early), the agentState update is deferred — makeInfoHandler
+// reads orgPropMarker before computing its initial hash, so the state is still correct.
+func (r *HTTPReceiver) setOrgPropMarker(opm string) {
+	r.orgPropMarker.Store(opm)
+	r.computeStateHashMu.Lock()
+	fn := r.computeStateHash
+	r.computeStateHashMu.Unlock()
+	if fn != nil {
+		r.agentState.Store(fn(opm))
+	}
+}
+
+// OrgPropMarker returns the current Org Propagation Marker, or the empty string
+// if it has not yet been fetched.
+func (r *HTTPReceiver) OrgPropMarker() string {
+	return r.orgPropMarker.Load()
+}
+
+// StartOPMFetch begins a background goroutine that fetches /api/v2/validate,
+// computes the OPM, and stores it on the receiver. It retries up to maxRetries
+// times with simple exponential backoff. retryBaseDelay controls the first
+// inter-attempt pause (doubled each retry); pass time.Second in production and
+// time.Millisecond in tests.
+//
+// The goroutine exits immediately if cfg.EnableOPMFetch is false, or when ctx
+// is cancelled (e.g. on agent shutdown).
+func (r *HTTPReceiver) StartOPMFetch(ctx context.Context, retryBaseDelay time.Duration) {
+	if !r.conf.EnableOPMFetch {
+		return
+	}
+	go func() {
+		const maxRetries = 3
+		client := r.conf.NewHTTPClient()
+
+		for attempt := 0; attempt <= maxRetries; attempt++ {
+			if attempt > 0 {
+				delay := retryBaseDelay * (1 << (attempt - 1)) // base, 2×, 4×
+				select {
+				case <-time.After(delay):
+				case <-ctx.Done():
+					return
+				}
+			}
+
+			opm, err := fetchOPM(ctx, client, r.conf)
+			if err != nil {
+				log.Warnf("OPM fetch attempt %d/%d failed: %v", attempt+1, maxRetries+1, err)
+				continue
+			}
+			r.setOrgPropMarker(opm)
+			log.Debugf("Org Propagation Marker set: %s", opm)
+			return
+		}
+		log.Warnf("OPM fetch failed after %d attempts, org_prop_marker will not be set", maxRetries+1)
+	}()
+}

--- a/pkg/trace/api/opm.go
+++ b/pkg/trace/api/opm.go
@@ -71,17 +71,20 @@ func fetchOPM(ctx context.Context, client *config.ResetClient, cfg *config.Agent
 }
 
 // setOrgPropMarker stores opm atomically and updates the agentState hash.
-// If computeStateHash has not yet been set by makeInfoHandler (possible when
-// the OPM arrives very early), the agentState update is deferred — makeInfoHandler
-// reads orgPropMarker before computing its initial hash, so the state is still correct.
+// The orgPropMarker write is outside the mutex (it is an atomic.String so
+// always safe), but the agentState write is held under computeStateHashMu so
+// that it cannot interleave with makeInfoHandler's own agentState initialisation.
+// If computeStateHash has not yet been set by makeInfoHandler, the agentState
+// update is skipped — makeInfoHandler reads orgPropMarker under the same mutex,
+// so it will pick up the already-stored value and initialise agentState correctly.
 func (r *HTTPReceiver) setOrgPropMarker(opm string) {
 	r.orgPropMarker.Store(opm)
 	r.computeStateHashMu.Lock()
 	fn := r.computeStateHash
-	r.computeStateHashMu.Unlock()
 	if fn != nil {
 		r.agentState.Store(fn(opm))
 	}
+	r.computeStateHashMu.Unlock()
 }
 
 // OrgPropMarker returns the current Org Propagation Marker, or the empty string

--- a/pkg/trace/api/opm.go
+++ b/pkg/trace/api/opm.go
@@ -70,23 +70,23 @@ func fetchOPM(ctx context.Context, client *config.ResetClient, cfg *config.Agent
 	return computeOPM(vr.Data.ID), nil
 }
 
-// setOrgPropMarker stores opm atomically and updates the agentState hash.
-// The orgPropMarker write is outside the mutex (it is an atomic.String so
-// always safe), but the agentState write is held under computeStateHashMu so
-// that it cannot interleave with makeInfoHandler's own agentState initialisation.
-// If computeStateHash has not yet been set by makeInfoHandler, the agentState
-// update is skipped — makeInfoHandler reads orgPropMarker under the same mutex,
-// so it will pick up the already-stored value and initialise agentState correctly.
+// setOrgPropMarker stores opm atomically and updates the agentState hash and
+// cached response body. The orgPropMarker write is outside the mutex (it is an
+// atomic.String so always safe), but the body/hash writes are held under
+// computeInfoAndHashMu so they cannot interleave with makeInfoHandler's own
+// initialisation. If computeInfoAndHash has not yet been set by makeInfoHandler,
+// the update is skipped — makeInfoHandler reads orgPropMarker under the same
+// mutex, so it will pick up the already-stored value and initialise both fields
+// correctly.
 func (r *HTTPReceiver) setOrgPropMarker(opm string) {
 	r.orgPropMarker.Store(opm)
-	r.computeStateHashMu.Lock()
-	if fn := r.computeStateHash; fn != nil {
-		r.agentState.Store(fn(opm))
+	r.computeInfoAndHashMu.Lock()
+	if fn := r.computeInfoAndHash; fn != nil {
+		body, hash := fn(opm)
+		r.cachedInfoResponse.Store(body)
+		r.agentState.Store(hash)
 	}
-	if fn := r.computeInfoResponse; fn != nil {
-		r.cachedInfoResponse.Store(fn(opm))
-	}
-	r.computeStateHashMu.Unlock()
+	r.computeInfoAndHashMu.Unlock()
 }
 
 // OrgPropMarker returns the current Org Propagation Marker, or the empty string

--- a/pkg/trace/api/opm_test.go
+++ b/pkg/trace/api/opm_test.go
@@ -231,8 +231,7 @@ func TestSetOrgPropMarker_UpdatesAgentState(t *testing.T) {
 }
 
 func TestSetOrgPropMarker_BeforeMakeInfoHandler(t *testing.T) {
-	// Simulate OPM arriving before makeInfoHandler initialises computeStateHash
-	// and computeInfoResponse.
+	// Simulate OPM arriving before makeInfoHandler initialises computeInfoAndHash.
 	rcv := newTestReceiverFromConfig(newTestReceiverConfig())
 
 	// setOrgPropMarker should not panic even when the compute functions are nil.

--- a/pkg/trace/api/opm_test.go
+++ b/pkg/trace/api/opm_test.go
@@ -207,28 +207,53 @@ func TestSetOrgPropMarker_UpdatesAgentState(t *testing.T) {
 	_, _ = rcv.makeInfoHandler()
 
 	before := rcv.agentState.Load()
+	beforeBytes, ok := rcv.cachedInfoResponse.Load().([]byte)
+	require.True(t, ok)
+
 	rcv.setOrgPropMarker("test-opm")
+
 	after := rcv.agentState.Load()
+	afterBytes, ok := rcv.cachedInfoResponse.Load().([]byte)
+	require.True(t, ok)
 
 	assert.NotEmpty(t, before)
 	assert.NotEmpty(t, after)
 	assert.NotEqual(t, before, after, "agentState should change when OPM is set")
 	assert.Equal(t, "test-opm", rcv.OrgPropMarker())
+
+	assert.NotEmpty(t, beforeBytes)
+	assert.NotEmpty(t, afterBytes)
+	assert.NotEqual(t, beforeBytes, afterBytes, "cachedInfoResponse should change when OPM is set")
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(afterBytes, &payload))
+	assert.Equal(t, "test-opm", payload["org_prop_marker"])
 }
 
 func TestSetOrgPropMarker_BeforeMakeInfoHandler(t *testing.T) {
-	// Simulate OPM arriving before makeInfoHandler initialises computeStateHash.
+	// Simulate OPM arriving before makeInfoHandler initialises computeStateHash
+	// and computeInfoResponse.
 	rcv := newTestReceiverFromConfig(newTestReceiverConfig())
 
-	// setOrgPropMarker should not panic even when computeStateHash is nil.
+	// setOrgPropMarker should not panic even when the compute functions are nil.
 	rcv.setOrgPropMarker("early-opm")
 	assert.Equal(t, "early-opm", rcv.OrgPropMarker())
+	// cachedInfoResponse must not be set yet — makeInfoHandler has not run.
+	assert.Nil(t, rcv.cachedInfoResponse.Load())
 
 	// makeInfoHandler should pick up the already-stored OPM.
 	hash, h := rcv.makeInfoHandler()
 	assert.NotEmpty(t, hash)
 	_ = h
+
 	// agentState should reflect the early OPM.
-	expectedHash := rcv.agentState.Load()
-	assert.NotEmpty(t, expectedHash)
+	assert.NotEmpty(t, rcv.agentState.Load())
+
+	// cachedInfoResponse should now be populated and include the early OPM.
+	cachedBytes, ok := rcv.cachedInfoResponse.Load().([]byte)
+	require.True(t, ok)
+	require.NotEmpty(t, cachedBytes)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(cachedBytes, &payload))
+	assert.Equal(t, "early-opm", payload["org_prop_marker"])
 }

--- a/pkg/trace/api/opm_test.go
+++ b/pkg/trace/api/opm_test.go
@@ -1,0 +1,234 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeOPM(t *testing.T) {
+	// Golden-value: known UUID → known OPM via SHA-256 → Trunc60 → base64url
+	opm := computeOPM("abc12312-000e-11ea-a34b-3f3c8bba65b8")
+	require.NotEmpty(t, opm)
+
+	// The OPM must be a valid base64url string without padding.
+	// 8 bytes (with top 60 bits meaningful) encoded as base64url = 11 chars (ceil(8*4/3) = 11).
+	assert.Regexp(t, `^[A-Za-z0-9_-]{11}$`, opm, "OPM must be an 11-char base64url string (8 bytes, 60 bits significant)")
+}
+
+// newTestReceiverWithOPM creates a minimal HTTPReceiver with EnableOPMFetch configured.
+func newTestReceiverWithOPM(url string) *HTTPReceiver {
+	conf := newTestReceiverConfig()
+	conf.EnableOPMFetch = true
+	conf.OPMValidateURL = url
+	return newTestReceiverFromConfig(conf)
+}
+
+func validateServerResponse(t *testing.T, orgID string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id": orgID,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}))
+}
+
+func TestFetchOPM_Success(t *testing.T) {
+	orgUUID := "abc12312-000e-11ea-a34b-3f3c8bba65b8"
+	srv := validateServerResponse(t, orgUUID)
+	defer srv.Close()
+
+	rcv := newTestReceiverWithOPM(srv.URL)
+	// initialise agentState so setOrgPropMarker can update it
+	_, _ = rcv.makeInfoHandler()
+
+	opm, err := fetchOPM(context.Background(), rcv.conf.NewHTTPClient(), rcv.conf)
+	require.NoError(t, err)
+	assert.Equal(t, computeOPM(orgUUID), opm)
+}
+
+func TestFetchOPM_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	rcv := newTestReceiverWithOPM(srv.URL)
+	_, err := fetchOPM(context.Background(), rcv.conf.NewHTTPClient(), rcv.conf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestFetchOPM_EmptyID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id": "",
+			},
+		}
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	rcv := newTestReceiverWithOPM(srv.URL)
+	_, err := fetchOPM(context.Background(), rcv.conf.NewHTTPClient(), rcv.conf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty org UUID")
+}
+
+func TestFetchOPM_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`not valid json`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	rcv := newTestReceiverWithOPM(srv.URL)
+	_, err := fetchOPM(context.Background(), rcv.conf.NewHTTPClient(), rcv.conf)
+	require.Error(t, err)
+}
+
+func TestStartOPMFetch_Disabled(t *testing.T) {
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	conf := newTestReceiverConfig()
+	conf.EnableOPMFetch = false
+	conf.OPMValidateURL = srv.URL
+	rcv := newTestReceiverFromConfig(conf)
+
+	rcv.StartOPMFetch(context.Background(), time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, int32(0), requestCount.Load(), "no request should be made when OPM fetch is disabled")
+	assert.Empty(t, rcv.OrgPropMarker())
+}
+
+func TestStartOPMFetch_RetrySuccess(t *testing.T) {
+	var requestCount atomic.Int32
+	orgUUID := "bd4276fd-000e-11ea-a34b-3f3c8bba65b8"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := requestCount.Add(1)
+		if n < 3 {
+			// fail the first two attempts
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		resp := map[string]interface{}{"data": map[string]interface{}{"id": orgUUID}}
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	rcv := newTestReceiverWithOPM(srv.URL)
+	_, _ = rcv.makeInfoHandler()
+
+	rcv.StartOPMFetch(context.Background(), time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return rcv.OrgPropMarker() != ""
+	}, 500*time.Millisecond, 5*time.Millisecond, "OPM should be set after retries")
+
+	assert.Equal(t, computeOPM(orgUUID), rcv.OrgPropMarker())
+	assert.Equal(t, int32(3), requestCount.Load(), "should have made exactly 3 requests")
+}
+
+func TestStartOPMFetch_AllRetriesExhausted(t *testing.T) {
+	var requestCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	rcv := newTestReceiverWithOPM(srv.URL)
+	_, _ = rcv.makeInfoHandler()
+
+	rcv.StartOPMFetch(context.Background(), time.Millisecond)
+
+	// Wait long enough for all 4 attempts (initial + 3 retries) plus delays
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Empty(t, rcv.OrgPropMarker(), "OPM should remain empty after all retries exhausted")
+	assert.Equal(t, int32(4), requestCount.Load(), "should have made exactly 4 attempts (initial + 3 retries)")
+}
+
+func TestStartOPMFetch_ContextCancellation(t *testing.T) {
+	var requestCount atomic.Int32
+
+	// First request fails, then we cancel. Subsequent retries should be aborted.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	rcv := newTestReceiverWithOPM(srv.URL)
+	_, _ = rcv.makeInfoHandler()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Use a large base delay so cancellation happens before any retry
+	rcv.StartOPMFetch(ctx, 10*time.Second)
+
+	// Wait for the first attempt to complete, then cancel
+	require.Eventually(t, func() bool {
+		return requestCount.Load() >= 1
+	}, 100*time.Millisecond, 1*time.Millisecond)
+	cancel()
+
+	// Give the goroutine time to see the cancellation
+	time.Sleep(20 * time.Millisecond)
+
+	assert.Empty(t, rcv.OrgPropMarker(), "OPM should not be set when context is cancelled")
+	assert.Equal(t, int32(1), requestCount.Load(), "only one request should have been made before cancellation")
+}
+
+func TestSetOrgPropMarker_UpdatesAgentState(t *testing.T) {
+	rcv := newTestReceiverFromConfig(newTestReceiverConfig())
+	_, _ = rcv.makeInfoHandler()
+
+	before := rcv.agentState.Load()
+	rcv.setOrgPropMarker("test-opm")
+	after := rcv.agentState.Load()
+
+	assert.NotEmpty(t, before)
+	assert.NotEmpty(t, after)
+	assert.NotEqual(t, before, after, "agentState should change when OPM is set")
+	assert.Equal(t, "test-opm", rcv.OrgPropMarker())
+}
+
+func TestSetOrgPropMarker_BeforeMakeInfoHandler(t *testing.T) {
+	// Simulate OPM arriving before makeInfoHandler initialises computeStateHash.
+	rcv := newTestReceiverFromConfig(newTestReceiverConfig())
+
+	// setOrgPropMarker should not panic even when computeStateHash is nil.
+	rcv.setOrgPropMarker("early-opm")
+	assert.Equal(t, "early-opm", rcv.OrgPropMarker())
+
+	// makeInfoHandler should pick up the already-stored OPM.
+	hash, h := rcv.makeInfoHandler()
+	assert.NotEmpty(t, hash)
+	_ = h
+	// agentState should reflect the early OPM.
+	expectedHash := rcv.agentState.Load()
+	assert.NotEmpty(t, expectedHash)
+}

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -578,9 +578,7 @@ type AgentConfig struct {
 	EnableOPMFetch bool
 
 	// OPMValidateURL is the full URL of the /api/v2/validate endpoint used by
-	// the OPM background fetch. Set by the binary's prepareConfig using
-	// utils.GetMainEndpoint so that IDNA normalisation, site-FQDN conversion,
-	// and any apm_config.opm_dd_url override are all applied correctly.
+	// the OPM background fetch. Derived from dd_url / site via utils.GetMainEndpoint.
 	// Empty when EnableOPMFetch is false.
 	OPMValidateURL string
 

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -571,6 +571,19 @@ type AgentConfig struct {
 	// When true, the tag "_dd.otel.gateway" will be attached to the AgentPayload.
 	OTelGateway bool
 
+	// EnableOPMFetch controls whether the trace-agent will make a background
+	// request to the /api/v2/validate intake endpoint to derive an Org
+	// Propagation Marker (OPM) and expose it in the /info endpoint.
+	// Disabled by default so library users of pkg/trace are unaffected.
+	EnableOPMFetch bool
+
+	// OPMValidateURL is the full URL of the /api/v2/validate endpoint used by
+	// the OPM background fetch. Set by the binary's prepareConfig using
+	// utils.GetMainEndpoint so that IDNA normalisation, site-FQDN conversion,
+	// and any apm_config.opm_dd_url override are all applied correctly.
+	// Empty when EnableOPMFetch is false.
+	OPMValidateURL string
+
 	// SecretsRefreshFn is called when a 403 response is received to trigger
 	// API key refresh from the secrets backend. It blocks until the refresh
 	// completes and returns a message and any error encountered.

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -169,3 +169,9 @@ func TestDefaultAPMMode(t *testing.T) {
 		assert.Empty(t, cfg.APMMode)
 	})
 }
+
+func TestEnableOPMFetchDefault(t *testing.T) {
+	cfg := New()
+	assert.False(t, cfg.EnableOPMFetch, "EnableOPMFetch must default to false so library users of pkg/trace are unaffected")
+	assert.Empty(t, cfg.OPMValidateURL, "OPMValidateURL must default to empty when EnableOPMFetch is false")
+}

--- a/releasenotes/notes/apm-org-propagation-marker-5ac971b43f9d9007.yaml
+++ b/releasenotes/notes/apm-org-propagation-marker-5ac971b43f9d9007.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    APM: Fetch Org Propagation Marker on startup to Org Propagation Guard. The
+    trace-agent now fetches ``/api/v2/validate`` at startup to derive an Org
+    Propagation Marker (OPM) and exposes it in the ``/info`` endpoint.


### PR DESCRIPTION
### What does this PR do?
Add the `org_prop_marker` field to the trace-agent's /info endpoint. The tracers will make use of this value to optionally perform Org Propagation Guarding (protecting sampling decisions from being inherited from x-org). This also moves the /info endpoint to no longer be a static response as the fields can dynamically change, while also updating the agent state header which can be used to detect change.

### Motivation
See https://docs.google.com/document/d/1SzZWivVWT79lJe80ZulEra6AARszjEYVEwWJ7IhJ6Xo/edit?pli=1&tab=t.0

### Describe how you validated your changes
Unit and integration tests, I also ran this build locally and verified the /info endpoint returned the data as expected

### Additional Notes
Much of this PR itself was written with Claude, I can provide the plan file I used if that would be helpful for review. However I ensured that all the code (and the plan) was reviewed by my eyes as well.
