### PR TITLE
Notarize `.pkg` before `.dmg` and staple both

### DIFF
--- a/.gitlab/build/package_build/build_agent_dmg.sh
+++ b/.gitlab/build/package_build/build_agent_dmg.sh
@@ -173,6 +173,9 @@ if [ "${SIGN:-false}" = true ]; then
     }
     export -f check_notarization_status
     tools/ci/retry.sh -n "$NOTARIZATION_ATTEMPTS" check_notarization_status "$SUBMISSION_ID"
+
+    echo "Stapling notarization ticket to DMG"
+    xcrun stapler staple "$LATEST_DMG"
     printf "\033[0Ksection_end:%s:notarization\r\033[0K\n" "$(date +%s)"
 fi
 

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -54,7 +54,7 @@ module Omnibus
       max_retries = 3
       attempts = 0
       delay = 2
-    
+
       begin
         attempts += 1
         cmd = Array.new.tap do |arr|
@@ -62,17 +62,17 @@ module Omnibus
           arr << "sign"
           arr << "\"#{file}\""
         end.join(" ")
-    
+
         status = shellout(cmd)
         if status.exitstatus != 0
           log.warn(self.class.name) do
             <<-EOH.strip
               Failed to sign with dd-wcs (Attempt #{attempts} of #{max_retries})
-    
+
               STDOUT
               ------
               #{status.stdout}
-    
+
               STDERR
               ------
               #{status.stderr}
@@ -116,6 +116,52 @@ module Omnibus
     expose :sign_file
     expose :chmod_before_packaging
   end
+
+  # Notarize and staple the .pkg after it is signed. Without this, Gatekeeper
+  # rejects the .pkg when extracted from the .dmg (e.g. by Homebrew), because
+  # the notarization ticket only covers the outer .dmg, not the .pkg inside it.
+  module PackagerPKGNotarizer
+    def run!
+      super
+      notarize_and_staple if signing_identity
+    end
+
+    private
+
+    def notarize_and_staple
+      pkg_path    = final_pkg
+      apple_id    = ENV.fetch('APPLE_ACCOUNT')
+      password    = ENV.fetch('NOTARIZATION_PWD')
+      team_id     = ENV.fetch('TEAM_ID')
+      timeout     = ENV.fetch('NOTARIZATION_TIMEOUT')
+      max_retries = Integer(ENV.fetch('NOTARIZATION_ATTEMPTS'))
+
+      log.info(self.class.name) { "Notarizing #{pkg_path}" }
+
+      submission_id = nil
+      max_retries.times do |attempt|
+        status = shellout("xcrun notarytool submit --apple-id '#{apple_id}' --password '#{password}' --team-id '#{team_id}' '#{pkg_path}'")
+        submission_id = status.stdout.match(/^\s*id:\s+(\S+)/)&.captures&.first if status.exitstatus == 0
+        break if submission_id
+        raise "Failed to submit #{pkg_path} for notarization" if attempt == max_retries - 1
+        sleep 2
+      end
+
+      max_retries.times do |attempt|
+        status = shellout("xcrun notarytool wait --apple-id '#{apple_id}' --password '#{password}' --team-id '#{team_id}' --timeout '#{timeout}' '#{submission_id}'")
+        break if status.exitstatus == 0
+        raise "Failed waiting for notarization of #{pkg_path}" if attempt == max_retries - 1
+        sleep 2
+      end
+
+      status = shellout("xcrun stapler staple '#{pkg_path}'")
+      raise "Failed to staple #{pkg_path}" unless status.exitstatus == 0
+
+      log.info(self.class.name) { "Notarized and stapled #{pkg_path}" }
+    end
+  end
+
+  Packager::PKG.prepend PackagerPKGNotarizer
 
   # Open the Builder class to allow adding custom DSL methods
   class Builder

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -98,7 +98,13 @@ OS_SPECIFIC_ENV_PASSTHROUGH = {
         'AGENT_DATA_PLANE_HASH_FIPS_LINUX_AMD64': 'Agent Data Plane Hash for FIPS Linux AMD64',
         'AGENT_DATA_PLANE_HASH_FIPS_LINUX_ARM64': 'Agent Data Plane Hash for FIPS Linux ARM64',
     },
-    'darwin': {},
+    'darwin': {
+        'APPLE_ACCOUNT': 'Apple developer account used for notarization',
+        'NOTARIZATION_ATTEMPTS': 'Number of retries for notarization steps',
+        'NOTARIZATION_PWD': 'App-specific password for notarization',
+        'NOTARIZATION_TIMEOUT': 'Timeout for xcrun notarytool wait',
+        'TEAM_ID': 'Apple developer team ID used for notarization',
+    },
 }
 
 


### PR DESCRIPTION
### What does this PR do?
- notarize and staple the` .pkg` inside an intermediate omnibus `PackagerPKGNotarizer` step, before `dmgbuild` wraps it in the `.dmg`,
- also staple the notarization ticket to the `.dmg` after Apple accepts it.

### Motivation
Gatekeeper checks a `.pkg` independently when it is extracted from a `.dmg` (e.g. by Homebrew).
The notarization ticket issued for the `.dmg` did not cover the `.pkg` inside it, causing the Homebrew cask to fail the Gatekeeper check, leading to deprecating Datadog Agent in Homebrew/homebrew-cask#257604:
<a href="https://formulae.brew.sh/cask/datadog-agent"><img width="640" height="246" alt="image" src="https://github.com/user-attachments/assets/02a63acc-401a-4c0b-b9b5-e5be4e69b153" /></a>
... bad karma, at least.