### PR TITLE
APM: Fix flaky test (APMSP-2613)

### DIFF
--- a/pkg/trace/containertags/buffer.go
+++ b/pkg/trace/containertags/buffer.go
@@ -129,10 +129,11 @@ func (p *containerTagsBuffer) resolvePendingContainers(now time.Time) {
 		if now.Before(buffer.expireTs) {
 			continue
 		}
-		// force flush + deny
+		// deny before flush so any goroutine receiving the callback result
+		// is guaranteed to observe the container as denied
+		p.deniedContainers.deny(now, cid)
 		buffer.flush(tagResult{tags: ctags, err: nil})
 		delete(p.containersBuffer, cid)
-		p.deniedContainers.deny(now, cid)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
Adjust containertags buffer code to mark containers as denied before flushing to resolve tiny race condition that can cause a flake on `TestAsyncEnrichment_Buffered_Expiration`

if a new AsyncEnrichment call for the same containerID arrives between deny and flush (i.e., between two consecutive function calls in the worker goroutine), that new call would be immediately rejected instead of being buffered. This is actually a good thing as we've already decided the container has timed out and can never resolve, so buffering new payloads for it is a waste.

### Motivation
Flakes are bad.

### Describe how you validated your changes
Unit tests and integration tests verify this behavior is OK. I also ran the same test many times and did not reproduce the flake.

### Additional Notes
