### PR TITLE
feat(logs): add pattern clustering, tag management, and JSON processor

### DIFF
--- a/pkg/logs/patterns/clustering/BUILD.bazel
+++ b/pkg/logs/patterns/clustering/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "clustering",
+    srcs = [
+        "cluster.go",
+        "cluster_manager.go",
+        "pattern.go",
+        "pattern_eviction.go",
+        "pattern_eviction_manager.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/logs/patterns/clustering",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/logs/patterns/clustering/merging",
+        "//pkg/logs/patterns/eviction",
+        "//pkg/logs/patterns/token",
+        "//pkg/trace/log",
+        "//pkg/util/log",
+        "@com_github_datadog_datadog_agent_pkg_config_setup//:setup",
+    ],
+)
+
+go_test(
+    name = "clustering_test",
+    srcs = [
+        "cluster_manager_test.go",
+        "cluster_test.go",
+        "pattern_eviction_manager_test.go",
+        "pattern_eviction_test.go",
+        "pattern_test.go",
+    ],
+    embed = [":clustering"],
+    deps = [
+        "//pkg/logs/patterns/clustering/merging",
+        "//pkg/logs/patterns/eviction",
+        "//pkg/logs/patterns/token",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/logs/patterns/clustering/cluster.go
+++ b/pkg/logs/patterns/clustering/cluster.go
@@ -1,0 +1,359 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package clustering provides clustering functionality for grouping similar TokenLists,
+// extracting patterns wildcard, and managing pattern lifecycle through eviction policies.
+package clustering
+
+import (
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/clustering/merging"
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/token"
+)
+
+// Cluster represents a cluster with a group of TokenLists that have identical signatures.
+// A cluster may contain multiple patterns if token lists with the same signature cannot be merged since structural Fidelity is Valuable.
+// Examples:
+// "Status: OK"     → HTTP response format
+// "Status; OK"     → CSV-like format
+// "Status OK"      → Plain text format
+// These are different log formats, even if semantically similar → we need to keep them separate.
+type Cluster struct {
+	Signature token.Signature
+	Patterns  []*Pattern // Multiple patterns per cluster
+
+	// Timestamp tracking for the cluster itself
+	CreatedAt time.Time // When cluster was first created
+	UpdatedAt time.Time // When cluster was last modified (any pattern changed)
+
+	// firstWordProtection is inherited from ClusterManager at cluster creation time.
+	// It can be automatically set to false when firstWordUniqueValues exceeds
+	// firstWordMaxCardinality (adaptive maxChild behavior).
+	firstWordProtection bool
+
+	// firstWordPos is the position of the first TokenWord in this cluster's token sequence.
+	// -1 if no TokenWord exists. Computed lazily on first pattern creation.
+	firstWordPos int
+
+	// firstWordUniqueValues tracks unique concrete values seen at firstWordPos.
+	// Once len > firstWordMaxCardinality, firstWordProtection is auto-disabled.
+	// Nilled after the threshold is reached to free memory.
+	firstWordUniqueValues map[string]struct{}
+
+	// firstWordMaxCardinality is the threshold for adaptive protection.
+	// 0 means no adaptive override (always use firstWordProtection as-is).
+	firstWordMaxCardinality int
+
+	// lastMatchedPattern is a one-entry cache pointing to the most recently matched
+	// pattern. In steady-state (post-convergence) the same 1-2 patterns absorb nearly
+	// all traffic, so this makes the common case O(1) instead of O(len(Patterns)).
+	// Nil initially and after the cached pattern is evicted.
+	lastMatchedPattern *Pattern
+
+	// saturatedThreshold is the number of consecutive identical merges (TryMerge returning
+	// tl1 unchanged) before a pattern is marked saturated. Once saturated, the
+	// CanMergeTokenLists pre-check is skipped for that pattern — single-pass TryMerge only.
+	// 0 disables saturation scoring entirely.
+	saturatedThreshold int
+
+	// maxPatternsPerCluster caps len(Patterns). When at cap, new unmatched messages are
+	// force-widened into the closest existing pattern instead of creating a new one.
+	// 0 = unlimited (backward compatible).
+	maxPatternsPerCluster int
+
+	// scanBudget limits CanMerge iterations in the full-scan loop per message.
+	// Move-to-front on hit keeps recently matched patterns within future budgets.
+	// 0 = unlimited (backward compatible).
+	scanBudget int
+}
+
+// NewCluster creates a new cluster.
+func NewCluster(signature token.Signature, firstWordProtection bool, firstWordMaxCardinality int, saturatedThreshold int, maxPatternsPerCluster int, scanBudget int) *Cluster {
+	now := time.Now()
+	return &Cluster{
+		Signature:               signature,
+		Patterns:                nil, // Will be generated when needed
+		CreatedAt:               now,
+		UpdatedAt:               now,
+		firstWordProtection:     firstWordProtection,
+		firstWordPos:            -1, // set lazily on first pattern
+		firstWordMaxCardinality: firstWordMaxCardinality,
+		saturatedThreshold:      saturatedThreshold,
+		maxPatternsPerCluster:   maxPatternsPerCluster,
+		scanBudget:              scanBudget,
+	}
+}
+
+// =============================================================================
+// Core Clustering Logic
+// =============================================================================
+
+// AddTokenListToPatterns adds a TokenList to the appropriate pattern in the cluster.
+// If no matching pattern exists, creates a new one.
+// Returns the matched/new pattern plus the old wildcard count and estimated bytes
+// of the matched pattern (both zero for new patterns), so the caller can compute deltas.
+func (c *Cluster) AddTokenListToPatterns(tokenList *token.TokenList, cm *ClusterManager) (*Pattern, int, int64) {
+	if len(c.Patterns) == 0 {
+		// Compute and cache the first-word position for this cluster's token structure.
+		c.firstWordPos = -1
+		for i, tok := range tokenList.Tokens {
+			if tok.Type == token.TokenWord {
+				c.firstWordPos = i
+				break
+			}
+		}
+		patternID := cm.generatePatternID()
+		pattern := newPattern(tokenList, patternID)
+		c.Patterns = []*Pattern{pattern}
+		c.lastMatchedPattern = pattern
+		c.UpdatedAt = time.Now()
+		return pattern, 0, 0
+	}
+
+	// Adaptive first-word protection: track unique concrete values at the first-word
+	// position. When the count exceeds firstWordMaxCardinality, the position is
+	// clearly a high-cardinality variable (e.g., username, transaction ID) rather than
+	// a semantic discriminator — auto-disable protection for this cluster.
+	effectiveProtection := c.firstWordProtection
+	if effectiveProtection && c.firstWordMaxCardinality > 0 && c.firstWordPos >= 0 &&
+		c.firstWordPos < len(tokenList.Tokens) {
+		tok := &tokenList.Tokens[c.firstWordPos]
+		if tok.Wildcard != token.IsWildcard && tok.Type == token.TokenWord {
+			if c.firstWordUniqueValues == nil {
+				c.firstWordUniqueValues = make(map[string]struct{})
+			}
+			c.firstWordUniqueValues[tok.Value] = struct{}{}
+			if len(c.firstWordUniqueValues) > c.firstWordMaxCardinality {
+				c.firstWordProtection = false // permanently disable for this cluster
+				c.firstWordUniqueValues = nil // free tracking memory
+				effectiveProtection = false
+			}
+		}
+	}
+
+	// Hot-pattern cache: try the last matched pattern first.
+	// For saturated patterns (consecutiveIdenticalMerges >= threshold), skip the
+	// CanMergeTokenLists pre-check (O(tokens)) and call TryMerge directly (single pass).
+	// For non-saturated patterns, keep the existing two-pass (CanMerge + TryMerge).
+	if c.lastMatchedPattern != nil && c.lastMatchedPattern.Template != nil {
+		lmp := c.lastMatchedPattern
+		oldWildcardCount := lmp.GetWildcardCount()
+		oldBytes := lmp.EstimatedBytes()
+		if lmp.saturated {
+			// Saturated fast path: single O(tokens) TryMerge call, no CanMerge pre-check.
+			if c.tryMergeIntoPattern(lmp, tokenList) {
+				return lmp, oldWildcardCount, oldBytes
+			}
+			// Unexpected miss: desaturate and fall through to full scan.
+			lmp.saturated = false
+			lmp.consecutiveIdenticalMerges = 0
+		} else {
+			if merging.CanMergeTokenLists(lmp.Template, tokenList, effectiveProtection) {
+				if c.tryMergeIntoPattern(lmp, tokenList) {
+					return lmp, oldWildcardCount, oldBytes
+				}
+			}
+		}
+	}
+
+	// Single pass: CanMerge against Template (not Sample), then TryMerge to apply.
+	// Using Template instead of Sample eliminates the redundant CanMerge-against-Sample
+	// pre-scan that ClusterManager.Add previously did. Template is at least as permissive
+	// as Sample for CanMerge (one-sided first-word protection).
+	// We cannot use TryMerge alone because it applies symmetric first-word protection
+	// which is stricter and would reject valid merges.
+	//
+	// scanBudget limits how many patterns we CanMerge-check per message. Move-to-front
+	// on hit keeps recently matched patterns within future budgets.
+	scanned := 0
+	for i, p := range c.Patterns {
+		if p == c.lastMatchedPattern {
+			// Already tried above; skip to avoid double-checking.
+			continue
+		}
+		if p.Template == nil {
+			continue
+		}
+		if c.scanBudget > 0 && scanned >= c.scanBudget {
+			break // budget exhausted — fall through to new-pattern / force-widen
+		}
+		scanned++
+		if !merging.CanMergeTokenLists(p.Template, tokenList, effectiveProtection) {
+			continue
+		}
+		oldWildcardCount := p.GetWildcardCount()
+		oldBytes := p.EstimatedBytes()
+		if c.tryMergeIntoPattern(p, tokenList) {
+			// Move-to-front: swap toward index 1 so future scan budgets cover it.
+			// Index 0 is often the oldest pattern; lastMatchedPattern covers the #1 hot slot.
+			if i > 1 {
+				c.Patterns[i], c.Patterns[1] = c.Patterns[1], c.Patterns[i]
+			}
+			c.lastMatchedPattern = p
+			return p, oldWildcardCount, oldBytes
+		}
+	}
+
+	// At cap: force-widen into closest match instead of creating a new pattern.
+	if c.maxPatternsPerCluster > 0 && len(c.Patterns) >= c.maxPatternsPerCluster {
+		if best := c.findClosestPattern(tokenList); best != nil {
+			oldWildcardCount := best.GetWildcardCount()
+			oldBytes := best.EstimatedBytes()
+			if widened := merging.ForceWiden(best.Template, tokenList); widened != nil {
+				c.applyWidenedTemplate(best, widened)
+				c.lastMatchedPattern = best
+				return best, oldWildcardCount, oldBytes
+			}
+		}
+		// Safety valve: ForceWiden only fails on length mismatch. All patterns in a cluster
+		// share the same signature/token-count, so this should not happen in practice.
+		// Fall through to newPattern as a defensive fallback.
+	}
+
+	patternID := cm.generatePatternID()
+	pattern := newPattern(tokenList, patternID)
+	c.Patterns = append(c.Patterns, pattern)
+	c.lastMatchedPattern = pattern // new pattern will likely be hit again
+	c.UpdatedAt = time.Now()
+	return pattern, 0, 0
+}
+
+// tryMergeIntoPattern attempts to merge tokenList into an existing pattern using
+// TryMergeTokenLists (single-pass CanMerge+Merge). Returns true if merge succeeded.
+func (c *Cluster) tryMergeIntoPattern(p *Pattern, tokenList *token.TokenList) bool {
+	if p.Template == nil {
+		return false
+	}
+
+	// Single-pass: check template compatibility and merge in one traversal.
+	// TryMergeTokenLists is symmetric (protects first-word from either list),
+	// so a single call suffices.
+	merged := merging.TryMergeTokenLists(p.Template, tokenList, c.firstWordProtection)
+	if merged == nil {
+		return false
+	}
+
+	now := time.Now()
+	p.LogCount++
+	p.LastAccessAt = now
+	p.UpdatedAt = now
+	c.UpdatedAt = now
+
+	if merged == p.Template {
+		// Zero-alloc identical path: TryMerge returned the template pointer unchanged.
+		// The incoming log was structurally identical — no wildcards added.
+		// Track consecutive identical merges for saturation scoring.
+		if c.saturatedThreshold > 0 {
+			p.consecutiveIdenticalMerges++
+			if p.consecutiveIdenticalMerges >= c.saturatedThreshold {
+				p.saturated = true
+			}
+		}
+		// Template and Positions are unchanged — skip the rebuild loop below.
+		return true
+	}
+
+	// Template structurally changed (new wildcards added): reset saturation.
+	p.consecutiveIdenticalMerges = 0
+	p.saturated = false
+
+	// Apply the merged template
+	p.Template = merged
+	p.Positions = p.Positions[:0]
+
+	n := len(merged.Tokens)
+	for i := 0; i < n; i++ {
+		tok := &merged.Tokens[i]
+		if tok.Wildcard == token.IsWildcard {
+			p.Positions = append(p.Positions, i)
+
+			if tok.Type == token.TokenAbsolutePath && p.Sample != nil && i < len(p.Sample.Tokens) {
+				tok.Value = getPathPattern(p.Sample.Tokens[i].Value)
+			}
+		}
+	}
+
+	return true
+}
+
+// findClosestPattern returns the pattern with the most token positions identical
+// to tokenList (fewest positions that would need wildcarding under ForceWiden).
+func (c *Cluster) findClosestPattern(tokenList *token.TokenList) *Pattern {
+	var best *Pattern
+	bestScore := -1
+	for _, p := range c.Patterns {
+		if p.Template == nil {
+			continue
+		}
+		score := countIdentical(p.Template, tokenList)
+		if score > bestScore {
+			bestScore = score
+			best = p
+		}
+	}
+	return best
+}
+
+// countIdentical returns the number of token positions where both lists are identical.
+func countIdentical(tl1, tl2 *token.TokenList) int {
+	n := len(tl1.Tokens)
+	if len(tl2.Tokens) < n {
+		n = len(tl2.Tokens)
+	}
+	count := 0
+	for i := 0; i < n; i++ {
+		if tl1.Tokens[i].Compare(&tl2.Tokens[i]) == token.Identical {
+			count++
+		}
+	}
+	return count
+}
+
+// applyWidenedTemplate updates a pattern with a force-widened template, rebuilds
+// Positions, resets saturation state, and updates timestamps.
+// If widened == p.Template (pointer-same, all-identical), only LogCount is bumped.
+func (c *Cluster) applyWidenedTemplate(p *Pattern, widened *token.TokenList) {
+	p.LogCount++
+	p.LastAccessAt = time.Now()
+	if widened == p.Template {
+		return // all-identical, nothing changed structurally
+	}
+	p.Template = widened
+	p.UpdatedAt = time.Now()
+	c.UpdatedAt = time.Now()
+	// Rebuild wildcard positions
+	p.Positions = p.Positions[:0]
+	for i, tok := range widened.Tokens {
+		if tok.Wildcard == token.IsWildcard {
+			p.Positions = append(p.Positions, i)
+		}
+	}
+	// Reset saturation — template changed structurally
+	p.consecutiveIdenticalMerges = 0
+	p.saturated = false
+}
+
+// getPathPattern converts a path to hierarchical wildcard pattern
+func getPathPattern(path string) string {
+	if path == "/" {
+		return "/"
+	}
+
+	// Remove leading/trailing slashes and split
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return "/"
+	}
+
+	parts := strings.Split(trimmed, "/")
+	result := ""
+	for i := 0; i < len(parts); i++ {
+		result += "/*"
+	}
+
+	return result
+}

--- a/pkg/logs/patterns/clustering/cluster_manager.go
+++ b/pkg/logs/patterns/clustering/cluster_manager.go
@@ -1,0 +1,346 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package clustering provides clustering functionality for grouping similar TokenLists,
+// extracting patterns wildcard, and managing pattern lifecycle through eviction policies.
+package clustering
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/token"
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
+)
+
+// PatternChangeType indicates what changed when adding a TokenList to the cluster manager
+type PatternChangeType int
+
+const (
+	// PatternNoChange means the TokenList was added to an existing cluster without structural changes
+	PatternNoChange PatternChangeType = iota
+	// PatternNew means a brand new pattern was created (either in a new cluster or within an existing one)
+	PatternNew
+	// PatternUpdated means an existing pattern's structure changed (more wildcards added)
+	PatternUpdated
+)
+
+// ClusterManager manages the clustering of TokenLists using hash-based bucketing.
+type ClusterManager struct {
+	mu          sync.RWMutex
+	hashBuckets map[uint64][]*Cluster
+	nextID      uint64
+
+	// patternCount tracks the total number of patterns across all clusters.
+	// This is maintained incrementally to avoid O(N) scans on every Add().
+	patternCount int
+
+	// estimatedBytes tracks an approximate memory footprint of patterns stored in this manager.
+	// This is an estimate (not exact Go heap usage) and is intended for threshold-based eviction triggers.
+	estimatedBytes int64
+
+	// firstWordProtection controls whether the first word token position is protected
+	// from becoming a wildcard during merge. When true (default), logs that differ only
+	// by first word (e.g., "ERROR" vs "WARN") create separate patterns.
+	firstWordProtection bool
+
+	// firstWordMaxCardinality is the per-cluster adaptive threshold. Once a cluster sees
+	// more than this many unique concrete values at the first-word position, protection is
+	// automatically disabled for that cluster. 0 means no adaptive override (uses firstWordProtection as-is).
+	firstWordMaxCardinality int
+
+	// saturatedThreshold is the number of consecutive identical TryMerge returns (tl1 pointer
+	// unchanged) before a pattern is marked saturated and eligible for the single-pass fast path.
+	// 0 disables saturation scoring.
+	saturatedThreshold int
+
+	// maxPatternsPerCluster caps len(Patterns) per cluster. 0 = unlimited.
+	maxPatternsPerCluster int
+	// scanBudget limits CanMerge iterations per message in the full-scan loop. 0 = unlimited.
+	scanBudget int
+}
+
+// NewClusterManager creates a new ClusterManager.
+func NewClusterManager() *ClusterManager {
+	return &ClusterManager{
+		hashBuckets:         make(map[uint64][]*Cluster),
+		nextID:              1,
+		firstWordProtection: true,
+	}
+}
+
+// NewClusterManagerWithConfig creates a new ClusterManager with configurable options.
+// firstWordProtection: global first-word merge protection toggle.
+// firstWordMaxCardinality: per-cluster adaptive threshold (0 = no adaptive override).
+// saturatedThreshold: consecutive identical merges before pattern is marked saturated (0 = disabled).
+// maxPatternsPerCluster: per-cluster pattern cap; 0 = unlimited.
+// scanBudget: CanMerge iterations per message in the full-scan loop; 0 = unlimited.
+func NewClusterManagerWithConfig(firstWordProtection bool, firstWordMaxCardinality int, saturatedThreshold int, maxPatternsPerCluster int, scanBudget int) *ClusterManager {
+	return &ClusterManager{
+		hashBuckets:             make(map[uint64][]*Cluster),
+		nextID:                  1,
+		firstWordProtection:     firstWordProtection,
+		firstWordMaxCardinality: firstWordMaxCardinality,
+		saturatedThreshold:      saturatedThreshold,
+		maxPatternsPerCluster:   maxPatternsPerCluster,
+		scanBudget:              scanBudget,
+	}
+}
+
+// PatternCount returns the total number of patterns currently stored.
+func (cm *ClusterManager) PatternCount() int {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.patternCount
+}
+
+// EstimatedBytes returns the approximate memory footprint (in bytes) of patterns currently stored.
+func (cm *ClusterManager) EstimatedBytes() int64 {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.estimatedBytes
+}
+
+// Add processes a TokenList and adds it to the appropriate cluster.
+// Returns:
+// - pattern: the pattern that was created/updated
+// - changeType: what changed (new/updated/no change)
+// - patternCount: total patterns after this addition
+// - estimatedBytes: total estimated memory after this addition
+func (cm *ClusterManager) Add(tokenList *token.TokenList) (*Pattern, PatternChangeType, int, int64) {
+	if tokenList == nil || tokenList.IsEmpty() {
+		log.Errorf("Cluster Manager failed to add log: %v for patterning. Token list is empty or nil.", tokenList.String())
+		return nil, PatternNoChange, 0, 0
+	}
+
+	// Lock the cluster manager to prevent concurrent access to the hash buckets. Current implementation is single-threaded on local pipeline, but we will eventually build a shared cluster manager across multiple pipelines.
+	// todo: implement a shared cluster manager across multiple pipelines
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	// Create new signature and hash it
+	signature := token.NewSignature(tokenList)
+	hash := signature.Hash
+
+	// Get hash bucket
+	clusters := cm.hashBuckets[hash]
+
+	// Look for existing cluster with matching signature
+	for _, cluster := range clusters {
+		if !cluster.Signature.Equals(signature) {
+			continue
+		}
+
+		oldPatternCount := len(cluster.Patterns)
+
+		// Delegate to AddTokenListToPatterns which checks CanMerge against Template
+		// (not Sample). The invariant Template >= Sample guarantees that
+		// CanMerge(Template, X) accepts whenever CanMerge(Sample, X) would.
+		// See TestClusterManager_TemplateAtLeastAsPermissiveAsSample.
+		pattern, oldWildcardCount, oldMatchedBytes := cluster.AddTokenListToPatterns(tokenList, cm)
+
+		newPatternCreated := len(cluster.Patterns) > oldPatternCount
+		if newPatternCreated {
+			cm.patternCount++
+			cm.estimatedBytes += pattern.EstimatedBytes()
+			return pattern, PatternNew, cm.patternCount, cm.estimatedBytes
+		}
+
+		cm.estimatedBytes += pattern.EstimatedBytes() - oldMatchedBytes
+
+		if pattern.GetWildcardCount() != oldWildcardCount {
+			return pattern, PatternUpdated, cm.patternCount, cm.estimatedBytes
+		}
+
+		return pattern, PatternNoChange, cm.patternCount, cm.estimatedBytes
+	}
+
+	// If no matching pattern was found, create a new cluster and pattern.
+	newCluster := NewCluster(signature, cm.firstWordProtection, cm.firstWordMaxCardinality, cm.saturatedThreshold, cm.maxPatternsPerCluster, cm.scanBudget)
+	pattern, _, _ := newCluster.AddTokenListToPatterns(tokenList, cm)
+	cm.hashBuckets[hash] = append(clusters, newCluster)
+
+	// New cluster always creates exactly one new pattern
+	cm.patternCount++
+	cm.estimatedBytes += pattern.EstimatedBytes()
+
+	return pattern, PatternNew, cm.patternCount, cm.estimatedBytes
+}
+
+// Clear removes all clusters.
+func (cm *ClusterManager) Clear() {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.hashBuckets = make(map[uint64][]*Cluster)
+	cm.patternCount = 0
+	cm.estimatedBytes = 0
+}
+
+// GetStats returns the current pattern count and estimated memory usage.
+// This is a read-only operation that acquires a read lock for thread safety.
+func (cm *ClusterManager) GetStats() (patternCount int, estimatedBytes int64) {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.patternCount, cm.estimatedBytes
+}
+
+// PositionStats describes the token distribution at one position across all patterns in a cluster.
+type PositionStats struct {
+	Pos           int
+	TokenType     string
+	WildcardCount int
+	ConcreteCount int
+	UniqueValues  int
+	ConflictRatio float64 // fraction of cross-pattern comparisons that are Conflict
+}
+
+// ClusterReport describes a cluster's pattern distribution for instrumentation.
+type ClusterReport struct {
+	Signature    string
+	PatternCount int
+	Positions    []PositionStats
+}
+
+// TopClusters returns the top N clusters by pattern count with per-position analysis.
+// Used for instrumentation to understand mega-cluster structure before implementing an index.
+func (cm *ClusterManager) TopClusters(n int) []ClusterReport {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	// Collect all clusters
+	type entry struct {
+		sig     string
+		cluster *Cluster
+	}
+	var all []entry
+	for _, clusters := range cm.hashBuckets {
+		for _, c := range clusters {
+			all = append(all, entry{c.Signature.String(), c})
+		}
+	}
+
+	// Sort by pattern count descending
+	sort.Slice(all, func(i, j int) bool {
+		return len(all[i].cluster.Patterns) > len(all[j].cluster.Patterns)
+	})
+
+	if n > len(all) {
+		n = len(all)
+	}
+
+	reports := make([]ClusterReport, 0, n)
+	for _, e := range all[:n] {
+		reports = append(reports, analyzeCluster(e.sig, e.cluster))
+	}
+	return reports
+}
+
+// analyzeCluster computes per-position stats for a cluster.
+func analyzeCluster(sig string, c *Cluster) ClusterReport {
+	patterns := c.Patterns
+	if len(patterns) == 0 {
+		return ClusterReport{Signature: sig}
+	}
+
+	nPos := 0
+	for _, p := range patterns {
+		if p.Template != nil && len(p.Template.Tokens) > nPos {
+			nPos = len(p.Template.Tokens)
+		}
+	}
+
+	positions := make([]PositionStats, nPos)
+	for pos := 0; pos < nPos; pos++ {
+		var wildcardCount, concreteCount int
+		uniqueValues := make(map[string]struct{})
+		tokenType := ""
+
+		for _, p := range patterns {
+			if p.Template == nil || pos >= len(p.Template.Tokens) {
+				continue
+			}
+			tok := p.Template.Tokens[pos]
+			tokenType = tok.Type.String()
+			if tok.Wildcard == token.IsWildcard {
+				wildcardCount++
+			} else {
+				concreteCount++
+				uniqueValues[tok.Value] = struct{}{}
+			}
+		}
+
+		// Sample conflict ratio: compare adjacent pattern pairs at this position
+		conflictCount, total := 0, 0
+		for i := 0; i+1 < len(patterns); i++ {
+			p1, p2 := patterns[i], patterns[i+1]
+			if p1.Template == nil || p2.Template == nil {
+				continue
+			}
+			if pos >= len(p1.Template.Tokens) || pos >= len(p2.Template.Tokens) {
+				continue
+			}
+			tok1, tok2 := &p1.Template.Tokens[pos], &p2.Template.Tokens[pos]
+			if tok1.Wildcard == token.IsWildcard || tok2.Wildcard == token.IsWildcard {
+				continue
+			}
+			result := tok1.Compare(tok2)
+			total++
+			if result == token.Conflict {
+				conflictCount++
+			}
+		}
+
+		conflictRatio := 0.0
+		if total > 0 {
+			conflictRatio = float64(conflictCount) / float64(total)
+		}
+
+		positions[pos] = PositionStats{
+			Pos:           pos,
+			TokenType:     tokenType,
+			WildcardCount: wildcardCount,
+			ConcreteCount: concreteCount,
+			UniqueValues:  len(uniqueValues),
+			ConflictRatio: conflictRatio,
+		}
+	}
+
+	return ClusterReport{
+		Signature:    sig,
+		PatternCount: len(patterns),
+		Positions:    positions,
+	}
+}
+
+// FormatTopClusters returns a human-readable summary of top cluster stats.
+func (cm *ClusterManager) FormatTopClusters(n int) string {
+	reports := cm.TopClusters(n)
+	if len(reports) == 0 {
+		return "no clusters"
+	}
+	var out string
+	for i, r := range reports {
+		out += fmt.Sprintf("\nCluster #%d sig=%s patterns=%d\n", i+1, r.Signature, r.PatternCount)
+		out += fmt.Sprintf("  %-5s %-20s %-8s %-8s %-8s %-12s\n",
+			"pos", "type", "wildcard", "concrete", "unique", "conflictRatio")
+		for _, p := range r.Positions {
+			if p.ConcreteCount == 0 && p.WildcardCount == 0 {
+				continue
+			}
+			out += fmt.Sprintf("  %-5d %-20s %-8d %-8d %-8d %.3f\n",
+				p.Pos, p.TokenType, p.WildcardCount, p.ConcreteCount, p.UniqueValues, p.ConflictRatio)
+		}
+	}
+	return out
+}
+
+// generatePatternID generates a unique pattern ID using a monotonic counter.
+// Must be called while holding the ClusterManager lock.
+func (cm *ClusterManager) generatePatternID() uint64 {
+	id := cm.nextID
+	cm.nextID++
+	return id
+}

--- a/pkg/logs/patterns/clustering/cluster_manager_test.go
+++ b/pkg/logs/patterns/clustering/cluster_manager_test.go
@@ -1,0 +1,399 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package clustering
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/clustering/merging"
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/token"
+)
+
+// Test-only helper functions
+
+// getCluster retrieves the cluster with the given signature.
+func getCluster(cm *ClusterManager, signature token.Signature) *Cluster {
+	hash := signature.Hash
+
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	clusters, exists := cm.hashBuckets[hash]
+	if !exists {
+		return nil
+	}
+
+	for _, cluster := range clusters {
+		if cluster.Signature.Equals(signature) {
+			return cluster
+		}
+	}
+
+	return nil
+}
+
+// getAllPatterns returns all patterns across all clusters.
+func getAllPatterns(cm *ClusterManager) []*Pattern {
+	var allPatterns []*Pattern
+
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	// Iterate through all clusters in all hash buckets
+	for _, clusters := range cm.hashBuckets {
+		for _, cluster := range clusters {
+			// Collect all patterns from this cluster
+			allPatterns = append(allPatterns, cluster.Patterns...)
+		}
+	}
+
+	return allPatterns
+}
+
+func TestClusterManager_NewClusterManager(t *testing.T) {
+	cm := NewClusterManager()
+
+	assert.NotNil(t, cm, "ClusterManager should not be nil")
+	assert.Equal(t, 0, cm.PatternCount(), "New ClusterManager should have 0 patterns")
+	assert.Equal(t, int64(0), cm.EstimatedBytes(), "New ClusterManager should have 0 estimated bytes")
+}
+
+func TestClusterManager_Add_NewCluster(t *testing.T) {
+	cm := NewClusterManager()
+
+	// Create TokenList
+	tokens := []token.Token{
+		{Value: "GET", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api", Type: token.TokenAbsolutePath},
+	}
+	tokenList := token.NewTokenListWithTokens(tokens)
+
+	pattern, changeType, _, _ := cm.Add(tokenList)
+
+	assert.NotNil(t, pattern, "Should return a pattern")
+	assert.Equal(t, 1, pattern.LogCount, "Pattern should have log count 1")
+	assert.Equal(t, PatternNew, changeType, "Expected PatternNew for first add")
+	assert.Equal(t, 1, cm.PatternCount(), "Should track 1 pattern after first add")
+	assert.Greater(t, cm.EstimatedBytes(), int64(0), "Estimated bytes should be > 0 after first add")
+}
+
+func TestClusterManager_Add_ExistingCluster(t *testing.T) {
+	cm := NewClusterManager()
+
+	// Create two TokenLists with same signature
+	tokens1 := []token.Token{
+		{Value: "GET", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api", Type: token.TokenAbsolutePath},
+	}
+	tokens2 := []token.Token{
+		{Value: "POST", Type: token.TokenHTTPMethod}, // Different value, same type
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/users", Type: token.TokenAbsolutePath}, // Different value, same type
+	}
+
+	tokenList1 := token.NewTokenListWithTokens(tokens1)
+	tokenList2 := token.NewTokenListWithTokens(tokens2)
+
+	pattern1, changeType1, _, _ := cm.Add(tokenList1)
+	pattern2, changeType2, _, _ := cm.Add(tokenList2)
+
+	// Should be the same pattern (same cluster, merged together)
+	assert.Equal(t, pattern1.PatternID, pattern2.PatternID, "TokenLists with same signature should merge into same pattern")
+	assert.Equal(t, 2, pattern2.LogCount, "Pattern should have log count 2")
+	assert.Equal(t, PatternNew, changeType1, "Expected PatternNew for first add")
+
+	// With eager pattern generation, adding the second token list creates wildcards (pattern update)
+	assert.Equal(t, PatternUpdated, changeType2, "Expected PatternUpdated for second add (creates wildcards)")
+	assert.Equal(t, 1, cm.PatternCount(), "Merging into existing pattern should not increase pattern count")
+}
+
+func TestClusterManager_Add_DifferentSignatures(t *testing.T) {
+	cm := NewClusterManager()
+
+	// Create TokenLists with different signatures
+	tokens1 := []token.Token{
+		{Value: "GET", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api", Type: token.TokenAbsolutePath},
+	}
+	tokens2 := []token.Token{
+		{Value: "ERROR", Type: token.TokenSeverityLevel}, // Different type
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "failed", Type: token.TokenWord}, // Different type
+	}
+
+	tokenList1 := token.NewTokenListWithTokens(tokens1)
+	tokenList2 := token.NewTokenListWithTokens(tokens2)
+
+	pattern1, _, _, _ := cm.Add(tokenList1)
+	pattern2, _, _, _ := cm.Add(tokenList2)
+
+	// Should be different patterns (different clusters)
+	assert.NotEqual(t, pattern1.PatternID, pattern2.PatternID, "TokenLists with different signatures should create different patterns")
+	assert.Equal(t, 2, cm.PatternCount(), "Different signatures should increase pattern count")
+}
+
+func TestClusterManager_GetCluster(t *testing.T) {
+	cm := NewClusterManager()
+
+	// Create and add TokenList
+	tokens := []token.Token{
+		{Value: "GET", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api", Type: token.TokenAbsolutePath},
+	}
+	tokenList := token.NewTokenListWithTokens(tokens)
+	signature := token.NewSignature(tokenList)
+
+	addedPattern, _, _, _ := cm.Add(tokenList)
+
+	// Retrieve cluster by signature
+	retrievedCluster := getCluster(cm, signature)
+
+	assert.NotNil(t, retrievedCluster, "Should retrieve cluster by signature")
+	assert.Equal(t, 1, len(retrievedCluster.Patterns), "Cluster should have 1 pattern")
+	assert.Equal(t, addedPattern.PatternID, retrievedCluster.Patterns[0].PatternID, "Pattern IDs should match")
+
+	// Try to get non-existent cluster
+	differentTokens := []token.Token{
+		{Value: "ERROR", Type: token.TokenSeverityLevel},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "failed", Type: token.TokenWord},
+	}
+	differentTokenList := token.NewTokenListWithTokens(differentTokens)
+	differentSignature := token.NewSignature(differentTokenList)
+
+	nonExistentCluster := getCluster(cm, differentSignature)
+	assert.Nil(t, nonExistentCluster, "Should return nil for non-existent cluster")
+}
+
+func TestClusterManager_Clear(t *testing.T) {
+	cm := NewClusterManager()
+
+	// Add some data
+	tokens := []token.Token{
+		{Value: "GET", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api", Type: token.TokenAbsolutePath},
+	}
+	tokenList := token.NewTokenListWithTokens(tokens)
+	signature := token.NewSignature(tokenList)
+
+	cm.Add(tokenList)
+	assert.Equal(t, 1, cm.PatternCount(), "Should track 1 pattern before clear")
+
+	// Verify data exists
+	assert.NotNil(t, getCluster(cm, signature), "Should have cluster before clear")
+
+	// Clear
+	cm.Clear()
+
+	// Verify data is gone
+	assert.Nil(t, getCluster(cm, signature), "Should have no cluster after clear")
+	assert.Equal(t, 0, cm.PatternCount(), "Should reset pattern count on clear")
+	assert.Equal(t, int64(0), cm.EstimatedBytes(), "Should reset estimated bytes on clear")
+}
+
+func TestClusterManager_GetAllPatterns(t *testing.T) {
+	cm := NewClusterManager()
+
+	// Initially empty
+	patterns := getAllPatterns(cm)
+	assert.Equal(t, 0, len(patterns), "Should have no patterns initially")
+
+	// Add pattern 1 (signature 1)
+	tokens1 := []token.Token{
+		{Value: "GET", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api", Type: token.TokenAbsolutePath},
+	}
+	pattern1, _, _, _ := cm.Add(token.NewTokenListWithTokens(tokens1))
+
+	// Add pattern 2 (same signature, should merge into pattern 1)
+	tokens2 := []token.Token{
+		{Value: "POST", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/users", Type: token.TokenAbsolutePath},
+	}
+	pattern2, _, _, _ := cm.Add(token.NewTokenListWithTokens(tokens2))
+
+	// Add pattern 3 (different signature)
+	tokens3 := []token.Token{
+		{Value: "ERROR", Type: token.TokenSeverityLevel},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "failed", Type: token.TokenWord},
+	}
+	pattern3, _, _, _ := cm.Add(token.NewTokenListWithTokens(tokens3))
+
+	// Get all patterns
+	allPatterns := getAllPatterns(cm)
+
+	// Should have 2 patterns: pattern1 (merged with pattern2) and pattern3
+	assert.Equal(t, 2, len(allPatterns), "Should have 2 patterns total")
+
+	// Verify we have both pattern IDs
+	patternIDs := make(map[uint64]bool)
+	for _, p := range allPatterns {
+		patternIDs[p.PatternID] = true
+	}
+	assert.True(t, patternIDs[pattern1.PatternID], "Should include pattern 1")
+	assert.True(t, patternIDs[pattern3.PatternID], "Should include pattern 3")
+	assert.Equal(t, pattern1.PatternID, pattern2.PatternID, "Pattern 1 and 2 should be the same (merged)")
+}
+
+func TestClusterManager_PatternChangeType(t *testing.T) {
+	cm := NewClusterManager()
+
+	// Create token lists with same signature (HTTP method, space, path)
+	tokens1 := []token.Token{
+		{Value: "GET", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api/users", Type: token.TokenAbsolutePath},
+	}
+	tokens2 := []token.Token{
+		{Value: "POST", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api/orders", Type: token.TokenAbsolutePath},
+	}
+	tokens3 := []token.Token{
+		{Value: "PUT", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api/items", Type: token.TokenAbsolutePath},
+	}
+	tokens4 := []token.Token{
+		{Value: "DELETE", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api/products", Type: token.TokenAbsolutePath},
+	}
+
+	tokenList1 := token.NewTokenListWithTokens(tokens1)
+	tokenList2 := token.NewTokenListWithTokens(tokens2)
+	tokenList3 := token.NewTokenListWithTokens(tokens3)
+	tokenList4 := token.NewTokenListWithTokens(tokens4)
+
+	// First add - should create a new pattern
+	pattern1, changeType1, _, _ := cm.Add(tokenList1)
+	assert.Equal(t, PatternNew, changeType1, "Expected PatternNew for first add")
+	t.Logf("✅ Add #1: PatternNew (created pattern with PatternID=%d)", pattern1.PatternID)
+
+	// Second add - same signature, adding to existing pattern creates wildcards (pattern update)
+	pattern2, changeType2, _, _ := cm.Add(tokenList2)
+	assert.Equal(t, PatternUpdated, changeType2, "Expected PatternUpdated for second add (creates wildcards)")
+	assert.Equal(t, pattern1.PatternID, pattern2.PatternID, "Should return same pattern for same signature")
+	t.Logf("✅ Add #2: PatternUpdated (wildcards created, logCount=%d)", pattern2.LogCount)
+	t.Logf("   Pattern after 2 logs: '%s'", pattern2.GetPatternString())
+
+	// Third add - pattern exists but wildcard count unchanged (still 2 wildcards)
+	pattern3, changeType3, _, _ := cm.Add(tokenList3)
+	assert.Equal(t, PatternNoChange, changeType3, "Expected PatternNoChange for third add (wildcard count unchanged)")
+	assert.Equal(t, pattern1.PatternID, pattern3.PatternID, "Should return same pattern for same signature")
+	t.Logf("✅ Add #3: PatternNoChange (wildcard count unchanged, logCount=%d)", pattern3.LogCount)
+	t.Logf("   Pattern after 3 logs: '%s'", pattern3.GetPatternString())
+
+	// Fourth add - pattern exists, wildcard count still unchanged
+	pattern4, changeType4, _, _ := cm.Add(tokenList4)
+	assert.Equal(t, PatternNoChange, changeType4, "Expected PatternNoChange for fourth add (wildcard count unchanged)")
+	t.Logf("✅ Add #4: PatternNoChange (wildcard count unchanged, logCount=%d)", pattern4.LogCount)
+
+	// Final pattern (eagerly generated by Add)
+	t.Logf("   Final pattern after 4 logs: '%s'", pattern4.GetPatternString())
+
+	// Verify all returned the same pattern
+	assert.Equal(t, 4, pattern4.LogCount, "Expected pattern log count 4")
+}
+
+// TestClusterManager_TemplateAtLeastAsPermissiveAsSample validates the invariant that
+// CanMerge(Template, X) succeeds whenever CanMerge(Sample, X) succeeds.
+// This invariant allows us to skip the CanMerge-against-Sample pre-scan in
+// ClusterManager.Add and check against Template directly in AddTokenListToPatterns.
+// Note: TryMerge has stricter symmetric first-word protection, so this invariant
+// does NOT hold for TryMerge — only for CanMerge.
+func TestClusterManager_TemplateAtLeastAsPermissiveAsSample(t *testing.T) {
+	cm := NewClusterManager()
+
+	// Build a multi-pattern cluster by feeding logs with different whitespace separators
+	seeds := [][]token.Token{
+		{
+			{Type: token.TokenWord, Value: "Error", Wildcard: token.NotWildcard},
+			{Type: token.TokenWhitespace, Value: " "},
+			{Type: token.TokenWord, Value: "connection", Wildcard: token.PotentialWildcard},
+			{Type: token.TokenWhitespace, Value: " "},
+			{Type: token.TokenWord, Value: "failed", Wildcard: token.PotentialWildcard},
+		},
+		{
+			{Type: token.TokenWord, Value: "Error", Wildcard: token.NotWildcard},
+			{Type: token.TokenWhitespace, Value: "  "},
+			{Type: token.TokenWord, Value: "timeout", Wildcard: token.PotentialWildcard},
+			{Type: token.TokenWhitespace, Value: "  "},
+			{Type: token.TokenWord, Value: "reached", Wildcard: token.PotentialWildcard},
+		},
+	}
+	for _, s := range seeds {
+		cm.Add(token.NewTokenListWithTokens(s))
+	}
+
+	// Evolve the first pattern's template by merging more logs
+	evolvers := [][]token.Token{
+		{
+			{Type: token.TokenWord, Value: "Error", Wildcard: token.NotWildcard},
+			{Type: token.TokenWhitespace, Value: " "},
+			{Type: token.TokenWord, Value: "database", Wildcard: token.PotentialWildcard},
+			{Type: token.TokenWhitespace, Value: " "},
+			{Type: token.TokenWord, Value: "error", Wildcard: token.PotentialWildcard},
+		},
+		{
+			{Type: token.TokenWord, Value: "Error", Wildcard: token.NotWildcard},
+			{Type: token.TokenWhitespace, Value: " "},
+			{Type: token.TokenWord, Value: "network", Wildcard: token.PotentialWildcard},
+			{Type: token.TokenWhitespace, Value: " "},
+			{Type: token.TokenWord, Value: "unreachable", Wildcard: token.PotentialWildcard},
+		},
+	}
+	for _, e := range evolvers {
+		cm.Add(token.NewTokenListWithTokens(e))
+	}
+
+	// Now verify the invariant: for every pattern, any tokenList that
+	// CanMerge with Sample must also CanMerge with Template.
+	probes := [][]token.Token{
+		{
+			{Type: token.TokenWord, Value: "Error", Wildcard: token.NotWildcard},
+			{Type: token.TokenWhitespace, Value: " "},
+			{Type: token.TokenWord, Value: "disk", Wildcard: token.PotentialWildcard},
+			{Type: token.TokenWhitespace, Value: " "},
+			{Type: token.TokenWord, Value: "full", Wildcard: token.PotentialWildcard},
+		},
+		{
+			{Type: token.TokenWord, Value: "Error", Wildcard: token.NotWildcard},
+			{Type: token.TokenWhitespace, Value: "  "},
+			{Type: token.TokenWord, Value: "auth", Wildcard: token.PotentialWildcard},
+			{Type: token.TokenWhitespace, Value: "  "},
+			{Type: token.TokenWord, Value: "denied", Wildcard: token.PotentialWildcard},
+		},
+	}
+
+	patterns := getAllPatterns(cm)
+	for _, probeTokens := range probes {
+		probe := token.NewTokenListWithTokens(probeTokens)
+		for _, p := range patterns {
+			if p.Sample == nil || p.Template == nil {
+				continue
+			}
+			sampleMatch := merging.CanMergeTokenLists(probe, p.Sample, true)
+			if sampleMatch {
+				templateMatch := merging.CanMergeTokenLists(p.Template, probe, true)
+				assert.Truef(t, templateMatch,
+					"Invariant violated: CanMerge(probe, Sample) succeeded but CanMerge(Template, probe) failed.\n"+
+						"  Pattern ID: %d\n  Sample: %s\n  Template: %s\n  Probe: %s",
+					p.PatternID, p.Sample.String(), p.Template.String(), probe.String())
+			}
+		}
+	}
+}

--- a/pkg/logs/patterns/clustering/cluster_test.go
+++ b/pkg/logs/patterns/clustering/cluster_test.go
@@ -1,0 +1,843 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package clustering
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/clustering/merging"
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/token"
+)
+
+func TestCluster_NewCluster(t *testing.T) {
+	// Create a simple TokenList
+	tokens := []token.Token{
+		{Value: "GET", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api", Type: token.TokenAbsolutePath},
+	}
+	tokenList := token.NewTokenListWithTokens(tokens)
+	signature := token.NewSignature(tokenList)
+
+	cluster := NewCluster(signature, true, 0, 0, 0, 0)
+
+	assert.Equal(t, 0, clusterSize(cluster), "Expected cluster size 0 initially")
+	assert.True(t, cluster.Signature.Equals(signature), "Cluster signature doesn't match expected signature")
+	assert.Empty(t, cluster.Patterns, "Patterns should be empty initially (computed lazily)")
+}
+
+func TestCluster_AddTokenListToPatterns(t *testing.T) {
+	// Create first TokenList
+	tokens1 := []token.Token{
+		{Value: "GET", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/api", Type: token.TokenAbsolutePath},
+	}
+	tokenList1 := token.NewTokenListWithTokens(tokens1)
+	signature1 := token.NewSignature(tokenList1)
+
+	cm := NewClusterManager()
+	cluster := NewCluster(signature1, true, 0, 0, 0, 0)
+	cluster.AddTokenListToPatterns(tokenList1, cm)
+
+	assert.Equal(t, 1, clusterSize(cluster), "Expected initial cluster size 1")
+
+	// Create second TokenList with same signature but different values
+	tokens2 := []token.Token{
+		{Value: "POST", Type: token.TokenHTTPMethod},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "/users", Type: token.TokenAbsolutePath},
+	}
+	tokenList2 := token.NewTokenListWithTokens(tokens2)
+
+	// Add tokenList with matching signature
+	cluster.AddTokenListToPatterns(tokenList2, cm)
+
+	assert.Equal(t, 2, clusterSize(cluster), "Expected cluster size 2 after adding")
+	assert.NotEmpty(t, cluster.Patterns, "Expected patterns to exist after adding TokenLists")
+}
+
+func TestCluster_SinglePattern_SingleLog(t *testing.T) {
+	// When a cluster has only one log, it creates one pattern with no wildcards
+	tokens := []token.Token{
+		{Value: "ERROR", Type: token.TokenSeverityLevel},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "failed", Type: token.TokenWord},
+	}
+	tokenList := token.NewTokenListWithTokens(tokens)
+	signature := token.NewSignature(tokenList)
+
+	cm := NewClusterManager()
+	cluster := NewCluster(signature, true, 0, 0, 0, 0)
+	cluster.AddTokenListToPatterns(tokenList, cm)
+
+	// Should have exactly one pattern (which is also the primary)
+	assert.Equal(t, 1, len(cluster.Patterns), "Should have exactly one pattern")
+
+	mostCommon := getMostCommonPattern(cluster)
+	assert.NotNil(t, mostCommon, "Most common pattern should not be nil")
+
+	pattern := mostCommon.Template
+	assert.NotNil(t, pattern, "Pattern template should not be nil")
+	assert.False(t, hasWildcards(cluster), "Single log should not have wildcards")
+	assert.Equal(t, tokenList.Length(), pattern.Length(), "Pattern length should match original TokenList")
+
+	for i, tok := range pattern.Tokens {
+		assert.Equal(t, tokenList.Tokens[i].Value, tok.Value,
+			"Pattern token %d value mismatch", i)
+	}
+}
+
+func TestCluster_MultiplePatterns_SpecialCharVariation(t *testing.T) {
+	// This is the key test for multi-pattern clusters!
+	// TokenLists with same signature but different special characters should create multiple patterns
+	// Note: Whitespace variations now merge (normalized to single space)
+
+	signature := token.Signature{
+		Position: "Error|Word|Whitespace|Word|Word|Word",
+		Length:   6,
+		Hash:     1234,
+	}
+
+	cluster := NewCluster(signature, true, 0, 0, 0, 0)
+
+	// Create TokenLists with different special characters (cannot merge - structural difference)
+	tokens1 := []token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard}, // Protected first word
+		{Value: ":", Type: token.TokenWord, Wildcard: token.NotWildcard},     // Colon
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "connection", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "failed", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	}
+	tokens2 := []token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: ";", Type: token.TokenWord, Wildcard: token.NotWildcard}, // Semicolon - DIFFERENT!
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "connection", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "timeout", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	}
+	tokens3 := []token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: ":", Type: token.TokenWord, Wildcard: token.NotWildcard}, // Colon - matches tokens1
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "database", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "error", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	}
+
+	tokenList1 := token.NewTokenListWithTokens(tokens1)
+	tokenList2 := token.NewTokenListWithTokens(tokens2)
+	tokenList3 := token.NewTokenListWithTokens(tokens3)
+
+	cm := NewClusterManager()
+	cluster.AddTokenListToPatterns(tokenList1, cm)
+	cluster.AddTokenListToPatterns(tokenList2, cm) // Different special char - new pattern
+	cluster.AddTokenListToPatterns(tokenList3, cm) // Same special char as tokens1 - same pattern
+
+	// Should have 2 patterns (one for colon, one for semicolon)
+	assert.Len(t, cluster.Patterns, 2, "Expected 2 patterns due to special character variation")
+
+	// Verify pattern sizes
+	pattern1Size := int(cluster.Patterns[0].GetFrequency())
+	pattern2Size := int(cluster.Patterns[1].GetFrequency())
+
+	// One pattern should have 2 token lists, the other should have 1
+	validSizes := (pattern1Size == 2 && pattern2Size == 1) || (pattern1Size == 1 && pattern2Size == 2)
+	assert.True(t, validSizes, "Expected pattern sizes [2, 1], got [%d, %d]", pattern1Size, pattern2Size)
+
+	t.Logf("✅ Multi-pattern cluster created: %d patterns", len(cluster.Patterns))
+	t.Logf("   Pattern 1: %d token lists", int(cluster.Patterns[0].GetFrequency()))
+	t.Logf("   Pattern 2: %d token lists", int(cluster.Patterns[1].GetFrequency()))
+}
+
+func TestCluster_FindMatchingPattern(t *testing.T) {
+	signature := token.Signature{
+		Position: "Error|Word|Whitespace|Word",
+		Length:   4,
+		Hash:     5678,
+	}
+
+	cluster := NewCluster(signature, true, 0, 0, 0, 0)
+
+	tokens1 := []token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: ":", Type: token.TokenWord},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "failed", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	}
+	tokens2 := []token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: ":", Type: token.TokenWord},
+		{Value: "  ", Type: token.TokenWhitespace}, // Different whitespace
+		{Value: "timeout", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	}
+
+	tokenList1 := token.NewTokenListWithTokens(tokens1)
+	tokenList2 := token.NewTokenListWithTokens(tokens2)
+
+	cm := NewClusterManager()
+	pattern1, _, _ := cluster.AddTokenListToPatterns(tokenList1, cm)
+	pattern2, _, _ := cluster.AddTokenListToPatterns(tokenList2, cm)
+
+	// Should return different patterns
+	assert.NotEqual(t, pattern1, pattern2, "Should create different patterns for different whitespace")
+
+	// findMatchingPattern should return the correct pattern for each token list
+	found1 := findMatchingPattern(cluster, tokenList1)
+	found2 := findMatchingPattern(cluster, tokenList2)
+
+	assert.Equal(t, pattern1, found1, "Should find the first pattern for tokenList1")
+	assert.Equal(t, pattern2, found2, "Should find the second pattern for tokenList2")
+}
+
+func TestCluster_GetMostCommonPattern(t *testing.T) {
+	signature := token.Signature{
+		Position: "Word|Whitespace|Word",
+		Length:   3,
+		Hash:     9999,
+	}
+
+	cluster := NewCluster(signature, true, 0, 0, 0, 0)
+	cm := NewClusterManager()
+
+	// Add multiple token lists that split into different patterns
+	// Pattern 1: 3 logs (should be most common)
+	for i := 0; i < 3; i++ {
+		tokens := []token.Token{
+			{Value: "Service", Type: token.TokenWord, Wildcard: token.NotWildcard},
+			{Value: " ", Type: token.TokenWhitespace},
+			{Value: "started", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		}
+		tokenList := token.NewTokenListWithTokens(tokens)
+		cluster.AddTokenListToPatterns(tokenList, cm)
+	}
+
+	// Pattern 2: 1 log (less common)
+	tokens2 := []token.Token{
+		{Value: "Service", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: "  ", Type: token.TokenWhitespace}, // Different whitespace
+		{Value: "stopped", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	}
+	tokenList2 := token.NewTokenListWithTokens(tokens2)
+	cluster.AddTokenListToPatterns(tokenList2, cm)
+
+	mostCommon := getMostCommonPattern(cluster)
+	assert.NotNil(t, mostCommon, "Most common pattern should not be nil")
+	assert.Equal(t, 3, mostCommon.LogCount, "Most common pattern should have 3 logs")
+}
+
+func TestCluster_GetAllPatterns(t *testing.T) {
+	signature := token.Signature{
+		Position: "Word|Whitespace|Numeric",
+		Length:   3,
+		Hash:     1111,
+	}
+
+	cluster := NewCluster(signature, true, 0, 0, 0, 0)
+	cm := NewClusterManager()
+
+	// Create 3 different patterns via whitespace variation
+	tokens1 := []token.Token{
+		{Value: "Count", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "42", Type: token.TokenNumeric},
+	}
+	tokens2 := []token.Token{
+		{Value: "Count", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: "  ", Type: token.TokenWhitespace}, // Different
+		{Value: "100", Type: token.TokenNumeric},
+	}
+	tokens3 := []token.Token{
+		{Value: "Count", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: "   ", Type: token.TokenWhitespace}, // Different
+		{Value: "200", Type: token.TokenNumeric},
+	}
+
+	cluster.AddTokenListToPatterns(token.NewTokenListWithTokens(tokens1), cm)
+	cluster.AddTokenListToPatterns(token.NewTokenListWithTokens(tokens2), cm)
+	cluster.AddTokenListToPatterns(token.NewTokenListWithTokens(tokens3), cm)
+
+	allPatterns := cluster.Patterns
+	assert.Len(t, allPatterns, 3, "Expected 3 patterns")
+}
+
+func TestCluster_ExtractWildcardValues_MultiPattern(t *testing.T) {
+	signature := token.Signature{
+		Position: "Error|Word|Whitespace|Word",
+		Length:   4,
+		Hash:     2222,
+	}
+
+	cluster := NewCluster(signature, true, 0, 0, 0, 0)
+
+	tokens1 := []token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: ":", Type: token.TokenWord},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "connection", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	}
+	tokens2 := []token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: ":", Type: token.TokenWord},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "timeout", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	}
+
+	tokenList1 := token.NewTokenListWithTokens(tokens1)
+	tokenList2 := token.NewTokenListWithTokens(tokens2)
+
+	cm := NewClusterManager()
+	cluster.AddTokenListToPatterns(tokenList1, cm)
+	cluster.AddTokenListToPatterns(tokenList2, cm)
+
+	// Both should merge into same pattern
+	// Extract wildcard values from tokenList2
+	values := extractWildcardValues(cluster, tokenList2)
+
+	// Should have one wildcard value for the last word token
+	assert.Len(t, values, 1, "Expected 1 wildcard value")
+	if len(values) > 0 {
+		assert.Equal(t, "timeout", values[0], "Expected wildcard value 'timeout'")
+	}
+}
+
+func TestCluster_Size_MultiPattern(t *testing.T) {
+	signature := token.Signature{
+		Position: "Word|Whitespace|Word",
+		Length:   3,
+		Hash:     3333,
+	}
+
+	cluster := NewCluster(signature, true, 0, 0, 0, 0)
+	cm := NewClusterManager()
+
+	// Add 2 token lists to pattern 1
+	for i := 0; i < 2; i++ {
+		tokens := []token.Token{
+			{Value: "Test", Type: token.TokenWord, Wildcard: token.NotWildcard},
+			{Value: " ", Type: token.TokenWhitespace},
+			{Value: "passed", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		}
+		cluster.AddTokenListToPatterns(token.NewTokenListWithTokens(tokens), cm)
+	}
+
+	// Add 3 token lists to pattern 2 (different whitespace)
+	for i := 0; i < 3; i++ {
+		tokens := []token.Token{
+			{Value: "Test", Type: token.TokenWord, Wildcard: token.NotWildcard},
+			{Value: "  ", Type: token.TokenWhitespace}, // Different
+			{Value: "failed", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		}
+		cluster.AddTokenListToPatterns(token.NewTokenListWithTokens(tokens), cm)
+	}
+
+	// Total size should be 5 (2 + 3)
+	assert.Equal(t, 5, clusterSize(cluster), "Expected cluster size 5 (2 + 3)")
+}
+
+// =============================================================================
+// Saturation Scoring Tests
+// =============================================================================
+
+func TestCluster_Saturation_BecomeSaturatedAfterThreshold(t *testing.T) {
+	threshold := 5
+	cm := NewClusterManagerWithConfig(true, 0, threshold, 0, 0)
+
+	// Seed: first log creates the pattern
+	seed := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn1", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	pattern, changeType, _, _ := cm.Add(seed)
+	assert.Equal(t, PatternNew, changeType)
+	assert.False(t, pattern.saturated)
+	assert.Equal(t, 0, pattern.consecutiveIdenticalMerges)
+
+	// Second log: creates wildcards (template structurally changes)
+	log2 := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn2", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	pattern, changeType, _, _ = cm.Add(log2)
+	assert.Equal(t, PatternUpdated, changeType)
+	assert.False(t, pattern.saturated)
+	assert.Equal(t, 0, pattern.consecutiveIdenticalMerges, "structural change resets counter")
+
+	// Logs 3 through 3+threshold-1: template is now converged (last token is wildcard),
+	// so TryMerge returns tl1 unchanged. Counter should increment each time.
+	for i := 0; i < threshold-1; i++ {
+		log := token.NewTokenListWithTokens([]token.Token{
+			{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+			{Value: " ", Type: token.TokenWhitespace},
+			{Value: "connX", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		})
+		pattern, _, _, _ = cm.Add(log)
+		assert.Equal(t, i+1, pattern.consecutiveIdenticalMerges, "counter should be %d after %d identical merges", i+1, i+1)
+		assert.False(t, pattern.saturated, "should not be saturated yet at count %d (threshold=%d)", i+1, threshold)
+	}
+
+	// One more identical merge should trigger saturation
+	log := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "connFinal", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	pattern, _, _, _ = cm.Add(log)
+	assert.Equal(t, threshold, pattern.consecutiveIdenticalMerges)
+	assert.True(t, pattern.saturated, "should be saturated after %d consecutive identical merges", threshold)
+}
+
+func TestCluster_Saturation_ResetOnStructuralChange(t *testing.T) {
+	threshold := 3
+	cm := NewClusterManagerWithConfig(true, 0, threshold, 0, 0)
+
+	// Seed + second log to create wildcards at position 2
+	seed := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn1", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "failed", Type: token.TokenWord, Wildcard: token.NotWildcard},
+	})
+	cm.Add(seed)
+
+	log2 := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn2", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "failed", Type: token.TokenWord, Wildcard: token.NotWildcard},
+	})
+	cm.Add(log2)
+
+	// Saturate the pattern (threshold=3 identical merges)
+	for i := 0; i < threshold; i++ {
+		log := token.NewTokenListWithTokens([]token.Token{
+			{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+			{Value: " ", Type: token.TokenWhitespace},
+			{Value: "connX", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+			{Value: " ", Type: token.TokenWhitespace},
+			{Value: "failed", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		})
+		cm.Add(log)
+	}
+
+	patterns := getAllPatterns(cm)
+	assert.Len(t, patterns, 1)
+	assert.True(t, patterns[0].saturated, "pattern should be saturated")
+
+	// Now send a log that causes a structural change (new wildcard at position 4)
+	structuralChange := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn99", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "timeout", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	pattern, _, _, _ := cm.Add(structuralChange)
+	assert.False(t, pattern.saturated, "structural change should reset saturation")
+	assert.Equal(t, 0, pattern.consecutiveIdenticalMerges, "structural change should reset counter")
+}
+
+func TestCluster_Saturation_DesaturateOnUnexpectedMiss(t *testing.T) {
+	threshold := 3
+
+	// Create cluster directly to control saturation state
+	sig := token.Signature{Position: "Word|Whitespace|Word", Length: 3, Hash: 7777}
+	cluster := NewCluster(sig, true, 0, threshold, 0, 0)
+	cm := NewClusterManager()
+
+	// Seed pattern
+	seed := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn1", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	cluster.AddTokenListToPatterns(seed, cm)
+
+	// Create wildcard at position 2
+	log2 := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn2", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	cluster.AddTokenListToPatterns(log2, cm)
+
+	// Saturate
+	for i := 0; i < threshold; i++ {
+		log := token.NewTokenListWithTokens([]token.Token{
+			{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+			{Value: " ", Type: token.TokenWhitespace},
+			{Value: "connX", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		})
+		cluster.AddTokenListToPatterns(log, cm)
+	}
+	assert.True(t, cluster.Patterns[0].saturated)
+	assert.Equal(t, cluster.lastMatchedPattern, cluster.Patterns[0])
+
+	// Send a structurally incompatible log (different first word — protected).
+	// TryMerge will return nil → desaturate → fall through → create new pattern.
+	incompatible := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Warn", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "slow", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	cluster.AddTokenListToPatterns(incompatible, cm)
+
+	// Original pattern should be desaturated
+	assert.False(t, cluster.Patterns[0].saturated, "should desaturate on unexpected miss")
+	assert.Equal(t, 0, cluster.Patterns[0].consecutiveIdenticalMerges, "counter should reset on miss")
+	// A new pattern should have been created
+	assert.Len(t, cluster.Patterns, 2, "incompatible log should create new pattern")
+}
+
+func TestCluster_Saturation_DisabledWhenThresholdZero(t *testing.T) {
+	cm := NewClusterManagerWithConfig(true, 0, 0, 0, 0) // threshold=0 disables saturation
+
+	seed := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn1", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	cm.Add(seed)
+
+	// Create wildcard
+	log2 := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn2", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	cm.Add(log2)
+
+	// Send 100 identical-structure logs — should never saturate
+	for i := 0; i < 100; i++ {
+		log := token.NewTokenListWithTokens([]token.Token{
+			{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+			{Value: " ", Type: token.TokenWhitespace},
+			{Value: "connX", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		})
+		cm.Add(log)
+	}
+
+	patterns := getAllPatterns(cm)
+	assert.Len(t, patterns, 1)
+	assert.False(t, patterns[0].saturated, "should never saturate when threshold=0")
+	assert.Equal(t, 0, patterns[0].consecutiveIdenticalMerges, "counter should stay 0 when disabled")
+}
+
+func TestCluster_Saturation_SkipsPositionsRebuildOnIdenticalMerge(t *testing.T) {
+	threshold := 2
+	cm := NewClusterManagerWithConfig(true, 0, threshold, 0, 0)
+
+	// Seed + second log to create wildcard at position 2
+	seed := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn1", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	pattern, _, _, _ := cm.Add(seed)
+	assert.Empty(t, pattern.Positions, "no wildcards after first log")
+
+	log2 := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn2", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	pattern, _, _, _ = cm.Add(log2)
+	assert.Equal(t, []int{2}, pattern.Positions, "wildcard at position 2 after second log")
+
+	// Capture the Positions slice header (pointer) before identical merges
+	positionsBefore := pattern.Positions
+
+	// Send identical-structure logs — Positions should not be rebuilt
+	for i := 0; i < threshold+5; i++ {
+		log := token.NewTokenListWithTokens([]token.Token{
+			{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+			{Value: " ", Type: token.TokenWhitespace},
+			{Value: "connX", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		})
+		pattern, _, _, _ = cm.Add(log)
+	}
+
+	// Positions content should be unchanged
+	assert.Equal(t, []int{2}, pattern.Positions)
+	// The slice should be the exact same backing array (not rebuilt)
+	assert.True(t, &positionsBefore[0] == &pattern.Positions[0],
+		"Positions slice should not be rebuilt on identical merges")
+}
+
+func TestCluster_Saturation_SaturatedPatternStillMergesCorrectly(t *testing.T) {
+	threshold := 3
+	cm := NewClusterManagerWithConfig(true, 0, threshold, 0, 0)
+
+	// Build and saturate a pattern
+	seed := token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn1", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	})
+	cm.Add(seed)
+	cm.Add(token.NewTokenListWithTokens([]token.Token{
+		{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "conn2", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+	}))
+	for i := 0; i < threshold; i++ {
+		cm.Add(token.NewTokenListWithTokens([]token.Token{
+			{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+			{Value: " ", Type: token.TokenWhitespace},
+			{Value: "connX", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		}))
+	}
+
+	patterns := getAllPatterns(cm)
+	assert.Len(t, patterns, 1)
+	assert.True(t, patterns[0].saturated)
+	logCountBefore := patterns[0].LogCount
+
+	// Send more logs after saturation — should still merge correctly
+	for i := 0; i < 10; i++ {
+		pattern, changeType, _, _ := cm.Add(token.NewTokenListWithTokens([]token.Token{
+			{Value: "Error", Type: token.TokenWord, Wildcard: token.NotWildcard},
+			{Value: " ", Type: token.TokenWhitespace},
+			{Value: "connPost", Type: token.TokenWord, Wildcard: token.PotentialWildcard},
+		}))
+		assert.Equal(t, PatternNoChange, changeType, "saturated pattern should still return PatternNoChange")
+		assert.Equal(t, patterns[0].PatternID, pattern.PatternID, "should merge into same pattern")
+	}
+
+	assert.Equal(t, logCountBefore+10, patterns[0].LogCount, "log count should increase by 10")
+	assert.True(t, patterns[0].saturated, "should remain saturated")
+	assert.Equal(t, 1, cm.PatternCount(), "no new patterns should be created")
+}
+
+// =============================================================================
+// Test Helper Functions
+// =============================================================================
+
+// getMostCommonPattern returns the pattern with the highest log count in the cluster.
+func getMostCommonPattern(c *Cluster) *Pattern {
+	if len(c.Patterns) == 0 {
+		return nil
+	}
+
+	mostCommonIdx := 0
+	maxLogCount := c.Patterns[0].LogCount
+	for idx, p := range c.Patterns {
+		if p.LogCount > maxLogCount {
+			maxLogCount = p.LogCount
+			mostCommonIdx = idx
+		}
+	}
+	return c.Patterns[mostCommonIdx]
+}
+
+// hasWildcards returns true if any pattern in this cluster contains wildcard positions.
+func hasWildcards(c *Cluster) bool {
+	for _, p := range c.Patterns {
+		if len(p.Positions) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// extractWildcardValues extracts wildcard values from a TokenList using the matching pattern.
+func extractWildcardValues(c *Cluster, tokenList *token.TokenList) []string {
+	p := findMatchingPattern(c, tokenList)
+	if p == nil {
+		return []string{}
+	}
+	return p.GetWildcardValues(tokenList)
+}
+
+// findMatchingPattern finds the Pattern that matches the given TokenList.
+func findMatchingPattern(c *Cluster, tokenList *token.TokenList) *Pattern {
+	if len(c.Patterns) == 0 {
+		return nil
+	}
+
+	// Try to find a Pattern where the TokenList can merge
+	for _, p := range c.Patterns {
+		// Check if this TokenList can merge with the pattern's sample
+		if p.Sample != nil && merging.CanMergeTokenLists(tokenList, p.Sample, true) {
+			return p
+		}
+	}
+
+	// No matching pattern found
+	return nil
+}
+
+// clusterSize returns the total number of logs across all patterns in the cluster.
+func clusterSize(c *Cluster) int {
+	total := 0
+	for _, p := range c.Patterns {
+		total += p.LogCount
+	}
+	return total
+}
+
+// =============================================================================
+// Scan Budget Tests
+// =============================================================================
+
+func makeWord(v string) token.Token {
+	return token.Token{Value: v, Type: token.TokenWord, Wildcard: token.PotentialWildcard}
+}
+
+func makeSpace() token.Token {
+	return token.Token{Value: " ", Type: token.TokenWhitespace}
+}
+
+// TestScanBudgetEnforced verifies that the scan loop stops after scanBudget patterns.
+// With budget=2 and 4 patterns, a value that only matches pattern #3 is NOT found,
+// causing a new pattern to be created instead.
+func TestScanBudgetEnforced(t *testing.T) {
+	sig := token.NewSignature(token.NewTokenListWithTokens([]token.Token{
+		makeWord("A"), makeSpace(), makeWord("B"),
+	}))
+	cm := NewClusterManager()
+	// first_word_protection=true keeps distinct first-word seeds as separate patterns
+	cluster := NewCluster(sig, true, 0, 0, 0, 2) // scanBudget=2
+
+	seeds := []string{"alpha", "beta", "gamma", "delta"}
+	for _, w := range seeds {
+		cluster.AddTokenListToPatterns(token.NewTokenListWithTokens([]token.Token{
+			makeWord(w), makeSpace(), makeWord("B"),
+		}), cm)
+	}
+	require.Equal(t, 4, len(cluster.Patterns), "need 4 distinct seed patterns")
+
+	// Reset cache and send "delta B" again — "delta" is at index 3, beyond budget=2.
+	// Budget skips it, so a new pattern is created (or it falls through to force-widen
+	// if maxPatterns is set; here maxPatterns=0 so a 5th pattern is created).
+	cluster.lastMatchedPattern = nil
+	patternsBefore := len(cluster.Patterns)
+	deltaVal := cluster.Patterns[3].Sample.Tokens[0].Value
+
+	cluster.AddTokenListToPatterns(token.NewTokenListWithTokens([]token.Token{
+		makeWord(deltaVal), makeSpace(), makeWord("B"),
+	}), cm)
+
+	// Budget=2 means indices 0 and 1 are scanned. Index 3 is not reached.
+	// "delta" doesn't match patterns at 0/1, so a new pattern is created.
+	assert.Equal(t, patternsBefore+1, len(cluster.Patterns), "budget should cause miss → new pattern")
+}
+
+// TestScanBudgetMoveToFront verifies that a scan hit within budget moves the matched
+// pattern to index 1, ensuring it's found on the next call without scanning further.
+func TestScanBudgetMoveToFront(t *testing.T) {
+	sig := token.NewSignature(token.NewTokenListWithTokens([]token.Token{
+		makeWord("X"), makeSpace(), makeWord("Y"),
+	}))
+	cm := NewClusterManager()
+	// first_word_protection=true keeps distinct first-word seeds as separate patterns
+	cluster := NewCluster(sig, true, 0, 0, 0, 5) // scanBudget=5 — large enough to scan all 3
+
+	// Create 3 patterns; protection=true keeps them separate
+	for _, w := range []string{"p0", "p1", "p2"} {
+		cluster.AddTokenListToPatterns(token.NewTokenListWithTokens([]token.Token{
+			makeWord(w), makeSpace(), makeWord("Y"),
+		}), cm)
+	}
+	require.Equal(t, 3, len(cluster.Patterns))
+
+	// "p2" is at index 2. Reset cache to force the full-scan loop.
+	cluster.lastMatchedPattern = nil
+	p2 := cluster.Patterns[2]
+	p2Val := p2.Sample.Tokens[0].Value
+
+	// Send "p2 Y" — should scan to index 2, find it, move it to index 1.
+	cluster.AddTokenListToPatterns(token.NewTokenListWithTokens([]token.Token{
+		makeWord(p2Val), makeSpace(), makeWord("Y"),
+	}), cm)
+
+	// p2 should now be at index 1 (moved from 2)
+	require.Equal(t, 3, len(cluster.Patterns), "no new pattern should be created")
+	assert.Same(t, p2, cluster.Patterns[1], "matched pattern should be at index 1 after move-to-front")
+}
+
+// =============================================================================
+// Max Patterns Per Cluster Tests
+// =============================================================================
+
+// TestMaxPatternsCapEnforced verifies that once a cluster reaches maxPatternsPerCluster,
+// new unmatched messages are force-widened into an existing pattern rather than creating
+// a new one.
+func TestMaxPatternsCapEnforced(t *testing.T) {
+	sig := token.NewSignature(token.NewTokenListWithTokens([]token.Token{
+		makeWord("svc"), makeSpace(), makeWord("val"),
+	}))
+	cm := NewClusterManager()
+	// first_word_protection=true prevents distinct first-words from merging,
+	// ensuring we actually reach the cap.
+	cluster := NewCluster(sig, true, 0, 0, 3, 0) // maxPatternsPerCluster=3
+
+	// Add 3 patterns; protection=true keeps them separate
+	for _, w := range []string{"aaa", "bbb", "ccc"} {
+		cluster.AddTokenListToPatterns(token.NewTokenListWithTokens([]token.Token{
+			makeWord(w), makeSpace(), makeWord(w),
+		}), cm)
+	}
+	assert.Equal(t, 3, len(cluster.Patterns), "should have exactly 3 patterns at cap")
+
+	// This 4th input would normally create a new pattern, but we're at cap.
+	cluster.AddTokenListToPatterns(token.NewTokenListWithTokens([]token.Token{
+		makeWord("ddd"), makeSpace(), makeWord("ddd"),
+	}), cm)
+
+	assert.Equal(t, 3, len(cluster.Patterns), "should still have 3 patterns — cap enforced")
+
+	// At least one pattern should now have a wildcard (force-widened)
+	widened := false
+	for _, p := range cluster.Patterns {
+		if len(p.Positions) > 0 {
+			widened = true
+			break
+		}
+	}
+	assert.True(t, widened, "at least one pattern should be widened (has wildcards)")
+}
+
+// TestMaxPatternsCapCorrectness verifies that force-widened patterns still match
+// subsequent messages of the same shape.
+func TestMaxPatternsCapCorrectness(t *testing.T) {
+	sig := token.NewSignature(token.NewTokenListWithTokens([]token.Token{
+		makeWord("svc"), makeSpace(), makeWord("val"),
+	}))
+	cm := NewClusterManager()
+	// first_word_protection=true keeps seeds separate so we reach the cap.
+	cluster := NewCluster(sig, true, 0, 0, 2, 0) // maxPatternsPerCluster=2
+
+	// Fill to cap — protection=true ensures these stay as two distinct patterns
+	for _, w := range []string{"aaa", "bbb"} {
+		cluster.AddTokenListToPatterns(token.NewTokenListWithTokens([]token.Token{
+			makeWord(w), makeSpace(), makeWord(w),
+		}), cm)
+	}
+	require.Equal(t, 2, len(cluster.Patterns), "need exactly 2 patterns at cap for this test")
+
+	// Force-widen with a new value
+	cluster.AddTokenListToPatterns(token.NewTokenListWithTokens([]token.Token{
+		makeWord("ccc"), makeSpace(), makeWord("ccc"),
+	}), cm)
+	assert.Equal(t, 2, len(cluster.Patterns), "cap still enforced after force-widen")
+
+	// A subsequent message should match the widened pattern (not create another)
+	initialCount := len(cluster.Patterns)
+	cluster.AddTokenListToPatterns(token.NewTokenListWithTokens([]token.Token{
+		makeWord("eee"), makeSpace(), makeWord("eee"),
+	}), cm)
+	assert.Equal(t, initialCount, len(cluster.Patterns), "subsequent message should not create new pattern")
+}

--- a/pkg/logs/patterns/clustering/merging/BUILD.bazel
+++ b/pkg/logs/patterns/clustering/merging/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "merging",
+    srcs = ["merging.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/logs/patterns/clustering/merging",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/logs/patterns/token"],
+)
+
+go_test(
+    name = "merging_test",
+    srcs = ["merging_test.go"],
+    embed = [":merging"],
+    deps = [
+        "//pkg/logs/patterns/token",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/logs/patterns/clustering/merging/merging.go
+++ b/pkg/logs/patterns/clustering/merging/merging.go
@@ -1,0 +1,209 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package merging provides intelligent mergeability logic for pattern generation.
+// It determines which TokenLists can be merged into unified patterns with wildcards,
+// and enforces protection rules to maintain semantic quality.
+package merging
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/token"
+)
+
+// CanMergeTokenLists checks if two TokenLists can merge — that is, whether all token positions
+// are either identical or mergeable according to their comparison results and protection rules.
+func CanMergeTokenLists(tl1, tl2 *token.TokenList, firstWordProtection bool) bool {
+	n := len(tl1.Tokens)
+	if n != len(tl2.Tokens) {
+		return false
+	}
+
+	// Fast pre-check: if first tokens conflict, skip the full loop.
+	// This is the most common rejection path — different log types rarely share position-0 tokens.
+	if n > 0 && tl1.Tokens[0].Type != tl2.Tokens[0].Type {
+		return false
+	}
+
+	// Precompute the position of the first word token in tl1 (only if protection is enabled).
+	firstWordPos1 := -1
+	if firstWordProtection {
+		for i, tok := range tl1.Tokens {
+			if tok.Type == token.TokenWord {
+				firstWordPos1 = i
+				break
+			}
+		}
+	}
+
+	tokens1 := tl1.Tokens[:n]
+	tokens2 := tl2.Tokens[:n]
+
+	for i := range n {
+		tok1 := &tokens1[i]
+		tok2 := &tokens2[i]
+
+		result := tok1.Compare(tok2)
+
+		// If tokens conflict, reject
+		if result == token.Conflict {
+			return false
+		}
+
+		// If tokens are identical, continue
+		if result == token.Identical {
+			continue
+		}
+
+		// For wildcard result, check first word protection rule
+		if result == token.Wildcard && tok1.Type == token.TokenWord && i == firstWordPos1 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// TryMergeTokenLists combines CanMergeTokenLists and MergeTokenLists into a single pass.
+// Returns the merged TokenList if compatible, or nil if incompatible.
+// This avoids walking the token arrays twice (once for CanMerge, once for Merge).
+// The first-word protection is symmetric: it protects the first word token position
+// from either list, making the function order-independent.
+func TryMergeTokenLists(tl1, tl2 *token.TokenList, firstWordProtection bool) *token.TokenList {
+	n := len(tl1.Tokens)
+	if n != len(tl2.Tokens) {
+		return nil
+	}
+
+	// Precompute the position of the first word token in each list (only if protection is enabled).
+	firstWordPos1 := -1
+	firstWordPos2 := -1
+	if firstWordProtection {
+		for i, tok := range tl1.Tokens {
+			if tok.Type == token.TokenWord {
+				firstWordPos1 = i
+				break
+			}
+		}
+		for i, tok := range tl2.Tokens {
+			if tok.Type == token.TokenWord {
+				firstWordPos2 = i
+				break
+			}
+		}
+	}
+
+	tokens1 := tl1.Tokens[:n]
+	tokens2 := tl2.Tokens[:n]
+
+	var tokens []token.Token
+
+	for i := range n {
+		tok1 := &tokens1[i]
+		tok2 := &tokens2[i]
+
+		result := tok1.Compare(tok2)
+
+		switch result {
+		case token.Conflict:
+			return nil
+
+		case token.Identical:
+			if tokens != nil {
+				tokens = append(tokens, *tok1)
+			}
+
+		case token.Wildcard:
+			// tok1.Type == tok2.Type is guaranteed here (Compare returns Wildcard only when types match)
+			if tok1.Type == token.TokenWord && (i == firstWordPos1 || i == firstWordPos2) {
+				return nil
+			}
+			if tokens == nil {
+				// First wildcard: allocate and copy all identical tokens seen so far
+				tokens = make([]token.Token, i, n)
+				copy(tokens, tokens1[:i])
+			}
+			tokens = append(tokens, token.Token{Type: tok1.Type, Value: tok1.Value, Wildcard: token.IsWildcard})
+		}
+	}
+
+	if tokens == nil {
+		return tl1 // all tokens identical — reuse existing list, zero allocation
+	}
+	return token.NewTokenListWithTokens(tokens)
+}
+
+// ForceWiden merges tokenList into template by wildcarding all non-identical positions.
+// No first-word protection. Returns nil if lengths differ; returns template (pointer-same)
+// if all positions are already identical (zero-alloc path).
+func ForceWiden(template, tokenList *token.TokenList) *token.TokenList {
+	if len(template.Tokens) != len(tokenList.Tokens) {
+		return nil
+	}
+	changed := false
+	for i := range template.Tokens {
+		if template.Tokens[i].Compare(&tokenList.Tokens[i]) != token.Identical {
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		return template
+	}
+	tokens := make([]token.Token, len(template.Tokens))
+	for i := range template.Tokens {
+		if template.Tokens[i].Compare(&tokenList.Tokens[i]) == token.Identical {
+			tokens[i] = template.Tokens[i]
+		} else {
+			tokens[i] = token.Token{Type: template.Tokens[i].Type, Wildcard: token.IsWildcard}
+		}
+	}
+	return token.NewTokenListWithTokens(tokens)
+}
+
+// MergeTokenLists performs the actual merge of two TokenLists, creating a new TokenList
+// with wildcards at positions where tokens differ but are mergeable.
+// Returns nil if the TokenLists cannot be merged.
+func MergeTokenLists(tl1, tl2 *token.TokenList, firstWordProtection bool) *token.TokenList {
+	n := len(tl1.Tokens)
+	if n != len(tl2.Tokens) {
+		return nil
+	}
+
+	// Precompute the position of the first word token in tl1 (only if protection is enabled).
+	firstWordPos1 := -1
+	if firstWordProtection {
+		for i, tok := range tl1.Tokens {
+			if tok.Type == token.TokenWord {
+				firstWordPos1 = i
+				break
+			}
+		}
+	}
+
+	tokens := make([]token.Token, 0, n)
+
+	for i := range n {
+		tok1 := &tl1.Tokens[i]
+		tok2 := &tl2.Tokens[i]
+
+		result := tok1.Compare(tok2)
+
+		switch result {
+		case token.Conflict:
+			return nil
+
+		case token.Identical:
+			tokens = append(tokens, *tok1)
+
+		case token.Wildcard:
+			if tok1.Type == token.TokenWord && i == firstWordPos1 {
+				return nil
+			}
+			tokens = append(tokens, token.Token{Type: tok1.Type, Value: tok1.Value, Wildcard: token.IsWildcard})
+		}
+	}
+
+	return token.NewTokenListWithTokens(tokens)
+}

--- a/pkg/logs/patterns/clustering/merging/merging_test.go
+++ b/pkg/logs/patterns/clustering/merging/merging_test.go
@@ -1,0 +1,605 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package merging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/token"
+)
+
+func TestFirstWordProtection_ViaCanMerge(t *testing.T) {
+	// Verify first-word protection semantics through the public CanMergeTokenLists API,
+	// replacing direct tests of the now-deleted shouldProtectPosition helper.
+
+	// First word at position 0 should be protected (merge blocked)
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "ERROR", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "failed", token.NotWildcard),
+	})
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "WARN", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "failed", token.NotWildcard),
+	})
+	assert.False(t, CanMergeTokenLists(tl1, tl2, true), "First word at position 0 should be protected")
+
+	// First numeric at position 0 is NOT protected (only words are)
+	tl3 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenNumeric, "2025", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "ERROR", token.NotWildcard),
+	})
+	tl4 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenNumeric, "2026", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "ERROR", token.NotWildcard),
+	})
+	assert.True(t, CanMergeTokenLists(tl3, tl4, true), "Numeric at position 0 should not be protected")
+
+	// Second word (not first) is NOT protected
+	tl5 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "ERROR", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "failed", token.PotentialWildcard),
+	})
+	tl6 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "ERROR", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "success", token.PotentialWildcard),
+	})
+	assert.True(t, CanMergeTokenLists(tl5, tl6, true), "Second word should not be protected")
+
+	// First word after timestamp should be protected
+	tl7 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenNumeric, "2025-11-16", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "07:03:09", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "ERROR", token.PotentialWildcard),
+	})
+	tl8 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenNumeric, "2025-11-17", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "08:00:00", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "WARN", token.PotentialWildcard),
+	})
+	assert.False(t, CanMergeTokenLists(tl7, tl8, true), "First word after timestamp should be protected")
+}
+
+func TestCanMergeTokenLists_IdenticalLists(t *testing.T) {
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "hello", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "world", token.NotWildcard),
+	})
+
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "hello", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "world", token.NotWildcard),
+	})
+
+	assert.True(t, CanMergeTokenLists(tl1, tl2, true))
+}
+
+func TestCanMergeTokenLists_PossiblyWildcardTokens(t *testing.T) {
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "logged", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "user123", token.PotentialWildcard),
+	})
+
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "logged", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "admin456", token.PotentialWildcard),
+	})
+
+	assert.True(t, CanMergeTokenLists(tl1, tl2, true))
+}
+
+func TestCanMergeTokenLists_GenericWords(t *testing.T) {
+	// Generic words without possiblyWildcard flag should not merge
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "bob", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "likes", token.NotWildcard),
+	})
+
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "cat", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "likes", token.NotWildcard),
+	})
+
+	assert.False(t, CanMergeTokenLists(tl1, tl2, true))
+}
+
+func TestCanMergeTokenLists_DifferentLengths(t *testing.T) {
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "hello", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "world", token.NotWildcard),
+	})
+
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "hello", token.NotWildcard),
+	})
+
+	assert.False(t, CanMergeTokenLists(tl1, tl2, true))
+}
+
+func TestCanMergeTokenLists_FirstWordProtection(t *testing.T) {
+	// First word protection should prevent merge even with possiblyWildcard
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "user123", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "logged", token.NotWildcard),
+	})
+
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "admin456", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "logged", token.NotWildcard),
+	})
+
+	assert.False(t, CanMergeTokenLists(tl1, tl2, true), "First word should be protected from wildcarding")
+}
+
+func TestMergeTokenLists_CreateWildcard(t *testing.T) {
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "logged", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "user123", token.PotentialWildcard),
+	})
+
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "logged", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "admin456", token.PotentialWildcard),
+	})
+
+	merged := MergeTokenLists(tl1, tl2, true)
+	assert.NotNil(t, merged)
+	assert.Equal(t, 3, merged.Length())
+	assert.Equal(t, "logged", merged.Tokens[0].Value)
+	assert.Equal(t, token.NotWildcard, merged.Tokens[0].Wildcard)
+	assert.Equal(t, " ", merged.Tokens[1].Value)
+	// Wildcard status is tracked via the Wildcard field; Value retains tok1's original value
+	assert.Equal(t, token.IsWildcard, merged.Tokens[2].Wildcard)
+	assert.Equal(t, token.TokenWord, merged.Tokens[2].Type)
+}
+
+func TestMergeTokenLists_UnmergeableReturnsNil(t *testing.T) {
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "bob", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "likes", token.NotWildcard),
+	})
+
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "cat", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "likes", token.NotWildcard),
+	})
+
+	merged := MergeTokenLists(tl1, tl2, true)
+	assert.Nil(t, merged, "Unmergeable TokenLists should return nil")
+}
+
+func TestMergeTokenLists_ProtectionRulesEnforced(t *testing.T) {
+	// Try to merge when first token is a word but differs
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "Login", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "successful", token.NotWildcard),
+	})
+
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "Logout", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "successful", token.NotWildcard),
+	})
+
+	// Should fail because first word is protected
+	merged := MergeTokenLists(tl1, tl2, true)
+	assert.Nil(t, merged, "Should not merge when first word differs (protected)")
+}
+
+func TestCanMergeTokenLists_TimestampPrefixedLogs(t *testing.T) {
+	// Test that first WORD (not severity level) after timestamp is protected
+	// Severity levels CAN wildcard, but the first actual word is protected
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenNumeric, "2025-11-16", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "07:03:09", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenSeverityLevel, "ERROR", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "Failed", token.NotWildcard),
+	})
+
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenNumeric, "2025-11-16", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "07:03:11", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenSeverityLevel, "WARN", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "Memory", token.NotWildcard),
+	})
+
+	// Should NOT merge because first word (Failed vs Memory) differs and is protected
+	// Note: Severity levels (ERROR vs WARN) CAN wildcard - they're not the "first word"
+	assert.False(t, CanMergeTokenLists(tl1, tl2, true), "First word token (after severity) should be protected")
+}
+
+func TestMergeTokenLists_TimestampPrefixedLogsSameFirstWord(t *testing.T) {
+	// Test that logs with same first word can merge, even with different timestamps and severity levels
+	// Pattern: * * * Failed *
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenNumeric, "2025-11-15", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "07:03:09", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenSeverityLevel, "ERROR", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "Failed", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "user123", token.PotentialWildcard),
+	})
+
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenNumeric, "2025-11-16", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "07:03:11", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenSeverityLevel, "WARN", token.PotentialWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "Failed", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenWord, "admin456", token.PotentialWildcard),
+	})
+
+	// Should merge - timestamps wildcard, severity wildcard, "Failed" is protected but identical, last word wildcards
+	merged := MergeTokenLists(tl1, tl2, true)
+	assert.NotNil(t, merged, "Should merge when first word matches")
+	assert.Equal(t, token.IsWildcard, merged.Tokens[0].Wildcard, "Date should be wildcarded")
+	assert.Equal(t, token.IsWildcard, merged.Tokens[2].Wildcard, "Time should be wildcarded")
+	assert.Equal(t, token.IsWildcard, merged.Tokens[4].Wildcard, "Severity level should be wildcarded")
+	assert.Equal(t, "Failed", merged.Tokens[6].Value, "Failed (first word) should be preserved")
+	assert.Equal(t, token.NotWildcard, merged.Tokens[6].Wildcard, "Failed should not be wildcarded (protected)")
+	assert.Equal(t, token.IsWildcard, merged.Tokens[8].Wildcard, "Last word should be wildcarded")
+}
+
+func TestTryMergeTokenLists_Equivalence(t *testing.T) {
+	type fixture struct {
+		name string
+		tl1  *token.TokenList
+		tl2  *token.TokenList
+	}
+
+	// --- fixtures where CanMergeTokenLists returns true ---
+	canMergeFixtures := []fixture{
+		{
+			name: "identical lists",
+			tl1: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "hello", token.NotWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "world", token.NotWildcard),
+			}),
+			tl2: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "hello", token.NotWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "world", token.NotWildcard),
+			}),
+		},
+		{
+			name: "wildcard-eligible words (non-first position)",
+			tl1: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "logged", token.NotWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "user123", token.PotentialWildcard),
+			}),
+			tl2: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "logged", token.NotWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "admin456", token.PotentialWildcard),
+			}),
+		},
+		{
+			name: "numeric at position 0 (not protected)",
+			tl1: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenNumeric, "2025", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "ERROR", token.NotWildcard),
+			}),
+			tl2: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenNumeric, "2026", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "ERROR", token.NotWildcard),
+			}),
+		},
+		{
+			name: "second word not protected",
+			tl1: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "ERROR", token.NotWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "failed", token.PotentialWildcard),
+			}),
+			tl2: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "ERROR", token.NotWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "success", token.PotentialWildcard),
+			}),
+		},
+		{
+			name: "timestamp-prefixed logs same first word",
+			tl1: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenNumeric, "2025-11-15", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenNumeric, "07:03:09", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenSeverityLevel, "ERROR", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "Failed", token.NotWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "user123", token.PotentialWildcard),
+			}),
+			tl2: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenNumeric, "2025-11-16", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenNumeric, "07:03:11", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenSeverityLevel, "WARN", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "Failed", token.NotWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "admin456", token.PotentialWildcard),
+			}),
+		},
+	}
+
+	// --- fixtures where CanMergeTokenLists returns false in BOTH directions ---
+	cannotMergeFixtures := []fixture{
+		{
+			name: "generic words no wildcard flag",
+			tl1: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "bob", token.NotWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "likes", token.NotWildcard),
+			}),
+			tl2: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "cat", token.NotWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "likes", token.NotWildcard),
+			}),
+		},
+		{
+			name: "different lengths",
+			tl1: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "hello", token.NotWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "world", token.NotWildcard),
+			}),
+			tl2: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "hello", token.NotWildcard),
+			}),
+		},
+		{
+			name: "first word at position 0 protected",
+			tl1: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "ERROR", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "failed", token.NotWildcard),
+			}),
+			tl2: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "WARN", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "failed", token.NotWildcard),
+			}),
+		},
+		{
+			name: "first word protected (first-word protection on position 0)",
+			tl1: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "user123", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "logged", token.NotWildcard),
+			}),
+			tl2: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenWord, "admin456", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "logged", token.NotWildcard),
+			}),
+		},
+		{
+			name: "timestamp-prefixed logs different first word after severity",
+			tl1: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenNumeric, "2025-11-16", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenNumeric, "07:03:09", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "ERROR", token.PotentialWildcard),
+			}),
+			tl2: token.NewTokenListWithTokens([]token.Token{
+				token.NewToken(token.TokenNumeric, "2025-11-17", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenNumeric, "08:00:00", token.PotentialWildcard),
+				token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+				token.NewToken(token.TokenWord, "WARN", token.PotentialWildcard),
+			}),
+		},
+	}
+
+	t.Run("CanMerge=true implies TryMerge returns non-nil and matches MergeTokenLists", func(t *testing.T) {
+		for _, f := range canMergeFixtures {
+			t.Run(f.name, func(t *testing.T) {
+				assert.True(t, CanMergeTokenLists(f.tl1, f.tl2, true), "prerequisite: CanMerge should be true")
+
+				tryResult := TryMergeTokenLists(f.tl1, f.tl2, true)
+				assert.NotNil(t, tryResult, "TryMerge should return non-nil when CanMerge is true")
+
+				mergeResult := MergeTokenLists(f.tl1, f.tl2, true)
+				assert.NotNil(t, mergeResult, "MergeTokenLists should return non-nil when CanMerge is true")
+
+				// Both must produce the same token sequence
+				assert.Equal(t, len(mergeResult.Tokens), len(tryResult.Tokens), "token count must match")
+				for i := range mergeResult.Tokens {
+					assert.Equal(t, mergeResult.Tokens[i].Type, tryResult.Tokens[i].Type,
+						"token[%d].Type mismatch", i)
+					assert.Equal(t, mergeResult.Tokens[i].Wildcard, tryResult.Tokens[i].Wildcard,
+						"token[%d].Wildcard mismatch", i)
+					// Only check Value for non-wildcard tokens (wildcard tokens have empty Value in TryMerge, matching MergeTokenLists)
+					if mergeResult.Tokens[i].Wildcard != token.IsWildcard {
+						assert.Equal(t, mergeResult.Tokens[i].Value, tryResult.Tokens[i].Value,
+							"token[%d].Value mismatch", i)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("CanMerge=false in both directions implies TryMerge returns nil", func(t *testing.T) {
+		for _, f := range cannotMergeFixtures {
+			t.Run(f.name, func(t *testing.T) {
+				// Confirm CanMerge is false in at least the forward direction for these fixtures
+				// (for different-length fixtures CanMerge is false in both directions trivially)
+				canFwd := CanMergeTokenLists(f.tl1, f.tl2, true)
+				canRev := CanMergeTokenLists(f.tl2, f.tl1, true)
+				assert.False(t, canFwd && canRev, "prerequisite: CanMerge should be false in at least one direction")
+
+				// TryMerge is symmetric; if CanMerge is false in both directions it must return nil
+				if !canFwd && !canRev {
+					tryFwd := TryMergeTokenLists(f.tl1, f.tl2, true)
+					tryRev := TryMergeTokenLists(f.tl2, f.tl1, true)
+					assert.Nil(t, tryFwd, "TryMerge(tl1,tl2) should return nil when both CanMerge directions are false")
+					assert.Nil(t, tryRev, "TryMerge(tl2,tl1) should return nil when both CanMerge directions are false")
+				}
+			})
+		}
+	})
+}
+
+func TestTryMergeTokenLists_IdentityOnIdentical(t *testing.T) {
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "Request", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "123", token.PotentialWildcard),
+	})
+
+	// tl2 is a separate allocation with identical token values
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "Request", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "123", token.PotentialWildcard),
+	})
+
+	result := TryMergeTokenLists(tl1, tl2, true)
+
+	// When all tokens are identical TryMerge must return tl1 itself (identity / zero alloc path)
+	assert.True(t, result == tl1, "TryMerge on identical lists must return the same pointer as tl1")
+	assert.NotNil(t, result)
+	assert.Equal(t, 3, result.Length(), "token count must be preserved")
+	assert.Equal(t, "Request", result.Tokens[0].Value)
+	assert.Equal(t, token.NotWildcard, result.Tokens[0].Wildcard)
+	assert.Equal(t, "123", result.Tokens[2].Value)
+
+	// Second merge: tl3 also identical → template must still be correct
+	tl3 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "Request", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "123", token.PotentialWildcard),
+	})
+
+	result2 := TryMergeTokenLists(result, tl3, true)
+	assert.True(t, result2 == result, "second TryMerge on identical lists must still return the same pointer")
+	assert.Equal(t, 3, result2.Length())
+	assert.Equal(t, "Request", result2.Tokens[0].Value)
+	assert.Equal(t, token.NotWildcard, result2.Tokens[0].Wildcard)
+}
+
+func TestMergeTokenLists_ProgressiveMerging(t *testing.T) {
+	// Test merging multiple TokenLists progressively
+	tl1 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "Request", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "123", token.PotentialWildcard),
+	})
+
+	tl2 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "Request", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "456", token.PotentialWildcard),
+	})
+
+	tl3 := token.NewTokenListWithTokens([]token.Token{
+		token.NewToken(token.TokenWord, "Request", token.NotWildcard),
+		token.NewToken(token.TokenWhitespace, " ", token.NotWildcard),
+		token.NewToken(token.TokenNumeric, "789", token.PotentialWildcard),
+	})
+
+	// Merge first two
+	merged12 := MergeTokenLists(tl1, tl2, true)
+	assert.NotNil(t, merged12)
+	assert.Equal(t, token.IsWildcard, merged12.Tokens[2].Wildcard)
+
+	// Merge result with third
+	merged123 := MergeTokenLists(merged12, tl3, true)
+	assert.NotNil(t, merged123)
+	assert.Equal(t, 3, merged123.Length())
+	assert.Equal(t, "Request", merged123.Tokens[0].Value)
+	// Wildcard status is tracked via the Wildcard field; Value retains tok1's original value
+	assert.Equal(t, token.IsWildcard, merged123.Tokens[2].Wildcard)
+	assert.Equal(t, token.TokenNumeric, merged123.Tokens[2].Type)
+}
+
+func TestForceWiden_IdenticalReturnsPointerSame(t *testing.T) {
+	tl := token.NewTokenListWithTokens([]token.Token{
+		{Value: "hello", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "world", Type: token.TokenWord, Wildcard: token.NotWildcard},
+	})
+	result := ForceWiden(tl, tl)
+	assert.Same(t, tl, result, "identical input should return same pointer (zero-alloc)")
+}
+
+func TestForceWiden_DifferingPositionBecomesWildcard(t *testing.T) {
+	template := token.NewTokenListWithTokens([]token.Token{
+		{Value: "ERROR", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "something", Type: token.TokenWord, Wildcard: token.NotWildcard},
+	})
+	incoming := token.NewTokenListWithTokens([]token.Token{
+		{Value: "WARN", Type: token.TokenWord, Wildcard: token.NotWildcard},
+		{Value: " ", Type: token.TokenWhitespace},
+		{Value: "something", Type: token.TokenWord, Wildcard: token.NotWildcard},
+	})
+	result := ForceWiden(template, incoming)
+	require.NotNil(t, result)
+	assert.NotSame(t, template, result, "different inputs should allocate new list")
+	assert.Equal(t, token.IsWildcard, result.Tokens[0].Wildcard, "differing pos 0 should be wildcard")
+	assert.Equal(t, token.TokenWord, result.Tokens[0].Type, "type should be preserved")
+	assert.Equal(t, token.NotWildcard, result.Tokens[2].Wildcard, "identical pos 2 should stay")
+	assert.Equal(t, "something", result.Tokens[2].Value, "identical value preserved")
+}
+
+func TestForceWiden_LengthMismatchReturnsNil(t *testing.T) {
+	short := token.NewTokenListWithTokens([]token.Token{
+		{Value: "A", Type: token.TokenWord},
+	})
+	long := token.NewTokenListWithTokens([]token.Token{
+		{Value: "A", Type: token.TokenWord},
+		{Value: "B", Type: token.TokenWord},
+	})
+	assert.Nil(t, ForceWiden(short, long))
+	assert.Nil(t, ForceWiden(long, short))
+}

--- a/pkg/logs/patterns/clustering/pattern.go
+++ b/pkg/logs/patterns/clustering/pattern.go
@@ -1,0 +1,283 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package clustering provides clustering functionality for grouping similar TokenLists,
+// extracting patterns wildcard, and managing pattern lifecycle through eviction policies.
+package clustering
+
+import (
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/token"
+)
+
+// Pattern represents a single pattern within a cluster.
+// A cluster with the same signature may contain multiple incompatible patterns
+// (e.g., different non-identical special characters that cannot merge).
+type Pattern struct {
+	Template  *token.TokenList // The pattern template with wildcards (matches proto "template")
+	Positions []int            // Token indices that are wildcards (matches proto "pos_list")
+	PatternID uint64           // Unique pattern ID (matches proto "pattern_id")
+	Sample    *token.TokenList // First log sample (for multi-pattern matching)
+	LogCount  int              // Total number of logs that matched this pattern
+
+	// Timestamp tracking for stateful encoding and eviction
+	CreatedAt    time.Time // When pattern was first created (used for age-based decay)
+	UpdatedAt    time.Time // When pattern was last modified (structure changed)
+	LastAccessAt time.Time // When pattern last matched a log (used for recency in eviction)
+
+	// Saturation tracking: once a pattern has converged (all variable positions are wildcards),
+	// TryMergeTokenLists returns the template pointer unchanged (zero-alloc identical path).
+	// After saturatedThreshold consecutive identical merges, CanMergeTokenLists pre-check is skipped.
+	consecutiveIdenticalMerges int
+	saturated                  bool
+}
+
+// newPattern creates a new pattern from a single token list.
+func newPattern(tokenList *token.TokenList, patternID uint64) *Pattern {
+	now := time.Now()
+	return &Pattern{
+		Template:     tokenList, // First log becomes initial template
+		Positions:    []int{},   // No wildcards yet
+		PatternID:    patternID,
+		Sample:       tokenList, // Store first log as sample
+		LogCount:     1,         // First log
+		CreatedAt:    now,       // Pattern birth time (for age decay)
+		UpdatedAt:    now,       // Last structure modification
+		LastAccessAt: now,       // Last match time (for recency in eviction)
+	}
+}
+
+// GetFrequency returns the usage frequency for eviction scoring
+func (p *Pattern) GetFrequency() float64 {
+	return float64(p.LogCount)
+}
+
+// GetCreatedAt returns when this pattern was created
+func (p *Pattern) GetCreatedAt() time.Time {
+	return p.CreatedAt
+}
+
+// GetLastAccessAt returns when this pattern was last accessed
+func (p *Pattern) GetLastAccessAt() time.Time {
+	return p.LastAccessAt
+}
+
+// EstimatedBytes returns an approximate memory footprint (in bytes) of this pattern.
+//
+// This is NOT exact Go heap usage; it is a heuristic used to trigger eviction before unbounded growth.
+// It focuses on the dominant contributors: token value strings, wildcard positions, and token slices.
+func (p *Pattern) EstimatedBytes() int64 {
+	var b int64
+
+	// Positions slice (ints)
+	b += int64(len(p.Positions)) * 8
+
+	// Estimate token lists (avoid double counting if Sample == Template)
+	b += estimateTokenListBytes(p.Template)
+	if p.Sample != nil && p.Sample != p.Template {
+		b += estimateTokenListBytes(p.Sample)
+	}
+
+	return b
+}
+
+func estimateTokenListBytes(tl *token.TokenList) int64 {
+	if tl == nil {
+		return 0
+	}
+
+	var b int64
+	// Token slice header/struct overhead is ignored; we approximate dominant string storage.
+	for _, tok := range tl.Tokens {
+		b += int64(len(tok.Value))
+	}
+	return b
+}
+
+// GetPatternString returns the pattern template.
+// Pattern template has no wildcard placeholders and wildcard tokens are completely omitted
+func (p *Pattern) GetPatternString() string {
+	if p.Template == nil {
+		return ""
+	}
+
+	var builder strings.Builder
+	estimatedLen := 0
+	for _, tok := range p.Template.Tokens {
+		// Skip wildcard tokens entirely
+		if tok.Wildcard == token.IsWildcard {
+			continue
+		}
+		estimatedLen += len(tok.Value)
+	}
+	builder.Grow(estimatedLen)
+
+	for _, tok := range p.Template.Tokens {
+		if tok.Wildcard == token.IsWildcard {
+			continue
+		}
+		if sanitizeForTemplateInto(&builder, tok.Value) == 0 {
+			continue
+		}
+	}
+
+	return builder.String()
+}
+
+// hasWildcards returns true if this pattern contains wildcard positions.
+func (p *Pattern) hasWildcards() bool {
+	return len(p.Positions) > 0
+}
+
+// GetWildcardCount returns the number of wildcard positions in this pattern.
+// This matches the ParamCount that will be sent in PatternDefine.
+func (p *Pattern) GetWildcardCount() int {
+	return len(p.Positions)
+}
+
+// GetWildcardCharPositions returns character indices where dynamic values should be injected.
+// The template does NOT contain wildcard placeholders - wildcards are omitted entirely.
+// Positions mark the injection points in the template string.
+// Example: Template "User  logged" (wildcard omitted) returns [5] (inject after "User ")
+func (p *Pattern) GetWildcardCharPositions() []int {
+	if p.Template == nil {
+		return nil
+	}
+
+	var charPositions []int
+	currentPos := 0
+
+	for _, tok := range p.Template.Tokens {
+		if tok.Wildcard == token.IsWildcard {
+			// Mark the injection point (current position in template which excludes wildcards)
+			charPositions = append(charPositions, currentPos)
+			// Wildcard tokens are NOT in the template, so don't advance currentPos
+		} else {
+			cleanedLen := sanitizeForTemplateLen(tok.Value)
+			if cleanedLen > 0 {
+				// Add the length of the cleaned token value
+				currentPos += cleanedLen
+			}
+		}
+	}
+
+	return charPositions
+}
+
+// GetWildcardValues extracts the wildcard values from a specific TokenList.
+// The caller (processMessage) must ensure tokenList is compatible with this pattern's
+// template — this was verified during AddTokenListToPatterns/TryMergeTokenLists.
+func (p *Pattern) GetWildcardValues(tokenList *token.TokenList) []string {
+	if p.Template == nil || len(p.Positions) == 0 {
+		return []string{}
+	}
+
+	n := len(tokenList.Tokens)
+	wildcardValues := make([]string, len(p.Positions))
+
+	for i, templatePos := range p.Positions {
+		if templatePos < n {
+			wildcardValues[i] = tokenList.Tokens[templatePos].Value
+		}
+	}
+
+	return wildcardValues
+}
+
+// sanitizeForTemplate removes non-printable characters from template strings
+func sanitizeForTemplate(s string) string {
+	var builder strings.Builder
+	written := sanitizeForTemplateInto(&builder, s)
+	if written == len(s) {
+		return s
+	}
+	return builder.String()
+}
+
+// sanitizeForTemplateLen returns the length of the sanitized string without allocating.
+func sanitizeForTemplateLen(s string) int {
+	return sanitizeForTemplateInto(nil, s)
+}
+
+// sanitizeForTemplateInto appends the sanitized string into builder when non-nil.
+// Uses an ASCII fast path: bytes < 0x80 are checked directly without rune decoding.
+func sanitizeForTemplateInto(builder *strings.Builder, s string) int {
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b < utf8.RuneSelf {
+			if b >= ' ' && b != 0x7F {
+				continue
+			}
+			// ASCII control character found — flush clean prefix then filter the rest
+			if builder != nil {
+				builder.WriteString(s[:i])
+			}
+			written := i
+			i++
+			for i < len(s) {
+				b = s[i]
+				if b < utf8.RuneSelf {
+					if b >= ' ' && b != 0x7F {
+						if builder != nil {
+							builder.WriteByte(b)
+						}
+						written++
+					}
+					i++
+					continue
+				}
+				r, size := utf8.DecodeRuneInString(s[i:])
+				if r >= ' ' && r != 0x7F && r != utf8.RuneError && r < 0xFFFD {
+					if builder != nil {
+						builder.WriteString(s[i : i+size])
+					}
+					written += size
+				}
+				i += size
+			}
+			return written
+		}
+		// Non-ASCII byte — decode rune
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r < ' ' || r == 0x7F || r == utf8.RuneError || r >= 0xFFFD {
+			if builder != nil {
+				builder.WriteString(s[:i])
+			}
+			written := i
+			i += size
+			for i < len(s) {
+				b = s[i]
+				if b < utf8.RuneSelf {
+					if b >= ' ' && b != 0x7F {
+						if builder != nil {
+							builder.WriteByte(b)
+						}
+						written++
+					}
+					i++
+					continue
+				}
+				r, size = utf8.DecodeRuneInString(s[i:])
+				if r >= ' ' && r != 0x7F && r != utf8.RuneError && r < 0xFFFD {
+					if builder != nil {
+						builder.WriteString(s[i : i+size])
+					}
+					written += size
+				}
+				i += size
+			}
+			return written
+		}
+		i += size - 1 // outer loop increments i
+	}
+
+	if builder != nil {
+		builder.WriteString(s)
+	}
+	return len(s)
+}

--- a/pkg/logs/patterns/clustering/pattern_eviction.go
+++ b/pkg/logs/patterns/clustering/pattern_eviction.go
@@ -1,0 +1,152 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package clustering provides clustering functionality for grouping similar TokenLists,
+// extracting patterns wildcard, and managing pattern lifecycle through eviction policies.
+package clustering
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/eviction"
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/token"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// CollectEvictables collects all patterns as evictables (implements eviction.EvictableCollection).
+func (cm *ClusterManager) CollectEvictables() []eviction.Evictable {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	evictables := make([]eviction.Evictable, 0, cm.patternCount)
+	for _, clusters := range cm.hashBuckets {
+		for _, cluster := range clusters {
+			for _, pattern := range cluster.Patterns {
+				evictables = append(evictables, pattern)
+			}
+		}
+	}
+	return evictables
+}
+
+// RemoveEvictable removes a specific pattern from the cluster manager (implements eviction.EvictableCollection).
+func (cm *ClusterManager) RemoveEvictable(item eviction.Evictable) {
+	pattern := item.(*Pattern)
+	cm.removePattern(pattern)
+}
+
+// removePattern removes a specific pattern from the cluster manager's hash buckets.
+func (cm *ClusterManager) removePattern(pattern *Pattern) {
+	var (
+		targetHash uint64
+		targetSig  *token.Signature
+	)
+
+	if pattern.Sample != nil && !pattern.Sample.IsEmpty() {
+		sig := token.NewSignature(pattern.Sample)
+		targetSig = &sig
+		targetHash = sig.GetHashBucket()
+	} else if pattern.Template != nil && !pattern.Template.IsEmpty() {
+		sig := token.NewSignature(pattern.Template)
+		targetSig = &sig
+		targetHash = sig.GetHashBucket()
+	}
+
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	removeFromBucket := func(hash uint64, clusters []*Cluster, verifySignature bool) bool {
+		for ci := 0; ci < len(clusters); ci++ {
+			cluster := clusters[ci]
+			if verifySignature && targetSig != nil && !targetSig.Equals(cluster.Signature) {
+				continue
+			}
+
+			for pi := 0; pi < len(cluster.Patterns); pi++ {
+				if cluster.Patterns[pi] != pattern {
+					continue
+				}
+
+				// Update counters before removing pattern
+				cm.patternCount--
+				cm.estimatedBytes -= pattern.EstimatedBytes()
+
+				// Invalidate hot-pattern cache if it points to the evicted pattern.
+				if cluster.lastMatchedPattern == pattern {
+					cluster.lastMatchedPattern = nil
+				}
+
+				// Remove pattern with swap delete for speed
+				lastPattern := len(cluster.Patterns) - 1
+				cluster.Patterns[pi] = cluster.Patterns[lastPattern]
+				cluster.Patterns = cluster.Patterns[:lastPattern]
+				cluster.UpdatedAt = time.Now()
+
+				if len(cluster.Patterns) == 0 {
+					// Remove cluster from bucket
+					lastCluster := len(clusters) - 1
+					clusters[ci] = clusters[lastCluster]
+					clusters = clusters[:lastCluster]
+
+					if len(clusters) == 0 {
+						delete(cm.hashBuckets, hash)
+					} else {
+						cm.hashBuckets[hash] = clusters
+					}
+				} else {
+					cm.hashBuckets[hash] = clusters
+				}
+				return true
+			}
+		}
+		return false
+	}
+
+	// Try targeted bucket first
+	if targetSig != nil {
+		if clusters, ok := cm.hashBuckets[targetHash]; ok {
+			if removeFromBucket(targetHash, clusters, true) {
+				return
+			}
+		}
+	}
+
+	// Fallback: full scan if signature was missing or not found in target bucket
+	for hash, clusters := range cm.hashBuckets {
+		if removeFromBucket(hash, clusters, false) {
+			return
+		}
+	}
+
+	log.Warnf("Pattern %d not found during eviction, may have been already removed", pattern.PatternID)
+}
+
+// EvictLowestScoringPatterns evicts up to numToEvict patterns with the lowest eviction scores.
+// Returns the list of evicted patterns.
+func (cm *ClusterManager) EvictLowestScoringPatterns(numToEvict int, decayFactor float64, gracePeriod time.Duration) []*Pattern {
+	evictables := eviction.EvictLowestScoring(cm, numToEvict, decayFactor, gracePeriod)
+	if len(evictables) == 0 {
+		return nil
+	}
+	patterns := make([]*Pattern, len(evictables))
+	for i, ev := range evictables {
+		patterns[i] = ev.(*Pattern)
+	}
+	return patterns
+}
+
+// EvictToMemoryTarget evicts patterns until the target memory is freed.
+// It uses actual pattern sizes rather than averages for precision.
+func (cm *ClusterManager) EvictToMemoryTarget(targetBytesToFree int64, decayFactor float64, gracePeriod time.Duration) []*Pattern {
+	evictables := eviction.EvictToMemoryTarget(cm, targetBytesToFree, decayFactor, gracePeriod)
+	if len(evictables) == 0 {
+		return nil
+	}
+	patterns := make([]*Pattern, len(evictables))
+	for i, ev := range evictables {
+		patterns[i] = ev.(*Pattern)
+	}
+	return patterns
+}

--- a/pkg/logs/patterns/clustering/pattern_eviction_manager.go
+++ b/pkg/logs/patterns/clustering/pattern_eviction_manager.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package clustering provides clustering functionality for grouping similar TokenLists,
+// extracting patterns wildcard, and managing pattern lifecycle through eviction policies.
+package clustering
+
+import (
+	"time"
+
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/eviction"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// EvictionManager handles pattern eviction using dual watermark system.
+// It wraps the generic eviction.Manager with clustering-specific configuration.
+type EvictionManager struct {
+	*eviction.Manager
+}
+
+// NewEvictionManager creates a new EvictionManager from config
+func NewEvictionManager() *EvictionManager {
+	cfg := pkgconfigsetup.Datadog()
+
+	gracePeriodSec := cfg.GetInt("logs_config.patterns.eviction_grace_period_seconds")
+
+	return &EvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          cfg.GetInt("logs_config.patterns.max_pattern_count"),
+			MaxMemoryBytes:        int64(cfg.GetInt("logs_config.patterns.max_memory_bytes")),
+			EvictionHighWatermark: cfg.GetFloat64("logs_config.patterns.eviction_high_watermark"),
+			EvictionLowWatermark:  cfg.GetFloat64("logs_config.patterns.eviction_low_watermark"),
+			AgeDecayFactor:        cfg.GetFloat64("logs_config.patterns.age_decay_factor"),
+			GracePeriod:           time.Duration(gracePeriodSec) * time.Second,
+		},
+	}
+}
+
+// Evict performs eviction on the cluster manager based on which threshold was exceeded
+// and returns the evicted patterns.
+func (em *EvictionManager) Evict(cm *ClusterManager, patternCount int, estimatedBytes int64, countOverLimit, bytesOverLimit bool) []*Pattern {
+	var evicted []*Pattern
+
+	numToEvict, bytesToFree, strategy := em.EvictionTargets(patternCount, estimatedBytes, countOverLimit, bytesOverLimit)
+
+	switch strategy {
+	// Memory-based eviction
+	case eviction.StrategyByBytes:
+		evicted = cm.EvictToMemoryTarget(bytesToFree, em.AgeDecayFactor, em.GracePeriod)
+
+		highWatermarkBytes := int64(float64(em.MaxMemoryBytes) * em.EvictionHighWatermark)
+		targetBytes := int64(float64(em.MaxMemoryBytes) * em.EvictionLowWatermark)
+		log.Tracef("Evicted %d patterns: memory %d bytes exceeded high watermark %d bytes (%.0f%% of %d max), now targeting %d bytes (%.0f%%)",
+			len(evicted), estimatedBytes, highWatermarkBytes,
+			em.EvictionHighWatermark*100, em.MaxMemoryBytes,
+			targetBytes, em.EvictionLowWatermark*100)
+
+	// Count-based eviction
+	case eviction.StrategyByCount:
+		evicted = cm.EvictLowestScoringPatterns(numToEvict, em.AgeDecayFactor, em.GracePeriod)
+
+		highWatermarkCount := int(float64(em.MaxItemCount) * em.EvictionHighWatermark)
+		targetCount := int(float64(em.MaxItemCount) * em.EvictionLowWatermark)
+		log.Tracef("Evicted %d patterns: count %d exceeded high watermark %d (%.0f%% of %d max), now targeting %d (%.0f%%)",
+			len(evicted), patternCount, highWatermarkCount,
+			em.EvictionHighWatermark*100, em.MaxItemCount,
+			targetCount, em.EvictionLowWatermark*100)
+	}
+	return evicted
+}

--- a/pkg/logs/patterns/clustering/pattern_eviction_manager_test.go
+++ b/pkg/logs/patterns/clustering/pattern_eviction_manager_test.go
@@ -1,0 +1,405 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package clustering
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/eviction"
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/token"
+)
+
+// TestEvictionManager_ShouldEvict_CountThreshold tests count-based eviction triggers
+func TestEvictionManager_ShouldEvict_CountThreshold(t *testing.T) {
+	em := &EvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	tests := []struct {
+		name             string
+		patternCount     int
+		estimatedBytes   int64
+		expectCountLimit bool
+		expectBytesLimit bool
+	}{
+		{
+			name:             "below both thresholds",
+			patternCount:     500,
+			estimatedBytes:   500_000,
+			expectCountLimit: false,
+			expectBytesLimit: false,
+		},
+		{
+			name:             "exactly at count high watermark",
+			patternCount:     900, // 1000 * 0.9
+			estimatedBytes:   500_000,
+			expectCountLimit: false,
+			expectBytesLimit: false,
+		},
+		{
+			name:             "just above count high watermark",
+			patternCount:     901,
+			estimatedBytes:   500_000,
+			expectCountLimit: true,
+			expectBytesLimit: false,
+		},
+		{
+			name:             "at max count",
+			patternCount:     1000,
+			estimatedBytes:   500_000,
+			expectCountLimit: true,
+			expectBytesLimit: false,
+		},
+		{
+			name:             "over max count",
+			patternCount:     1100,
+			estimatedBytes:   500_000,
+			expectCountLimit: true,
+			expectBytesLimit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			countLimit, bytesLimit := em.ShouldEvict(tt.patternCount, tt.estimatedBytes)
+			assert.Equal(t, tt.expectCountLimit, countLimit, "count limit mismatch")
+			assert.Equal(t, tt.expectBytesLimit, bytesLimit, "bytes limit mismatch")
+		})
+	}
+}
+
+// TestEvictionManager_ShouldEvict_MemoryThreshold tests memory-based eviction triggers
+func TestEvictionManager_ShouldEvict_MemoryThreshold(t *testing.T) {
+	em := &EvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	tests := []struct {
+		name             string
+		patternCount     int
+		estimatedBytes   int64
+		expectCountLimit bool
+		expectBytesLimit bool
+	}{
+		{
+			name:             "exactly at memory high watermark",
+			patternCount:     500,
+			estimatedBytes:   900_000, // 1_000_000 * 0.9
+			expectCountLimit: false,
+			expectBytesLimit: false,
+		},
+		{
+			name:             "just above memory high watermark",
+			patternCount:     500,
+			estimatedBytes:   900_001,
+			expectCountLimit: false,
+			expectBytesLimit: true,
+		},
+		{
+			name:             "at max memory",
+			patternCount:     500,
+			estimatedBytes:   1_000_000,
+			expectCountLimit: false,
+			expectBytesLimit: true,
+		},
+		{
+			name:             "over max memory",
+			patternCount:     500,
+			estimatedBytes:   1_100_000,
+			expectCountLimit: false,
+			expectBytesLimit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			countLimit, bytesLimit := em.ShouldEvict(tt.patternCount, tt.estimatedBytes)
+			assert.Equal(t, tt.expectCountLimit, countLimit, "count limit mismatch")
+			assert.Equal(t, tt.expectBytesLimit, bytesLimit, "bytes limit mismatch")
+		})
+	}
+}
+
+// TestEvictionManager_ShouldEvict_BothThresholds tests when both thresholds are exceeded
+func TestEvictionManager_ShouldEvict_BothThresholds(t *testing.T) {
+	em := &EvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	// Both thresholds exceeded
+	countLimit, bytesLimit := em.ShouldEvict(1000, 1_000_000)
+	assert.True(t, countLimit, "count limit should be true")
+	assert.True(t, bytesLimit, "bytes limit should be true")
+}
+
+// TestEvictionManager_EvictionTargets_CountBased tests count-based eviction target calculations
+func TestEvictionManager_EvictionTargets_CountBased(t *testing.T) {
+	em := &EvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	tests := []struct {
+		name              string
+		patternCount      int
+		estimatedBytes    int64
+		countOverLimit    bool
+		bytesOverLimit    bool
+		expectNumToEvict  int
+		expectBytesToFree int64
+		expectStrategy    eviction.Strategy
+	}{
+		{
+			name:              "count over limit - evict to low watermark",
+			patternCount:      950,
+			estimatedBytes:    500_000,
+			countOverLimit:    true,
+			bytesOverLimit:    false,
+			expectNumToEvict:  250, // 950 - (1000 * 0.7)
+			expectBytesToFree: 0,
+			expectStrategy:    eviction.StrategyByCount,
+		},
+		{
+			name:              "count at max - evict to low watermark",
+			patternCount:      1000,
+			estimatedBytes:    500_000,
+			countOverLimit:    true,
+			bytesOverLimit:    false,
+			expectNumToEvict:  300, // 1000 - 700
+			expectBytesToFree: 0,
+			expectStrategy:    eviction.StrategyByCount,
+		},
+		{
+			name:              "count barely over - evict at least 1",
+			patternCount:      701,
+			estimatedBytes:    500_000,
+			countOverLimit:    true,
+			bytesOverLimit:    false,
+			expectNumToEvict:  1, // min(701 - 700, 1)
+			expectBytesToFree: 0,
+			expectStrategy:    eviction.StrategyByCount,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			numToEvict, bytesToFree, strategy := em.EvictionTargets(
+				tt.patternCount, tt.estimatedBytes, tt.countOverLimit, tt.bytesOverLimit)
+
+			assert.Equal(t, tt.expectNumToEvict, numToEvict, "numToEvict mismatch")
+			assert.Equal(t, tt.expectBytesToFree, bytesToFree, "bytesToFree mismatch")
+			assert.Equal(t, tt.expectStrategy, strategy, "strategy mismatch")
+		})
+	}
+}
+
+// TestEvictionManager_EvictionTargets_MemoryBased tests memory-based eviction target calculations
+func TestEvictionManager_EvictionTargets_MemoryBased(t *testing.T) {
+	em := &EvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	tests := []struct {
+		name              string
+		patternCount      int
+		estimatedBytes    int64
+		countOverLimit    bool
+		bytesOverLimit    bool
+		expectNumToEvict  int
+		expectBytesToFree int64
+		expectStrategy    eviction.Strategy
+	}{
+		{
+			name:              "memory over limit - evict to low watermark",
+			patternCount:      500,
+			estimatedBytes:    950_000,
+			countOverLimit:    false,
+			bytesOverLimit:    true,
+			expectNumToEvict:  0,
+			expectBytesToFree: 250_000, // 950_000 - (1_000_000 * 0.7)
+			expectStrategy:    eviction.StrategyByBytes,
+		},
+		{
+			name:              "memory at max - evict to low watermark",
+			patternCount:      500,
+			estimatedBytes:    1_000_000,
+			countOverLimit:    false,
+			bytesOverLimit:    true,
+			expectNumToEvict:  0,
+			expectBytesToFree: 300_000, // 1_000_000 - 700_000
+			expectStrategy:    eviction.StrategyByBytes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			numToEvict, bytesToFree, strategy := em.EvictionTargets(
+				tt.patternCount, tt.estimatedBytes, tt.countOverLimit, tt.bytesOverLimit)
+
+			assert.Equal(t, tt.expectNumToEvict, numToEvict, "numToEvict mismatch")
+			assert.Equal(t, tt.expectBytesToFree, bytesToFree, "bytesToFree mismatch")
+			assert.Equal(t, tt.expectStrategy, strategy, "strategy mismatch")
+		})
+	}
+}
+
+// TestEvictionManager_EvictionTargets_PrioritizeMemory tests that memory eviction takes priority
+func TestEvictionManager_EvictionTargets_PrioritizeMemory(t *testing.T) {
+	em := &EvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	// Both limits exceeded - memory should take priority
+	numToEvict, bytesToFree, strategy := em.EvictionTargets(1000, 1_000_000, true, true)
+
+	assert.Equal(t, 0, numToEvict, "numToEvict should be 0 when evicting by memory")
+	assert.Equal(t, int64(300_000), bytesToFree, "should evict to memory low watermark")
+	assert.Equal(t, eviction.StrategyByBytes, strategy, "should prioritize memory-based eviction")
+}
+
+// TestEvictionManager_Evict_Integration tests the full eviction flow
+func TestEvictionManager_Evict_Integration(t *testing.T) {
+	em := &EvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          100,
+			MaxMemoryBytes:        10_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	cm := NewClusterManager()
+	now := time.Now()
+
+	// Add 100 unique patterns (at count limit)
+	for i := 0; i < 100; i++ {
+		tl := token.NewTokenList()
+		// Make each pattern unique
+		tl.Add(token.NewToken(token.TokenWord, fmt.Sprintf("pattern-%d", i), token.NotWildcard))
+		pattern, _, _, _ := cm.Add(tl)
+
+		// Make some patterns more valuable (higher scores)
+		if i < 50 {
+			pattern.LogCount = 100 // Low score
+			pattern.CreatedAt = now.Add(-10 * 24 * time.Hour)
+			pattern.LastAccessAt = now.Add(-9 * 24 * time.Hour)
+		} else {
+			pattern.LogCount = 10000 // High score
+			pattern.CreatedAt = now.Add(-1 * 24 * time.Hour)
+			pattern.LastAccessAt = now
+		}
+	}
+
+	initialCount := cm.PatternCount()
+	require.Equal(t, 100, initialCount)
+
+	// Trigger count-based eviction
+	countLimit, bytesLimit := em.ShouldEvict(initialCount, cm.EstimatedBytes())
+	require.True(t, countLimit, "count limit should be exceeded")
+
+	// Perform eviction
+	_ = em.Evict(cm, initialCount, cm.EstimatedBytes(), countLimit, bytesLimit)
+
+	// Verify patterns were evicted
+	finalCount := cm.PatternCount()
+	assert.Less(t, finalCount, initialCount, "patterns should be evicted")
+	assert.LessOrEqual(t, finalCount, 70, "should evict to around low watermark (70)")
+
+	// Verify we're below the limit now
+	countLimit, _ = em.ShouldEvict(finalCount, cm.EstimatedBytes())
+	assert.False(t, countLimit, "should be below count limit after eviction")
+}
+
+// TestEvictionManager_Evict_MemoryBased tests memory-based eviction
+func TestEvictionManager_Evict_MemoryBased(t *testing.T) {
+	em := &EvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        5_000, // Low memory limit
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	cm := NewClusterManager()
+	now := time.Now()
+
+	// Add unique patterns until memory is exceeded
+	for i := 0; i < 50; i++ {
+		tl := token.NewTokenList()
+		// Make each pattern unique
+		tl.Add(token.NewToken(token.TokenWord, fmt.Sprintf("test_pattern_with_long_name_for_memory_%d", i), token.NotWildcard))
+		pattern, _, _, _ := cm.Add(tl)
+
+		// Vary scores
+		if i%2 == 0 {
+			pattern.LogCount = 100
+			pattern.CreatedAt = now.Add(-10 * 24 * time.Hour)
+			pattern.LastAccessAt = now.Add(-9 * 24 * time.Hour)
+		} else {
+			pattern.LogCount = 10000
+			pattern.CreatedAt = now
+			pattern.LastAccessAt = now
+		}
+	}
+
+	initialBytes := cm.EstimatedBytes()
+
+	// Check if we're over memory limit
+	_, bytesLimit := em.ShouldEvict(cm.PatternCount(), initialBytes)
+	if !bytesLimit {
+		t.Skip("Not over memory limit, skipping memory eviction test")
+	}
+
+	// Perform eviction
+	_ = em.Evict(cm, cm.PatternCount(), initialBytes, false, bytesLimit)
+
+	// Verify memory was freed
+	finalBytes := cm.EstimatedBytes()
+	assert.Less(t, finalBytes, initialBytes, "memory should decrease after eviction")
+}

--- a/pkg/logs/patterns/clustering/pattern_eviction_test.go
+++ b/pkg/logs/patterns/clustering/pattern_eviction_test.go
@@ -1,0 +1,145 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package clustering
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/token"
+)
+
+// TestPattern_ImplementsEvictable verifies Pattern correctly implements the eviction.Evictable interface
+func TestPattern_ImplementsEvictable(t *testing.T) {
+	now := time.Now()
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "test", token.NotWildcard))
+
+	pattern := newPattern(tl, 123)
+	pattern.LogCount = 500
+	pattern.CreatedAt = now.Add(-10 * 24 * time.Hour)
+	pattern.LastAccessAt = now.Add(-1 * time.Hour)
+
+	// Verify all Evictable methods work
+	assert.Equal(t, 500.0, pattern.GetFrequency(), "GetFrequency should return LogCount")
+	assert.Equal(t, pattern.CreatedAt, pattern.GetCreatedAt(), "GetCreatedAt should return CreatedAt")
+	assert.Equal(t, pattern.LastAccessAt, pattern.GetLastAccessAt(), "GetLastAccessAt should return LastAccessAt")
+	assert.Greater(t, pattern.EstimatedBytes(), int64(0), "EstimatedBytes should be positive")
+}
+
+// TestClusterManager_ImplementsEvictableCollection verifies ClusterManager implements EvictableCollection
+func TestClusterManager_ImplementsEvictableCollection(t *testing.T) {
+	cm := NewClusterManager()
+
+	// Add some patterns
+	tl1 := token.NewTokenList()
+	tl1.Add(token.NewToken(token.TokenWord, "error", token.NotWildcard))
+	cm.Add(tl1)
+
+	tl2 := token.NewTokenList()
+	tl2.Add(token.NewToken(token.TokenWord, "warning", token.NotWildcard))
+	cm.Add(tl2)
+
+	// Test CollectEvictables
+	evictables := cm.CollectEvictables()
+	assert.Equal(t, 2, len(evictables), "Should collect all patterns as evictables")
+
+	// Test RemoveEvictable
+	cm.RemoveEvictable(evictables[0])
+	assert.Equal(t, 1, cm.PatternCount(), "Should remove pattern via RemoveEvictable")
+}
+
+// TestClusterManager_EvictLowestScoringPatterns_Integration tests end-to-end eviction by count
+func TestClusterManager_EvictLowestScoringPatterns_Integration(t *testing.T) {
+	cm := NewClusterManager()
+	now := time.Now()
+
+	// Add 3 patterns with different characteristics
+	// Pattern 1: High frequency, should be kept
+	tl1 := token.NewTokenList()
+	tl1.Add(token.NewToken(token.TokenWord, "error", token.NotWildcard))
+	p1, _, _, _ := cm.Add(tl1)
+	p1.LogCount = 10000
+	p1.CreatedAt = now.Add(-10 * 24 * time.Hour)
+	p1.LastAccessAt = now
+
+	// Pattern 2: Low frequency, should be evicted
+	tl2 := token.NewTokenList()
+	tl2.Add(token.NewToken(token.TokenWord, "warning", token.NotWildcard))
+	p2, _, _, _ := cm.Add(tl2)
+	p2.LogCount = 100
+	p2.CreatedAt = now.Add(-5 * 24 * time.Hour)
+	p2.LastAccessAt = now.Add(-4 * 24 * time.Hour)
+
+	// Pattern 3: Medium frequency, should be kept
+	tl3 := token.NewTokenList()
+	tl3.Add(token.NewToken(token.TokenWord, "info", token.NotWildcard))
+	p3, _, _, _ := cm.Add(tl3)
+	p3.LogCount = 5000
+	p3.CreatedAt = now.Add(-15 * 24 * time.Hour)
+	p3.LastAccessAt = now.Add(-1 * time.Hour)
+
+	// Evict 1 pattern
+	evicted := cm.EvictLowestScoringPatterns(1, 0.5, 0)
+
+	assert.Equal(t, 1, len(evicted), "Should evict exactly 1 pattern")
+	assert.Equal(t, p2.PatternID, evicted[0].PatternID, "Should evict the lowest scoring pattern (p2)")
+	assert.Equal(t, 2, cm.PatternCount(), "Should have 2 patterns remaining")
+}
+
+// TestClusterManager_EvictToMemoryTarget_Integration tests end-to-end eviction by memory
+func TestClusterManager_EvictToMemoryTarget_Integration(t *testing.T) {
+	cm := NewClusterManager()
+	now := time.Now()
+
+	// Add patterns with known memory footprints
+	tl1 := token.NewTokenList()
+	tl1.Add(token.NewToken(token.TokenWord, "error", token.NotWildcard))
+	p1, _, _, _ := cm.Add(tl1)
+	p1.LogCount = 100 // Low score
+	p1.CreatedAt = now.Add(-10 * 24 * time.Hour)
+	p1.LastAccessAt = now.Add(-9 * 24 * time.Hour)
+
+	tl2 := token.NewTokenList()
+	tl2.Add(token.NewToken(token.TokenWord, "warning", token.NotWildcard))
+	p2, _, _, _ := cm.Add(tl2)
+	p2.LogCount = 10000 // High score
+	p2.CreatedAt = now.Add(-5 * 24 * time.Hour)
+	p2.LastAccessAt = now
+
+	initialBytes := cm.EstimatedBytes()
+
+	// Evict until we free at least 50% of memory
+	targetBytes := initialBytes / 2
+	evicted := cm.EvictToMemoryTarget(targetBytes, 0.5, 0)
+
+	assert.Greater(t, len(evicted), 0, "Should evict at least one pattern")
+	assert.Less(t, cm.EstimatedBytes(), initialBytes, "Memory should decrease")
+
+	// Verify low-scoring pattern was evicted
+	if len(evicted) > 0 {
+		assert.Equal(t, p1.PatternID, evicted[0].PatternID, "Should evict lowest scoring pattern first")
+	}
+}
+
+// TestClusterManager_EvictZero tests that evicting 0 or negative patterns returns nil
+func TestClusterManager_EvictZero(t *testing.T) {
+	cm := NewClusterManager()
+
+	evicted := cm.EvictLowestScoringPatterns(0, 0.5, 0)
+	assert.Nil(t, evicted, "Evicting 0 patterns should return nil")
+
+	evicted = cm.EvictLowestScoringPatterns(-5, 0.5, 0)
+	assert.Nil(t, evicted, "Evicting negative patterns should return nil")
+
+	evicted = cm.EvictToMemoryTarget(0, 0.5, 0)
+	assert.Nil(t, evicted, "Evicting 0 bytes should return nil")
+
+	evicted = cm.EvictToMemoryTarget(-100, 0.5, 0)
+	assert.Nil(t, evicted, "Evicting negative bytes should return nil")
+}

--- a/pkg/logs/patterns/clustering/pattern_test.go
+++ b/pkg/logs/patterns/clustering/pattern_test.go
@@ -1,0 +1,432 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package clustering
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/token"
+)
+
+// Test-only helper functions
+
+func TestNewPattern(t *testing.T) {
+	// Create a simple token list
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Service", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, "started", token.PotentialWildcard))
+
+	patternID := uint64(12345)
+	pattern := newPattern(tl, patternID)
+
+	assert.NotNil(t, pattern)
+	assert.Equal(t, patternID, pattern.PatternID)
+	assert.Equal(t, tl, pattern.Template, "Template should be the initial token list")
+	assert.Equal(t, tl, pattern.Sample, "Sample should be the initial token list")
+	assert.Equal(t, 1, pattern.LogCount, "LogCount should be 1 for first log")
+	assert.Equal(t, 0, len(pattern.Positions), "No wildcards initially")
+	assert.False(t, pattern.CreatedAt.IsZero(), "CreatedAt should be set")
+	assert.False(t, pattern.UpdatedAt.IsZero(), "UpdatedAt should be set")
+}
+
+func TestAddTokenList(t *testing.T) {
+	// Note: addTokenList() was inlined into Cluster.AddTokenListToPatterns()
+	// This test now verifies that LogCount and UpdatedAt can be modified directly
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Service", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, "started", token.PotentialWildcard))
+
+	pattern := newPattern(tl, 12345)
+	initialLogCount := pattern.LogCount
+	initialUpdatedAt := pattern.UpdatedAt
+
+	// Simulate what cluster does when adding to existing pattern
+	time.Sleep(1 * time.Millisecond) // Ensure time difference
+	pattern.LogCount++
+	pattern.UpdatedAt = time.Now()
+
+	assert.Equal(t, initialLogCount+1, pattern.LogCount, "LogCount should increment")
+	assert.True(t, pattern.UpdatedAt.After(initialUpdatedAt), "UpdatedAt should be updated")
+}
+
+func TestSize(t *testing.T) {
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Test", token.PotentialWildcard))
+
+	pattern := newPattern(tl, 12345)
+	assert.Equal(t, 1.0, pattern.GetFrequency())
+
+	// Simulate adding more logs (what cluster does)
+	pattern.LogCount++
+	assert.Equal(t, 2.0, pattern.GetFrequency())
+
+	pattern.LogCount++
+	assert.Equal(t, 3.0, pattern.GetFrequency())
+}
+
+func TestGetPatternString_NoWildcards(t *testing.T) {
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Service", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, "started", token.PotentialWildcard))
+
+	pattern := newPattern(tl, 12345)
+	result := pattern.GetPatternString()
+
+	assert.Equal(t, "Service started", result)
+}
+
+func TestGetPatternString_WithWildcards(t *testing.T) {
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Service", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, "value", token.IsWildcard))
+
+	pattern := newPattern(tl, 12345)
+	pattern.Positions = []int{2}
+	result := pattern.GetPatternString()
+
+	// Wildcard tokens are omitted from the template
+	assert.Equal(t, "Service ", result)
+}
+
+func TestGetPatternString_NilTemplate(t *testing.T) {
+	pattern := &Pattern{
+		Template: nil,
+	}
+	result := pattern.GetPatternString()
+
+	assert.Equal(t, "", result)
+}
+
+func TestHasWildcards(t *testing.T) {
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Test", token.PotentialWildcard))
+
+	pattern := newPattern(tl, 12345)
+
+	// No wildcards initially
+	assert.False(t, pattern.hasWildcards())
+
+	// Add wildcard positions
+	pattern.Positions = []int{1, 3}
+	assert.True(t, pattern.hasWildcards())
+}
+
+func TestGetWildcardPositions(t *testing.T) {
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Test", token.PotentialWildcard))
+
+	pattern := newPattern(tl, 12345)
+	pattern.Positions = []int{1, 3, 5}
+
+	assert.Equal(t, []int{1, 3, 5}, pattern.Positions)
+}
+
+// getParamCount returns the number of parameters/wildcards in a pattern.
+func getParamCount(p *Pattern) int {
+	return len(p.Positions)
+}
+
+func TestGetParamCount(t *testing.T) {
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Test", token.PotentialWildcard))
+
+	pattern := newPattern(tl, 12345)
+
+	// No wildcards
+	assert.Equal(t, 0, getParamCount(pattern))
+
+	// Add wildcard positions
+	pattern.Positions = []int{1, 3, 5}
+	assert.Equal(t, 3, getParamCount(pattern))
+}
+
+func TestGetWildcardCharPositions(t *testing.T) {
+	// Create pattern: "Service " (wildcard omitted from template)
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Service", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, "value", token.IsWildcard))
+
+	pattern := newPattern(tl, 12345)
+	pattern.Positions = []int{2}
+
+	charPositions := pattern.GetWildcardCharPositions()
+	// "Service " = 8 chars, wildcard injection point is at position 8
+	assert.Equal(t, []int{8}, charPositions)
+}
+
+func TestGetWildcardCharPositions_MultipleWildcards(t *testing.T) {
+	// Create pattern: "Error  in " (both wildcards omitted from template)
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Error", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, "code", token.IsWildcard))
+	tl.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, "in", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, "module", token.IsWildcard))
+
+	pattern := newPattern(tl, 12345)
+	pattern.Positions = []int{2, 6}
+
+	charPositions := pattern.GetWildcardCharPositions()
+	// Template is "Error  in " (wildcards omitted): "Error " (6 chars) + " in " (4 chars) = 10 chars
+	// First wildcard injection at position 6 (after "Error ")
+	// Second wildcard injection at position 10 (after "Error  in ")
+	assert.Equal(t, []int{6, 10}, charPositions)
+}
+
+func TestGetWildcardCharPositions_NilTemplate(t *testing.T) {
+	pattern := &Pattern{
+		Template: nil,
+	}
+
+	charPositions := pattern.GetWildcardCharPositions()
+	assert.Nil(t, charPositions)
+}
+
+func TestGetWildcardValues(t *testing.T) {
+	// Create sample log: "Service started"
+	sample := token.NewTokenList()
+	sample.Add(token.NewToken(token.TokenWord, "Service", token.NotWildcard))
+	sample.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	sample.Add(token.NewToken(token.TokenWord, "started", token.PotentialWildcard))
+
+	// Create template with wildcard: "Service *"
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Service", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	tl.Add(token.NewToken(token.TokenWord, "value", token.IsWildcard))
+
+	pattern := newPattern(sample, 12345)
+	pattern.Template = tl
+	pattern.Positions = []int{2}
+
+	values := pattern.GetWildcardValues(sample)
+	assert.Equal(t, []string{"started"}, values)
+}
+
+func TestGetWildcardValues_NilTemplate(t *testing.T) {
+	sample := token.NewTokenList()
+	sample.Add(token.NewToken(token.TokenWord, "Test", token.PotentialWildcard))
+
+	pattern := newPattern(sample, 12345)
+	pattern.Template = nil
+
+	values := pattern.GetWildcardValues(sample)
+	assert.Empty(t, values)
+}
+
+func TestGetWildcardValues_NilSample(t *testing.T) {
+	tl := token.NewTokenList()
+	tl.Add(token.NewToken(token.TokenWord, "Test", token.IsWildcard))
+
+	pattern := newPattern(tl, 12345)
+	pattern.Sample = nil
+	pattern.Positions = []int{0}
+
+	// Test with the template itself since sample is nil
+	values := pattern.GetWildcardValues(tl)
+	assert.Equal(t, []string{"Test"}, values)
+}
+
+func TestExtractWildcardValues(t *testing.T) {
+	// Create template: "Service *"
+	template := token.NewTokenList()
+	template.Add(token.NewToken(token.TokenWord, "Service", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, "value", token.IsWildcard))
+
+	pattern := newPattern(template, 12345)
+	pattern.Template = template
+	pattern.Positions = []int{2}
+
+	// Create incoming log: "Service crashed"
+	incoming := token.NewTokenList()
+	incoming.Add(token.NewToken(token.TokenWord, "Service", token.NotWildcard))
+	incoming.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	incoming.Add(token.NewToken(token.TokenWord, "crashed", token.PotentialWildcard))
+
+	values := pattern.GetWildcardValues(incoming)
+	assert.Equal(t, []string{"crashed"}, values)
+}
+
+func TestExtractWildcardValues_MultipleWildcards(t *testing.T) {
+	// Create template: "* in * at *"
+	template := token.NewTokenList()
+	template.Add(token.NewToken(token.TokenWord, "value1", token.IsWildcard))
+	template.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, "in", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, "value2", token.IsWildcard))
+	template.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, "at", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, "value3", token.IsWildcard))
+
+	pattern := newPattern(template, 12345)
+	pattern.Template = template
+	pattern.Positions = []int{0, 4, 8}
+
+	// Create incoming log: "Error in module at line"
+	incoming := token.NewTokenList()
+	incoming.Add(token.NewToken(token.TokenWord, "Error", token.PotentialWildcard))
+	incoming.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	incoming.Add(token.NewToken(token.TokenWord, "in", token.NotWildcard))
+	incoming.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	incoming.Add(token.NewToken(token.TokenWord, "module", token.PotentialWildcard))
+	incoming.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	incoming.Add(token.NewToken(token.TokenWord, "at", token.NotWildcard))
+	incoming.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	incoming.Add(token.NewToken(token.TokenWord, "line", token.PotentialWildcard))
+
+	values := pattern.GetWildcardValues(incoming)
+	assert.Equal(t, []string{"Error", "module", "line"}, values)
+}
+
+func TestExtractWildcardValues_NilTemplate(t *testing.T) {
+	pattern := &Pattern{
+		Template:  nil,
+		Positions: []int{0},
+	}
+
+	incoming := token.NewTokenList()
+	incoming.Add(token.NewToken(token.TokenWord, "Test", token.PotentialWildcard))
+
+	values := pattern.GetWildcardValues(incoming)
+	assert.Equal(t, []string{}, values)
+}
+
+func TestExtractWildcardValues_NoPositions(t *testing.T) {
+	template := token.NewTokenList()
+	template.Add(token.NewToken(token.TokenWord, "Test", token.NotWildcard))
+
+	pattern := newPattern(template, 12345)
+	pattern.Positions = []int{} // No wildcards
+
+	incoming := token.NewTokenList()
+	incoming.Add(token.NewToken(token.TokenWord, "Test", token.NotWildcard))
+
+	values := pattern.GetWildcardValues(incoming)
+	assert.Equal(t, []string{}, values)
+}
+
+func TestExtractWildcardValues_PositionOutOfBounds(t *testing.T) {
+	template := token.NewTokenList()
+	template.Add(token.NewToken(token.TokenWord, "Test", token.IsWildcard))
+
+	pattern := newPattern(template, 12345)
+	pattern.Positions = []int{0, 5} // Position 5 is out of bounds
+
+	incoming := token.NewTokenList()
+	incoming.Add(token.NewToken(token.TokenWord, "Value", token.PotentialWildcard))
+
+	values := pattern.GetWildcardValues(incoming)
+	// CRITICAL: Must return same length as Positions to match ParamCount
+	// Out-of-bounds positions are filled with empty strings
+	assert.Equal(t, []string{"Value", ""}, values, "Should maintain Positions length with empty strings for out-of-bounds")
+}
+
+func TestSanitizeForTemplate_PrintableChars(t *testing.T) {
+	input := "Hello World 123"
+	result := sanitizeForTemplate(input)
+	assert.Equal(t, "Hello World 123", result)
+}
+
+func TestSanitizeForTemplate_NonPrintableChars(t *testing.T) {
+	// Include null byte, bell, backspace
+	input := "Hello\x00\x07\x08World"
+	result := sanitizeForTemplate(input)
+	assert.Equal(t, "HelloWorld", result, "Non-printable characters should be removed")
+}
+
+func TestSanitizeForTemplate_DELCharacter(t *testing.T) {
+	input := "Hello\x7FWorld"
+	result := sanitizeForTemplate(input)
+	assert.Equal(t, "HelloWorld", result, "DEL character should be removed")
+}
+
+func TestSanitizeForTemplate_SpecialChars(t *testing.T) {
+	input := "Service: Error! @user #tag"
+	result := sanitizeForTemplate(input)
+	assert.Equal(t, "Service: Error! @user #tag", result, "Special chars should be kept")
+}
+
+func TestSanitizeForTemplate_EmptyString(t *testing.T) {
+	input := ""
+	result := sanitizeForTemplate(input)
+	assert.Equal(t, "", result)
+}
+
+func TestSanitizeForTemplate_UnicodeChars(t *testing.T) {
+	input := "Hello 世界 🌍"
+	result := sanitizeForTemplate(input)
+	// Emoji (🌍) is above 0xFFFD and gets filtered out by sanitizeForTemplate
+	// CJK characters (世界) are within the acceptable range
+	assert.Equal(t, "Hello 世界 ", result, "CJK chars preserved, emoji filtered")
+}
+
+func TestPattern_IntegrationScenario(t *testing.T) {
+	// Simulate a realistic pattern lifecycle
+
+	// 1. First log arrives
+	log1 := token.NewTokenList()
+	log1.Add(token.NewToken(token.TokenWord, "ERROR", token.NotWildcard))
+	log1.Add(token.NewToken(token.TokenWord, ":", token.NotWildcard))
+	log1.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	log1.Add(token.NewToken(token.TokenWord, "Database", token.PotentialWildcard))
+	log1.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	log1.Add(token.NewToken(token.TokenWord, "connection", token.PotentialWildcard))
+	log1.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	log1.Add(token.NewToken(token.TokenWord, "failed", token.PotentialWildcard))
+
+	pattern := newPattern(log1, 9999)
+
+	assert.Equal(t, 1, pattern.LogCount)
+	assert.False(t, pattern.hasWildcards())
+	assert.Equal(t, "ERROR: Database connection failed", pattern.GetPatternString())
+
+	// 2. Pattern updated with wildcards (simulated)
+	template := token.NewTokenList()
+	template.Add(token.NewToken(token.TokenWord, "ERROR", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, ":", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, "value", token.IsWildcard))
+	template.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, "value", token.IsWildcard))
+	template.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	template.Add(token.NewToken(token.TokenWord, "value", token.IsWildcard))
+
+	pattern.Template = template
+	pattern.Positions = []int{3, 5, 7}
+	pattern.LogCount++ // Simulate second log being added
+	pattern.UpdatedAt = time.Now()
+
+	assert.Equal(t, 2, pattern.LogCount)
+	assert.True(t, pattern.hasWildcards())
+	assert.Equal(t, 3, getParamCount(pattern))
+	// Wildcard tokens are omitted from template, leaving: "ERROR: " + " " + " " = "ERROR:   "
+	assert.Equal(t, "ERROR:   ", pattern.GetPatternString())
+
+	// 3. Extract wildcard values from new log
+	log2 := token.NewTokenList()
+	log2.Add(token.NewToken(token.TokenWord, "ERROR", token.NotWildcard))
+	log2.Add(token.NewToken(token.TokenWord, ":", token.NotWildcard))
+	log2.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	log2.Add(token.NewToken(token.TokenWord, "Network", token.PotentialWildcard))
+	log2.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	log2.Add(token.NewToken(token.TokenWord, "timeout", token.PotentialWildcard))
+	log2.Add(token.NewToken(token.TokenWord, " ", token.NotWildcard))
+	log2.Add(token.NewToken(token.TokenWord, "reached", token.PotentialWildcard))
+
+	values := pattern.GetWildcardValues(log2)
+	assert.Equal(t, []string{"Network", "timeout", "reached"}, values)
+}

--- a/pkg/logs/patterns/processor/BUILD.bazel
+++ b/pkg/logs/patterns/processor/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "processor",
+    srcs = ["json.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/logs/patterns/processor",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "processor_test",
+    srcs = ["json_test.go"],
+    embed = [":processor"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/logs/patterns/processor/json.go
+++ b/pkg/logs/patterns/processor/json.go
@@ -1,0 +1,176 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package processor provides JSON-aware preprocessing for stateful log encoding.
+// It extracts message fields from JSON logs and serializes remaining fields into ordered json_context.
+package processor
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// ExtractionResult contains the result of JSON preprocessing
+type ExtractionResult struct {
+	// IsJSON indicates whether the input was valid JSON
+	IsJSON bool
+	// Message is the extracted message field (empty if not found or not JSON)
+	Message string
+	// JSONContext is the ordered, serialized remaining JSON fields (nil if not JSON or extraction failed)
+	JSONContext []byte
+}
+
+// Common top-level message field names (Layer 0)
+// These cover the vast majority of structured logs from popular logging libraries
+var topLevelMessageKeys = []string{
+	"message",
+	"msg",
+	"log",
+	"text",
+}
+
+// Common nested paths (Layer 1 fallback)
+// Some applications wrap their log message in a data/event/payload envelope
+var nestedMessagePaths = []string{
+	"data.message",    // Generic data wrapper
+	"event.message",   // Event-based logs
+	"payload.message", // Payload wrapper
+}
+
+// PreprocessJSON attempts to extract a message field from JSON logs and serialize remaining fields.
+func PreprocessJSON(content []byte) ExtractionResult {
+	fail := ExtractionResult{IsJSON: false}
+
+	// Check if it's a JSON object (handles leading whitespace)
+	if !isJSONObject(content) {
+		return fail
+	}
+
+	// Parse JSON
+	var data map[string]interface{}
+	if err := json.Unmarshal(content, &data); err != nil {
+		return fail
+	}
+
+	// Try to extract message using layered strategy
+	message, extractedPath := extractMessage(data)
+	if message == "" {
+		return fail
+	}
+
+	// Remove the extracted message field from data for jsoncontext construction
+	removeFieldByPath(data, extractedPath)
+
+	// If no fields remain after removing the message, keep json_context nil (avoid sending "{}").
+	if len(data) == 0 {
+		return ExtractionResult{
+			IsJSON:      true,
+			Message:     message,
+			JSONContext: nil,
+		}
+	}
+
+	// Serialize remaining fields as JSON context.
+	// encoding/json marshals maps with deterministic key ordering for better compression.
+	jsonContext, err := json.Marshal(data)
+	if err != nil {
+		return fail
+	}
+
+	return ExtractionResult{
+		IsJSON:      true,
+		Message:     message,
+		JSONContext: jsonContext,
+	}
+}
+
+// extractMessage attempts to extract a message field using the layered strategy
+func extractMessage(data map[string]interface{}) (string, string) {
+	// Layer 0: Top-level common keys
+	for _, key := range topLevelMessageKeys {
+		if val, ok := data[key]; ok {
+			if str, ok := val.(string); ok && str != "" {
+				return str, key
+			}
+		}
+	}
+
+	// Layer 1: Common nested paths (e.g., data.message, event.message)
+	for _, path := range nestedMessagePaths {
+		if val := getValueByPath(data, path); val != "" {
+			return val, path
+		}
+	}
+
+	return "", ""
+}
+
+// getValueByPath retrieves a string value from nested JSON using dot notation
+// e.g., "data.message" -> data["data"]["message"]
+func getValueByPath(data map[string]interface{}, path string) string {
+	parts := strings.Split(path, ".")
+	if len(parts) == 0 {
+		return ""
+	}
+
+	current := data
+	for _, part := range parts[:len(parts)-1] {
+		val, ok := current[part]
+		if !ok {
+			return ""
+		}
+
+		nextMap, ok := val.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current = nextMap
+	}
+
+	leaf, ok := current[parts[len(parts)-1]]
+	if !ok {
+		return ""
+	}
+	str, _ := leaf.(string)
+	return str
+}
+
+// removeFieldByPath removes a field from nested JSON using dot notation
+func removeFieldByPath(data map[string]interface{}, path string) {
+	if path == "" {
+		return
+	}
+
+	parts := strings.Split(path, ".")
+	if len(parts) == 1 {
+		// Top-level key
+		delete(data, parts[0])
+		return
+	}
+
+	// Navigate to parent
+	current := data
+	for i := 0; i < len(parts)-1; i++ {
+		val, ok := current[parts[i]]
+		if !ok {
+			return
+		}
+		if nextMap, ok := val.(map[string]interface{}); ok {
+			current = nextMap
+		} else {
+			return
+		}
+	}
+
+	// Delete the final key
+	delete(current, parts[len(parts)-1])
+}
+
+// isJSONObject checks if content is a JSON object, handling leading whitespace
+func isJSONObject(content []byte) bool {
+	trimmed := bytes.TrimLeft(content, " \t\n\r")
+	return len(trimmed) > 0 && trimmed[0] == '{'
+}

--- a/pkg/logs/patterns/processor/json_test.go
+++ b/pkg/logs/patterns/processor/json_test.go
@@ -1,0 +1,373 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package processor
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreprocessJSON_NotJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+	}{
+		{
+			name:    "plain text",
+			content: []byte("This is a plain log message"),
+		},
+		{
+			name:    "empty",
+			content: []byte(""),
+		},
+		{
+			name:    "invalid JSON",
+			content: []byte("{invalid json}"),
+		},
+		{
+			name:    "starts with text",
+			content: []byte("2024-01-01 ERROR something"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PreprocessJSON(tt.content)
+			assert.False(t, result.IsJSON)
+			assert.Empty(t, result.Message)
+			assert.Nil(t, result.JSONContext)
+		})
+	}
+}
+
+func TestPreprocessJSON_TopLevelMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectedMsg string
+		expectedCtx map[string]interface{}
+	}{
+		{
+			name:        "message field",
+			input:       `{"message":"Processing order","level":"info","service":"api"}`,
+			expectedMsg: "Processing order",
+			expectedCtx: map[string]interface{}{"level": "info", "service": "api"},
+		},
+		{
+			name:        "msg field",
+			input:       `{"msg":"User login","timestamp":1234567890}`,
+			expectedMsg: "User login",
+			expectedCtx: map[string]interface{}{"timestamp": float64(1234567890)},
+		},
+		{
+			name:        "log field",
+			input:       `{"log":"Container started","container_id":"abc123"}`,
+			expectedMsg: "Container started",
+			expectedCtx: map[string]interface{}{"container_id": "abc123"},
+		},
+		{
+			name:        "text field",
+			input:       `{"text":"System event","severity":"warning"}`,
+			expectedMsg: "System event",
+			expectedCtx: map[string]interface{}{"severity": "warning"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PreprocessJSON([]byte(tt.input))
+			assert.True(t, result.IsJSON)
+			assert.Equal(t, tt.expectedMsg, result.Message)
+			assert.NotNil(t, result.JSONContext)
+
+			// Verify json_context contains expected fields
+			var ctx map[string]interface{}
+			err := json.Unmarshal(result.JSONContext, &ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedCtx, ctx)
+		})
+	}
+}
+
+func TestPreprocessJSON_TopLevelKeys(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectedMsg string
+	}{
+		{
+			name:        "Kubernetes/Docker log field",
+			input:       `{"log":"Pod started\n","stream":"stdout","time":"2024-01-01"}`,
+			expectedMsg: "Pod started\n",
+		},
+		{
+			name:        "Standard message field",
+			input:       `{"message":"Container log","level":"info"}`,
+			expectedMsg: "Container log",
+		},
+		{
+			name:        "msg field (common in Go logs)",
+			input:       `{"msg":"Service started","service":"api"}`,
+			expectedMsg: "Service started",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PreprocessJSON([]byte(tt.input))
+			assert.True(t, result.IsJSON)
+			assert.Equal(t, tt.expectedMsg, result.Message)
+			assert.NotNil(t, result.JSONContext)
+		})
+	}
+}
+
+func TestPreprocessJSON_GenericNestedPaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectedMsg string
+	}{
+		{
+			name:        "data.message",
+			input:       `{"data":{"message":"Nested message","id":123}}`,
+			expectedMsg: "Nested message",
+		},
+		{
+			name:        "event.message",
+			input:       `{"event":{"message":"Event occurred","type":"alert"}}`,
+			expectedMsg: "Event occurred",
+		},
+		{
+			name:        "payload.message",
+			input:       `{"payload":{"message":"Payload data","size":1024}}`,
+			expectedMsg: "Payload data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PreprocessJSON([]byte(tt.input))
+			assert.True(t, result.IsJSON)
+			assert.Equal(t, tt.expectedMsg, result.Message)
+			assert.NotNil(t, result.JSONContext)
+		})
+	}
+}
+
+func TestPreprocessJSON_NoMessageFound(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "no message field",
+			input: `{"level":"info","service":"api","timestamp":1234567890}`,
+		},
+		{
+			name:  "empty message",
+			input: `{"message":"","level":"info"}`,
+		},
+		{
+			name:  "message is not string",
+			input: `{"message":123,"level":"info"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PreprocessJSON([]byte(tt.input))
+			// Fail-fast: if no message found, treat as plain text
+			assert.False(t, result.IsJSON)
+			assert.Empty(t, result.Message)
+			assert.Nil(t, result.JSONContext)
+		})
+	}
+}
+
+func TestPreprocessJSON_OrderedJSONContext(t *testing.T) {
+	// Test that json_context has deterministic ordering
+	input := `{"message":"test","zebra":"z","apple":"a","banana":"b"}`
+
+	result := PreprocessJSON([]byte(input))
+	require.True(t, result.IsJSON)
+	require.NotNil(t, result.JSONContext)
+
+	// Parse and verify keys are in sorted order
+	var ctx map[string]interface{}
+	err := json.Unmarshal(result.JSONContext, &ctx)
+	require.NoError(t, err)
+
+	// Re-marshal to check ordering
+	expected := `{"apple":"a","banana":"b","zebra":"z"}`
+	assert.JSONEq(t, expected, string(result.JSONContext))
+}
+
+func TestPreprocessJSON_NestedObjectsOrdered(t *testing.T) {
+	input := `{
+		"message":"test",
+		"nested": {
+			"zebra":"z",
+			"apple":"a"
+		},
+		"array": [1, 2, 3]
+	}`
+
+	result := PreprocessJSON([]byte(input))
+	require.True(t, result.IsJSON)
+	require.NotNil(t, result.JSONContext)
+
+	var ctx map[string]interface{}
+	err := json.Unmarshal(result.JSONContext, &ctx)
+	require.NoError(t, err)
+
+	// Verify nested map is also ordered
+	nested := ctx["nested"].(map[string]interface{})
+	assert.Equal(t, "a", nested["apple"])
+	assert.Equal(t, "z", nested["zebra"])
+}
+
+func TestPreprocessJSON_EmptyContextAfterExtraction(t *testing.T) {
+	// If only message field exists, json_context should be nil
+	input := `{"message":"only message here"}`
+
+	result := PreprocessJSON([]byte(input))
+	assert.True(t, result.IsJSON)
+	assert.Equal(t, "only message here", result.Message)
+	assert.Nil(t, result.JSONContext) // No remaining fields
+}
+
+func TestPreprocessJSON_ComplexRealWorld(t *testing.T) {
+	// Real-world example from the CSV analysis
+	input := `{
+		"level":"info",
+		"msg":"Processing payment",
+		"service":"payment-api",
+		"timestamp":"2024-01-01T12:00:00Z",
+		"user_id":"user123",
+		"amount":99.99,
+		"currency":"USD"
+	}`
+
+	result := PreprocessJSON([]byte(input))
+	require.True(t, result.IsJSON)
+	assert.Equal(t, "Processing payment", result.Message)
+	require.NotNil(t, result.JSONContext)
+
+	var ctx map[string]interface{}
+	err := json.Unmarshal(result.JSONContext, &ctx)
+	require.NoError(t, err)
+
+	// Verify all non-message fields are preserved
+	assert.Equal(t, "info", ctx["level"])
+	assert.Equal(t, "payment-api", ctx["service"])
+	assert.Equal(t, float64(99.99), ctx["amount"])
+	assert.Equal(t, "USD", ctx["currency"])
+	assert.NotContains(t, ctx, "msg") // Message field removed
+}
+
+func TestGetValueByPath(t *testing.T) {
+	data := map[string]interface{}{
+		"top": "value",
+		"nested": map[string]interface{}{
+			"level2": map[string]interface{}{
+				"level3": "deep value",
+			},
+		},
+	}
+
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"top", "value"},
+		{"nested.level2.level3", "deep value"},
+		{"nonexistent", ""},
+		{"nested.nonexistent", ""},
+		{"nested.level2.nonexistent", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			result := getValueByPath(data, tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRemoveFieldByPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]interface{}
+		path     string
+		expected map[string]interface{}
+	}{
+		{
+			name:     "top level",
+			data:     map[string]interface{}{"a": "1", "b": "2"},
+			path:     "a",
+			expected: map[string]interface{}{"b": "2"},
+		},
+		{
+			name: "nested",
+			data: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"inner": "value",
+					"keep":  "this",
+				},
+			},
+			path: "outer.inner",
+			expected: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"keep": "this",
+				},
+			},
+		},
+		{
+			name:     "nonexistent path",
+			data:     map[string]interface{}{"a": "1"},
+			path:     "nonexistent",
+			expected: map[string]interface{}{"a": "1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			removeFieldByPath(tt.data, tt.path)
+			assert.Equal(t, tt.expected, tt.data)
+		})
+	}
+}
+
+func TestMarshalJSONDeterministicOrdering(t *testing.T) {
+	data := map[string]interface{}{
+		"z": "last",
+		"a": "first",
+		"m": "middle",
+	}
+
+	result, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	// Keys should be in sorted order
+	expected := `{"a":"first","m":"middle","z":"last"}`
+	assert.JSONEq(t, expected, string(result))
+}
+
+func TestMarshalJSON_EmptyContextIsNil(t *testing.T) {
+	data := map[string]interface{}{}
+	// We intentionally avoid marshalling empty maps for json_context to save bytes.
+	if len(data) == 0 {
+		var result []byte
+		assert.Nil(t, result)
+		return
+	}
+
+	t.Fatal("unexpected non-empty map")
+}

--- a/pkg/logs/patterns/tags/BUILD.bazel
+++ b/pkg/logs/patterns/tags/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "tags",
+    srcs = [
+        "tag.go",
+        "tag_eviction.go",
+        "tag_eviction_manager.go",
+        "tag_manager.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/logs/patterns/tags",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/logs/patterns/eviction",
+        "//pkg/proto/pbgo/statefulpb",
+        "//pkg/util/log",
+        "@com_github_datadog_datadog_agent_pkg_config_setup//:setup",
+    ],
+)
+
+go_test(
+    name = "tags_test",
+    srcs = [
+        "tag_eviction_manager_test.go",
+        "tag_manager_test.go",
+    ],
+    embed = [":tags"],
+    deps = [
+        "//pkg/logs/patterns/eviction",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/logs/patterns/tags/tag.go
+++ b/pkg/logs/patterns/tags/tag.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tags
+
+import (
+	"time"
+)
+
+// tagEntry represents a dictionary entry with usage tracking metadata for eviction.
+type tagEntry struct {
+	id           uint64
+	str          string
+	usageCount   int64
+	createdAt    time.Time
+	lastAccessAt time.Time
+}
+
+// EstimatedBytes returns the estimated memory usage of a tag entry
+func (e *tagEntry) EstimatedBytes() int64 {
+	// id uint64 (8) + string (16 bytes header + string length) + usage count int64 (8) + 2 time.Time (24 each)
+	return int64(8 + (16 + len(e.str)) + 8 + 24 + 24)
+}
+
+// GetFrequency returns the usage frequency for eviction scoring (implements eviction.Evictable).
+func (e *tagEntry) GetFrequency() float64 {
+	return float64(e.usageCount)
+}
+
+// GetCreatedAt returns when this tag was created (implements eviction.Evictable).
+func (e *tagEntry) GetCreatedAt() time.Time {
+	return e.createdAt
+}
+
+// GetLastAccessAt returns when this tag was last accessed (implements eviction.Evictable).
+func (e *tagEntry) GetLastAccessAt() time.Time {
+	return e.lastAccessAt
+}

--- a/pkg/logs/patterns/tags/tag_eviction.go
+++ b/pkg/logs/patterns/tags/tag_eviction.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tags
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/eviction"
+)
+
+// CollectEvictables collects all tag entries as evictables (implements eviction.EvictableCollection).
+func (tm *TagManager) CollectEvictables() []eviction.Evictable {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	evictables := make([]eviction.Evictable, 0, len(tm.stringToEntry))
+	for _, entry := range tm.stringToEntry {
+		evictables = append(evictables, entry)
+	}
+	return evictables
+}
+
+// RemoveEvictable removes a specific tag entry from the manager (implements eviction.EvictableCollection).
+func (tm *TagManager) RemoveEvictable(item eviction.Evictable) {
+	entry := item.(*tagEntry)
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tm.cachedMemoryBytes.Add(-entry.EstimatedBytes())
+	delete(tm.stringToEntry, entry.str)
+	delete(tm.idToEntry, entry.id)
+}
+
+// EvictLowestScoringStrings evicts up to numToEvict tag entries with the lowest eviction scores.
+// Returns the list of evicted IDs.
+func (tm *TagManager) EvictLowestScoringStrings(numToEvict int, decayFactor float64) []uint64 {
+	evictables := eviction.EvictLowestScoring(tm, numToEvict, decayFactor, 0)
+	if len(evictables) == 0 {
+		return nil
+	}
+	evictedIDs := make([]uint64, len(evictables))
+	for i, ev := range evictables {
+		evictedIDs[i] = ev.(*tagEntry).id
+	}
+	return evictedIDs
+}
+
+// EvictToMemoryTarget evicts tag entries until the target memory is freed.
+// It uses actual entry sizes rather than averages for precision.
+// Returns the list of evicted IDs.
+func (tm *TagManager) EvictToMemoryTarget(targetBytesToFree int64, decayFactor float64) []uint64 {
+	evictables := eviction.EvictToMemoryTarget(tm, targetBytesToFree, decayFactor, 0)
+	if len(evictables) == 0 {
+		return nil
+	}
+	evictedIDs := make([]uint64, len(evictables))
+	for i, ev := range evictables {
+		evictedIDs[i] = ev.(*tagEntry).id
+	}
+	return evictedIDs
+}
+
+// EstimatedMemoryBytes returns the estimated total memory usage of all tag entries
+func (tm *TagManager) EstimatedMemoryBytes() int64 {
+	return tm.cachedMemoryBytes.Load()
+}

--- a/pkg/logs/patterns/tags/tag_eviction_manager.go
+++ b/pkg/logs/patterns/tags/tag_eviction_manager.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package tags provides a thread-safe dictionary manager for encoding tag strings into dictionary indices
+// for efficient storage and transmission in log pattern clustering.
+package tags
+
+import (
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/eviction"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// TagEvictionManager handles tag dictionary eviction using dual watermark system.
+// It wraps the generic eviction.Manager with tag-specific configuration.
+type TagEvictionManager struct {
+	*eviction.Manager
+}
+
+// NewTagEvictionManager creates a new TagEvictionManager from config
+func NewTagEvictionManager() *TagEvictionManager {
+	cfg := pkgconfigsetup.Datadog()
+
+	return &TagEvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          cfg.GetInt("logs_config.tags.max_tag_count"),
+			MaxMemoryBytes:        int64(cfg.GetInt("logs_config.tags.max_memory_bytes")),
+			EvictionHighWatermark: cfg.GetFloat64("logs_config.tags.eviction_high_watermark"),
+			EvictionLowWatermark:  cfg.GetFloat64("logs_config.tags.eviction_low_watermark"),
+			AgeDecayFactor:        cfg.GetFloat64("logs_config.tags.age_decay_factor"),
+		},
+	}
+}
+
+// Evict performs eviction on the tag manager based on which threshold was exceeded
+func (em *TagEvictionManager) Evict(tm *TagManager, tagCount int, estimatedBytes int64, countOverLimit, bytesOverLimit bool) {
+	var evictedIDs []uint64
+
+	numToEvict, bytesToFree, strategy := em.EvictionTargets(tagCount, estimatedBytes, countOverLimit, bytesOverLimit)
+
+	switch strategy {
+
+	// Memory-based eviction
+	case eviction.StrategyByBytes:
+		evictedIDs = tm.EvictToMemoryTarget(bytesToFree, em.AgeDecayFactor)
+
+		highWatermarkBytes := int64(float64(em.MaxMemoryBytes) * em.EvictionHighWatermark)
+		targetBytes := int64(float64(em.MaxMemoryBytes) * em.EvictionLowWatermark)
+		log.Infof("Evicted %d tags: memory %d bytes exceeded high watermark %d bytes (%.0f%% of %d max), now targeting %d bytes (%.0f%%)",
+			len(evictedIDs), estimatedBytes, highWatermarkBytes,
+			em.EvictionHighWatermark*100, em.MaxMemoryBytes,
+			targetBytes, em.EvictionLowWatermark*100)
+
+	// Tag count-based eviction
+	case eviction.StrategyByCount:
+		evictedIDs = tm.EvictLowestScoringStrings(numToEvict, em.AgeDecayFactor)
+
+		highWatermarkCount := int(float64(em.MaxItemCount) * em.EvictionHighWatermark)
+		targetCount := int(float64(em.MaxItemCount) * em.EvictionLowWatermark)
+		log.Infof("Evicted %d tags: count %d exceeded high watermark %d (%.0f%% of %d max), now targeting %d (%.0f%%)",
+			len(evictedIDs), tagCount, highWatermarkCount,
+			em.EvictionHighWatermark*100, em.MaxItemCount,
+			targetCount, em.EvictionLowWatermark*100)
+	}
+}

--- a/pkg/logs/patterns/tags/tag_eviction_manager_test.go
+++ b/pkg/logs/patterns/tags/tag_eviction_manager_test.go
@@ -1,0 +1,453 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tags
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/patterns/eviction"
+)
+
+// TestTagEvictionManager_ShouldEvict_CountThreshold tests count-based eviction triggers
+func TestTagEvictionManager_ShouldEvict_CountThreshold(t *testing.T) {
+	em := &TagEvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	tests := []struct {
+		name             string
+		tagCount         int
+		estimatedBytes   int64
+		expectCountLimit bool
+		expectBytesLimit bool
+	}{
+		{
+			name:             "below both thresholds",
+			tagCount:         500,
+			estimatedBytes:   500_000,
+			expectCountLimit: false,
+			expectBytesLimit: false,
+		},
+		{
+			name:             "exactly at count high watermark",
+			tagCount:         900, // 1000 * 0.9
+			estimatedBytes:   500_000,
+			expectCountLimit: false,
+			expectBytesLimit: false,
+		},
+		{
+			name:             "just above count high watermark",
+			tagCount:         901,
+			estimatedBytes:   500_000,
+			expectCountLimit: true,
+			expectBytesLimit: false,
+		},
+		{
+			name:             "at max count",
+			tagCount:         1000,
+			estimatedBytes:   500_000,
+			expectCountLimit: true,
+			expectBytesLimit: false,
+		},
+		{
+			name:             "over max count",
+			tagCount:         1100,
+			estimatedBytes:   500_000,
+			expectCountLimit: true,
+			expectBytesLimit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			countLimit, bytesLimit := em.ShouldEvict(tt.tagCount, tt.estimatedBytes)
+			assert.Equal(t, tt.expectCountLimit, countLimit, "count limit mismatch")
+			assert.Equal(t, tt.expectBytesLimit, bytesLimit, "bytes limit mismatch")
+		})
+	}
+}
+
+// TestTagEvictionManager_ShouldEvict_MemoryThreshold tests memory-based eviction triggers
+func TestTagEvictionManager_ShouldEvict_MemoryThreshold(t *testing.T) {
+	em := &TagEvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	tests := []struct {
+		name             string
+		tagCount         int
+		estimatedBytes   int64
+		expectCountLimit bool
+		expectBytesLimit bool
+	}{
+		{
+			name:             "exactly at memory high watermark",
+			tagCount:         500,
+			estimatedBytes:   900_000, // 1_000_000 * 0.9
+			expectCountLimit: false,
+			expectBytesLimit: false,
+		},
+		{
+			name:             "just above memory high watermark",
+			tagCount:         500,
+			estimatedBytes:   900_001,
+			expectCountLimit: false,
+			expectBytesLimit: true,
+		},
+		{
+			name:             "at max memory",
+			tagCount:         500,
+			estimatedBytes:   1_000_000,
+			expectCountLimit: false,
+			expectBytesLimit: true,
+		},
+		{
+			name:             "over max memory",
+			tagCount:         500,
+			estimatedBytes:   1_100_000,
+			expectCountLimit: false,
+			expectBytesLimit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			countLimit, bytesLimit := em.ShouldEvict(tt.tagCount, tt.estimatedBytes)
+			assert.Equal(t, tt.expectCountLimit, countLimit, "count limit mismatch")
+			assert.Equal(t, tt.expectBytesLimit, bytesLimit, "bytes limit mismatch")
+		})
+	}
+}
+
+// TestTagEvictionManager_ShouldEvict_BothThresholds tests when both thresholds are exceeded
+func TestTagEvictionManager_ShouldEvict_BothThresholds(t *testing.T) {
+	em := &TagEvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	// Both thresholds exceeded
+	countLimit, bytesLimit := em.ShouldEvict(1000, 1_000_000)
+	assert.True(t, countLimit, "count limit should be true")
+	assert.True(t, bytesLimit, "bytes limit should be true")
+}
+
+// TestTagEvictionManager_EvictionTargets_CountBased tests count-based eviction target calculations
+func TestTagEvictionManager_EvictionTargets_CountBased(t *testing.T) {
+	em := &TagEvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	tests := []struct {
+		name              string
+		tagCount          int
+		estimatedBytes    int64
+		countOverLimit    bool
+		bytesOverLimit    bool
+		expectNumToEvict  int
+		expectBytesToFree int64
+		expectStrategy    eviction.Strategy
+	}{
+		{
+			name:              "count over limit - evict to low watermark",
+			tagCount:          950,
+			estimatedBytes:    500_000,
+			countOverLimit:    true,
+			bytesOverLimit:    false,
+			expectNumToEvict:  250, // 950 - (1000 * 0.7)
+			expectBytesToFree: 0,
+			expectStrategy:    eviction.StrategyByCount,
+		},
+		{
+			name:              "count at max - evict to low watermark",
+			tagCount:          1000,
+			estimatedBytes:    500_000,
+			countOverLimit:    true,
+			bytesOverLimit:    false,
+			expectNumToEvict:  300, // 1000 - 700
+			expectBytesToFree: 0,
+			expectStrategy:    eviction.StrategyByCount,
+		},
+		{
+			name:              "count barely over - evict at least 1",
+			tagCount:          701,
+			estimatedBytes:    500_000,
+			countOverLimit:    true,
+			bytesOverLimit:    false,
+			expectNumToEvict:  1, // min(701 - 700, 1)
+			expectBytesToFree: 0,
+			expectStrategy:    eviction.StrategyByCount,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			numToEvict, bytesToFree, strategy := em.EvictionTargets(
+				tt.tagCount, tt.estimatedBytes, tt.countOverLimit, tt.bytesOverLimit)
+
+			assert.Equal(t, tt.expectNumToEvict, numToEvict, "numToEvict mismatch")
+			assert.Equal(t, tt.expectBytesToFree, bytesToFree, "bytesToFree mismatch")
+			assert.Equal(t, tt.expectStrategy, strategy, "strategy mismatch")
+		})
+	}
+}
+
+// TestTagEvictionManager_EvictionTargets_MemoryBased tests memory-based eviction target calculations
+func TestTagEvictionManager_EvictionTargets_MemoryBased(t *testing.T) {
+	em := &TagEvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	tests := []struct {
+		name              string
+		tagCount          int
+		estimatedBytes    int64
+		countOverLimit    bool
+		bytesOverLimit    bool
+		expectNumToEvict  int
+		expectBytesToFree int64
+		expectStrategy    eviction.Strategy
+	}{
+		{
+			name:              "memory over limit - evict to low watermark",
+			tagCount:          500,
+			estimatedBytes:    950_000,
+			countOverLimit:    false,
+			bytesOverLimit:    true,
+			expectNumToEvict:  0,
+			expectBytesToFree: 250_000, // 950_000 - (1_000_000 * 0.7)
+			expectStrategy:    eviction.StrategyByBytes,
+		},
+		{
+			name:              "memory at max - evict to low watermark",
+			tagCount:          500,
+			estimatedBytes:    1_000_000,
+			countOverLimit:    false,
+			bytesOverLimit:    true,
+			expectNumToEvict:  0,
+			expectBytesToFree: 300_000, // 1_000_000 - 700_000
+			expectStrategy:    eviction.StrategyByBytes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			numToEvict, bytesToFree, strategy := em.EvictionTargets(
+				tt.tagCount, tt.estimatedBytes, tt.countOverLimit, tt.bytesOverLimit)
+
+			assert.Equal(t, tt.expectNumToEvict, numToEvict, "numToEvict mismatch")
+			assert.Equal(t, tt.expectBytesToFree, bytesToFree, "bytesToFree mismatch")
+			assert.Equal(t, tt.expectStrategy, strategy, "strategy mismatch")
+		})
+	}
+}
+
+// TestTagEvictionManager_EvictionTargets_PrioritizeMemory tests that memory eviction takes priority
+func TestTagEvictionManager_EvictionTargets_PrioritizeMemory(t *testing.T) {
+	em := &TagEvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	// Both limits exceeded - memory should take priority
+	numToEvict, bytesToFree, strategy := em.EvictionTargets(1000, 1_000_000, true, true)
+
+	assert.Equal(t, 0, numToEvict, "numToEvict should be 0 when evicting by memory")
+	assert.Equal(t, int64(300_000), bytesToFree, "should evict to memory low watermark")
+	assert.Equal(t, eviction.StrategyByBytes, strategy, "should prioritize memory-based eviction")
+}
+
+// TestTagEvictionManager_Evict_Integration tests the full eviction flow
+func TestTagEvictionManager_Evict_Integration(t *testing.T) {
+	em := &TagEvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          100,
+			MaxMemoryBytes:        10_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	tm := NewTagManager()
+
+	// Add 100 tags (at count limit)
+	for i := 0; i < 100; i++ {
+		tag := fmt.Sprintf("tag-%d", i)
+		tm.AddString(tag)
+	}
+
+	initialCount := tm.Count()
+	require.Equal(t, 100, initialCount)
+
+	// Manually adjust some tags to have low scores (simulate old, rarely used tags)
+	tm.mu.Lock()
+	now := time.Now()
+	idx := 0
+	for _, entry := range tm.stringToEntry {
+		if idx < 50 {
+			// Low score tags
+			entry.usageCount = 1
+			entry.createdAt = now.Add(-30 * 24 * time.Hour)
+			entry.lastAccessAt = now.Add(-29 * 24 * time.Hour)
+		} else {
+			// High score tags
+			entry.usageCount = 1000
+			entry.createdAt = now.Add(-1 * time.Hour)
+			entry.lastAccessAt = now
+		}
+		idx++
+	}
+	tm.mu.Unlock()
+
+	initialBytes := tm.EstimatedMemoryBytes()
+
+	// Trigger count-based eviction
+	countLimit, bytesLimit := em.ShouldEvict(initialCount, initialBytes)
+	require.True(t, countLimit, "count limit should be exceeded")
+
+	// Perform eviction
+	em.Evict(tm, initialCount, initialBytes, countLimit, bytesLimit)
+
+	// Verify tags were evicted
+	finalCount := tm.Count()
+	assert.Less(t, finalCount, initialCount, "tags should be evicted")
+	assert.LessOrEqual(t, finalCount, 70, "should evict to around low watermark (70)")
+
+	// Verify we're below the limit now
+	countLimit, _ = em.ShouldEvict(finalCount, tm.EstimatedMemoryBytes())
+	assert.False(t, countLimit, "should be below count limit after eviction")
+}
+
+// TestTagEvictionManager_Evict_MemoryBased tests memory-based eviction
+func TestTagEvictionManager_Evict_MemoryBased(t *testing.T) {
+	em := &TagEvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        3_000, // Low memory limit
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	tm := NewTagManager()
+	now := time.Now()
+
+	// Add tags with long names to consume memory
+	for i := 0; i < 50; i++ {
+		tag := fmt.Sprintf("very-long-tag-name-to-consume-more-memory-%d", i)
+		tm.AddString(tag)
+	}
+
+	// Adjust scores manually
+	tm.mu.Lock()
+	idx := 0
+	for _, entry := range tm.stringToEntry {
+		if idx%2 == 0 {
+			// Low score
+			entry.usageCount = 1
+			entry.createdAt = now.Add(-30 * 24 * time.Hour)
+			entry.lastAccessAt = now.Add(-29 * 24 * time.Hour)
+		} else {
+			// High score
+			entry.usageCount = 1000
+			entry.createdAt = now
+			entry.lastAccessAt = now
+		}
+		idx++
+	}
+	tm.mu.Unlock()
+
+	initialBytes := tm.EstimatedMemoryBytes()
+
+	// Check if we're over memory limit
+	_, bytesLimit := em.ShouldEvict(tm.Count(), initialBytes)
+	if !bytesLimit {
+		t.Skip("Not over memory limit, skipping memory eviction test")
+	}
+
+	// Perform eviction
+	em.Evict(tm, tm.Count(), initialBytes, false, bytesLimit)
+
+	// Verify memory was freed
+	finalBytes := tm.EstimatedMemoryBytes()
+	assert.Less(t, finalBytes, initialBytes, "memory should decrease after eviction")
+}
+
+// TestTagEvictionManager_Evict_NoEvictionNeeded tests that nothing happens when no eviction is needed
+func TestTagEvictionManager_Evict_NoEvictionNeeded(t *testing.T) {
+	em := &TagEvictionManager{
+		Manager: &eviction.Manager{
+			MaxItemCount:          1000,
+			MaxMemoryBytes:        1_000_000,
+			EvictionHighWatermark: 0.9,
+			EvictionLowWatermark:  0.7,
+			AgeDecayFactor:        0.5,
+		},
+	}
+
+	tm := NewTagManager()
+
+	// Add only 10 tags (well below threshold)
+	for i := 0; i < 10; i++ {
+		tm.AddString(fmt.Sprintf("tag-%d", i))
+	}
+
+	initialCount := tm.Count()
+	initialBytes := tm.EstimatedMemoryBytes()
+
+	// Should not trigger eviction
+	countLimit, bytesLimit := em.ShouldEvict(initialCount, initialBytes)
+	assert.False(t, countLimit, "count limit should not be exceeded")
+	assert.False(t, bytesLimit, "bytes limit should not be exceeded")
+
+	// Call evict anyway (should be a no-op)
+	em.Evict(tm, initialCount, initialBytes, false, false)
+
+	// Verify nothing changed
+	assert.Equal(t, initialCount, tm.Count(), "count should not change")
+	assert.Equal(t, initialBytes, tm.EstimatedMemoryBytes(), "memory should not change")
+}

--- a/pkg/logs/patterns/tags/tag_manager.go
+++ b/pkg/logs/patterns/tags/tag_manager.go
@@ -1,0 +1,170 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package tags provides a thread-safe dictionary manager for encoding tag strings into dictionary indices
+// for efficient storage and transmission in log pattern clustering.
+package tags
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/statefulpb"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// TagManager manages a dictionary of unique tag strings (keys and values) to dictionary IDs.
+// It provides thread-safe operations for retrieving/creating IDs and building Tag proto messages
+// that reference those IDs.
+type TagManager struct {
+	stringToEntry    map[string]*tagEntry
+	idToEntry        map[uint64]*tagEntry
+	nextID           atomic.Uint64
+	cachedMemoryBytes atomic.Int64
+	mu               sync.RWMutex
+}
+
+// NewTagManager creates a new TagManager instance
+func NewTagManager() *TagManager {
+	tm := &TagManager{
+		stringToEntry: make(map[string]*tagEntry),
+		idToEntry:     make(map[uint64]*tagEntry),
+	}
+	return tm
+}
+
+// AddString adds a string to the dictionary and returns its dictionary ID
+// If the string already exists, updates its access metadata and returns the existing ID
+// Returns the dictionary ID and a boolean indicating if it was newly added
+func (tm *TagManager) AddString(s string) (dictID uint64, isNew bool) {
+	tm.mu.RLock()
+	if entry, exists := tm.stringToEntry[s]; exists {
+		tm.mu.RUnlock()
+		// Update access metadata with write lock
+		tm.mu.Lock()
+		entry.usageCount++
+		entry.lastAccessAt = time.Now()
+		tm.mu.Unlock()
+		return entry.id, false
+	}
+	tm.mu.RUnlock()
+
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	// Double-check locking in case another goroutine added it between locks
+	if entry, exists := tm.stringToEntry[s]; exists {
+		entry.usageCount++
+		entry.lastAccessAt = time.Now()
+		return entry.id, false
+	}
+
+	id := tm.nextID.Add(1)
+	entry := &tagEntry{
+		id:           id,
+		str:          s,
+		usageCount:   1,
+		createdAt:    time.Now(),
+		lastAccessAt: time.Now(),
+	}
+	tm.stringToEntry[s] = entry
+	tm.idToEntry[id] = entry
+	tm.cachedMemoryBytes.Add(entry.EstimatedBytes())
+	return id, true
+}
+
+// EncodeTagStrings converts a slice of "key:value" tag strings into Tag proto messages
+// backed by dictionary indices. It returns the encoded tags plus the dictionary entries
+// that must be flushed upstream (ID -> string) for any newly-seen key/value strings.
+func (tm *TagManager) EncodeTagStrings(tagStrings []string) (tag []*statefulpb.Tag, dict map[uint64]string) {
+	if len(tagStrings) == 0 {
+		return []*statefulpb.Tag{}, map[uint64]string{}
+	}
+
+	encoded := make([]*statefulpb.Tag, 0, len(tagStrings))
+	newEntries := map[uint64]string{}
+
+	for _, tagStr := range tagStrings {
+		if tagStr == "" {
+			continue
+		}
+
+		key, value, hasDelimiter := strings.Cut(tagStr, ":")
+
+		switch {
+		case !hasDelimiter:
+			// Treat bare value tags as key-only tags.
+			keyID, keyNew := tm.AddString(tagStr)
+			if keyNew {
+				newEntries[keyID] = tagStr
+			}
+			encoded = append(encoded, &statefulpb.Tag{
+				Key: dictIndexValue(keyID),
+			})
+		case key == "":
+			// Assume that user mistype the tag string, skip it.
+			log.Warnf("Invalid tag string: %s", tagStr)
+			continue
+		default:
+			keyID, keyNew := tm.AddString(key)
+			if keyNew {
+				newEntries[keyID] = key
+			}
+
+			tag := &statefulpb.Tag{
+				Key: dictIndexValue(keyID),
+			}
+
+			// Only add value to dictionary if it's not empty
+			if value != "" {
+				valueID, valueNew := tm.AddString(value)
+				if valueNew {
+					newEntries[valueID] = value
+				}
+				tag.Value = dictIndexValue(valueID)
+			}
+
+			encoded = append(encoded, tag)
+		}
+	}
+
+	return encoded, newEntries
+}
+
+// GetStringID returns the dictionary ID for a string, if it exists
+// Returns the ID and a boolean indicating if the string was found
+func (tm *TagManager) GetStringID(s string) (uint64, bool) {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	entry, exists := tm.stringToEntry[s]
+	if !exists {
+		return 0, false
+	}
+	return entry.id, true
+}
+
+// Get returns the dictionary ID for a tag string, if it exists
+// Returns the ID and a boolean indicating if the tag was found
+// Deprecated: Use GetStringID instead
+func (tm *TagManager) Get(tag string) (uint64, bool) {
+	return tm.GetStringID(tag)
+}
+
+// Count returns the number of strings in the dictionary
+func (tm *TagManager) Count() int {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	return len(tm.stringToEntry)
+}
+
+// dictIndexValue converts a dictionary ID to a DynamicValue proto message
+func dictIndexValue(id uint64) *statefulpb.DynamicValue {
+	return &statefulpb.DynamicValue{
+		Value: &statefulpb.DynamicValue_DictIndex{
+			DictIndex: id,
+		},
+	}
+}

--- a/pkg/logs/patterns/tags/tag_manager_test.go
+++ b/pkg/logs/patterns/tags/tag_manager_test.go
@@ -1,0 +1,255 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tags
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTagManager(t *testing.T) {
+	tm := NewTagManager()
+	require.NotNil(t, tm)
+	assert.Equal(t, 0, tm.Count())
+}
+
+func TestTagManager_EncodeTagStrings_NewEntries(t *testing.T) {
+	tm := NewTagManager()
+
+	encoded, newEntries := tm.EncodeTagStrings([]string{"env:production"})
+
+	require.Len(t, encoded, 1)
+	require.Len(t, newEntries, 2) // key + value strings
+
+	keyID := encoded[0].GetKey().GetDictIndex()
+	valID := encoded[0].GetValue().GetDictIndex()
+
+	assert.NotZero(t, keyID)
+	assert.NotZero(t, valID)
+	assert.NotEqual(t, keyID, valID)
+	assert.Equal(t, "env", newEntries[keyID])
+	assert.Equal(t, "production", newEntries[valID])
+	assert.Equal(t, 2, tm.Count())
+}
+
+func TestTagManager_EncodeTagStrings_ReusesIDs(t *testing.T) {
+	tm := NewTagManager()
+
+	first, firstEntries := tm.EncodeTagStrings([]string{"env:production"})
+	require.Len(t, first, 1)
+	require.Len(t, firstEntries, 2)
+
+	second, secondEntries := tm.EncodeTagStrings([]string{"env:production"})
+	require.Len(t, second, 1)
+	assert.Len(t, secondEntries, 0, "no new dictionary entries expected")
+
+	assert.Equal(t, first[0].GetKey().GetDictIndex(), second[0].GetKey().GetDictIndex())
+	assert.Equal(t, first[0].GetValue().GetDictIndex(), second[0].GetValue().GetDictIndex())
+	assert.Equal(t, 2, tm.Count())
+}
+
+func TestTagManager_EncodeTagStrings_MixedNewAndExisting(t *testing.T) {
+	tm := NewTagManager()
+
+	_, firstEntries := tm.EncodeTagStrings([]string{"env:production"})
+	require.Len(t, firstEntries, 2)
+
+	_, secondEntries := tm.EncodeTagStrings([]string{"env:production", "service:api"})
+	assert.Len(t, secondEntries, 2)
+	assert.Equal(t, "service", secondEntries[3])
+	assert.Equal(t, "api", secondEntries[4])
+	assert.Equal(t, 4, tm.Count())
+}
+
+func TestTagManager_EncodeTagStrings_InvalidFormats(t *testing.T) {
+	tm := NewTagManager()
+
+	encoded, newEntries := tm.EncodeTagStrings([]string{
+		"valid:tag",
+		"",         // empty string should be skipped
+		":novalue", // colon should not be used as a delimiter for key-only tags, skip it
+	})
+
+	assert.Len(t, encoded, 1)
+	assert.Len(t, newEntries, 2)
+	assert.Equal(t, 2, tm.Count())
+}
+
+func TestTagManager_EncodeTagStrings_KeyOnly(t *testing.T) {
+	tm := NewTagManager()
+
+	encoded, newEntries := tm.EncodeTagStrings([]string{
+		"env",
+		"service:", // assume colon is mistyped, result in a key-only tag
+	})
+
+	require.Len(t, encoded, 2)
+	require.Len(t, newEntries, 2)
+
+	keyOnly := encoded[0]
+	assert.NotNil(t, keyOnly.GetKey())
+	assert.Nil(t, keyOnly.GetValue())
+
+	keyWithEmptyValue := encoded[1]
+	assert.NotNil(t, keyWithEmptyValue.GetKey())
+	assert.Nil(t, keyWithEmptyValue.GetValue())
+
+	fmt.Println(newEntries)
+
+	assert.Equal(t, 2, tm.Count())
+}
+
+func TestTagManager_EncodeTagStrings_EmptyInput(t *testing.T) {
+	tm := NewTagManager()
+
+	encoded, newEntries := tm.EncodeTagStrings(nil)
+
+	assert.Len(t, encoded, 0)
+	assert.Len(t, newEntries, 0)
+	assert.Equal(t, 0, tm.Count())
+}
+
+func TestTagManager_GetStringID(t *testing.T) {
+	tm := NewTagManager()
+
+	_, newEntries := tm.EncodeTagStrings([]string{"env:production"})
+	require.Len(t, newEntries, 2)
+
+	id, exists := tm.GetStringID("env")
+	assert.True(t, exists)
+	assert.NotZero(t, id)
+
+	id, exists = tm.GetStringID("does-not-exist")
+	assert.False(t, exists)
+	assert.Equal(t, uint64(0), id)
+}
+
+func TestTagManager_Concurrency(t *testing.T) {
+	tm := NewTagManager()
+
+	// Number of goroutines
+	numGoroutines := 10
+	tagsPerGoroutine := 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Each goroutine adds the same set of tags repeatedly
+	for i := 0; i < numGoroutines; i++ {
+		go func(_ int) {
+			defer wg.Done()
+			for j := 0; j < tagsPerGoroutine; j++ {
+				encoded, _ := tm.EncodeTagStrings([]string{"env:production", "service:api", "team:platform"})
+				assert.Len(t, encoded, 3)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Should only have 6 unique strings (3 keys + 3 values)
+	assert.Equal(t, 6, tm.Count())
+}
+
+func TestTagManager_EvictLowestScoringStrings(t *testing.T) {
+	tm := NewTagManager()
+
+	// Add some tag entries
+	tm.EncodeTagStrings([]string{"env:production", "service:api", "team:platform"})
+
+	// Add more entries with varied usage
+	for i := 0; i < 5; i++ {
+		tm.EncodeTagStrings([]string{"env:production"}) // Increases usage count
+	}
+
+	initialCount := tm.Count()
+	require.Equal(t, 6, initialCount, "should have 6 entries (3 keys + 3 values)")
+
+	// Evict 2 entries (the least used ones)
+	evictedIDs := tm.EvictLowestScoringStrings(2, 1.0)
+
+	assert.Len(t, evictedIDs, 2)
+	assert.Equal(t, 4, tm.Count(), "should have 4 entries remaining")
+
+	// The most used entries (env, production) should still exist
+	_, exists := tm.GetStringID("env")
+	assert.True(t, exists, "frequently used 'env' should not be evicted")
+	_, exists = tm.GetStringID("production")
+	assert.True(t, exists, "frequently used 'production' should not be evicted")
+}
+
+func TestTagManager_EvictToMemoryTarget(t *testing.T) {
+	tm := NewTagManager()
+
+	// Add entries
+	tm.EncodeTagStrings([]string{"env:production", "service:api", "team:platform", "region:us-east-1"})
+
+	initialMemory := tm.EstimatedMemoryBytes()
+	require.Greater(t, initialMemory, int64(0))
+
+	// Evict entries until we free at least 50 bytes
+	targetBytes := int64(50)
+	evictedIDs := tm.EvictToMemoryTarget(targetBytes, 1.0)
+
+	assert.NotEmpty(t, evictedIDs)
+
+	finalMemory := tm.EstimatedMemoryBytes()
+	assert.Less(t, finalMemory, initialMemory, "memory usage should decrease")
+}
+
+func TestTagManager_EstimatedMemoryBytes(t *testing.T) {
+	tm := NewTagManager()
+
+	// Empty manager should have 0 bytes
+	assert.Equal(t, int64(0), tm.EstimatedMemoryBytes())
+
+	// Add some entries
+	tm.EncodeTagStrings([]string{"env:production"})
+
+	memory := tm.EstimatedMemoryBytes()
+	assert.Greater(t, memory, int64(0), "should have positive memory usage")
+
+	// Add more entries
+	tm.EncodeTagStrings([]string{"service:api"})
+
+	newMemory := tm.EstimatedMemoryBytes()
+	assert.Greater(t, newMemory, memory, "memory should increase with more entries")
+}
+
+func TestTagManager_EvictZero(t *testing.T) {
+	tm := NewTagManager()
+
+	tm.EncodeTagStrings([]string{"env:production"})
+
+	// Evicting 0 or negative should do nothing
+	evictedIDs := tm.EvictLowestScoringStrings(0, 1.0)
+	assert.Nil(t, evictedIDs)
+	assert.Equal(t, 2, tm.Count())
+
+	evictedIDs = tm.EvictToMemoryTarget(0, 1.0)
+	assert.Nil(t, evictedIDs)
+	assert.Equal(t, 2, tm.Count())
+}
+
+func TestTagEntry_EstimatedBytes(t *testing.T) {
+	entry := &tagEntry{
+		id:           1,
+		str:          "test",
+		usageCount:   10,
+		createdAt:    time.Now(),
+		lastAccessAt: time.Now(),
+	}
+
+	bytes := entry.EstimatedBytes()
+	// string header (16) + len("test") (4) + uint64 (8) + int64 (8) + 2*time.Time (48)
+	expectedMin := int64(16 + 4 + 8 + 8 + 48)
+	assert.GreaterOrEqual(t, bytes, expectedMin)
+}


### PR DESCRIPTION
### What does this PR do?

Adds the pattern intelligence layer — clustering, tag management, and JSON processing:

- **Clustering** (`pkg/logs/patterns/clustering/`): `ClusterManager` groups logs by structural similarity using tokenized signatures. Includes `Pattern` abstraction, pattern-level eviction (using the eviction framework from PR 3), and a `merging/` sub-package for cluster consolidation
- **Tag management** (`pkg/logs/patterns/tags/`): `TagManager` tracks per-tag pattern state so patterns can be scoped to log sources. Includes tag-level eviction to bound memory per source
- **JSON processor** (`pkg/logs/patterns/processor/`): Extracts and processes JSON-structured logs before tokenization, handling nested fields and array normalization

> **This is PR 4/6 in a stack.** Depends on PR 3 (#49217) for the eviction framework. The gRPC sender (PR 5) consumes cluster/tag state for encoding decisions.

### Motivation

This is the core intelligence of the stateful encoding feature: deciding which logs share patterns, tracking those patterns per source/tag, and evicting stale patterns to bound memory. These modules sit between raw tokenization (PR 2) and the network sender (PR 5).

### Describe how you validated your changes

- Unit tests for cluster formation, pattern matching, and merging
- Tag manager tests covering lifecycle, eviction, and multi-tag scenarios
- Pattern eviction manager tests verifying bounded growth
- JSON processor tests for nested extraction and edge cases

### How to Review this PR

1. `clustering/cluster_manager.go` — the main entry point for pattern grouping
2. `clustering/pattern.go` + `pattern_eviction.go` — how patterns are tracked and evicted
3. `tags/tag_manager.go` — per-source pattern scoping
4. `processor/json.go` — JSON log preprocessing
5. `merging/merging.go` — cluster consolidation logic

### Additional Notes

~6,000 lines including tests. The clustering and tag modules both implement the `Evictable` interface from PR 3, demonstrating the framework's reuse.