### PR TITLE
Fix sampled_count aliasing after pattern table resort

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
@@ -256,14 +256,12 @@ rule EmitMatchingLog {
     @guidance
         -- If prior_sampled_count > 0 the emitted message is tagged
         -- adaptive_sampler_sampled_count:<n>. If 0 no tag is added.
-        -- This models the common case where no bubbling occurs. When
-        -- the entry does bubble (see open question on aliasing), the
-        -- sampled_count read and reset target a different entry.
         --
         -- After updating, the entry is bubbled toward the front of
         -- the sorted table to maintain descending match_count order.
         -- The implementation achieves this via a swap chain (bubble
-        -- sort step), not a full sort.
+        -- sort step), not a full sort. All entry mutations complete
+        -- before bubbling to avoid pointer aliasing.
 }
 
 -- A log matches an existing pattern but credits are insufficient.
@@ -292,11 +290,6 @@ rule DropMatchingLog {
     ensures: LogDropped(message)
 
     @guidance
-        -- The sampled_count increment targets the matched entry when
-        -- no bubbling occurs. When the entry bubbles (see open
-        -- question on aliasing), the increment targets a different
-        -- entry.
-        --
         -- After updating, the entry is bubbled toward the front of
         -- the sorted table (same as EmitMatchingLog).
 }
@@ -426,9 +419,3 @@ deferred "ValidateMatchThreshold"
     -- this range (user_samples.go); the same validation needs to be
     -- added when match_threshold is wired up as user-configurable
     -- for the adaptive sampler.
-
-------------------------------------------------------------
--- Open Questions
-------------------------------------------------------------
-
-open question "After a matched entry bubbles forward in the sorted table (its incremented match_count exceeds its predecessor's), the pointer used for sampled_count operations still addresses the original array position — which now holds a different entry. In the emit path, this reads and clears the displaced entry's sampled_count instead of the matched entry's, so the adaptive_sampler_sampled_count tag may carry the wrong value or be absent when it should be present. In the drop path, the displaced entry's sampled_count is incremented instead of the matched entry's. Credit, last_seen and match_count updates are unaffected because they complete before bubbling. The bug manifests only when bubbling occurs — when two or more patterns have similar match_counts and one crosses a sort boundary. Is this intentional, or should the sampled_count operations be captured before the re-sort?"

--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -152,11 +152,18 @@ func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message
 		e.lastSeen = now
 		e.matchCount++
 
-		// Determine outcome before bubbling: bubbling swaps entries by value, so
-		// e (= &s.entries[i]) would alias a different entry after the first swap.
+		// All mutations to e must complete before bubbling: bubbling swaps
+		// entries by value, so e (= &s.entries[i]) aliases a different
+		// entry after the first swap.
 		allow := e.credits >= 1.0
 		if allow {
 			e.credits--
+			if e.sampled > 0 {
+				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, adaptiveSamplerSampledCountTag(e.sampled))
+			}
+			e.sampled = 0
+		} else {
+			e.sampled++
 		}
 
 		// Bubble the matched entry toward the front to maintain descending order.
@@ -166,15 +173,10 @@ func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message
 		}
 
 		if allow {
-			if e.sampled > 0 {
-				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, adaptiveSamplerSampledCountTag(e.sampled))
-			}
-			e.sampled = 0
 			tlmAdaptiveSamplerKept.Inc(s.source)
 			return msg
 		}
 		tlmAdaptiveSamplerDropped.Inc(s.source)
-		e.sampled++
 		return nil
 	}
 

--- a/pkg/logs/internal/decoder/preprocessor/sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_test.go
@@ -256,6 +256,47 @@ func TestAdaptiveSampler_EvictsLeastFrequentWhenFull(t *testing.T) {
 	assert.Contains(t, counts, int64(2), "high-frequency pattern A should be retained")
 }
 
+// --- AdaptiveSampler: bubbling aliasing ---
+
+// When a matched entry's incremented matchCount exceeds its predecessor's, the
+// entry bubbles forward via value swaps. All entry mutations (including
+// sampled_count) must complete before bubbling, otherwise the pointer aliases a
+// different entry after the swap.
+func TestAdaptiveSampler_BubblingAliasesSampledCount(t *testing.T) {
+	s := newSampler(10, 1.0, 1.0) // burst=1, rate=1/sec
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	// Create A and bump its matchCount to 3.
+	s.Process(testMsg(), patternA)
+	s.now = func() time.Time { return t0.Add(1 * time.Second) }
+	s.Process(testMsg(), patternA)
+	s.now = func() time.Time { return t0.Add(2 * time.Second) }
+	s.Process(testMsg(), patternA)
+	// entries: [A(mc=3)]
+
+	// Create B and bump its matchCount to 3 (same as A).
+	s.now = func() time.Time { return t0.Add(3 * time.Second) }
+	s.Process(testMsg(), patternB)
+	s.now = func() time.Time { return t0.Add(4 * time.Second) }
+	s.Process(testMsg(), patternB)
+	s.now = func() time.Time { return t0.Add(5 * time.Second) }
+	s.Process(testMsg(), patternB)
+	// entries: [A(mc=3), B(mc=3)]
+
+	// Drop a B at the same timestamp (no credit refill). B.matchCount
+	// becomes 4, exceeding A's 3, so B bubbles past A. The pointer
+	// aliasing causes the sampled_count increment to land on A.
+	assert.Nil(t, s.Process(testMsg(), patternB), "B should be dropped (no credits)")
+
+	// Refill B's credits and emit. The emitted message should carry a tag
+	// reporting the 1 dropped message above.
+	s.now = func() time.Time { return t0.Add(6 * time.Second) }
+	out := s.Process(testMsg(), patternB)
+	require.NotNil(t, out, "B should be emitted after credit refill")
+	requireSampledCountTag(t, out, 1)
+}
+
 // --- AdaptiveSampler: misc ---
 
 func TestAdaptiveSampler_FlushReturnsNil(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

After a match entry bubbles forward in teh sorted pattern table the
pointer to the original array position addresses a different entry.
sampled_count reads, resets and increments were happening after the
resort. All entry mutations are now before the bubble loop.

### Motivation

SMP forward deploy is looking to create an externally validated property test
for adaptive sampling. Scoping the problem to validation of the integration of
individually fit-for-purpose components is a tidier problem than otherwise.

### Additional Notes

This removes an allium spec open question.