### PR TITLE
Add gitlab.pipeline_source to native e2e CI Visibility events

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -59,6 +59,7 @@
     - export DD_CIVISIBILITY_ENABLED=true
     - export DD_CIVISIBILITY_AGENTLESS_ENABLED=true
     - export DD_CIVISIBILITY_FLAKY_RETRY_ENABLED=false
+    - export DD_TAGS="gitlab.pipeline_source:${CI_PIPELINE_SOURCE}"
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
     # set the environment variables for the windows test signing
     - export WINDOWS_DDNPM_DRIVER=${WINDOWS_DDNPM_DRIVER:-$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDNPM_DRIVER" --no-worktree)}


### PR DESCRIPTION
## Summary
- Add `DD_TAGS="gitlab.pipeline_source:${CI_PIPELINE_SOURCE}"` to e2e test CI config
- dd-trace-go does not auto-detect `CI_PIPELINE_SOURCE` from GitLab CI environment, so we pass it via `DD_TAGS` which flows as a global span-level tag on all native test events
- This tag is needed to filter out downstream pipeline test failures (e.g. integrations-core triggering datadog-agent) when querying CI Visibility

This is Phase 0 of the migration from JUnit upload to native Orchestrion/dd-trace-go instrumentation for e2e tests.

## Test plan
- [ ] Run an e2e test job on this branch
- [ ] Verify native events (`@test.service:gitlab-runner`) carry `@gitlab.pipeline_source` tag in CI Visibility
- [ ] Confirm the tag value matches `CI_PIPELINE_SOURCE` (e.g., `push`, `merge_request_event`, `parent_pipeline`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)