### PR TITLE
Update sqlite3 to 3.53.0

### DIFF
--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -13,7 +13,7 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_fil
 python_externals = {
     "bzip2": "1.0.8",
     "mpdecimal": "4.0.0",
-    "sqlite": "3.50.4.0",
+    "sqlite": "3.53.0.0",
     "xz": "5.2.5",
     "zlib": "1.3.1",
     "libffi": "3.4.4",

--- a/deps/cpython/cpython.MODULE.bazel
+++ b/deps/cpython/cpython.MODULE.bazel
@@ -24,10 +24,20 @@ http_archive(
 python_src_deps = {
     "bzip2": ("1.0.8", "12c17d15f99e27235529574a722fb484a4e8fdf2427cef53b1b68bdf07e404a9"),
     "mpdecimal": ("4.0.0", "270f5fbee4cc02f6ebe28d5be9c4e1268696bff9ead14d1e7f674e2eef759a07"),
-    "sqlite": ("3.50.4.0", "dc5e26c19a73160244fdba918df385ced399b309941da3d9365ba34afb421c2f"),
     "xz": ("5.2.5", "6a4389cc05143beb2679b1299cecee71b02baa55e70f68a88b44dc01ad495424"),
     "zlib": ("1.3.1", "a8f166f0f819ff084042554f39d763c41de5f19f8e9cdc68bc3e7f373cfba036"),
 }
+
+# TODO: Move back into python_src_deps once cpython-source-deps has sqlite-3.53.0.0.
+# As of 2026-04-13, neither CPython 3.13 nor main have bumped past 3.50.4.
+# Fetched directly from sqlite.org; the amalgamation contents are identical.
+http_archive(
+    name = "sqlite_win",
+    build_file_content = "filegroup(name = 'sqlite_win', srcs = glob(['**']), visibility = ['//visibility:public'])",
+    sha256 = "bf3733d7c71b3ab0f6fd8a9ea0052ad87fa037d94333e14ce09878ba3492c3b0",
+    strip_prefix = "sqlite-amalgamation-3530000",
+    url = "https://www.sqlite.org/2026/sqlite-amalgamation-3530000.zip",
+)
 
 [
     http_archive(

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -4,7 +4,7 @@ http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "ht
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
-sqlite_ver = ("3", "50", "04")
+sqlite_ver = ("3", "53", "00")
 
 sqlite_amalgamation = "sqlite-amalgamation-{}00".format("".join(sqlite_ver))
 
@@ -14,16 +14,16 @@ http_archive(
         "BUILD.bazel": "//deps:sqlite3.BUILD.bazel",
         "LICENSE.md": "@sqlite3_license//file:LICENSE.md",
     },
-    sha256 = "1d3049dd0f830a025a53105fc79fd2ab9431aea99e137809d064d8ee8356b032",
+    sha256 = "bf3733d7c71b3ab0f6fd8a9ea0052ad87fa037d94333e14ce09878ba3492c3b0",
     strip_prefix = sqlite_amalgamation,
-    url = "https://www.sqlite.org/2025/{}.zip".format(sqlite_amalgamation),
+    url = "https://www.sqlite.org/2026/{}.zip".format(sqlite_amalgamation),
 )
 
 http_file(
     name = "sqlite3_license",
     downloaded_file_path = "LICENSE.md",
-    sha256 = "a7a58d6022c090c528e3167026167b3141d682efc6a3c188b473ba59f1788fc7",
-    urls = [url.format(".".join([v.lstrip("0") for v in sqlite_ver])) for url in (
+    sha256 = "ee6af51062b30d532991face5164136ae6f84e265ecf8abe89dc69dac45ca1e7",
+    urls = [url.format(".".join([v.replace("00", "0") for v in sqlite_ver])) for url in (
         "https://raw.githubusercontent.com/sqlite/sqlite/version-{}/LICENSE.md",
     )],
 )

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -9,7 +9,7 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
-VERSION = "3.50.4"
+VERSION = "3.53.0"
 
 license(
     name = "license",


### PR DESCRIPTION
### What does this PR do?

Updates sqlite3 from 3.50.4 to 3.53.0 across Bazel dependencies:
- `deps/repos.MODULE.bazel` — main sqlite3 archive
- `deps/sqlite3.BUILD.bazel` — shared library version
- `deps/cpython/cpython.MODULE.bazel` — Windows CPython build (fetched from sqlite.org directly since `cpython-source-deps` doesn't have 3.53.0 yet)
- `deps/cpython.BUILD.bazel` — Windows dependency directory version

### Motivation

Keep sqlite3 up to date.

### Describe how you validated your changes

QA needed.

I downloaded the [package](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1588971818/artifacts/file/omnibus/pkg/datadog-agent_7.79.0~devel.git.663.e4755b0.pipeline.107331729-1_arm64.deb) produced by the pipeline and ran the following script:
```shell
 /opt/datadog-agent/embedded/bin/python3 -c "import sqlite3; print(sqlite3.sqlite_version)"
3.53.0
```
The version is correct.

### Additional Notes

The Windows CPython sqlite dependency is temporarily fetched from sqlite.org instead of `python/cpython-source-deps` because the latter hasn't published a `sqlite-3.53.0.0` tag yet. A TODO is left to revert once upstream catches up.