### PR TITLE
Broaden cws-btfhub-sync trust policy to create PR to any branch

### DIFF
--- a/.github/chainguard/self.cws-btfhub-sync.create-pr.sts.yaml
+++ b/.github/chainguard/self.cws-btfhub-sync.create-pr.sts.yaml
@@ -1,13 +1,13 @@
 ---
 issuer: https://token.actions.githubusercontent.com
 
-subject: repo:DataDog/datadog-agent:ref:refs/heads/main
+subject_pattern: repo:DataDog/datadog-agent:ref:refs/heads/.*
 
 claim_pattern:
   event_name: (workflow_dispatch|schedule)
-  ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-agent/\.github/workflows/cws-btfhub-sync\.yml@refs/heads/main
+  ref: refs/heads/.*
+  repository: DataDog/datadog-agent
 
 permissions:
   contents: write


### PR DESCRIPTION
### What does this PR do?

Broaden the trust policy of the `cws-btfhub-sync` Github workflow to allow the creation of pull requests targeting any branch. This change updates the policy to allow any branch ref while keeping `job_workflow_ref` pinned to main so only the trusted workflow version can run.

### Motivation

The `cws-btfhub-sync` workflow supports a base_branch input for manual dispatch but the trust policy was locked to main. However, we sometimes have to manually run this workflow targeting dev branches before these can be merged to main. Example: https://github.com/DataDog/datadog-agent/actions/runs/24253329079  

### Describe how you validated your changes

### Additional Notes

The `job_workflow_ref` is kept pinned to main so only the trusted workflow version from main can run.
