### PR TITLE
Fix nil pointer panic in TestTryReparentFromKernelPPid

### DIFF
--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -1214,8 +1214,9 @@ func TestTryReparentFromKernelPPid(t *testing.T) {
 		resolver.AddForkEntry(parent, model.CGroupContext{}, nil)
 		resolver.AddForkEntry(child, model.CGroupContext{}, nil)
 
-		// Kernel reports ppid=99997 which is not in cache and unresolvable
-		resolver.TryReparentFromKernelPPid(child.ProcessCacheEntry, 99997, nil)
+		// Kernel reports a ppid above pid_max (4194304) so it can never exist in
+		// procfs and is guaranteed to be unresolvable regardless of host state.
+		resolver.TryReparentFromKernelPPid(child.ProcessCacheEntry, 5_000_099, nil)
 
 		assert.Equal(t, uint32(5000020), child.ProcessCacheEntry.PPid)
 		assert.Equal(t, parent.ProcessCacheEntry, child.ProcessCacheEntry.Ancestor)


### PR DESCRIPTION
### What does this PR do?

Use a PID above `pid_max` (4,194,304) as the unresolvable ppid in the `different-ppid-parent-not-in-cache` subtest of `TestTryReparentFromKernelPPid`, matching the convention already used elsewhere in the file.

### Motivation

The test was using ppid `99997` to exercise the "parent not in cache and unresolvable" path. On a busy CI runner where that PID happens to exist, `resolveFromProcfs` would succeed and actually reparent the process, causing the test to fail nondeterministically. Using a PID above `pid_max` guarantees it can never exist in procfs regardless of host state.

Failing job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1588964315

### Describe how you validated your changes

CI

### Additional Notes