### PR TITLE
[SINT-5065] Use New Windows Code Signing Client

### DIFF
--- a/.gitlab/windows/build/powershell_script_signing/windows.yml
+++ b/.gitlab/windows/build/powershell_script_signing/windows.yml
@@ -17,5 +17,15 @@ powershell_script_signing:
       - $WINDOWS_POWERSHELL_DIR
   script:
     - mkdir $WINDOWS_POWERSHELL_DIR
-    - docker run --rm -v "$(Get-Location):c:\mnt" -e AWS_NETWORKING=true -e CI -e IS_AWS_CONTAINER=true ${WINBUILDIMAGE} powershell -C "dd-wcs sign \mnt\tools\windows\DatadogAgentInstallScript\Install-Datadog.ps1"
+    # documentation: https://github.com/DataDog/windows-code-signer
+    - docker run --rm
+      -v "$(Get-Location):c:\mnt"
+      -e AWS_NETWORKING=true
+      -e CI
+      -e IS_AWS_CONTAINER=true
+      -e CI_IDENTITIES_GITLAB_ID_TOKEN
+      -e CI_JOB_NAME_SLUG
+      ${WINBUILDIMAGE}
+      powershell -C "windows-code-signer.exe
+      sign \mnt\tools\windows\DatadogAgentInstallScript\Install-Datadog.ps1"
     - copy .\tools\windows\DatadogAgentInstallScript\Install-Datadog.ps1 $WINDOWS_POWERSHELL_DIR\Install-Datadog.ps1

--- a/.gitlab/windows/build/powershell_script_signing/windows.yml
+++ b/.gitlab/windows/build/powershell_script_signing/windows.yml
@@ -20,6 +20,8 @@ powershell_script_signing:
     # documentation: https://github.com/DataDog/windows-code-signer
     - docker run --rm
       -v "$(Get-Location):c:\mnt"
+      -v "${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}:C:\aws\credentials"
+      -e "AWS_SHARED_CREDENTIALS_FILE=C:\aws\credentials"
       -e AWS_NETWORKING=true
       -e CI
       -e IS_AWS_CONTAINER=true

--- a/.gitlab/windows/build/powershell_script_signing/windows.yml
+++ b/.gitlab/windows/build/powershell_script_signing/windows.yml
@@ -20,8 +20,8 @@ powershell_script_signing:
     # documentation: https://github.com/DataDog/windows-code-signer
     - docker run --rm
       -v "$(Get-Location):c:\mnt"
-      -v "${CI_PROJECT_DIR}\.aws\credentials-by-job-id\${CI_JOB_ID}:C:\aws\credentials"
-      -e "AWS_SHARED_CREDENTIALS_FILE=C:\aws\credentials"
+      -v "${CI_PROJECT_DIR}\.aws\credentials-by-job-id:C:\aws-creds"
+      -e "AWS_SHARED_CREDENTIALS_FILE=C:\aws-creds\${CI_JOB_ID}"
       -e AWS_NETWORKING=true
       -e CI
       -e IS_AWS_CONTAINER=true

--- a/.gitlab/windows/build/powershell_script_signing/windows.yml
+++ b/.gitlab/windows/build/powershell_script_signing/windows.yml
@@ -26,6 +26,6 @@ powershell_script_signing:
       -e CI_IDENTITIES_GITLAB_ID_TOKEN
       -e CI_JOB_NAME_SLUG
       ${WINBUILDIMAGE}
-      powershell -C "windows-code-signer.exe
+      powershell -C "C:\devtools\windows-code-signer.exe
       sign \mnt\tools\windows\DatadogAgentInstallScript\Install-Datadog.ps1"
     - copy .\tools\windows\DatadogAgentInstallScript\Install-Datadog.ps1 $WINDOWS_POWERSHELL_DIR\Install-Datadog.ps1


### PR DESCRIPTION
### What does this PR do?

Use `windows-code-signer.exe` instead of the old `dd-wcs` program.

### Motivation

* better observability
* better reliability
* better user support
* can use CI Identities
* simpler use of cert distribution channels

### Describe how you validated your changes

### Additional Notes
