### PR TITLE
[CONTINT-5144] Fix Cluster Name detection from label

### DIFF
--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -79,16 +79,21 @@ var resourceGroupNameFetcher = cachedfetch.Fetcher{
 }
 
 // GetClusterName returns the name of the cluster containing the current VM by parsing the resource group name.
-// It expects the resource group name to have the format (MC|mc)_resource-group_cluster-name_zone
+
 func GetClusterName(ctx context.Context) (string, error) {
 	all, err := resourceGroupNameFetcher.FetchString(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	splitAll := strings.Split(all, "_")
+	return ParseClusterNameFromResouceGroup(all)
+}
+
+// ParseClusterNameFromResouceGroup expects the rg name to have the format (MC|mc)_resource-group_cluster-name_zone
+func ParseClusterNameFromResouceGroup(rg string) (string, error) {
+	splitAll := strings.Split(rg, "_")
 	if len(splitAll) < 4 || strings.ToLower(splitAll[0]) != "mc" {
-		return "", fmt.Errorf("cannot parse the clustername from resource group name: %s", all)
+		return "", fmt.Errorf("cannot parse the clustername from resource group name: %s", rg)
 	}
 
 	return splitAll[len(splitAll)-2], nil

--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -86,11 +86,11 @@ func GetClusterName(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return ParseClusterNameFromResouceGroup(all)
+	return ParseClusterNameFromResourceGroup(all)
 }
 
 // ParseClusterNameFromResouceGroup expects the rg name to have the format (MC|mc)_resource-group_cluster-name_zone
-func ParseClusterNameFromResouceGroup(rg string) (string, error) {
+func ParseClusterNameFromResourceGroup(rg string) (string, error) {
 	splitAll := strings.Split(rg, "_")
 	if len(splitAll) < 4 || strings.ToLower(splitAll[0]) != "mc" {
 		return "", fmt.Errorf("cannot parse the clustername from resource group name: %s", rg)

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -89,6 +89,41 @@ func TestGetClusterName(t *testing.T) {
 	}
 }
 
+func TestParseClusterNameFromResourceGroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		rgName  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "uppercase prefix",
+			rgName:  "MC_aks-kenafeh_aks-kenafeh-eu_westeurope",
+			want:    "aks-kenafeh-eu",
+			wantErr: false,
+		},
+		{
+			name:    "lowercase prefix",
+			rgName:  "mc_foo-bar-aks-k8s-rg_foo-bar-aks-k8s_westeurope",
+			want:    "foo-bar-aks-k8s",
+			wantErr: false,
+		},
+		{
+			name:    "invalid",
+			rgName:  "unexpected-resource-group-name-format",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseClusterNameFromResourceGroup(tt.rgName)
+			assert.Equal(t, tt.wantErr, (err != nil))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGetNTPHosts(t *testing.T) {
 	ctx := context.Background()
 	expectedHosts := []string{"time.windows.com"}

--- a/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label.go
+++ b/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/azure"
 )
 
 const (
@@ -23,16 +24,16 @@ type clusterNameLabelType struct {
 	key string
 	// shouldOverride if set to true override previous cluster-name
 	shouldOverride bool
+	// parser is used to parse label content to grab cluster name for AKS for example
+	parser func(string) string
 }
 
-var (
-	// We use a slice to define the default Node label key to keep the ordering
-	defaultClusterNameLabelKeyConfigs = []clusterNameLabelType{
-		{key: eksClusterNameLabelKey, shouldOverride: false},
-		{key: aksClusterNameLabelKey, shouldOverride: false},
-		{key: datadogADClusterNameLabelKey, shouldOverride: true},
-	}
-)
+// We use a slice to define the default Node label key to keep the ordering
+var defaultClusterNameLabelKeyConfigs = []clusterNameLabelType{
+	{key: eksClusterNameLabelKey, shouldOverride: false},
+	{key: aksClusterNameLabelKey, shouldOverride: false, parser: aksClusterNameLabelParser},
+	{key: datadogADClusterNameLabelKey, shouldOverride: true},
+}
 
 // GetNodeClusterNameLabel returns clustername by fetching a node label
 func (n *NodeInfo) GetNodeClusterNameLabel(ctx context.Context, clusterName string) (string, error) {
@@ -52,6 +53,9 @@ func (n *NodeInfo) GetNodeClusterNameLabel(ctx context.Context, clusterName stri
 
 	for _, labelConfig := range clusterNameLabelKeys {
 		if v, ok := nodeLabels[labelConfig.key]; ok {
+			if labelConfig.parser != nil {
+				v = labelConfig.parser(v)
+			}
 			if clusterName == "" {
 				clusterName = v
 				continue
@@ -63,4 +67,14 @@ func (n *NodeInfo) GetNodeClusterNameLabel(ctx context.Context, clusterName stri
 		}
 	}
 	return clusterName, nil
+}
+
+// aksClusterNameLabelParser tries to parse cluster name from resource group.
+// If parsed cluster name is empty label is used unparsed instead.
+func aksClusterNameLabelParser(label string) string {
+	n, _ := azure.ParseClusterNameFromResouceGroup(label)
+	if n != "" {
+		return n
+	}
+	return label
 }

--- a/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label.go
+++ b/pkg/util/kubernetes/hostinfo/cluster_name_from_node_label.go
@@ -72,7 +72,7 @@ func (n *NodeInfo) GetNodeClusterNameLabel(ctx context.Context, clusterName stri
 // aksClusterNameLabelParser tries to parse cluster name from resource group.
 // If parsed cluster name is empty label is used unparsed instead.
 func aksClusterNameLabelParser(label string) string {
-	n, _ := azure.ParseClusterNameFromResouceGroup(label)
+	n, _ := azure.ParseClusterNameFromResourceGroup(label)
 	if n != "" {
 		return n
 	}

--- a/pkg/util/kubernetes/hostinfo/node_labels_test.go
+++ b/pkg/util/kubernetes/hostinfo/node_labels_test.go
@@ -64,7 +64,7 @@ func TestNodeInfo_GetNodeClusterNameLabel(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "clusterName label not set, AKS label set",
+			name: "clusterName label not set, AKS label unparsed",
 			mockClientFunc: func(ku *kubeUtilMock) {
 				ku.On("GetNodename").Return("node-name", nil)
 			},
@@ -73,6 +73,18 @@ func TestNodeInfo_GetNodeClusterNameLabel(t *testing.T) {
 			},
 			ctx:     context.Background(),
 			want:    "foo",
+			wantErr: false,
+		},
+		{
+			name: "clusterName label not set, AKS label parsed",
+			mockClientFunc: func(ku *kubeUtilMock) {
+				ku.On("GetNodename").Return("node-name", nil)
+			},
+			nodeLabels: map[string]string{
+				"kubernetes.azure.com/cluster": "MC_aks-kenafeh_aks-kenafeh-eu_westeurope",
+			},
+			ctx:     context.Background(),
+			want:    "aks-kenafeh-eu",
 			wantErr: false,
 		},
 		{

--- a/releasenotes/notes/fix-aks-cluster-name-detection-a0eba602ab12e478.yaml
+++ b/releasenotes/notes/fix-aks-cluster-name-detection-a0eba602ab12e478.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix AKS cluster name parsing from kubernetes.azure.com/cluster label.


### PR DESCRIPTION
### What does this PR do?

Fix AKS cluster name detection based on `kubernetes.azure.com/cluster` label content.

### Motivation

Created from customer ticket (no escalation). 
See: https://datadoghq.atlassian.net/browse/CONTINT-5144

### Describe how you validated your changes

Steps to Reproduce

Use an AKS cluster and validate that your nodes have the label kubernetes.azure.com/cluster 

Setup your Agent with a Helm config like:
```
datadog:
  apiKeyExistingSecret: datadog-secret
  logLevel: debug
  env:
    - name: DD_CLOUD_PROVIDER_METADATA
      value: "aws"
```
By setting the Cloud Provider Metadata to aws this forces the Agent to skip the azure provider, which for the sake of this is equivalent to functionally failing it

Let all the components deploy

Once the Cluster Agent pod is healthy, delete one of the Agent pods

The Node label handling requires access to the Cluster Agent so if the Agent is up first the results change a bit

See that the Agent’s Cluster Name gets picked from node label

Agent Status sould confirm valid cluster name

### Additional Notes

Bug confirmations on current the version (Datadog Cluster Agent 7.77.3):
```
2026-04-14 14:32:23 UTC | CORE | DEBUG | (pkg/api/util/util_dca.go:94 in GetCrossNodeClientTLSConfig) | TLS verification is bypassed for Cross-node communication
2026-04-14 14:32:23 UTC | CORE | INFO | (pkg/util/clusteragent/clusteragent.go:147 in init) | Successfully connected to the Datadog Cluster Agent 7.77.3+commit.b5ce41533e
2026-04-14 14:32:23 UTC | CORE | WARN | (pkg/util/kubernetes/clustername/clustername.go:128 in getClusterName) | Cluster name "MC_croissant_dep-test_eastus" is not RFC 1123 compliant, it will be converted,
2026-04-14 14:32:23 UTC | CORE | INFO | (pkg/util/kubernetes/clustername/clustername.go:131 in getClusterName) | Using cluster name MC-croissant-dep-test-eastus from the node label
2026-04-14 14:32:23 UTC | CORE | INFO | (pkg/util/kubernetes/clustername/clustername.go:136 in getClusterName) | Putting cluster name "MC-croissant-dep-test-eastus" in lowercase, became: "mc-croissant-dep-test-eastus"

Run fixed agent version on local cluster with custom set AKS label.
Trigger cluster name detection as described in the original ticket.

```
2026-04-15 11:37:37 UTC | CLUSTER | INFO | (pkg/util/kubernetes/clustername/clustername.go:135 in getClusterName) | Using cluster name dep-test from the node label
```

========
Hostname
========

  cluster-name: mc-croissant-dep-test-eastus
```
