### PR TITLE
[CWS] fix cgroup propagation on process context resolution

### DIFF
--- a/pkg/security/ebpf/c/include/constants/custom.h
+++ b/pkg/security/ebpf/c/include/constants/custom.h
@@ -227,6 +227,11 @@ enum FLUSH_NETWORK_STATS_TYPE
     NETWORK_STATS_TICKER,
 };
 
+enum CACHE_SYSCALL_TYPE
+{
+    CACHE_SYSCALL_UPDATE_PROC_CACHE_CGROUP_KEY,
+};
+
 static __attribute__((always_inline)) u64 get_network_monitor_period() {
     u64 network_monitor_period;
     LOAD_CONSTANT("network_monitor_period", network_monitor_period);

--- a/pkg/security/ebpf/c/include/constants/enums.h
+++ b/pkg/security/ebpf/c/include/constants/enums.h
@@ -106,8 +106,8 @@ enum
 
 enum
 {
-    ACTIVITY_DUMP_RUNNING = 1 << 0, // defines if an activity dump is running
-    SAVED_BY_ACTIVITY_DUMP = 1 << 1, // defines if the dentry should have been discarded, but was saved because of an activity dump
+    RESOLVER_FLAG_ACTIVITY_DUMP_RUNNING = 1 << 0, // defines if an activity dump is running
+    RESOLVER_FLAG_SAVED_BY_ACTIVITY_DUMP = 1 << 1, // defines if the dentry should have been discarded, but was saved because of an activity dump
 };
 
 enum policy_mode

--- a/pkg/security/ebpf/c/include/helpers/approvers.h
+++ b/pkg/security/ebpf/c/include/helpers/approvers.h
@@ -676,7 +676,7 @@ enum SYSCALL_STATE __attribute__((always_inline)) approve_syscall_with_tgid(u32 
             // is this event type traced ?
             if (mask_has_event(config->event_mask, syscall->type) && activity_dump_rate_limiter_allow(config->events_rate, *cookie, now, 0)) {
                 if (syscall->state == DISCARDED) {
-                    syscall->resolver.flags |= SAVED_BY_ACTIVITY_DUMP;
+                    syscall->resolver.flags |= RESOLVER_FLAG_SAVED_BY_ACTIVITY_DUMP;
                 }
 
                 // force to be accepted as this event will be part of a dump
@@ -686,7 +686,7 @@ enum SYSCALL_STATE __attribute__((always_inline)) approve_syscall_with_tgid(u32 
     }
 
     if (syscall->state == SAMPLED) {
-        syscall->resolver.flags |= SAVED_BY_ACTIVITY_DUMP;
+        syscall->resolver.flags |= RESOLVER_FLAG_SAVED_BY_ACTIVITY_DUMP;
 
         // force to be accepted as this event will be part of a dump
         syscall->state = ACCEPTED;

--- a/pkg/security/ebpf/c/include/helpers/process.h
+++ b/pkg/security/ebpf/c/include/helpers/process.h
@@ -4,6 +4,7 @@
 #include "constants/custom.h"
 #include "constants/enums.h"
 #include "constants/offsets/process.h"
+#include "cgroup.h"
 #include "maps.h"
 #include "events_definition.h"
 
@@ -65,6 +66,20 @@ struct proc_cache_t *__attribute__((always_inline)) get_proc_cache(u32 tgid) {
 
     // Select the cache entry
     return get_proc_from_cookie(pid_entry->cookie);
+}
+
+// update_proc_cache_cgroup refreshes the cached cgroup inode of the current task inline,
+// for hook points that cannot use the tail-call variant because they already chain to a
+// different tail call (e.g. resolve_dentry).
+static __attribute__((always_inline)) void update_proc_cache_cgroup() {
+    u64 cgroup_id = get_current_cgroup_id();
+    if (cgroup_id) {
+        u32 pid = bpf_get_current_pid_tgid() >> 32;
+        struct proc_cache_t *entry = get_proc_cache(pid);
+        if (entry) {
+            entry->cgroup.path_key.ino = cgroup_id;
+        }
+    }
 }
 
 static u32 __attribute__((always_inline)) get_current_ppid(void) {

--- a/pkg/security/ebpf/c/include/helpers/syscalls.h
+++ b/pkg/security/ebpf/c/include/helpers/syscalls.h
@@ -122,6 +122,18 @@ static void __attribute__((always_inline)) cache_syscall(struct syscall_cache_t 
 
     bpf_map_update_elem(&syscalls, &pid_tgid, syscall, BPF_ANY);
 
+    // update the cgroup id
+    u64 has_current_cgroup_id_helper = 0;
+    LOAD_CONSTANT("has_current_cgroup_id_helper", has_current_cgroup_id_helper);
+    if (has_current_cgroup_id_helper) {
+        u64 cgroup_id = bpf_get_current_cgroup_id();
+
+        struct proc_cache_t *entry = get_proc_cache(pid);
+        if (entry && entry->cgroup.cgroup_file.ino != cgroup_id) {
+            entry->cgroup.cgroup_file.ino = cgroup_id;
+        }
+    }
+
     monitor_syscalls(syscall->type, 1);
 }
 

--- a/pkg/security/ebpf/c/include/helpers/syscalls.h
+++ b/pkg/security/ebpf/c/include/helpers/syscalls.h
@@ -113,16 +113,7 @@ static struct policy_t __attribute__((always_inline)) fetch_policy(u64 event_typ
     return empty_policy;
 }
 
-// cache_syscall checks the event policy in order to see if the syscall struct can be cached
-static void __attribute__((always_inline)) cache_syscall(struct syscall_cache_t *syscall) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    u32 pid = pid_tgid >> 32;
-
-    // handle kill action
-    send_signal(pid);
-
-    bpf_map_update_elem(&syscalls, &pid_tgid, syscall, BPF_ANY);
-
+static void __attribute__((always_inline)) update_proc_cache_cgroup(u32 pid) {
     // keep the cached cgroup inode in sync with the kernel's view: a process may have
     // migrated to a new cgroup since proc_cache was populated, and downstream consumers
     // (cgroup/container context resolution) rely on this field being current.
@@ -133,8 +124,21 @@ static void __attribute__((always_inline)) cache_syscall(struct syscall_cache_t 
             entry->cgroup.path_key.ino = cgroup_id;
         }
     }
+}
+
+// cache_syscall checks the event policy in order to see if the syscall struct can be cached
+static void __attribute__((always_inline)) cache_syscall(struct syscall_cache_t *syscall) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+
+    // handle kill action
+    send_signal(pid);
+
+    bpf_map_update_elem(&syscalls, &pid_tgid, syscall, BPF_ANY);
 
     monitor_syscalls(syscall->type, 1);
+
+    update_proc_cache_cgroup(pid);
 }
 
 static struct syscall_cache_t *__attribute__((always_inline)) peek_task_syscall(u64 pid_tgid, u64 type) {

--- a/pkg/security/ebpf/c/include/helpers/syscalls.h
+++ b/pkg/security/ebpf/c/include/helpers/syscalls.h
@@ -113,21 +113,10 @@ static struct policy_t __attribute__((always_inline)) fetch_policy(u64 event_typ
     return empty_policy;
 }
 
-static void __attribute__((always_inline)) update_proc_cache_cgroup(u32 pid) {
-    // keep the cached cgroup inode in sync with the kernel's view: a process may have
-    // migrated to a new cgroup since proc_cache was populated, and downstream consumers
-    // (cgroup/container context resolution) rely on this field being current.
-    u64 cgroup_id = get_current_cgroup_id();
-    if (cgroup_id) {
-        struct proc_cache_t *entry = get_proc_cache(pid);
-        if (entry) {
-            entry->cgroup.path_key.ino = cgroup_id;
-        }
-    }
-}
-
-// cache_syscall checks the event policy in order to see if the syscall struct can be cached
-static void __attribute__((always_inline)) cache_syscall(struct syscall_cache_t *syscall) {
+// cache_syscall caches the syscall struct for the current task. Hook points that don't
+// follow up with another tail call should prefer cache_syscall_update_cgroup so the cached
+// cgroup inode is also refreshed.
+static void __attribute__((always_inline)) cache_syscall(void *ctx, struct syscall_cache_t *syscall) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
 
@@ -137,8 +126,18 @@ static void __attribute__((always_inline)) cache_syscall(struct syscall_cache_t 
     bpf_map_update_elem(&syscalls, &pid_tgid, syscall, BPF_ANY);
 
     monitor_syscalls(syscall->type, 1);
+}
 
-    update_proc_cache_cgroup(pid);
+// cache_syscall_update_cgroup caches the syscall struct and then tail-calls
+// update_proc_cache_cgroup. It must be the very last function call in each hook point that
+// uses it: on success the tail call replaces the running program.
+static void __attribute__((always_inline)) cache_syscall_update_cgroup(void *ctx, struct syscall_cache_t *syscall) {
+    cache_syscall(ctx, syscall);
+
+    // keep the cached cgroup inode in sync with the kernel's view: a process may have
+    // migrated to a new cgroup since proc_cache was populated, and downstream consumers
+    // (cgroup/container context resolution) rely on this field being current.
+    bpf_tail_call_compat(ctx, &cache_syscall_progs, CACHE_SYSCALL_UPDATE_PROC_CACHE_CGROUP_KEY);
 }
 
 static struct syscall_cache_t *__attribute__((always_inline)) peek_task_syscall(u64 pid_tgid, u64 type) {

--- a/pkg/security/ebpf/c/include/helpers/syscalls.h
+++ b/pkg/security/ebpf/c/include/helpers/syscalls.h
@@ -7,6 +7,7 @@
 #include "events.h"
 #include "activity_dump.h"
 #include "span.h"
+#include "cgroup.h"
 #include <uapi/linux/filter.h>
 
 
@@ -125,14 +126,11 @@ static void __attribute__((always_inline)) cache_syscall(struct syscall_cache_t 
     // keep the cached cgroup inode in sync with the kernel's view: a process may have
     // migrated to a new cgroup since proc_cache was populated, and downstream consumers
     // (cgroup/container context resolution) rely on this field being current.
-    u64 has_current_cgroup_id_helper = 0;
-    LOAD_CONSTANT("has_current_cgroup_id_helper", has_current_cgroup_id_helper);
-    if (has_current_cgroup_id_helper) {
-        u64 cgroup_id = bpf_get_current_cgroup_id();
-
+    u64 cgroup_id = get_current_cgroup_id();
+    if (cgroup_id) {
         struct proc_cache_t *entry = get_proc_cache(pid);
-        if (entry && entry->cgroup.cgroup_file.ino != cgroup_id) {
-            entry->cgroup.cgroup_file.ino = cgroup_id;
+        if (entry) {
+            entry->cgroup.path_key.ino = cgroup_id;
         }
     }
 

--- a/pkg/security/ebpf/c/include/helpers/syscalls.h
+++ b/pkg/security/ebpf/c/include/helpers/syscalls.h
@@ -122,6 +122,20 @@ static void __attribute__((always_inline)) cache_syscall(struct syscall_cache_t 
 
     bpf_map_update_elem(&syscalls, &pid_tgid, syscall, BPF_ANY);
 
+    // keep the cached cgroup inode in sync with the kernel's view: a process may have
+    // migrated to a new cgroup since proc_cache was populated, and downstream consumers
+    // (cgroup/container context resolution) rely on this field being current.
+    u64 has_current_cgroup_id_helper = 0;
+    LOAD_CONSTANT("has_current_cgroup_id_helper", has_current_cgroup_id_helper);
+    if (has_current_cgroup_id_helper) {
+        u64 cgroup_id = bpf_get_current_cgroup_id();
+
+        struct proc_cache_t *entry = get_proc_cache(pid);
+        if (entry && entry->cgroup.cgroup_file.ino != cgroup_id) {
+            entry->cgroup.cgroup_file.ino = cgroup_id;
+        }
+    }
+
     monitor_syscalls(syscall->type, 1);
 }
 

--- a/pkg/security/ebpf/c/include/hooks/bpf.h
+++ b/pkg/security/ebpf/c/include/hooks/bpf.h
@@ -64,8 +64,7 @@ HOOK_SYSCALL_ENTRY3(bpf, int, cmd, union bpf_attr __user *, uattr, unsigned int,
     };
     bpf_probe_read(&syscall.bpf.attr, sizeof(syscall.bpf.attr), &uattr);
 
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/cgroup.h
+++ b/pkg/security/ebpf/c/include/hooks/cgroup.h
@@ -4,12 +4,21 @@
 #include "constants/custom.h"
 #include "constants/offsets/filesystem.h"
 #include "helpers/process.h"
+#include "helpers/syscalls.h"
 #include "helpers/utils.h"
 #include "hooks/dentry_resolver.h"
 #include "structs/dentry_resolver.h"
 #include "maps.h"
 
 #define ROOT_CGROUP_PROCS_FILE_INO 2
+
+// tail call invoked from cache_syscall_update_cgroup; see update_proc_cache_cgroup in
+// helpers/syscalls.h for the inline counterpart used by hooks that chain to another tail
+// call.
+TAIL_CALL_FNC(update_proc_cache_cgroup, void *ctx) {
+    update_proc_cache_cgroup();
+    return 0;
+}
 
 static __attribute__((always_inline)) int trace__cgroup_write(ctx_t *ctx) {
     u32 cgroup_write_type = get_cgroup_write_type();

--- a/pkg/security/ebpf/c/include/hooks/chdir.h
+++ b/pkg/security/ebpf/c/include/hooks/chdir.h
@@ -8,7 +8,7 @@
 #include "helpers/syscalls.h"
 #include "helpers/discarders.h"
 
-long __attribute__((always_inline)) trace__sys_chdir(const char *path) {
+long __attribute__((always_inline)) trace__sys_chdir(void *ctx, const char *path) {
     if (is_discarded_by_pid() || is_auid_discarder(EVENT_CHDIR)) {
         return 0;
     }
@@ -21,17 +21,16 @@ long __attribute__((always_inline)) trace__sys_chdir(const char *path) {
     };
 
     collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_STR(0), (void *)path, NULL, NULL);
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY1(chdir, const char *, path) {
-    return trace__sys_chdir(path);
+    return trace__sys_chdir(ctx, path);
 }
 
 HOOK_SYSCALL_ENTRY1(fchdir, unsigned int, fd) {
-    return trace__sys_chdir(NULL);
+    return trace__sys_chdir(ctx, NULL);
 }
 
 HOOK_ENTRY("set_fs_pwd")

--- a/pkg/security/ebpf/c/include/hooks/chmod.h
+++ b/pkg/security/ebpf/c/include/hooks/chmod.h
@@ -7,7 +7,7 @@
 #include "helpers/syscalls.h"
 #include "helpers/discarders.h"
 
-int __attribute__((always_inline)) trace__sys_chmod(const char *path, umode_t mode) {
+int __attribute__((always_inline)) trace__sys_chmod(void *ctx, const char *path, umode_t mode) {
     if (is_discarded_by_pid() || is_auid_discarder(EVENT_CHMOD)) {
         return 0;
     }
@@ -21,25 +21,24 @@ int __attribute__((always_inline)) trace__sys_chmod(const char *path, umode_t mo
         }
     };
     collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_STR(0) | SYSCALL_CTX_ARG_INT(1), (void *)path, (void *)&mode, NULL);
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY2(chmod, const char *, filename, umode_t, mode) {
-    return trace__sys_chmod(filename, mode);
+    return trace__sys_chmod(ctx, filename, mode);
 }
 
 HOOK_SYSCALL_ENTRY2(fchmod, int, fd, umode_t, mode) {
-    return trace__sys_chmod(NULL, mode);
+    return trace__sys_chmod(ctx, NULL, mode);
 }
 
 HOOK_SYSCALL_ENTRY3(fchmodat, int, dirfd, const char *, filename, umode_t, mode) {
-    return trace__sys_chmod(filename, mode);
+    return trace__sys_chmod(ctx, filename, mode);
 }
 
 HOOK_SYSCALL_ENTRY4(fchmodat2, int, dirfd, const char *, filename, umode_t, mode, int, flag) {
-    return trace__sys_chmod(filename, mode);
+    return trace__sys_chmod(ctx, filename, mode);
 }
 
 int __attribute__((always_inline)) sys_chmod_ret(void *ctx, int retval) {

--- a/pkg/security/ebpf/c/include/hooks/chown.h
+++ b/pkg/security/ebpf/c/include/hooks/chown.h
@@ -7,7 +7,7 @@
 #include "helpers/syscalls.h"
 #include "helpers/discarders.h"
 
-int __attribute__((always_inline)) trace__sys_chown(const char *filename, uid_t user, gid_t group) {
+int __attribute__((always_inline)) trace__sys_chown(void *ctx, const char *filename, uid_t user, gid_t group) {
     if (is_discarded_by_pid() || is_auid_discarder(EVENT_CHOWN)) {
         return 0;
     }
@@ -22,37 +22,36 @@ int __attribute__((always_inline)) trace__sys_chown(const char *filename, uid_t 
     };
 
     collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_STR(0) | SYSCALL_CTX_ARG_INT(1) | SYSCALL_CTX_ARG_INT(2), (void *)filename, (void *)&user, (void *)&group);
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY3(lchown, const char *, filename, uid_t, user, gid_t, group) {
-    return trace__sys_chown(filename, user, group);
+    return trace__sys_chown(ctx, filename, user, group);
 }
 
 HOOK_SYSCALL_ENTRY3(fchown, int, fd, uid_t, user, gid_t, group) {
-    return trace__sys_chown(NULL, user, group);
+    return trace__sys_chown(ctx, NULL, user, group);
 }
 
 HOOK_SYSCALL_ENTRY3(chown, const char *, filename, uid_t, user, gid_t, group) {
-    return trace__sys_chown(filename, user, group);
+    return trace__sys_chown(ctx, filename, user, group);
 }
 
 HOOK_SYSCALL_ENTRY3(lchown16, const char *, filename, uid_t, user, gid_t, group) {
-    return trace__sys_chown(filename, user, group);
+    return trace__sys_chown(ctx, filename, user, group);
 }
 
 HOOK_SYSCALL_ENTRY3(fchown16, int, fd, uid_t, user, gid_t, group) {
-    return trace__sys_chown(NULL, user, group);
+    return trace__sys_chown(ctx, NULL, user, group);
 }
 
 HOOK_SYSCALL_ENTRY3(chown16, const char *, filename, uid_t, user, gid_t, group) {
-    return trace__sys_chown(filename, user, group);
+    return trace__sys_chown(ctx, filename, user, group);
 }
 
 HOOK_SYSCALL_ENTRY4(fchownat, int, dirfd, const char *, filename, uid_t, user, gid_t, group) {
-    return trace__sys_chown(filename, user, group);
+    return trace__sys_chown(ctx, filename, user, group);
 }
 
 int __attribute__((always_inline)) sys_chown_ret(void *ctx, int retval) {

--- a/pkg/security/ebpf/c/include/hooks/commit_creds.h
+++ b/pkg/security/ebpf/c/include/hooks/commit_creds.h
@@ -5,12 +5,12 @@
 #include "helpers/syscalls.h"
 #include "helpers/events_predicates.h"
 
-int __attribute__((always_inline)) credentials_update(u64 type) {
+int __attribute__((always_inline)) credentials_update(void *ctx, u64 type) {
     struct syscall_cache_t syscall = {
         .type = type,
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
@@ -72,7 +72,7 @@ int __attribute__((always_inline)) credentials_update_ret(void *ctx, int retval)
 }
 
 HOOK_SYSCALL_ENTRY0(setuid) {
-    return credentials_update(EVENT_SETUID);
+    return credentials_update(ctx, EVENT_SETUID);
 }
 
 HOOK_SYSCALL_EXIT(setuid) {
@@ -81,7 +81,7 @@ HOOK_SYSCALL_EXIT(setuid) {
 }
 
 HOOK_SYSCALL_ENTRY0(setfsuid) {
-    return credentials_update(EVENT_SETUID);
+    return credentials_update(ctx, EVENT_SETUID);
 }
 
 HOOK_SYSCALL_EXIT(setfsuid) {
@@ -90,7 +90,7 @@ HOOK_SYSCALL_EXIT(setfsuid) {
 }
 
 HOOK_SYSCALL_ENTRY0(setreuid) {
-    return credentials_update(EVENT_SETUID);
+    return credentials_update(ctx, EVENT_SETUID);
 }
 
 HOOK_SYSCALL_EXIT(setreuid) {
@@ -99,7 +99,7 @@ HOOK_SYSCALL_EXIT(setreuid) {
 }
 
 HOOK_SYSCALL_ENTRY0(setresuid) {
-    return credentials_update(EVENT_SETUID);
+    return credentials_update(ctx, EVENT_SETUID);
 }
 
 HOOK_SYSCALL_EXIT(setresuid) {
@@ -108,7 +108,7 @@ HOOK_SYSCALL_EXIT(setresuid) {
 }
 
 HOOK_SYSCALL_ENTRY0(setuid16) {
-    return credentials_update(EVENT_SETUID);
+    return credentials_update(ctx, EVENT_SETUID);
 }
 
 HOOK_SYSCALL_EXIT(setuid16) {
@@ -117,7 +117,7 @@ HOOK_SYSCALL_EXIT(setuid16) {
 }
 
 HOOK_SYSCALL_ENTRY0(setfsuid16) {
-    return credentials_update(EVENT_SETUID);
+    return credentials_update(ctx, EVENT_SETUID);
 }
 
 HOOK_SYSCALL_EXIT(setfsuid16) {
@@ -126,7 +126,7 @@ HOOK_SYSCALL_EXIT(setfsuid16) {
 }
 
 HOOK_SYSCALL_ENTRY0(setreuid16) {
-    return credentials_update(EVENT_SETUID);
+    return credentials_update(ctx, EVENT_SETUID);
 }
 
 HOOK_SYSCALL_EXIT(setreuid16) {
@@ -135,7 +135,7 @@ HOOK_SYSCALL_EXIT(setreuid16) {
 }
 
 HOOK_SYSCALL_ENTRY0(setresuid16) {
-    return credentials_update(EVENT_SETUID);
+    return credentials_update(ctx, EVENT_SETUID);
 }
 
 HOOK_SYSCALL_EXIT(setresuid16) {
@@ -144,7 +144,7 @@ HOOK_SYSCALL_EXIT(setresuid16) {
 }
 
 HOOK_SYSCALL_ENTRY0(setgid) {
-    return credentials_update(EVENT_SETGID);
+    return credentials_update(ctx, EVENT_SETGID);
 }
 
 HOOK_SYSCALL_EXIT(setgid) {
@@ -153,7 +153,7 @@ HOOK_SYSCALL_EXIT(setgid) {
 }
 
 HOOK_SYSCALL_ENTRY0(setfsgid) {
-    return credentials_update(EVENT_SETGID);
+    return credentials_update(ctx, EVENT_SETGID);
 }
 
 HOOK_SYSCALL_EXIT(setfsgid) {
@@ -162,7 +162,7 @@ HOOK_SYSCALL_EXIT(setfsgid) {
 }
 
 HOOK_SYSCALL_ENTRY0(setregid) {
-    return credentials_update(EVENT_SETGID);
+    return credentials_update(ctx, EVENT_SETGID);
 }
 
 HOOK_SYSCALL_EXIT(setregid) {
@@ -171,7 +171,7 @@ HOOK_SYSCALL_EXIT(setregid) {
 }
 
 HOOK_SYSCALL_ENTRY0(setresgid) {
-    return credentials_update(EVENT_SETGID);
+    return credentials_update(ctx, EVENT_SETGID);
 }
 
 HOOK_SYSCALL_EXIT(setresgid) {
@@ -180,7 +180,7 @@ HOOK_SYSCALL_EXIT(setresgid) {
 }
 
 HOOK_SYSCALL_ENTRY0(setgid16) {
-    return credentials_update(EVENT_SETGID);
+    return credentials_update(ctx, EVENT_SETGID);
 }
 
 HOOK_SYSCALL_EXIT(setgid16) {
@@ -189,7 +189,7 @@ HOOK_SYSCALL_EXIT(setgid16) {
 }
 
 HOOK_SYSCALL_ENTRY0(setfsgid16) {
-    return credentials_update(EVENT_SETGID);
+    return credentials_update(ctx, EVENT_SETGID);
 }
 
 HOOK_SYSCALL_EXIT(setfsgid16) {
@@ -198,7 +198,7 @@ HOOK_SYSCALL_EXIT(setfsgid16) {
 }
 
 HOOK_SYSCALL_ENTRY0(setregid16) {
-    return credentials_update(EVENT_SETGID);
+    return credentials_update(ctx, EVENT_SETGID);
 }
 
 HOOK_SYSCALL_EXIT(setregid16) {
@@ -207,7 +207,7 @@ HOOK_SYSCALL_EXIT(setregid16) {
 }
 
 HOOK_SYSCALL_ENTRY0(setresgid16) {
-    return credentials_update(EVENT_SETGID);
+    return credentials_update(ctx, EVENT_SETGID);
 }
 
 HOOK_SYSCALL_EXIT(setresgid16) {
@@ -216,7 +216,7 @@ HOOK_SYSCALL_EXIT(setresgid16) {
 }
 
 HOOK_SYSCALL_ENTRY0(capset) {
-    return credentials_update(EVENT_CAPSET);
+    return credentials_update(ctx, EVENT_CAPSET);
 }
 
 HOOK_SYSCALL_EXIT(capset) {

--- a/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
@@ -50,8 +50,8 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(void *ctx, struct de
             params->discarder.is_leaf = i == 0;
 
             if (is_discarded_by_inode(params)) {
-                if (input->flags & ACTIVITY_DUMP_RUNNING) {
-                    input->flags |= SAVED_BY_ACTIVITY_DUMP;
+                if (input->flags & RESOLVER_FLAG_ACTIVITY_DUMP_RUNNING) {
+                    input->flags |= RESOLVER_FLAG_SAVED_BY_ACTIVITY_DUMP;
                 } else {
                     return DENTRY_DISCARDED;
                 }
@@ -354,7 +354,7 @@ TAIL_CALL_FNC(dentry_resolver_ad_filter, ctx_t *ctx) {
     }
 
     if (is_activity_dump_running(ctx, bpf_get_current_pid_tgid() >> 32, bpf_ktime_get_ns(), syscall->type)) {
-        syscall->resolver.flags |= ACTIVITY_DUMP_RUNNING;
+        syscall->resolver.flags |= RESOLVER_FLAG_ACTIVITY_DUMP_RUNNING;
     }
 
     tail_call_dr_progs(ctx, KPROBE_OR_FENTRY_TYPE, DR_DENTRY_RESOLVER_KERN_KEY);
@@ -368,7 +368,7 @@ TAIL_CALL_TRACEPOINT_FNC(dentry_resolver_ad_filter, void *ctx) {
     }
 
     if (is_activity_dump_running(ctx, bpf_get_current_pid_tgid() >> 32, bpf_ktime_get_ns(), syscall->type)) {
-        syscall->resolver.flags |= ACTIVITY_DUMP_RUNNING;
+        syscall->resolver.flags |= RESOLVER_FLAG_ACTIVITY_DUMP_RUNNING;
     }
 
     tail_call_dr_progs(ctx, TRACEPOINT_TYPE, DR_DENTRY_RESOLVER_KERN_KEY);

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -27,7 +27,6 @@ int __attribute__((always_inline)) trace__sys_execveat(ctx_t *ctx, const char *p
             } }
     };
     collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_STR(0), (void *)path, NULL, NULL);
-    cache_syscall(&syscall);
 
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 tgid = pid_tgid >> 32;
@@ -41,6 +40,7 @@ int __attribute__((always_inline)) trace__sys_execveat(ctx_t *ctx, const char *p
         bpf_map_update_elem(&exec_pid_transfer, &tgid, &pid_tgid, BPF_ANY);
     }
 
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
@@ -138,8 +138,7 @@ int __attribute__((always_inline)) handle_do_fork(ctx_t *ctx) {
 
     syscall.fork.flags = flags;
 
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/link.h
+++ b/pkg/security/ebpf/c/include/hooks/link.h
@@ -7,7 +7,7 @@
 #include "helpers/filesystem.h"
 #include "helpers/syscalls.h"
 
-int __attribute__((always_inline)) trace__sys_link(u8 async, const char *oldpath, const char *newpath) {
+int __attribute__((always_inline)) trace__sys_link(void *ctx, u8 async, const char *oldpath, const char *newpath) {
     struct policy_t policy = fetch_policy(EVENT_LINK);
     struct syscall_cache_t syscall = {
         .type = EVENT_LINK,
@@ -18,24 +18,23 @@ int __attribute__((always_inline)) trace__sys_link(u8 async, const char *oldpath
     if (!async) {
         collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_STR(0) | SYSCALL_CTX_ARG_STR(1), (void *)oldpath, (void *)newpath, NULL);
     }
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY2(link, const char *, oldpath, const char *, newpath) {
-    return trace__sys_link(SYNC_SYSCALL, oldpath, newpath);
+    return trace__sys_link(ctx, SYNC_SYSCALL, oldpath, newpath);
 }
 
 HOOK_SYSCALL_ENTRY4(linkat, int, olddirfd, const char *, oldpath, int, newdirfd, const char *, newpath) {
-    return trace__sys_link(SYNC_SYSCALL, oldpath, newpath);
+    return trace__sys_link(ctx, SYNC_SYSCALL, oldpath, newpath);
 }
 
 HOOK_ENTRY("do_linkat")
 int hook_do_linkat(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_LINK);
     if (!syscall) {
-        return trace__sys_link(ASYNC_SYSCALL, NULL, NULL);
+        return trace__sys_link(ctx, ASYNC_SYSCALL, NULL, NULL);
     }
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/login_uid.h
+++ b/pkg/security/ebpf/c/include/hooks/login_uid.h
@@ -12,7 +12,7 @@ int hook_audit_set_loginuid(ctx_t *ctx) {
         },
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/memfd.h
+++ b/pkg/security/ebpf/c/include/hooks/memfd.h
@@ -64,8 +64,7 @@ HOOK_SYSCALL_ENTRY2(memfd_create, const char *, uname, unsigned int, flags) {
     for (int i = 0; i < TRACER_MEMFD_SUFFIX_LEN; i++) {
         syscall.tracer_memfd_create.suffix[i] = name[MEMFD_TRACER_PREFIX_LEN + i];
     }
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/mkdir.h
+++ b/pkg/security/ebpf/c/include/hooks/mkdir.h
@@ -8,7 +8,7 @@
 #include "helpers/syscalls.h"
 #include "helpers/discarders.h"
 
-long __attribute__((always_inline)) trace__sys_mkdir(u8 async, const char *filename, umode_t mode) {
+long __attribute__((always_inline)) trace__sys_mkdir(void *ctx, u8 async, const char *filename, umode_t mode) {
     if (is_discarded_by_pid() || is_auid_discarder(EVENT_MKDIR)) {
         return 0;
     }
@@ -25,17 +25,16 @@ long __attribute__((always_inline)) trace__sys_mkdir(u8 async, const char *filen
     if (!async) {
         collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_STR(0) | SYSCALL_CTX_ARG_INT(1), (void *)filename, (void *)&mode, NULL);
     }
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY2(mkdir, const char *, filename, umode_t, mode) {
-    return trace__sys_mkdir(SYNC_SYSCALL, filename, mode);
+    return trace__sys_mkdir(ctx, SYNC_SYSCALL, filename, mode);
 }
 
 HOOK_SYSCALL_ENTRY3(mkdirat, int, dirfd, const char *, filename, umode_t, mode) {
-    return trace__sys_mkdir(SYNC_SYSCALL, filename, mode);
+    return trace__sys_mkdir(ctx, SYNC_SYSCALL, filename, mode);
 }
 
 int __attribute__((always_inline)) filename_create_common(struct path *p) {
@@ -127,7 +126,7 @@ int hook_do_mkdirat(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MKDIR);
     if (!syscall) {
         umode_t mode = (umode_t)CTX_PARM3(ctx);
-        return trace__sys_mkdir(ASYNC_SYSCALL, NULL, mode);
+        return trace__sys_mkdir(ctx, ASYNC_SYSCALL, NULL, mode);
     }
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/mmap.h
+++ b/pkg/security/ebpf/c/include/hooks/mmap.h
@@ -26,7 +26,7 @@ int hook_vm_mmap_pgoff(ctx_t *ctx) {
         .mmap.flags = flags,
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -5,7 +5,7 @@
 #include "helpers/filesystem.h"
 #include "helpers/syscalls.h"
 
-int __attribute__((always_inline)) trace_init_module(u32 loaded_from_memory, const char *uargs) {
+int __attribute__((always_inline)) trace_init_module(void *ctx, u32 loaded_from_memory, const char *uargs) {
     struct syscall_cache_t syscall = {
         .type = EVENT_INIT_MODULE,
         .init_module = {
@@ -18,16 +18,16 @@ int __attribute__((always_inline)) trace_init_module(u32 loaded_from_memory, con
         syscall.init_module.args_truncated = 1;
     }
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY3(init_module, void *, umod, unsigned long, len, const char *, uargs) {
-    return trace_init_module(1, uargs);
+    return trace_init_module(ctx, 1, uargs);
 }
 
 HOOK_SYSCALL_ENTRY3(finit_module, int, fd, const char *, uargs, int, flags) {
-    return trace_init_module(0, uargs);
+    return trace_init_module(ctx, 0, uargs);
 }
 
 int __attribute__((always_inline)) trace_kernel_file(ctx_t *ctx, struct file *f, enum TAIL_CALL_PROG_TYPE prog_type) {
@@ -162,7 +162,7 @@ HOOK_SYSCALL_ENTRY1(delete_module, const char *, name_user) {
         },
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -119,7 +119,7 @@ HOOK_SYSCALL_COMPAT_ENTRY3(mount, const char *, source, const char *, target, co
     };
 
     collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_STR(0) | SYSCALL_CTX_ARG_STR(1) | SYSCALL_CTX_ARG_STR(2), (void *)source, (void *)target, (void *)fstype);
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
 
     return 0;
 }
@@ -134,7 +134,7 @@ HOOK_SYSCALL_ENTRY1(unshare, unsigned long, flags) {
         .type = EVENT_UNSHARE_MNTNS,
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
 
     return 0;
 }
@@ -574,7 +574,7 @@ HOOK_SYSCALL_ENTRY3(open_tree, int, dfd, const char *, filename, unsigned int, f
     struct syscall_cache_t syscall = {
         .type = EVENT_OPEN_TREE,
     };
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
@@ -589,7 +589,7 @@ HOOK_SYSCALL_ENTRY3(fsmount, int, fs_fd, unsigned int, flags, unsigned int, attr
         .type = EVENT_FSMOUNT,
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
 
     return 0;
 }
@@ -614,7 +614,7 @@ HOOK_SYSCALL_ENTRY4(move_mount, int, from_dfd, const char *, from_pathname, int,
         .type = EVENT_MOVE_MOUNT,
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
 
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/mprotect.h
+++ b/pkg/security/ebpf/c/include/hooks/mprotect.h
@@ -17,7 +17,7 @@ HOOK_SYSCALL_ENTRY0(mprotect) {
         .policy = policy,
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/network/bind.h
+++ b/pkg/security/ebpf/c/include/hooks/network/bind.h
@@ -6,7 +6,7 @@
 #include "helpers/discarders.h"
 #include "helpers/syscalls.h"
 
-int __attribute__((always_inline)) sys_bind(u64 pid_tgid) {
+int __attribute__((always_inline)) sys_bind(void *ctx, u64 pid_tgid) {
     struct syscall_cache_t syscall = {
         .type = EVENT_BIND,
         .async = pid_tgid ? 1: 0,
@@ -14,7 +14,7 @@ int __attribute__((always_inline)) sys_bind(u64 pid_tgid) {
             .pid_tgid = pid_tgid,
         }
     };
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
@@ -23,7 +23,7 @@ HOOK_SYSCALL_ENTRY3(bind, int, socket, struct sockaddr *, addr, unsigned int, ad
         return 0;
     }
 
-    return sys_bind(0);
+    return sys_bind(ctx, 0);
 }
 
 int __attribute__((always_inline)) sys_bind_ret(void *ctx, int retval) {
@@ -82,7 +82,7 @@ HOOK_ENTRY("io_bind")
 int hook_io_bind(ctx_t *ctx) {
     void *raw_req = (void *)CTX_PARM1(ctx);
     u64 pid_tgid = get_pid_tgid_from_iouring(raw_req);
-    return sys_bind(pid_tgid);
+    return sys_bind(ctx, pid_tgid);
 }
 
 HOOK_EXIT("io_bind")

--- a/pkg/security/ebpf/c/include/hooks/network/connect.h
+++ b/pkg/security/ebpf/c/include/hooks/network/connect.h
@@ -52,7 +52,7 @@ int __attribute__((always_inline)) sys_connect_ret(void *ctx, int retval) {
         .family = syscall->connect.family,
         .port = syscall->connect.port,
         .protocol = syscall->connect.protocol,
-        .event.flags = (syscall->resolver.flags & SAVED_BY_ACTIVITY_DUMP ? (EVENT_FLAGS_SAVED_BY_AD | EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE) : 0),
+        .event.flags = (syscall->resolver.flags & RESOLVER_FLAG_SAVED_BY_ACTIVITY_DUMP ? (EVENT_FLAGS_SAVED_BY_AD | EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE) : 0),
     };
 
     struct proc_cache_t *entry;

--- a/pkg/security/ebpf/c/include/hooks/network/connect.h
+++ b/pkg/security/ebpf/c/include/hooks/network/connect.h
@@ -5,7 +5,7 @@
 #include "constants/syscall_macro.h"
 #include "helpers/discarders.h"
 
-int __attribute__((always_inline)) sys_connect(u64 pid_tgid) {
+int __attribute__((always_inline)) sys_connect(void *ctx, u64 pid_tgid) {
     struct policy_t policy = fetch_policy(EVENT_CONNECT);
     struct syscall_cache_t syscall = {
         .policy = policy,
@@ -15,7 +15,7 @@ int __attribute__((always_inline)) sys_connect(u64 pid_tgid) {
             .pid_tgid = pid_tgid,
         }
     };
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
@@ -24,7 +24,7 @@ HOOK_SYSCALL_ENTRY3(connect, int, socket, struct sockaddr *, addr, unsigned int,
         return 0;
     }
 
-    return sys_connect(0);
+    return sys_connect(ctx, 0);
 }
 
 int __attribute__((always_inline)) sys_connect_ret(void *ctx, int retval) {
@@ -118,7 +118,7 @@ HOOK_ENTRY("io_connect")
 int hook_io_connect(ctx_t *ctx) {
     void *raw_req = (void *)CTX_PARM1(ctx);
     u64 pid_tgid = get_pid_tgid_from_iouring(raw_req);
-    return sys_connect(pid_tgid);
+    return sys_connect(ctx, pid_tgid);
 }
 
 HOOK_EXIT("io_connect")

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -98,17 +98,25 @@ int __attribute__((always_inline)) handle_open(ctx_t *ctx, struct path *path) {
 
     set_file_inode(dentry, &syscall->open.file, PATH_ID_INVALIDATE_TYPE_NONE);
 
-    // do not pop, we want to keep track of the mount ref counter later in the stack
     approve_syscall(syscall, open_approvers);
 
-    if (is_cgroup2fs(syscall->open.dentry) && syscall->state != ACCEPTED) {
-        // do not discard INTERNAL events as we need to resolve the mode later in the call path
+    // the runtime itself opens cgroupfs paths during cgroup resolution; those reads
+    // must not be promoted to INTERNAL events or they would feed the resolver in a loop.
+    u8 is_cgroupfs = is_cgroup2fs(syscall->open.dentry) && !is_runtime_request();
+
+    if (syscall->state != ACCEPTED && is_cgroupfs) {
         syscall->state = INTERNAL;
+    }
+
+    if (syscall->state == DISCARDED) {
+        return 0;
     }
 
     syscall->resolver.key = syscall->open.file.path_key;
     syscall->resolver.dentry = syscall->open.dentry;
-    syscall->resolver.discarder_event_type = syscall->state != INTERNAL ? dentry_resolver_discarder_event_type(syscall) : 0;
+    // disable the dentry-resolver discarder for cgroupfs events: userspace needs them
+    // to track cgroup lifecycle, and a discarder match here would drop them.
+    syscall->resolver.discarder_event_type = !is_cgroupfs ? dentry_resolver_discarder_event_type(syscall) : 0;
     syscall->resolver.iteration = 0;
     syscall->resolver.ret = 0;
 
@@ -242,8 +250,8 @@ int __attribute__((always_inline)) _sys_open_ret(void *ctx, struct syscall_cache
         .syscall.retval = syscall->retval,
         .syscall_ctx.id = syscall->ctx_id,
         .event.flags = (syscall->async ? EVENT_FLAGS_ASYNC : 0) |
-                       (syscall->resolver.flags & SAVED_BY_ACTIVITY_DUMP ? EVENT_FLAGS_SAVED_BY_AD : 0) |
-                       (syscall->resolver.flags & ACTIVITY_DUMP_RUNNING ? EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE : 0) |
+                       (syscall->resolver.flags & RESOLVER_FLAG_SAVED_BY_ACTIVITY_DUMP ? EVENT_FLAGS_SAVED_BY_AD : 0) |
+                       (syscall->resolver.flags & RESOLVER_FLAG_ACTIVITY_DUMP_RUNNING ? EVENT_FLAGS_ACTIVITY_DUMP_SAMPLE : 0) |
                        (syscall->state == INTERNAL ? EVENT_FLAGS_INTERNAL : 0),
         .file = syscall->open.file,
         .flags = syscall->open.flags,
@@ -252,7 +260,8 @@ int __attribute__((always_inline)) _sys_open_ret(void *ctx, struct syscall_cache
 
     fill_file(syscall->open.dentry, &event.file);
 
-    // cgroup internal event, allow only dir event
+    // INTERNAL cgroupfs events are forwarded only to feed the userspace cgroup resolver,
+    // which only cares about directory entries; drop the rest.
     if (syscall->state == INTERNAL && !S_ISDIR(event.file.metadata.mode)) {
         return 0;
     }

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -10,7 +10,9 @@
 #include "helpers/iouring.h"
 #include "helpers/syscalls.h"
 
-int __attribute__((always_inline)) trace__sys_openat2(const char *path, u8 async, int flags, umode_t mode, u64 pid_tgid) {
+// pid_tgid == 0 selects SYNC_SYSCALL with the current task; a non-zero pid_tgid
+// switches the syscall to ASYNC_SYSCALL and identifies the owner thread.
+int __attribute__((always_inline)) trace__sys_openat2(void *ctx, const char *path, int flags, umode_t mode, u64 pid_tgid) {
     if (is_discarded_by_pid() || is_auid_discarder(EVENT_OPEN)) {
         return 0;
     }
@@ -19,62 +21,58 @@ int __attribute__((always_inline)) trace__sys_openat2(const char *path, u8 async
     struct syscall_cache_t syscall = {
         .type = EVENT_OPEN,
         .policy = policy,
-        .async = async,
+        .async = pid_tgid ? ASYNC_SYSCALL : SYNC_SYSCALL,
         .open = {
             .flags = flags,
             .mode = mode & S_IALLUGO,
+            .pid_tgid = pid_tgid,
         }
     };
 
-    if (pid_tgid > 0) {
-        syscall.open.pid_tgid = pid_tgid;
-    }
-
     collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_STR(0) | SYSCALL_CTX_ARG_INT(1) | SYSCALL_CTX_ARG_INT(2), (void *)path, (void *)&flags, (void *)&mode);
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
-int __attribute__((always_inline)) trace__sys_openat(const char *path, u8 async, int flags, umode_t mode) {
-    return trace__sys_openat2(path, async, flags, mode, 0);
+int __attribute__((always_inline)) trace__sys_openat(void *ctx, const char *path, int flags, umode_t mode) {
+    return trace__sys_openat2(ctx, path, flags, mode, 0);
 }
 
 HOOK_SYSCALL_ENTRY2(creat, const char *, filename, umode_t, mode) {
     int flags = O_CREAT | O_WRONLY | O_TRUNC;
-    return trace__sys_openat(filename, SYNC_SYSCALL, flags, mode);
+    return trace__sys_openat(ctx, filename, flags, mode);
 }
 
 HOOK_SYSCALL_COMPAT_ENTRY3(open_by_handle_at, int, mount_fd, struct file_handle *, handle, int, flags) {
     umode_t mode = 0;
-    return trace__sys_openat(NULL, SYNC_SYSCALL, flags, mode);
+    return trace__sys_openat(ctx, NULL, flags, mode);
 }
 
 HOOK_SYSCALL_COMPAT_ENTRY1(truncate, const char *, filename) {
     int flags = O_CREAT | O_WRONLY | O_TRUNC;
     umode_t mode = 0;
-    return trace__sys_openat(filename, SYNC_SYSCALL, flags, mode);
+    return trace__sys_openat(ctx, filename, flags, mode);
 }
 
 HOOK_SYSCALL_COMPAT_ENTRY0(ftruncate) {
     int flags = O_CREAT | O_WRONLY | O_TRUNC;
     umode_t mode = 0;
     char filename[1] = "";
-    return trace__sys_openat(filename, SYNC_SYSCALL, flags, mode);
+    return trace__sys_openat(ctx, filename, flags, mode);
 }
 
 HOOK_SYSCALL_COMPAT_ENTRY3(open, const char *, filename, int, flags, umode_t, mode) {
-    return trace__sys_openat(filename, SYNC_SYSCALL, flags, mode);
+    return trace__sys_openat(ctx, filename, flags, mode);
 }
 
 HOOK_SYSCALL_COMPAT_ENTRY4(openat, int, dirfd, const char *, filename, int, flags, umode_t, mode) {
-    return trace__sys_openat(filename, SYNC_SYSCALL, flags, mode);
+    return trace__sys_openat(ctx, filename, flags, mode);
 }
 
 HOOK_SYSCALL_ENTRY4(openat2, int, dirfd, const char *, filename, struct openat2_open_how *, phow, size_t, size) {
     struct openat2_open_how how;
     bpf_probe_read(&how, sizeof(struct openat2_open_how), phow);
-    return trace__sys_openat(filename, SYNC_SYSCALL, how.flags, how.mode);
+    return trace__sys_openat(ctx, filename, how.flags, how.mode);
 }
 
 int __attribute__((always_inline)) handle_open(ctx_t *ctx, struct path *path) {
@@ -209,7 +207,7 @@ int __attribute__((always_inline)) trace_io_openat(ctx_t *ctx) {
     if (!syscall) {
         unsigned int flags = req.how.flags & VALID_OPEN_FLAGS;
         umode_t mode = req.how.mode & S_IALLUGO;
-        return trace__sys_openat2(NULL, ASYNC_SYSCALL, flags, mode, pid_tgid);
+        return trace__sys_openat2(ctx, NULL, flags, mode, pid_tgid);
     } else {
         syscall->open.pid_tgid = get_pid_tgid_from_iouring(raw_req);
     }

--- a/pkg/security/ebpf/c/include/hooks/pivot_root.h
+++ b/pkg/security/ebpf/c/include/hooks/pivot_root.h
@@ -9,8 +9,7 @@ HOOK_SYSCALL_ENTRY0(pivot_root) {
         .type = EVENT_PIVOT_ROOT,
     };
 
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/prctl.h
+++ b/pkg/security/ebpf/c/include/hooks/prctl.h
@@ -8,7 +8,7 @@
 #include "helpers/strings.h"
 #include <linux/prctl.h>
 
-long __attribute__((always_inline)) trace__sys_prctl(u8 async, int option, void * arg2) {
+long __attribute__((always_inline)) trace__sys_prctl(void *ctx, u8 async, int option, void * arg2) {
     if (is_discarded_by_pid()) {
         return 0;
     }
@@ -41,7 +41,7 @@ long __attribute__((always_inline)) trace__sys_prctl(u8 async, int option, void 
         };
     }
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
@@ -69,7 +69,7 @@ int __attribute__((always_inline)) sys_prctl_ret(void *ctx, int retval) {
 }
 
 HOOK_SYSCALL_ENTRY2(prctl, int, option, void *, arg2) {
-    return trace__sys_prctl(SYNC_SYSCALL, option, arg2);
+    return trace__sys_prctl(ctx, SYNC_SYSCALL, option, arg2);
 }
 
 HOOK_SYSCALL_EXIT(prctl) {

--- a/pkg/security/ebpf/c/include/hooks/procfs.h
+++ b/pkg/security/ebpf/c/include/hooks/procfs.h
@@ -28,7 +28,7 @@ static __attribute__((always_inline)) void cache_file(struct dentry *dentry, u32
     bpf_map_update_elem(&inode_file, &entry.path_key.ino, &entry, BPF_EXIST);
 }
 
-static __attribute__((always_inline)) int handle_stat() {
+static __attribute__((always_inline)) int handle_stat(void *ctx) {
     if (!is_runtime_request()) {
         return 0;
     }
@@ -36,12 +36,12 @@ static __attribute__((always_inline)) int handle_stat() {
     struct syscall_cache_t syscall = {
         .type = EVENT_STAT,
     };
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY0(newfstatat) {
-    return handle_stat();
+    return handle_stat(ctx);
 }
 
 static __attribute__((always_inline)) int handle_ret_stat() {

--- a/pkg/security/ebpf/c/include/hooks/ptrace.h
+++ b/pkg/security/ebpf/c/include/hooks/ptrace.h
@@ -40,7 +40,7 @@ HOOK_SYSCALL_ENTRY3(ptrace, u32, request, pid_t, pid, void *, addr) {
         }
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/rename.h
+++ b/pkg/security/ebpf/c/include/hooks/rename.h
@@ -7,7 +7,7 @@
 #include "helpers/syscalls.h"
 #include "helpers/discarders.h"
 
-int __attribute__((always_inline)) trace__sys_rename(u8 async, const char *oldpath, const char *newpath) {
+int __attribute__((always_inline)) trace__sys_rename(void *ctx, u8 async, const char *oldpath, const char *newpath) {
     struct syscall_cache_t syscall = {
         .policy = fetch_policy(EVENT_RENAME),
         .async = async,
@@ -17,28 +17,27 @@ int __attribute__((always_inline)) trace__sys_rename(u8 async, const char *oldpa
     if (!async) {
         collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_STR(0) | SYSCALL_CTX_ARG_STR(1), (void *)oldpath, (void *)newpath, NULL);
     }
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY2(rename, const char *, oldpath, const char *, newpath) {
-    return trace__sys_rename(SYNC_SYSCALL, oldpath, newpath);
+    return trace__sys_rename(ctx, SYNC_SYSCALL, oldpath, newpath);
 }
 
 HOOK_SYSCALL_ENTRY4(renameat, int, olddirfd, const char *, oldpath, int, newdirfd, const char *, newpath) {
-    return trace__sys_rename(SYNC_SYSCALL, oldpath, newpath);
+    return trace__sys_rename(ctx, SYNC_SYSCALL, oldpath, newpath);
 }
 
 HOOK_SYSCALL_ENTRY4(renameat2, int , olddirfd, const char *, oldpath, int, newdirfd, const char *, newpath) {
-    return trace__sys_rename(SYNC_SYSCALL, oldpath, newpath);
+    return trace__sys_rename(ctx, SYNC_SYSCALL, oldpath, newpath);
 }
 
 HOOK_ENTRY("do_renameat2")
 int hook_do_renameat2(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_RENAME);
     if (!syscall) {
-        return trace__sys_rename(ASYNC_SYSCALL, NULL, NULL);
+        return trace__sys_rename(ctx, ASYNC_SYSCALL, NULL, NULL);
     }
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -46,6 +46,7 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
 
     struct path_key_t key = {};
     struct dentry *dentry = NULL;
+    u8 is_cgroup_dentry = 0;
 
     switch (syscall->type) {
     case EVENT_RMDIR:
@@ -70,8 +71,10 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
             syscall->state = DISCARDED;
         }
 
+        is_cgroup_dentry = is_cgroup2fs(syscall->rmdir.dentry) && S_ISDIR(syscall->rmdir.file.metadata.mode) && !is_runtime_request();
+
         // let the cgroup event being forwarded as it is used userspace side to track the cgroups
-        if (is_cgroup2fs(syscall->rmdir.dentry) && S_ISDIR(syscall->rmdir.file.metadata.mode)) {
+        if (syscall->state != ACCEPTED && is_cgroup_dentry) {
             syscall->state = INTERNAL;
         }
 
@@ -101,25 +104,29 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
 
         approve_syscall(syscall, rmdir_approvers);
 
-        // let the cgroup event being forwarded as it is used userspace side to track the cgroups
-        if (is_cgroup2fs(syscall->unlink.dentry) && S_ISDIR(syscall->unlink.file.metadata.mode)) {
-            syscall->state = INTERNAL;
-        }
-
-        // do not pop, we want to invalidate the inode even if the syscall is discarded
-        if (syscall->state == DISCARDED) {
-            return 0;
-        }
+        is_cgroup_dentry = is_cgroup2fs(syscall->unlink.dentry) && S_ISDIR(syscall->unlink.file.metadata.mode) && !is_runtime_request();
 
         break;
     default:
         return 0;
     }
 
+    // let the cgroup event being forwarded as it is used userspace side to track the cgroups
+    if (syscall->state != ACCEPTED && is_cgroup_dentry) {
+        syscall->state = INTERNAL;
+    }
+
+    // do not pop, we want to invalidate the inode even if the syscall is discarded
+    if (syscall->state == DISCARDED) {
+        return 0;
+    }
+
     if (dentry != NULL) {
         syscall->resolver.key = key;
         syscall->resolver.dentry = dentry;
-        syscall->resolver.discarder_event_type = dentry_resolver_discarder_event_type(syscall);
+        // disable the dentry-resolver discarder for cgroupfs events: userspace needs them
+        // to track cgroup lifecycle, and a discarder match here would drop them.
+        syscall->resolver.discarder_event_type = !is_cgroup_dentry ? dentry_resolver_discarder_event_type(syscall) : 0;
         syscall->resolver.callback = DR_SECURITY_INODE_RMDIR_CALLBACK_KPROBE_KEY;
         syscall->resolver.iteration = 0;
         syscall->resolver.ret = 0;
@@ -138,7 +145,7 @@ TAIL_CALL_FNC(dr_security_inode_rmdir_callback, ctx_t *ctx) {
         return 0;
     }
 
-    if (syscall->resolver.ret == DENTRY_DISCARDED && syscall->state != INTERNAL) {
+    if (syscall->resolver.ret == DENTRY_DISCARDED) {
         monitor_discarded(syscall->type);
         // do not pop, we want to invalidate the inode even if the syscall is discarded
         syscall->state = DISCARDED;

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -8,7 +8,7 @@
 #include "helpers/syscalls.h"
 #include "helpers/discarders.h"
 
-int __attribute__((always_inline)) trace__sys_rmdir(u8 async, const char *filename) {
+int __attribute__((always_inline)) trace__sys_rmdir(void *ctx, u8 async, const char *filename) {
     struct syscall_cache_t syscall = {
         .type = EVENT_RMDIR,
         .policy = fetch_policy(EVENT_RMDIR),
@@ -18,20 +18,19 @@ int __attribute__((always_inline)) trace__sys_rmdir(u8 async, const char *filena
     if (!async) {
         collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_STR(0), (void *)filename, NULL, NULL);
     }
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY1(rmdir, const char *, filename) {
-    return trace__sys_rmdir(SYNC_SYSCALL, filename);
+    return trace__sys_rmdir(ctx, SYNC_SYSCALL, filename);
 }
 
 HOOK_ENTRY("do_rmdir")
 int hook_do_rmdir(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(rmdir_predicate);
     if (!syscall) {
-        return trace__sys_rmdir(ASYNC_SYSCALL, NULL);
+        return trace__sys_rmdir(ctx, ASYNC_SYSCALL, NULL);
     }
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/selinux.h
+++ b/pkg/security/ebpf/c/include/hooks/selinux.h
@@ -64,7 +64,8 @@ int __attribute__((always_inline)) handle_selinux_event(void *ctx, struct file *
     syscall.resolver.iteration = 0;
     syscall.resolver.ret = 0;
 
-    cache_syscall(&syscall);
+    cache_syscall(ctx, &syscall);
+    update_proc_cache_cgroup();
 
     // tail call
     resolve_dentry(ctx, KPROBE_OR_FENTRY_TYPE);

--- a/pkg/security/ebpf/c/include/hooks/setrlimit.h
+++ b/pkg/security/ebpf/c/include/hooks/setrlimit.h
@@ -17,7 +17,7 @@ static const int important_resources[] = {
     RLIMIT_CORE
 };
 
-static __always_inline int handle_setrlimit_common(unsigned int resource, const struct rlimit __user *new_rlim, u32 target_pid)
+static __always_inline int handle_setrlimit_common(void *ctx, unsigned int resource, const struct rlimit __user *new_rlim, u32 target_pid)
 {
     bool is_important = false;
     for (int i = 0; i < ARRAY_SIZE(important_resources); i++) {
@@ -46,7 +46,7 @@ static __always_inline int handle_setrlimit_common(unsigned int resource, const 
         }
     };
 
-    cache_syscall(&cache);
+    cache_syscall_update_cgroup(ctx, &cache);
     return 0;
 }
 
@@ -54,7 +54,7 @@ HOOK_SYSCALL_ENTRY2(setrlimit,
                     unsigned int, resource,
                     const struct rlimit __user *, new_rlim)
 {
-    return handle_setrlimit_common(resource, new_rlim, 0);
+    return handle_setrlimit_common(ctx, resource, new_rlim, 0);
 }
 
 HOOK_ENTRY("security_task_setrlimit")
@@ -135,7 +135,7 @@ HOOK_SYSCALL_ENTRY4(prlimit64,
         return 0;
     }
     
-    return handle_setrlimit_common(resource, new_limit, pid);
+    return handle_setrlimit_common(ctx, resource, new_limit, pid);
 }
 
 HOOK_SYSCALL_EXIT(prlimit64) {

--- a/pkg/security/ebpf/c/include/hooks/setsid.h
+++ b/pkg/security/ebpf/c/include/hooks/setsid.h
@@ -26,7 +26,7 @@ HOOK_SYSCALL_ENTRY0(setsid) {
     struct syscall_cache_t syscall = {
         .type = EVENT_SETSID,
     };
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/setsockopt.h
+++ b/pkg/security/ebpf/c/include/hooks/setsockopt.h
@@ -7,7 +7,7 @@
 #include <uapi/linux/filter.h>
 #include <helpers/approvers.h>
 
-static long __attribute__((always_inline)) trace__sys_setsock_opt(u8 async, int socket_fd, int level, int optname) {
+static long __attribute__((always_inline)) trace__sys_setsock_opt(void *ctx, u8 async, int socket_fd, int level, int optname) {
     if (is_discarded_by_pid()) {
         return 0;
     }
@@ -23,7 +23,7 @@ static long __attribute__((always_inline)) trace__sys_setsock_opt(u8 async, int 
         }
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
@@ -63,7 +63,7 @@ static int __attribute__((always_inline)) sys_set_sock_opt_ret(void *ctx, int re
 }
 
 HOOK_SYSCALL_ENTRY3(setsockopt, int, socket, int, level, int, optname) {
-    return trace__sys_setsock_opt(SYNC_SYSCALL, socket, level, optname);
+    return trace__sys_setsock_opt(ctx, SYNC_SYSCALL, socket, level, optname);
 }
 
 HOOK_SYSCALL_EXIT(setsockopt) {

--- a/pkg/security/ebpf/c/include/hooks/setxattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setxattr.h
@@ -6,7 +6,7 @@
 #include "helpers/filesystem.h"
 #include "helpers/syscalls.h"
 
-int __attribute__((always_inline)) trace__sys_setxattr(const char *xattr_name, u8 async, u64 pid_tgid) {
+int __attribute__((always_inline)) trace__sys_setxattr(void *ctx, const char *xattr_name, u8 async, u64 pid_tgid) {
     if (is_discarded_by_pid()) {
         return 0;
     }
@@ -25,24 +25,23 @@ int __attribute__((always_inline)) trace__sys_setxattr(const char *xattr_name, u
         syscall.xattr.pid_tgid = pid_tgid;
     }
 
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY2(setxattr, const char *, filename, const char *, name) {
-    return trace__sys_setxattr(name, 0, 0);
+    return trace__sys_setxattr(ctx, name, 0, 0);
 }
 
 HOOK_SYSCALL_ENTRY2(lsetxattr, const char *, filename, const char *, name) {
-    return trace__sys_setxattr(name, 0, 0);
+    return trace__sys_setxattr(ctx, name, 0, 0);
 }
 
 HOOK_SYSCALL_ENTRY2(fsetxattr, int, fd, const char *, name) {
-    return trace__sys_setxattr(name, 0, 0);
+    return trace__sys_setxattr(ctx, name, 0, 0);
 }
 
-int __attribute__((always_inline)) trace__sys_removexattr(const char *xattr_name) {
+int __attribute__((always_inline)) trace__sys_removexattr(void *ctx, const char *xattr_name) {
     struct policy_t policy = fetch_policy(EVENT_REMOVEXATTR);
     struct syscall_cache_t syscall = {
         .type = EVENT_REMOVEXATTR,
@@ -52,21 +51,20 @@ int __attribute__((always_inline)) trace__sys_removexattr(const char *xattr_name
         }
     };
 
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY2(removexattr, const char *, filename, const char *, name) {
-    return trace__sys_removexattr(name);
+    return trace__sys_removexattr(ctx, name);
 }
 
 HOOK_SYSCALL_ENTRY2(lremovexattr, const char *, filename, const char *, name) {
-    return trace__sys_removexattr(name);
+    return trace__sys_removexattr(ctx, name);
 }
 
 HOOK_SYSCALL_ENTRY2(fremovexattr, int, fd, const char *, name) {
-    return trace__sys_removexattr(name);
+    return trace__sys_removexattr(ctx, name);
 }
 
 int __attribute__((always_inline)) trace__vfs_setxattr(ctx_t *ctx, u64 event_type) {
@@ -136,7 +134,7 @@ int hook_vfs_removexattr(ctx_t *ctx) {
 int __attribute__((always_inline)) trace_io_fsetxattr(ctx_t *ctx) {
     void *raw_req = (void *)CTX_PARM1(ctx);
     u64 pid_tgid = get_pid_tgid_from_iouring(raw_req);
-    return trace__sys_setxattr(NULL, 1, pid_tgid);
+    return trace__sys_setxattr(ctx, NULL, 1, pid_tgid);
 }
 
 int __attribute__((always_inline)) sys_xattr_ret(void *ctx, int retval, u64 event_type) {

--- a/pkg/security/ebpf/c/include/hooks/signal.h
+++ b/pkg/security/ebpf/c/include/hooks/signal.h
@@ -29,7 +29,7 @@ HOOK_SYSCALL_ENTRY2(kill, int, pid, int, type) {
         syscall.signal.pid = 0; // it will be resolved later on by check_kill_permission
     }
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/splice.h
+++ b/pkg/security/ebpf/c/include/hooks/splice.h
@@ -19,7 +19,7 @@ HOOK_SYSCALL_ENTRY0(splice) {
         .policy = policy,
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/umount.h
+++ b/pkg/security/ebpf/c/include/hooks/umount.h
@@ -15,7 +15,7 @@ int hook_security_sb_umount(ctx_t *ctx) {
         }
     };
 
-    cache_syscall(&syscall);
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/unlink.h
+++ b/pkg/security/ebpf/c/include/hooks/unlink.h
@@ -8,7 +8,7 @@
 #include "helpers/filesystem.h"
 #include "helpers/syscalls.h"
 
-int __attribute__((always_inline)) trace__sys_unlink(u8 async, int dirfd, const char *filename, int flags) {
+int __attribute__((always_inline)) trace__sys_unlink(void *ctx, u8 async, int dirfd, const char *filename, int flags) {
     struct syscall_cache_t syscall = {
         .type = EVENT_UNLINK,
         .policy = fetch_policy(EVENT_UNLINK),
@@ -21,26 +21,25 @@ int __attribute__((always_inline)) trace__sys_unlink(u8 async, int dirfd, const 
     if (!async) {
         collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_INT(0) | SYSCALL_CTX_ARG_STR(1) | SYSCALL_CTX_ARG_INT(2), (void *)&dirfd, (void *)filename, (void *)&flags);
     }
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 HOOK_SYSCALL_ENTRY1(unlink, const char *, filename) {
     int dirfd = AT_FDCWD;
     int flags = 0;
-    return trace__sys_unlink(SYNC_SYSCALL, dirfd, filename, flags);
+    return trace__sys_unlink(ctx, SYNC_SYSCALL, dirfd, filename, flags);
 }
 
 HOOK_SYSCALL_ENTRY3(unlinkat, int, dirfd, const char *, filename, int, flags) {
-    return trace__sys_unlink(SYNC_SYSCALL, dirfd, filename, flags);
+    return trace__sys_unlink(ctx, SYNC_SYSCALL, dirfd, filename, flags);
 }
 
 HOOK_ENTRY("do_unlinkat")
 int hook_do_unlinkat(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
     if (!syscall) {
-        return trace__sys_unlink(ASYNC_SYSCALL, 0, NULL, 0);
+        return trace__sys_unlink(ctx, ASYNC_SYSCALL, 0, NULL, 0);
     }
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/unlink.h
+++ b/pkg/security/ebpf/c/include/hooks/unlink.h
@@ -77,18 +77,28 @@ int hook_vfs_unlink(ctx_t *ctx) {
         expire_inode_discarders(syscall->unlink.file.path_key.mount_id, syscall->unlink.file.path_key.ino);
     }
 
-    if (approve_syscall(syscall, unlink_approvers) == DISCARDED) {
-        // do not pop, we want to invalidate the inode even if the syscall is discarded
-        return 0;
-    }
-    if (is_auid_discarder(EVENT_UNLINK)) {
+    approve_syscall(syscall, unlink_approvers);
+
+    if (syscall->state != DISCARDED && is_auid_discarder(EVENT_UNLINK)) {
         syscall->state = DISCARDED;
+    }
+
+    u8 is_cgroupfs = is_cgroup2fs(dentry) && !is_runtime_request();
+
+    if (syscall->state != ACCEPTED && is_cgroupfs) {
+        syscall->state = INTERNAL;
+    }
+
+    if (syscall->state == DISCARDED) {
         return 0;
     }
+
     // the mount id of path_key is resolved by kprobe/mnt_want_write. It is already set by the time we reach this probe.
     syscall->resolver.dentry = dentry;
     syscall->resolver.key = syscall->unlink.file.path_key;
-    syscall->resolver.discarder_event_type = dentry_resolver_discarder_event_type(syscall);
+    // disable the dentry-resolver discarder for cgroupfs events: userspace needs them
+    // to track cgroup lifecycle, and a discarder match here would drop them.
+    syscall->resolver.discarder_event_type = !is_cgroupfs ? dentry_resolver_discarder_event_type(syscall) : 0;
     syscall->resolver.callback = DR_UNLINK_CALLBACK_KPROBE_KEY;
     syscall->resolver.iteration = 0;
     syscall->resolver.ret = 0;
@@ -141,6 +151,12 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
 
             send_event(ctx, EVENT_RMDIR, event);
         } else {
+            // INTERNAL here means a cgroupfs unlink on a non-directory; the userspace
+            // cgroup resolver only consumes directory events, so drop these.
+            if (syscall->state == INTERNAL) {
+                return 0;
+            }
+
             struct unlink_event_t event = {
                 .syscall.retval = retval,
                 .syscall_ctx.id = syscall->ctx_id,

--- a/pkg/security/ebpf/c/include/hooks/utimes.h
+++ b/pkg/security/ebpf/c/include/hooks/utimes.h
@@ -5,7 +5,7 @@
 #include "helpers/discarders.h"
 #include "helpers/syscalls.h"
 
-int __attribute__((always_inline)) trace__sys_utimes(const char *filename) {
+int __attribute__((always_inline)) trace__sys_utimes(void *ctx, const char *filename) {
     if (is_discarded_by_pid() || is_auid_discarder(EVENT_UTIME)) {
         return 0;
     }
@@ -17,31 +17,30 @@ int __attribute__((always_inline)) trace__sys_utimes(const char *filename) {
     };
 
     collect_syscall_ctx(&syscall, SYSCALL_CTX_ARG_STR(0), (void *)filename, NULL, NULL);
-    cache_syscall(&syscall);
-
+    cache_syscall_update_cgroup(ctx, &syscall);
     return 0;
 }
 
 // On old kernels, we have sys_utime and compat_sys_utime.
 // On new kernels, we have _x64_sys_utime32, __ia32_sys_utime32, __x64_sys_utime, __ia32_sys_utime
 HOOK_SYSCALL_COMPAT_ENTRY1(utime, const char *, filename) {
-    return trace__sys_utimes(filename);
+    return trace__sys_utimes(ctx, filename);
 }
 
 HOOK_SYSCALL_ENTRY1(utime32, const char *, filename) {
-    return trace__sys_utimes(filename);
+    return trace__sys_utimes(ctx, filename);
 }
 
 HOOK_SYSCALL_COMPAT_TIME_ENTRY1(utimes, const char *, filename) {
-    return trace__sys_utimes(filename);
+    return trace__sys_utimes(ctx, filename);
 }
 
 HOOK_SYSCALL_COMPAT_TIME_ENTRY2(utimensat, int, dirfd, const char *, filename) {
-    return trace__sys_utimes(filename);
+    return trace__sys_utimes(ctx, filename);
 }
 
 HOOK_SYSCALL_COMPAT_TIME_ENTRY2(futimesat, int, dirfd, const char *, filename) {
-    return trace__sys_utimes(filename);
+    return trace__sys_utimes(ctx, filename);
 }
 
 int __attribute__((always_inline)) sys_utimes_ret(void *ctx, int retval) {

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -151,6 +151,7 @@ BPF_PROG_ARRAY(raw_packet_classifier_router_0, 32)
 BPF_PROG_ARRAY(raw_packet_classifier_router_1, 32)
 BPF_PROG_ARRAY(flush_network_stats_progs, 2)
 BPF_PROG_ARRAY(open_ret_progs, 1)
+BPF_PROG_ARRAY(cache_syscall_progs, 1)
 
 BPF_PERF_EVENT_ARRAY_MAP(events, u32)
 BPF_PERCPU_ARRAY_MAP(events_stats, struct perf_map_stats_t, EVENT_MAX)

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -452,6 +452,7 @@ func AllTailRoutes(eRPCDentryResolutionEnabled, networkEnabled, networkFlowMonit
 	routes = append(routes, getExecTailCallRoutes()...)
 	routes = append(routes, getDentryResolverTailCallRoutes(eRPCDentryResolutionEnabled, supportMmapableMaps)...)
 	routes = append(routes, getSysExitTailCallRoutes()...)
+	routes = append(routes, getCacheSyscallTailCallRoutes()...)
 	if networkEnabled {
 		routes = append(routes, getTCTailCallRoutes(rawPacketEnabled)...)
 	}

--- a/pkg/security/ebpf/probes/cache_syscall.go
+++ b/pkg/security/ebpf/probes/cache_syscall.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package probes
+
+import manager "github.com/DataDog/ebpf-manager"
+
+func getCacheSyscallTailCallRoutes() []manager.TailCallRoute {
+	return []manager.TailCallRoute{
+		{
+			ProgArrayName: "cache_syscall_progs",
+			Key:           CacheSyscallUpdateProcCacheCgroupKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: tailCallFnc("update_proc_cache_cgroup"),
+			},
+		},
+	}
+}

--- a/pkg/security/ebpf/probes/const.go
+++ b/pkg/security/ebpf/probes/const.go
@@ -117,3 +117,8 @@ const (
 	// FlushNetworkStatsExecKey is the key to the program that flushes network stats before resuming the normal exec event processing
 	FlushNetworkStatsExecKey
 )
+
+const (
+	// CacheSyscallUpdateProcCacheCgroupKey is the key to the program that refreshes the cached cgroup inode of the current process
+	CacheSyscallUpdateProcCacheCgroupKey uint32 = iota
+)

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1113,7 +1113,7 @@ func (p *EBPFProbe) triggerNopEvent() error {
 }
 
 // setProcessContext set the process context, should return false if the event shouldn't be dispatched
-func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Event, newEntryCb func(entry *model.ProcessCacheEntry, err error)) bool {
+func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Event, cgroupContext model.CGroupContext, newEntryCb func(entry *model.ProcessCacheEntry, err error)) bool {
 	entry, isResolved := p.fieldHandlers.ResolveProcessCacheEntry(event, newEntryCb)
 	event.ProcessCacheEntry = entry
 	if event.ProcessCacheEntry == nil {
@@ -1145,6 +1145,15 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 			if _, err := entry.HasValidLineage(); err != nil {
 				event.Error = &model.ErrProcessBrokenLineage{Err: err}
 				p.Resolvers.ProcessResolver.CountBrokenLineage()
+			}
+
+			// check the cgroup transition
+			if entry.CGroup.CGroupPathKey.Inode != cgroupContext.CGroupPathKey.Inode {
+				if cacheEntry := p.Resolvers.CGroupResolver.AddPID(entry.Pid, entry.PPid, cgroupContext); cacheEntry == nil {
+					seclog.Debugf("Failed to resolve cgroup for pid %d: %+v", entry.Pid, cgroupContext.CGroupPathKey)
+				} else {
+					p.Resolvers.ProcessResolver.UpdateProcessContexts(entry, cacheEntry.GetCGroupContext(), cacheEntry.GetContainerContext())
+				}
 			}
 		}
 	}
@@ -1271,7 +1280,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		return
 	}
 	// resolve process context
-	if !p.setProcessContext(eventType, event, newEntryCb) {
+	if !p.setProcessContext(eventType, event, cgroupContext, newEntryCb) {
 		return
 	}
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -128,6 +128,7 @@ type EBPFProbe struct {
 	variableStore   *eval.VariableStore
 	variableStoreMu sync.RWMutex
 	numCPU          int
+	pid             uint32
 
 	ctx       context.Context
 	cancelFnc context.CancelFunc
@@ -430,7 +431,7 @@ func (p *EBPFProbe) VerifyEnvironment() *multierror.Error {
 			err = multierror.Append(err, fmt.Errorf("%s doesn't seem to be a mountpoint", securityFSPath))
 		}
 
-		capsEffective, _, capErr := utils.CapEffCapEprm(utils.Getpid())
+		capsEffective, _, capErr := utils.CapEffCapEprm(p.pid)
 		if capErr != nil {
 			err = multierror.Append(capErr, errors.New("failed to get process capabilities"))
 		} else {
@@ -1112,7 +1113,7 @@ func (p *EBPFProbe) triggerNopEvent() error {
 }
 
 // setProcessContext set the process context, should return false if the event shouldn't be dispatched
-func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Event, newEntryCb func(entry *model.ProcessCacheEntry, err error)) bool {
+func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Event, cgroupContext model.CGroupContext, newEntryCb func(entry *model.ProcessCacheEntry, err error)) bool {
 	entry, isResolved := p.fieldHandlers.ResolveProcessCacheEntry(event, newEntryCb)
 	event.ProcessCacheEntry = entry
 	if event.ProcessCacheEntry == nil {
@@ -1151,6 +1152,18 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 			if _, err := entry.HasValidLineage(); err != nil {
 				event.Error = &model.ErrProcessBrokenLineage{Err: err}
 				p.Resolvers.ProcessResolver.CountBrokenLineage()
+			}
+
+			// the kernel updates proc_cache's cgroup inode on every syscall (see
+			// cache_syscall); a divergence here means the process migrated cgroups
+			// since the cache entry was created, so refresh both resolvers from the
+			// authoritative event-time cgroupContext.
+			if entry.CGroup.CGroupPathKey.Inode != cgroupContext.CGroupPathKey.Inode && event.PIDContext.Pid != p.pid {
+				if cacheEntry := p.Resolvers.CGroupResolver.AddPID(entry.Pid, cgroupContext); cacheEntry == nil {
+					seclog.Debugf("Failed to resolve cgroup for pid %d: %+v", entry.Pid, cgroupContext.CGroupPathKey)
+				} else {
+					p.Resolvers.ProcessResolver.UpdateProcessContexts(entry, cacheEntry.GetCGroupContext(), cacheEntry.GetContainerContext())
+				}
 			}
 		}
 	}
@@ -1277,7 +1290,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		return
 	}
 	// resolve process context
-	if !p.setProcessContext(eventType, event, newEntryCb) {
+	if !p.setProcessContext(eventType, event, cgroupContext, newEntryCb) {
 		return
 	}
 
@@ -1357,19 +1370,21 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		fs := p.fieldHandlers.ResolveFileFilesystem(event, &event.Open.File)
 
 		if fs == "cgroup2" && event.Open.File.PathKey.Inode != 0 && event.Open.File.FileFields.IsDir() {
-			cgroupContext := model.CGroupContext{
-				CGroupPathKey: event.Open.File.PathKey,
-				CGroupSource:  model.CGroupSourceEvent,
-				CreatedAt:     uint64(time.Now().UnixNano()),
+			if event.Open.Retval >= 0 && event.PIDContext.Pid != p.pid {
+				cgroupContext := model.CGroupContext{
+					CGroupPathKey: event.Open.File.PathKey,
+					CGroupSource:  model.CGroupSourceEvent,
+					CreatedAt:     uint64(time.Now().UnixNano()),
+				}
+				p.Resolvers.CGroupResolver.Add(cgroupContext)
 			}
-			p.Resolvers.CGroupResolver.Add(cgroupContext)
-		}
 
-		// internal open events are emitted only to populate the cgroup
-		// resolver above; they don't reflect a user action so skip rule
-		// evaluation
-		if event.IsEventInternal() {
-			return false
+			// internal open events are emitted only to populate the cgroup
+			// resolver above; they don't reflect a user action so skip rule
+			// evaluation
+			if event.IsEventInternal() || event.PIDContext.Pid == p.pid {
+				return false
+			}
 		}
 	case model.FileMkdirEventType:
 		if !p.regularUnmarshalEvent(&event.Mkdir, eventType, offset, dataLen, data) {
@@ -1382,15 +1397,17 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 
 		// handle cgroup v2 deletion
 		fs := p.fieldHandlers.ResolveFileFilesystem(event, &event.Rmdir.File)
-		if fs == "cgroup2" && event.Rmdir.File.PathKey.Inode != 0 && event.Rmdir.File.IsDir() && event.Rmdir.Retval == 0 {
-			p.Resolvers.CGroupResolver.Delete(event.Rmdir.File.PathKey.Inode)
-		}
+		if fs == "cgroup2" && event.Rmdir.File.PathKey.Inode != 0 && event.Rmdir.File.IsDir() {
+			if event.Rmdir.Retval == 0 && event.PIDContext.Pid != p.pid {
+				p.Resolvers.CGroupResolver.Delete(event.Rmdir.File.PathKey.Inode)
+			}
 
-		// internal rmdir events are emitted only to update the cgroup
-		// resolver above; they don't reflect a user action so skip rule
-		// evaluation
-		if event.IsEventInternal() {
-			return false
+			// internal rmdir events are emitted only to populate the cgroup
+			// resolver above; they don't reflect a user action so skip rule
+			// evaluation
+			if event.IsEventInternal() || event.PIDContext.Pid == p.pid {
+				return false
+			}
 		}
 	case model.FileUnlinkEventType:
 		if !p.regularUnmarshalEvent(&event.Unlink, eventType, offset, dataLen, data) {
@@ -1399,15 +1416,16 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 
 		// handle cgroup v2 deletion
 		fs := p.fieldHandlers.ResolveFileFilesystem(event, &event.Unlink.File)
-		if fs == "cgroup2" && event.Unlink.File.PathKey.Inode != 0 && event.Unlink.File.IsDir() && event.Unlink.Retval == 0 {
-			p.Resolvers.CGroupResolver.Delete(event.Unlink.File.PathKey.Inode)
-		}
-
-		// internal unlink events are emitted only to update the cgroup
-		// resolver above; they don't reflect a user action so skip rule
-		// evaluation
-		if event.IsEventInternal() {
-			return false
+		if fs == "cgroup2" && event.Unlink.File.PathKey.Inode != 0 && event.Unlink.File.IsDir() {
+			if event.Unlink.Retval == 0 && event.PIDContext.Pid != p.pid {
+				p.Resolvers.CGroupResolver.Delete(event.Unlink.File.PathKey.Inode)
+			}
+			// internal unlink events are emitted only to populate the cgroup
+			// resolver above; they don't reflect a user action so skip rule
+			// evaluation
+			if event.IsEventInternal() || event.PIDContext.Pid == p.pid {
+				return false
+			}
 		}
 	case model.FileRenameEventType:
 		if !p.regularUnmarshalEvent(&event.Rename, eventType, offset, dataLen, data) {
@@ -2690,7 +2708,7 @@ func (p *EBPFProbe) initManagerOptionsConstants() {
 		},
 		manager.ConstantEditor{
 			Name:  "runtime_pid",
-			Value: uint64(utils.Getpid()),
+			Value: uint64(p.pid),
 		},
 		manager.ConstantEditor{
 			Name:  "do_fork_input",
@@ -3069,6 +3087,7 @@ func NewEBPFProbe(probe *Probe, config *config.Config, hostname string, opts Opt
 		BPFFilterTruncated:   atomic.NewUint64(0),
 		MetricNameTruncated:  atomic.NewUint64(0),
 		activeRemediations:   make(map[string]*Remediation),
+		pid:                  utils.Getpid(),
 	}
 
 	if err := p.detectKernelVersion(); err != nil {

--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"slices"
@@ -194,6 +195,63 @@ ExecStart=/usr/bin/touch ` + testFile2
 			test.validateOpenSchema(t, event)
 		}, "test_cgroup_systemd")
 	})
+}
+
+func TestCGroupPropagation(t *testing.T) {
+	if testEnvironment == DockerEnvironment {
+		t.Skip("skipping cgroup propagation test in docker")
+	}
+
+	SkipIfNotAvailable(t)
+
+	checkKernelCompatibility(t, "CLONE_INTO_CGROUP requires kernel >= 5.7", func(kv *kernel.Version) bool {
+		return kv.Code < kernel.Kernel5_7
+	})
+
+	if !utils.IsPureCGroupV2Available() {
+		t.Skip("cgroup v2 unified hierarchy not available")
+	}
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_cgroup_propagation",
+			Expression: `open.file.path == "{{.Root}}/test-cgroup-propagation" && process.cgroup.id =~ "*/cg-propagation"`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	targetCGroupPath := "/sys/fs/cgroup/cg-propagation"
+	if err := os.MkdirAll(targetCGroupPath, 0700); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(targetCGroupPath)
+
+	testFile, _, err := test.Path("test-cgroup-propagation")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	test.WaitSignalFromRule(t, func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return runSyscallTesterFunc(ctx, t, syscallTester, "process-clone-into-cgroup", targetCGroupPath, testFile)
+	}, func(event *model.Event, rule *rules.Rule) {
+		assertTriggeredRule(t, rule, "test_cgroup_propagation")
+		assertFieldEqual(t, event, "open.file.path", testFile)
+		assertFieldIsOneOf(t, event, "process.cgroup.id", []string{"/cg-propagation", "/systemd/cg-propagation"})
+
+		test.validateOpenSchema(t, event)
+	}, "test_cgroup_propagation")
 }
 
 func TestCGroupSnapshot(t *testing.T) {

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -23,6 +23,7 @@
 #include <netdb.h>
 #include <linux/un.h>
 #include <linux/prctl.h>
+#include <linux/sched.h>
 #include <err.h>
 #include <limits.h>
 #include <sys/time.h>
@@ -1999,6 +2000,67 @@ int test_subreaper(int argc, char **argv) {
     return EXIT_SUCCESS;
 }
 
+/* clone3 is not wrapped by glibc, call it directly. */
+static pid_t sys_clone3(struct clone_args *args, size_t size) {
+    return (pid_t)syscall(__NR_clone3, args, size);
+}
+
+// test_clone_into_cgroup forks a child directly into the given cgroup v2
+// directory using clone3 + CLONE_INTO_CGROUP, then has the child open the
+// given file with O_CREAT.
+// Usage: syscall_tester process-clone-into-cgroup <cgroup_v2_dir> <file>
+int test_clone_into_cgroup(int argc, char **argv) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: process-clone-into-cgroup <cgroup_v2_dir> <file>\n");
+        return EXIT_FAILURE;
+    }
+
+    const char *cgroup_path = argv[1];
+    const char *file_path = argv[2];
+
+    int cgroup_fd = open(cgroup_path, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (cgroup_fd < 0) {
+        perror("open cgroup");
+        return EXIT_FAILURE;
+    }
+
+    struct clone_args args = {
+        .flags = CLONE_INTO_CGROUP,
+        .exit_signal = SIGCHLD,
+        .cgroup = (uint64_t)cgroup_fd,
+    };
+
+    pid_t pid = sys_clone3(&args, sizeof(args));
+    if (pid < 0) {
+        perror("clone3");
+        close(cgroup_fd);
+        return EXIT_FAILURE;
+    }
+
+    if (pid == 0) {
+        int fd = open(file_path, O_RDONLY | O_CREAT, 0400);
+        if (fd < 0) {
+            _exit(EXIT_FAILURE);
+        }
+        close(fd);
+        _exit(EXIT_SUCCESS);
+    }
+
+    close(cgroup_fd);
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0) {
+        perror("waitpid");
+        return EXIT_FAILURE;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "child failed: status=%d\n", status);
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
 int main(int argc, char **argv) {
     setbuf(stdout, NULL);
 
@@ -2120,6 +2182,8 @@ int main(int argc, char **argv) {
             exit_code = test_dnsloop(sub_argc, sub_argv);
         } else if (strcmp(cmd, "subreaper") == 0) {
             exit_code = test_subreaper(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "process-clone-into-cgroup") == 0) {
+            exit_code = test_clone_into_cgroup(sub_argc, sub_argv);
         } else {
             fprintf(stderr, "Unknown command: %s\n", cmd);
             exit_code = EXIT_FAILURE;


### PR DESCRIPTION
When a process migrates to a new cgroup between events, the kernel-side cgroup inode (updated via bpf_get_current_cgroup_id in cache_syscall) can diverge from the cached value. Propagate the event's cgroupContext to the process resolver so that the cgroup and container contexts are kept in sync.

Also fix a debug log in setProcessContext: the format string used %d with a *ProcessCacheEntry pointer instead of entry.Pid, and referenced event.CgroupWrite.File.PathKey (unrelated to the failure path) instead of cgroupContext.CGroupPathKey.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
