### PR TITLE
[SNMP] Deflake SNMP traps listener tests via deterministic ports

### DIFF
--- a/comp/snmptraps/listener/impl/listener_test.go
+++ b/comp/snmptraps/listener/impl/listener_test.go
@@ -54,9 +54,8 @@ func listenerTestSetup(t *testing.T, conf *config.TrapsConfig) *services {
 }
 
 func TestListenV1GenericTrap(t *testing.T) {
-	serverPort, err := ndmtestutils.GetFreePort()
-	require.NoError(t, err)
-	config := &config.TrapsConfig{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
+	port := ndmtestutils.UniqueTestPort(t.Name())
+	config := &config.TrapsConfig{Port: port, BindHost: "127.0.0.1", CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	s := listenerTestSetup(t, config)
 
 	sendTestV1GenericTrap(t, s.Config.Get(), "public")
@@ -67,9 +66,8 @@ func TestListenV1GenericTrap(t *testing.T) {
 }
 
 func TestServerV1SpecificTrap(t *testing.T) {
-	serverPort, err := ndmtestutils.GetFreePort()
-	require.NoError(t, err)
-	config := &config.TrapsConfig{Port: serverPort, CommunityStrings: []string{"public"}}
+	port := ndmtestutils.UniqueTestPort(t.Name())
+	config := &config.TrapsConfig{Port: port, BindHost: "127.0.0.1", CommunityStrings: []string{"public"}}
 	s := listenerTestSetup(t, config)
 
 	sendTestV1SpecificTrap(t, config, "public")
@@ -80,9 +78,8 @@ func TestServerV1SpecificTrap(t *testing.T) {
 }
 
 func TestServerV2(t *testing.T) {
-	serverPort, err := ndmtestutils.GetFreePort()
-	require.NoError(t, err)
-	config := &config.TrapsConfig{Port: serverPort, CommunityStrings: []string{"public"}}
+	port := ndmtestutils.UniqueTestPort(t.Name())
+	config := &config.TrapsConfig{Port: port, BindHost: "127.0.0.1", CommunityStrings: []string{"public"}}
 	s := listenerTestSetup(t, config)
 
 	sendTestV2Trap(t, config, "public")
@@ -93,9 +90,8 @@ func TestServerV2(t *testing.T) {
 }
 
 func TestServerV2BadCredentials(t *testing.T) {
-	serverPort, err := ndmtestutils.GetFreePort()
-	require.NoError(t, err)
-	config := &config.TrapsConfig{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
+	port := ndmtestutils.UniqueTestPort(t.Name())
+	config := &config.TrapsConfig{Port: port, BindHost: "127.0.0.1", CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	s := listenerTestSetup(t, config)
 
 	sendTestV2Trap(t, config, "wrong-community")
@@ -107,10 +103,9 @@ func TestServerV2BadCredentials(t *testing.T) {
 }
 
 func TestServerV3(t *testing.T) {
-	serverPort, err := ndmtestutils.GetFreePort()
-	require.NoError(t, err)
+	port := ndmtestutils.UniqueTestPort(t.Name())
 	userV3 := config.UserV3{Username: "user", AuthKey: "password", AuthProtocol: "sha", PrivKey: "password", PrivProtocol: "aes"}
-	config := &config.TrapsConfig{Port: serverPort, Users: []config.UserV3{userV3}}
+	config := &config.TrapsConfig{Port: port, BindHost: "127.0.0.1", Users: []config.UserV3{userV3}}
 	s := listenerTestSetup(t, config)
 
 	sendTestV3Trap(t, config, gosnmp.AuthPriv, &gosnmp.UsmSecurityParameters{
@@ -184,10 +179,9 @@ func TestServerV3MultipleCredentials(t *testing.T) {
 			},
 		},
 	}
-	serverPort, err := ndmtestutils.GetFreePort()
-	require.NoError(t, err)
+	port := ndmtestutils.UniqueTestPort(t.Name())
 
-	config := &config.TrapsConfig{Port: serverPort, Users: users}
+	config := &config.TrapsConfig{Port: port, BindHost: "127.0.0.1", Users: users}
 	s := listenerTestSetup(t, config)
 
 	for _, test := range tests {
@@ -199,9 +193,8 @@ func TestServerV3MultipleCredentials(t *testing.T) {
 }
 
 func TestServerV3BadCredentialsWithMultipleUsers(t *testing.T) {
-	serverPort, err := ndmtestutils.GetFreePort()
-	require.NoError(t, err)
-	config := &config.TrapsConfig{Port: serverPort, Users: users}
+	port := ndmtestutils.UniqueTestPort(t.Name())
+	config := &config.TrapsConfig{Port: port, BindHost: "127.0.0.1", Users: users}
 	s := listenerTestSetup(t, config)
 
 	sendTestV3Trap(t, config, gosnmp.AuthPriv, &gosnmp.UsmSecurityParameters{
@@ -216,10 +209,9 @@ func TestServerV3BadCredentialsWithMultipleUsers(t *testing.T) {
 }
 
 func TestServerV3BadCredentials(t *testing.T) {
-	serverPort, err := ndmtestutils.GetFreePort()
-	require.NoError(t, err)
+	port := ndmtestutils.UniqueTestPort(t.Name())
 	userV3 := config.UserV3{Username: "user", AuthKey: "password", AuthProtocol: "sha", PrivKey: "password", PrivProtocol: "aes"}
-	config := &config.TrapsConfig{Port: serverPort, Users: []config.UserV3{userV3}}
+	config := &config.TrapsConfig{Port: port, BindHost: "127.0.0.1", Users: []config.UserV3{userV3}}
 	s := listenerTestSetup(t, config)
 
 	sendTestV3Trap(t, config, gosnmp.AuthPriv, &gosnmp.UsmSecurityParameters{
@@ -234,9 +226,8 @@ func TestServerV3BadCredentials(t *testing.T) {
 }
 
 func TestListenerTrapsReceivedTelemetry(t *testing.T) {
-	serverPort, err := ndmtestutils.GetFreePort()
-	require.NoError(t, err)
-	config := &config.TrapsConfig{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
+	port := ndmtestutils.UniqueTestPort(t.Name())
+	config := &config.TrapsConfig{Port: port, BindHost: "127.0.0.1", CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	s := listenerTestSetup(t, config)
 
 	sendTestV1GenericTrap(t, config, "public")

--- a/comp/snmptraps/server/serverimpl/server_test.go
+++ b/comp/snmptraps/server/serverimpl/server_test.go
@@ -8,10 +8,8 @@
 package serverimpl
 
 import (
-	"hash/fnv"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,17 +19,9 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/senderhelper"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/server"
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
-
-// uniqueTestPort returns a deterministic high-range UDP port derived from inputs,
-// reducing the chance of collisions across concurrent tests without TOCTOU races.
-func uniqueTestPort(keys ...string) uint16 {
-	h := fnv.New32a()
-	h.Write([]byte(strings.Join(keys, "|")))
-	// Choose from 62000-63999 (typically outside Linux default ephemeral range)
-	return uint16(62000 + (h.Sum32() % 2000))
-}
 
 func TestServer(t *testing.T) {
 	confdPath, err := os.MkdirTemp("", "trapsdb")
@@ -43,7 +33,7 @@ func TestServer(t *testing.T) {
 	require.NoError(t, os.Mkdir(tdb, 0777))
 	require.NoError(t, os.WriteFile(filepath.Join(tdb, "foo.json"), []byte{}, 0666))
 	// Pick a deterministic port specific to this test run to avoid collisions
-	port := uniqueTestPort(t.Name(), confdPath)
+	port := ndmtestutils.UniqueTestPort(t.Name(), confdPath)
 	server := fxutil.Test[server.Component](t,
 		senderhelper.Opts,
 		fx.Provide(func(t testing.TB) config.Component {
@@ -66,7 +56,7 @@ func TestNonBlockingFailure(t *testing.T) {
 	confdPath, err := os.MkdirTemp("", "trapsdb")
 	require.NoError(t, err)
 	defer os.RemoveAll(confdPath)
-	port := uniqueTestPort(t.Name(), confdPath)
+	port := ndmtestutils.UniqueTestPort(t.Name(), confdPath)
 	server := fxutil.Test[server.Component](t,
 		senderhelper.Opts,
 		fx.Provide(func(t testing.TB) config.Component {

--- a/pkg/networkdevice/testutils/freeport.go
+++ b/pkg/networkdevice/testutils/freeport.go
@@ -9,8 +9,10 @@ package testutils
 
 import (
 	"fmt"
+	"hash/fnv"
 	"net"
 	"strconv"
+	"strings"
 )
 
 // GetFreePort finds a free port to use for testing.
@@ -31,4 +33,13 @@ func GetFreePort() (uint16, error) {
 	}
 
 	return uint16(portInt), nil
+}
+
+// UniqueTestPort returns a deterministic high-range UDP port derived from inputs,
+// reducing the chance of collisions across concurrent tests without TOCTOU races.
+func UniqueTestPort(keys ...string) uint16 {
+	h := fnv.New32a()
+	h.Write([]byte(strings.Join(keys, "|")))
+	// Choose from 62000-63999 (typically outside Linux default ephemeral range)
+	return uint16(62000 + (h.Sum32() % 2000))
 }


### PR DESCRIPTION
### What does this PR do?

https://datadoghq.atlassian.net/browse/NDMC-228

This is the same fix as in this PR: https://github.com/DataDog/datadog-agent/pull/46667, which the test has been passing since the PR was merged.

Before (tests fail with the same error from the ticket):
<img width="1512" height="197" alt="image" src="https://github.com/user-attachments/assets/42425611-8af5-4dc1-81c8-822dccb5ce23" />

After (tests do not fail):
<img width="1512" height="167" alt="image" src="https://github.com/user-attachments/assets/5dd0853a-baad-47c5-8e14-55f67c3aeef1" />

### Motivation

### Describe how you validated your changes

Unit tests + CI pass.

### Additional Notes
