### PR TITLE
NDMC-285: Retry GetBulk with smaller batches when response has fewer varbinds t…

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
@@ -128,6 +128,16 @@ func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions u
 			log.Debug(fetchErr.Error())
 			return nil, fetchErr
 		}
+
+		// Some devices truncate GetBulk responses without returning an SNMP
+		// error. Treat that as a fetch failure so batching retries with a
+		// smaller request instead of silently losing metrics.
+		if len(getBulkResults.Variables) < len(requestOids) {
+			err := fmt.Errorf("response truncated: got %d varbinds for %d OIDs", len(getBulkResults.Variables), len(requestOids))
+			fetchErr := newFetchError(columnOid, requestOids, snmpGetBulk, err)
+			log.Debug(fetchErr.Error())
+			return nil, fetchErr
+		}
 		results = getBulkResults
 		if log.ShouldLog(log.DebugLvl) {
 			log.Debugf("fetch column: GetBulk results: %v", gosnmplib.PacketAsString(results))

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
@@ -307,6 +307,59 @@ func Test_fetchColumnOidsBatch_usingGetNext(t *testing.T) {
 	assert.Equal(t, expectedColumnValues, columnValues)
 }
 
+func Test_fetchColumnOidsBatch_truncatedResponse_reducesBatchSize(t *testing.T) {
+	sess := session.CreateMockSession()
+
+	// First call with both OIDs in one batch — device truncates, returning
+	// only 1 varbind for 2 requested OIDs.
+	truncatedPacket := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.1.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 11,
+			},
+		},
+	}
+	sess.On("GetBulk", []string{"1.1.1", "1.1.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&truncatedPacket, nil)
+
+	// After batch size is halved to 1, each OID is fetched individually.
+	// OID 1.1.1: one row, then walk past the column prefix to end.
+	singlePacket1 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{Name: "1.1.1.1", Type: gosnmp.TimeTicks, Value: 11},
+			{Name: "1.1.2.1", Type: gosnmp.TimeTicks, Value: 999}, // outside prefix → walk ends
+		},
+	}
+	sess.On("GetBulk", []string{"1.1.1"}, checkconfig.DefaultBulkMaxRepetitions).Return(&singlePacket1, nil)
+
+	// OID 1.1.2: one row, then walk past the column prefix to end.
+	singlePacket2 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{Name: "1.1.2.1", Type: gosnmp.TimeTicks, Value: 21},
+			{Name: "1.1.3.1", Type: gosnmp.TimeTicks, Value: 999}, // outside prefix → walk ends
+		},
+	}
+	sess.On("GetBulk", []string{"1.1.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&singlePacket2, nil)
+
+	oids := []string{"1.1.1", "1.1.2"}
+	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 2)
+
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
+	require.NoError(t, err)
+
+	expectedColumnValues := valuestore.ColumnResultValuesType{
+		"1.1.1": {
+			"1": valuestore.ResultValue{Value: float64(11)},
+		},
+		"1.1.2": {
+			"1": valuestore.ResultValue{Value: float64(21)},
+		},
+	}
+	assert.Equal(t, expectedColumnValues, columnValues)
+	assert.Equal(t, 1, batchSizeOptimizer.lastSuccessfulBatchSize)
+}
+
 func Test_fetchColumnOidsBatch_usingGetBulkAndGetNextFallback(t *testing.T) {
 	sess := session.CreateMockSession()
 	// When using snmp v2+, we will try GetBulk first and fallback using GetNext

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
@@ -360,6 +360,28 @@ func Test_fetchColumnOidsBatch_truncatedResponse_reducesBatchSize(t *testing.T) 
 	assert.Equal(t, 1, batchSizeOptimizer.lastSuccessfulBatchSize)
 }
 
+func Test_fetchColumnOidsBatch_truncatedResponseAtBatchSizeOne_returnsError(t *testing.T) {
+	sess := session.CreateMockSession()
+
+	// Device keeps truncating even at batch size 1: returns 0 varbinds for
+	// the single requested OID. The fetch must terminate with an error
+	// rather than retrying indefinitely.
+	truncatedPacket := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{},
+	}
+	sess.On("GetBulk", []string{"1.1.1"}, checkconfig.DefaultBulkMaxRepetitions).Return(&truncatedPacket, nil)
+
+	oids := []string{"1.1.1"}
+	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 1)
+
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "response truncated")
+	assert.Nil(t, columnValues)
+	assert.Equal(t, 1, batchSizeOptimizer.batchSize)
+	sess.AssertNumberOfCalls(t, "GetBulk", 1)
+}
+
 func Test_fetchColumnOidsBatch_usingGetBulkAndGetNextFallback(t *testing.T) {
 	sess := session.CreateMockSession()
 	// When using snmp v2+, we will try GetBulk first and fallback using GetNext

--- a/releasenotes/notes/snmp-getbulk-truncation-retry-3ff2698fa88a6c5c.yaml
+++ b/releasenotes/notes/snmp-getbulk-truncation-retry-3ff2698fa88a6c5c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    SNMP: Detect GetBulk response truncation (fewer varbinds than requested OIDs) and
+    automatically reduce the batch size, preventing silent metric loss on devices that
+    truncate large SNMP responses.


### PR DESCRIPTION
### What does this PR do?

Detects GetBulk response truncation in the SNMP column fetch path and triggers automatic batch size reduction via the existing oidBatchSizeOptimizer.

When a device returns fewer varbinds than the number of requested OIDs in a GetBulk response, the new guard in getResults() returns a fetchError. The caller in fetchColumnOidsWithBatching catches this error type and halves the batch size through onBatchSizeFailure(), then retries recursively with smaller batches until all OIDs receive responses.

Changes:
  - pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go: Added truncation check (len(Variables) < len(requestOids)) after successful GetBulk calls, returning a fetchError to trigger the batch size optimizer
  - pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go: Added Test_fetchColumnOidsBatch_truncatedResponse_reducesBatchSize verifying the full truncation → batch reduction → successful retry flow

### Motivation

Fixes NDMC-285. Reported via support escalation (AGENT-15763).

When a GetBulk batch contains OIDs the device does not support, the device wraps around to an earlier OID in the MIB tree (typically sysDescr). If sysDescr is large, a few wrap-around values can fill the entire UDP response PDU (~1500 bytes), causing the device to legitimately truncate the response. ResultToColumnValues maps varbinds to column OIDs using columnOids[i % len(columnOids)] — when the response has fewer varbinds than requested OIDs, the trailing OIDs are silently dropped with no retry.


### Describe how you validated your changes

- Added unit test and made sure existing unit tests pass
- Used an SNMP Test Server run locally to simulate the scenario that would lead to truncated data, and connected it to a locally run version of the agent to check if the error is called (which means it eventually leads to halving)
- Tested in staging that checks return the same amount of metrics

### Additional Notes

- The oidBatchSizeOptimizer persists the lastSuccessfulBatchSize across check runs and gradually tries to increase it (+1 per success), so the agent self-heals if the truncation condition is transient, but it self-heals quite slowly.
