### PR TITLE
Enable protocol classification on fentry tracer

### DIFF
--- a/pkg/network/ebpf/c/co-re/tracer-fentry.c
+++ b/pkg/network/ebpf/c/co-re/tracer-fentry.c
@@ -18,6 +18,8 @@
 #include "tracer/telemetry.h"
 #include "tracer/port.h"
 
+#include "protocols/classification/protocol-classification.h"
+
 BPF_PERCPU_HASH_MAP(udp6_send_skb_args, u64, u64, 1024)
 BPF_PERCPU_HASH_MAP(udp_send_skb_args, u64, conn_tuple_t, 1024)
 
@@ -239,6 +241,14 @@ int BPF_PROG(tcp_close, struct sock *sk, long timeout) {
         return 0;
     }
     log_debug("fentry/tcp_close: netns: %u, sport: %u, dport: %u", t.netns, t.sport, t.dport);
+
+    // Protocol classification cleanup: fentry has direct access to the
+    // conn_tuple, so we can clean up inline without the kretprobe two-phase
+    // pattern (kprobe stores to tcp_close_args, kretprobe reads it).
+    // This eliminates the PREEMPT_LAZY-vulnerable tcp_close_args map.
+    if (is_protocol_classification_supported()) {
+        clean_protocol_classification(&t);
+    }
 
     skp_conn_tuple_t skp_conn = {.sk = sk, .tup = t};
     skp_conn.tup.pid = 0;
@@ -619,6 +629,105 @@ SEC("kprobe/tcp_send_probe0")
 int BPF_BYPASSABLE_KPROBE(kprobe__tcp_send_probe0, struct sock *sk) {
     handle_tcp_send_probe0(sk);
     return 0;
+}
+
+// =============================================================================
+// Protocol classification support
+// =============================================================================
+
+// Socket filter programs for protocol classification.
+// These are BPF_PROG_TYPE_SOCKET_FILTER programs that work independently
+// of the tracer attachment type (kprobe vs fentry).
+
+SEC("socket/classifier_entry")
+int socket__classifier_entry(struct __sk_buff *skb) {
+    protocol_classifier_entrypoint(skb);
+    return 0;
+}
+
+SEC("socket/classifier_tls_handshake_client")
+int socket__classifier_tls_handshake_client(struct __sk_buff *skb) {
+    protocol_classifier_entrypoint_tls_handshake_client(skb);
+    return 0;
+}
+
+SEC("socket/classifier_tls_handshake_server")
+int socket__classifier_tls_handshake_server(struct __sk_buff *skb) {
+    protocol_classifier_entrypoint_tls_handshake_server(skb);
+    return 0;
+}
+
+SEC("socket/classifier_queues")
+int socket__classifier_queues(struct __sk_buff *skb) {
+    protocol_classifier_entrypoint_queues(skb);
+    return 0;
+}
+
+SEC("socket/classifier_dbs")
+int socket__classifier_dbs(struct __sk_buff *skb) {
+    protocol_classifier_entrypoint_dbs(skb);
+    return 0;
+}
+
+SEC("socket/classifier_grpc")
+int socket__classifier_grpc(struct __sk_buff *skb) {
+    protocol_classifier_entrypoint_grpc(skb);
+    return 0;
+}
+
+// net_dev_queue raw tracepoint: maps sk_buff tuples to socket tuples for
+// NAT correlation. Required for protocol classification to work correctly
+// when NAT is involved. The fentry tracer only needs the raw_tracepoint
+// variant since it requires kernel >= 5.8 (raw_tracepoint available since 4.17).
+
+static __always_inline struct sock *sk_buff_sk(struct sk_buff *skb) {
+    struct sock *sk = NULL;
+    BPF_CORE_READ_INTO(&sk, skb, sk);
+    return sk;
+}
+
+static __always_inline int handle_net_dev_queue(struct sk_buff* skb) {
+    struct sock *sk = sk_buff_sk(skb);
+    if (!sk) {
+        return 0;
+    }
+
+    conn_tuple_t skb_tup;
+    bpf_memset(&skb_tup, 0, sizeof(conn_tuple_t));
+    if (sk_buff_to_tuple(skb, &skb_tup) <= 0) {
+        return 0;
+    }
+
+    if (!(skb_tup.metadata & CONN_TYPE_TCP)) {
+        return 0;
+    }
+
+    conn_tuple_t sock_tup;
+    bpf_memset(&sock_tup, 0, sizeof(conn_tuple_t));
+    if (!read_conn_tuple(&sock_tup, sk, 0, CONN_TYPE_TCP)) {
+        return 0;
+    }
+    sock_tup.netns = 0;
+    sock_tup.pid = 0;
+
+    if (!is_equal(&skb_tup, &sock_tup)) {
+        normalize_tuple(&skb_tup);
+        normalize_tuple(&sock_tup);
+        // We skip EEXIST because of the use of BPF_NOEXIST flag.
+        bpf_map_update_with_telemetry(conn_tuple_to_socket_skb_conn_tuple, &sock_tup, &skb_tup, BPF_NOEXIST, -EEXIST);
+    }
+
+    return 0;
+}
+
+SEC("raw_tracepoint/net/net_dev_queue")
+int BPF_PROG(raw_tracepoint__net__net_dev_queue, struct sk_buff *skb) {
+    CHECK_BPF_PROGRAM_BYPASSED()
+    if (!skb) {
+        return 0;
+    }
+
+    return handle_net_dev_queue(skb);
 }
 
 char _license[] SEC("license") = "GPL";

--- a/pkg/network/tracer/connection/fentry/manager.go
+++ b/pkg/network/tracer/connection/fentry/manager.go
@@ -26,6 +26,11 @@ func initManager(mgr *ddebpf.Manager) {
 		{Name: probes.UDPPortBindingsMap},
 		{Name: "pending_bind"},
 		{Name: probes.TelemetryMap},
+		// Protocol classification maps
+		{Name: probes.ConnectionProtocolMap},
+		{Name: probes.ClassificationProgsMap},
+		{Name: probes.ConnectionTupleToSocketSKBConnMap},
+		{Name: probes.EnhancedTLSTagsMap},
 	}
 	for funcName := range programs {
 		p := &manager.Probe{
@@ -36,4 +41,9 @@ func initManager(mgr *ddebpf.Manager) {
 		}
 		mgr.Probes = append(mgr.Probes, p)
 	}
+
+	// Raw tracepoint for net_dev_queue (protocol classification NAT correlation)
+	mgr.Probes = append(mgr.Probes,
+		&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: probes.NetDevQueueRawTracepoint, UID: probeUID}, TracepointName: "net_dev_queue", TracepointCategory: "net"},
+	)
 }

--- a/pkg/network/tracer/connection/fentry/probes.go
+++ b/pkg/network/tracer/connection/fentry/probes.go
@@ -44,7 +44,10 @@ const (
 	udpRecvMsgReturn        = "udp_recvmsg_exit"
 	udpRecvMsgPre5190Return = "udp_recvmsg_exit_pre_5_19_0"
 	udpSendMsgReturn        = "udp_sendmsg_exit"
-	udpSendSkb              = "kprobe__udp_send_skb"
+	// udpSendSkb uses kprobe because udp_send_skb is a static kernel function
+	// (not exported via BTF), so fentry attach is not possible.
+	// The pid_tgid-keyed handoff in tracer-fentry.c is PREEMPT_LAZY-sensitive.
+	udpSendSkb = "kprobe__udp_send_skb"
 
 	skbFreeDatagramLocked   = "skb_free_datagram_locked"
 	__skbFreeDatagramLocked = "__skb_free_datagram_locked" // nolint:revive
@@ -54,7 +57,10 @@ const (
 	udpv6RecvMsgReturn        = "udpv6_recvmsg_exit"
 	udpv6RecvMsgPre5190Return = "udpv6_recvmsg_exit_pre_5_19_0"
 	udpv6SendMsgReturn        = "udpv6_sendmsg_exit"
-	udpv6SendSkb              = "kprobe__udp_v6_send_skb"
+	// udpv6SendSkb uses kprobe because udp_v6_send_skb is a static kernel
+	// function (not exported via BTF), so fentry attach is not possible.
+	// The pid_tgid-keyed handoff in tracer-fentry.c is PREEMPT_LAZY-sensitive.
+	udpv6SendSkb = "kprobe__udp_v6_send_skb"
 
 	// udpDestroySock traces the udp_destroy_sock() function
 	udpDestroySock = "udp_destroy_sock"

--- a/pkg/network/tracer/connection/fentry/probes.go
+++ b/pkg/network/tracer/connection/fentry/probes.go
@@ -132,7 +132,6 @@ var programs = map[string]struct{}{
 	probes.ProtocolClassifierQueuesSocketFilter:      {},
 	probes.ProtocolClassifierDBsSocketFilter:         {},
 	probes.ProtocolClassifierGRPCSocketFilter:        {},
-	netDevQueueRawTracepoint:                         {},
 }
 
 func enableProgram(enabled map[string]struct{}, name string) {
@@ -173,7 +172,9 @@ func enabledPrograms(c *config.Config) (map[string]struct{}, error) {
 			enableProgram(enabled, probes.ProtocolClassifierQueuesSocketFilter)
 			enableProgram(enabled, probes.ProtocolClassifierDBsSocketFilter)
 			enableProgram(enabled, probes.ProtocolClassifierGRPCSocketFilter)
-			enableProgram(enabled, netDevQueueRawTracepoint)
+			// Raw tracepoint is registered separately in initManager with
+			// tracepoint metadata, so enable it directly (not via programs map).
+			enabled[netDevQueueRawTracepoint] = struct{}{}
 		}
 
 		if hasSendPage {

--- a/pkg/network/tracer/connection/fentry/probes.go
+++ b/pkg/network/tracer/connection/fentry/probes.go
@@ -126,12 +126,12 @@ var programs = map[string]struct{}{
 	udpRecvMsgPre5190Return:   {},
 	udpv6RecvMsgPre5190Return: {},
 	// Protocol classification socket filters
-	probes.ProtocolClassifierEntrySocketFilter:       {},
-	probes.ProtocolClassifierTLSClientSocketFilter:   {},
-	probes.ProtocolClassifierTLSServerSocketFilter:   {},
-	probes.ProtocolClassifierQueuesSocketFilter:      {},
-	probes.ProtocolClassifierDBsSocketFilter:         {},
-	probes.ProtocolClassifierGRPCSocketFilter:        {},
+	probes.ProtocolClassifierEntrySocketFilter:     {},
+	probes.ProtocolClassifierTLSClientSocketFilter: {},
+	probes.ProtocolClassifierTLSServerSocketFilter: {},
+	probes.ProtocolClassifierQueuesSocketFilter:    {},
+	probes.ProtocolClassifierDBsSocketFilter:       {},
+	probes.ProtocolClassifierGRPCSocketFilter:      {},
 }
 
 func enableProgram(enabled map[string]struct{}, name string) {

--- a/pkg/network/tracer/connection/fentry/probes.go
+++ b/pkg/network/tracer/connection/fentry/probes.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
@@ -84,6 +85,9 @@ const (
 	inetBindRet = "inet_bind_exit"
 	// inet6BindRet traces the bind() syscall for IPv6
 	inet6BindRet = "inet6_bind_exit"
+
+	// netDevQueueRawTracepoint maps sk_buff to sock tuples for NAT correlation
+	netDevQueueRawTracepoint = "raw_tracepoint__net__net_dev_queue"
 )
 
 var programs = map[string]struct{}{
@@ -121,6 +125,14 @@ var programs = map[string]struct{}{
 	tcpRecvMsgPre5190Return:   {},
 	udpRecvMsgPre5190Return:   {},
 	udpv6RecvMsgPre5190Return: {},
+	// Protocol classification socket filters
+	probes.ProtocolClassifierEntrySocketFilter:       {},
+	probes.ProtocolClassifierTLSClientSocketFilter:   {},
+	probes.ProtocolClassifierTLSServerSocketFilter:   {},
+	probes.ProtocolClassifierQueuesSocketFilter:      {},
+	probes.ProtocolClassifierDBsSocketFilter:         {},
+	probes.ProtocolClassifierGRPCSocketFilter:        {},
+	netDevQueueRawTracepoint:                         {},
 }
 
 func enableProgram(enabled map[string]struct{}, name string) {
@@ -154,13 +166,15 @@ func enabledPrograms(c *config.Config) (map[string]struct{}, error) {
 		enableProgram(enabled, tcpEnterRecovery)
 		enableProgram(enabled, tcpSendProbe0)
 
-		// TODO: see comments above on availability for these
-		//       hooks
-		// ksymPath := filepath.Join(c.ProcRoot, "kallsyms")
-		// missing, err := ebpf.VerifyKernelFuncs(ksymPath, []string{"sockfd_lookup_light"})
-		// if err == nil && len(missing) == 0 {
-		// 	enableProgram(enabled, sockFDLookupRet)
-		// }
+		if util.ClassificationSupported(c) {
+			enableProgram(enabled, probes.ProtocolClassifierEntrySocketFilter)
+			enableProgram(enabled, probes.ProtocolClassifierTLSClientSocketFilter)
+			enableProgram(enabled, probes.ProtocolClassifierTLSServerSocketFilter)
+			enableProgram(enabled, probes.ProtocolClassifierQueuesSocketFilter)
+			enableProgram(enabled, probes.ProtocolClassifierDBsSocketFilter)
+			enableProgram(enabled, probes.ProtocolClassifierGRPCSocketFilter)
+			enableProgram(enabled, netDevQueueRawTracepoint)
+		}
 
 		if hasSendPage {
 			enableProgram(enabled, tcpSendPageReturn)

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -22,6 +22,9 @@ import (
 	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
+	"github.com/DataDog/datadog-agent/pkg/network/filter"
+	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection/util"
 )
 
 const probeUID = "net"
@@ -44,33 +47,36 @@ func LoadTracer(config *config.Config, mgrOpts manager.Options, connCloseEventHa
 	}
 
 	m := ddebpf.NewManagerWithDefault(&manager.Manager{}, "network", &ebpftelemetry.ErrorsTelemetryModifier{}, connCloseEventHandler)
+	var closeProtocolClassifierSocketFilterFn func()
 	err = ddebpf.LoadCOREAsset(netebpf.ModuleFileName("tracer-fentry", config.BPFDebug), func(ar bytecode.AssetReader, o manager.Options) error {
 		o.RemoveRlimit = mgrOpts.RemoveRlimit
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
 		o.ConstantEditors = mgrOpts.ConstantEditors
-		return initFentryTracer(ar, o, config, m)
+		var initErr error
+		closeProtocolClassifierSocketFilterFn, initErr = initFentryTracer(ar, o, config, m)
+		return initErr
 	})
 
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return m, nil, nil
+	return m, closeProtocolClassifierSocketFilterFn, nil
 }
 
 // Use a function so someone doesn't accidentally use mgrOpts from the outer scope in LoadTracer
-func initFentryTracer(ar bytecode.AssetReader, o manager.Options, config *config.Config, m *ddebpf.Manager) error {
+func initFentryTracer(ar bytecode.AssetReader, o manager.Options, config *config.Config, m *ddebpf.Manager) (func(), error) {
 	// Use the config to determine what kernel probes should be enabled
 	enabledProbes, err := enabledPrograms(config)
 	if err != nil {
-		return fmt.Errorf("invalid probe configuration: %v", err)
+		return nil, fmt.Errorf("invalid probe configuration: %v", err)
 	}
 
 	initManager(m)
 
 	file, err := os.Stat("/proc/self/ns/pid")
 	if err != nil {
-		return fmt.Errorf("could not load sysprobe pid: %w", err)
+		return nil, fmt.Errorf("could not load sysprobe pid: %w", err)
 	}
 	pidStat := file.Sys().(*syscall.Stat_t)
 	o.ConstantEditors = append(o.ConstantEditors, manager.ConstantEditor{
@@ -81,6 +87,38 @@ func initFentryTracer(ar bytecode.AssetReader, o manager.Options, config *config
 		Value: pidStat.Ino,
 	})
 
+	// Protocol classification setup
+	var closeProtocolClassifierSocketFilterFn func()
+	classificationSupported := util.ClassificationSupported(config)
+	util.AddBoolConst(&o, "protocol_classification_enabled", classificationSupported)
+
+	var tailCallsIdentifiersSet map[manager.ProbeIdentificationPair]struct{}
+	if classificationSupported {
+		pcTailCalls := protocolClassificationTailCalls()
+		tailCallsIdentifiersSet = make(map[manager.ProbeIdentificationPair]struct{}, len(pcTailCalls))
+		for _, tailCall := range pcTailCalls {
+			tailCallsIdentifiersSet[tailCall.ProbeIdentificationPair] = struct{}{}
+		}
+		socketFilterProbe, _ := m.GetProbe(manager.ProbeIdentificationPair{
+			EBPFFuncName: probes.ProtocolClassifierEntrySocketFilter,
+			UID:          probeUID,
+		})
+		if socketFilterProbe == nil {
+			return nil, errors.New("error retrieving protocol classifier socket filter")
+		}
+
+		closeProtocolClassifierSocketFilterFn, err = filter.HeadlessSocketFilter(config, socketFilterProbe)
+		if err != nil {
+			return nil, fmt.Errorf("error enabling protocol classifier: %w", err)
+		}
+
+		o.TailCallRouter = append(o.TailCallRouter, pcTailCalls...)
+	}
+
+	if config.FailedConnectionsSupported() {
+		util.AddBoolConst(&o, "tcp_failed_connections_enabled", true)
+	}
+
 	// exclude all non-enabled probes to ensure we don't run into problems with unsupported probe types
 	for _, p := range m.Probes {
 		if _, enabled := enabledProbes[p.EBPFFuncName]; !enabled {
@@ -88,6 +126,10 @@ func initFentryTracer(ar bytecode.AssetReader, o manager.Options, config *config
 		}
 	}
 	for funcName := range enabledProbes {
+		if _, ok := tailCallsIdentifiersSet[manager.ProbeIdentificationPair{EBPFFuncName: funcName, UID: probeUID}]; ok {
+			// tail calls should be enabled (a.k.a. not excluded) but not activated.
+			continue
+		}
 		o.ActivatedProbes = append(
 			o.ActivatedProbes,
 			&manager.ProbeSelector{
@@ -98,5 +140,53 @@ func initFentryTracer(ar bytecode.AssetReader, o manager.Options, config *config
 			})
 	}
 
-	return m.InitWithOptions(ar, &o)
+	if err := m.InitWithOptions(ar, &o); err != nil {
+		return nil, err
+	}
+	return closeProtocolClassifierSocketFilterFn, nil
+}
+
+func protocolClassificationTailCalls() []manager.TailCallRoute {
+	return []manager.TailCallRoute{
+		{
+			ProgArrayName: probes.ClassificationProgsMap,
+			Key:           netebpf.ClassificationTLSClient,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: probes.ProtocolClassifierTLSClientSocketFilter,
+				UID:          probeUID,
+			},
+		},
+		{
+			ProgArrayName: probes.ClassificationProgsMap,
+			Key:           netebpf.ClassificationTLSServer,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: probes.ProtocolClassifierTLSServerSocketFilter,
+				UID:          probeUID,
+			},
+		},
+		{
+			ProgArrayName: probes.ClassificationProgsMap,
+			Key:           netebpf.ClassificationQueues,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: probes.ProtocolClassifierQueuesSocketFilter,
+				UID:          probeUID,
+			},
+		},
+		{
+			ProgArrayName: probes.ClassificationProgsMap,
+			Key:           netebpf.ClassificationDBs,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: probes.ProtocolClassifierDBsSocketFilter,
+				UID:          probeUID,
+			},
+		},
+		{
+			ProgArrayName: probes.ClassificationProgsMap,
+			Key:           netebpf.ClassificationGRPC,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: probes.ProtocolClassifierGRPCSocketFilter,
+				UID:          probeUID,
+			},
+		},
+	}
 }

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -52,6 +52,7 @@ func LoadTracer(config *config.Config, mgrOpts manager.Options, connCloseEventHa
 		o.RemoveRlimit = mgrOpts.RemoveRlimit
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
 		o.ConstantEditors = mgrOpts.ConstantEditors
+		o.BypassEnabled = mgrOpts.BypassEnabled
 		var initErr error
 		closeProtocolClassifierSocketFilterFn, initErr = initFentryTracer(ar, o, config, m)
 		return initErr

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -46,11 +46,6 @@ const (
 )
 
 var (
-	// The kernel has to be newer than 4.11.0 since we are using bpf_skb_load_bytes (4.5.0+), which
-	// was added to socket filters in 4.11.0:
-	// - 2492d3b867043f6880708d095a7a5d65debcfc32
-	classificationMinimumKernel = kernel.VersionCode(4, 11, 0)
-
 	// these primarily exist for mocking out in tests
 	coreTracerLoader          = loadCORETracer
 	rcTracerLoader            = loadRuntimeCompiledTracer
@@ -59,43 +54,12 @@ var (
 	tracerOffsetGuesserRunner = offsetguess.TracerOffsets.Offsets
 
 	errCORETracerNotSupported = errors.New("CO-RE tracer not supported on this platform")
-
-	rhel9KernelVersion = kernel.VersionCode(5, 14, 0)
 )
 
 // ClassificationSupported returns true if the current kernel version supports the classification feature.
-// The kernel has to be newer than 4.11.0 since we are using bpf_skb_load_bytes (4.5.0+) method which was added to
-// socket filters in 4.11.0, and a tracepoint (4.7.0+)
+// Delegates to util.ClassificationSupported for the shared implementation.
 func ClassificationSupported(config *config.Config) bool {
-	if !config.ProtocolClassificationEnabled {
-		return false
-	}
-	if !config.CollectTCPv4Conns && !config.CollectTCPv6Conns {
-		return false
-	}
-	currentKernelVersion, err := kernel.HostVersion()
-	if err != nil {
-		log.Warn("could not determine the current kernel version. classification monitoring disabled.")
-		return false
-	}
-
-	if currentKernelVersion < classificationMinimumKernel {
-		return false
-	}
-
-	// TODO: fix protocol classification is not supported on RHEL 9+
-	family, err := kernel.Family()
-	if err != nil {
-		log.Warnf("could not determine OS family: %s", err)
-		return false
-	}
-
-	if family == "rhel" && currentKernelVersion >= rhel9KernelVersion {
-		log.Warn("protocol classification is currently not supported on RHEL 9+")
-		return false
-	}
-
-	return true
+	return util.ClassificationSupported(config)
 }
 
 // LoadTracer loads the co-re/prebuilt/runtime compiled network tracer, depending on config

--- a/pkg/network/tracer/connection/util/classification.go
+++ b/pkg/network/tracer/connection/util/classification.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package util
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	// The kernel has to be newer than 4.11.0 since we are using bpf_skb_load_bytes (4.5.0+), which
+	// was added to socket filters in 4.11.0:
+	// - 2492d3b867043f6880708d095a7a5d65debcfc32
+	classificationMinimumKernel = kernel.VersionCode(4, 11, 0)
+
+	rhel9KernelVersion = kernel.VersionCode(5, 14, 0)
+)
+
+// ClassificationSupported returns true if the current kernel version supports the classification feature.
+// The kernel has to be newer than 4.11.0 since we are using bpf_skb_load_bytes (4.5.0+) method which was added to
+// socket filters in 4.11.0, and a tracepoint (4.7.0+)
+func ClassificationSupported(config *config.Config) bool {
+	if !config.ProtocolClassificationEnabled {
+		return false
+	}
+	if !config.CollectTCPv4Conns && !config.CollectTCPv6Conns {
+		return false
+	}
+	currentKernelVersion, err := kernel.HostVersion()
+	if err != nil {
+		log.Warn("could not determine the current kernel version. classification monitoring disabled.")
+		return false
+	}
+
+	if currentKernelVersion < classificationMinimumKernel {
+		return false
+	}
+
+	// TODO: fix protocol classification is not supported on RHEL 9+
+	family, err := kernel.Family()
+	if err != nil {
+		log.Warnf("could not determine OS family: %s", err)
+		return false
+	}
+
+	if family == "rhel" && currentKernelVersion >= rhel9KernelVersion {
+		log.Warn("protocol classification is currently not supported on RHEL 9+")
+		return false
+	}
+
+	return true
+}

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1830,9 +1830,6 @@ func (s *TracerSuite) TestSendfileRegression() {
 }
 
 func httpSupported() bool {
-	if ebpftest.GetBuildMode() == ebpftest.Fentry {
-		return false
-	}
 	return kv >= usmconfig.MinimumKernelVersion
 }
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2474,7 +2474,6 @@ func testConfig() *config.Config {
 		cfg.ProtocolClassificationEnabled = false
 	}
 
-
 	// prebuilt on 5.18+ does not support UDPv6
 	if isPrebuilt(cfg) && kv >= kernel.VersionCode(5, 18, 0) {
 		cfg.CollectUDPv6Conns = false

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2476,9 +2476,7 @@ func testConfig() *config.Config {
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false
 	}
-	if ebpftest.GetBuildMode() == ebpftest.Fentry {
-		cfg.ProtocolClassificationEnabled = false
-	}
+
 
 	// prebuilt on 5.18+ does not support UDPv6
 	if isPrebuilt(cfg) && kv >= kernel.VersionCode(5, 18, 0) {
@@ -2954,9 +2952,6 @@ func (s *TracerSuite) TestTLSClassification() {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if ebpftest.GetBuildMode() == ebpftest.Fentry {
-				t.Skip("protocol classification not supported for fentry tracer")
-			}
 			t.Cleanup(func() {
 				tr.RemoveClient(clientID)
 				_ = tr.Pause()

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -84,10 +84,6 @@ func setupTracer(t testing.TB, cfg *config.Config) *Tracer {
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false
 	}
-	if ebpftest.GetBuildMode() == ebpftest.Fentry {
-		cfg.ProtocolClassificationEnabled = false
-	}
-
 	tr, err := NewTracer(cfg, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)

--- a/pkg/network/usm/tests/tracer_classification_test.go
+++ b/pkg/network/usm/tests/tracer_classification_test.go
@@ -54,10 +54,6 @@ func setupTracer(t testing.TB, cfg *config.Config) *tracer.Tracer {
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false
 	}
-	if ebpftest.GetBuildMode() == ebpftest.Fentry {
-		cfg.ProtocolClassificationEnabled = false
-	}
-
 	tr, err := tracer.NewTracer(cfg, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -96,9 +96,6 @@ const (
 )
 
 func httpSupported() bool {
-	if ebpftest.GetBuildMode() == ebpftest.Fentry {
-		return false
-	}
 	return kv >= usmconfig.MinimumKernelVersion
 }
 
@@ -520,9 +517,6 @@ func (s *USMSuite) TestTLSClassification() {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if ebpftest.GetBuildMode() == ebpftest.Fentry {
-				t.Skip("protocol classification not supported for fentry tracer")
-			}
 			t.Cleanup(func() { tr.RemoveClient(clientID) })
 			t.Cleanup(func() { _ = tr.Pause() })
 

--- a/pkg/network/usm/testutil/buildmode.go
+++ b/pkg/network/usm/testutil/buildmode.go
@@ -9,16 +9,31 @@ package testutil
 
 import (
 	"os"
+	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/prebuilt"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
+
+var (
+	hostPlatform string
+	kv           = kernel.MustHostVersion()
+)
+
+func init() {
+	hostPlatform, _ = kernel.Platform()
+}
 
 // SupportedBuildModes returns the build modes supported on the current host
 func SupportedBuildModes() []ebpftest.BuildMode {
 	modes := []ebpftest.BuildMode{ebpftest.RuntimeCompiled, ebpftest.CORE}
 	if !prebuilt.IsDeprecated() || os.Getenv("TEST_PREBUILT_OVERRIDE") == "true" {
 		modes = append(modes, ebpftest.Prebuilt)
+	}
+	if os.Getenv("TEST_FENTRY_OVERRIDE") == "true" ||
+		(runtime.GOARCH == "amd64" && (hostPlatform == "amazon" || hostPlatform == "amzn") && kv.Major() == 5 && kv.Minor() == 10) {
+		modes = append(modes, ebpftest.Fentry)
 	}
 
 	return modes

--- a/releasenotes/notes/fentry-protocol-classification-ecaa3cc7936c2b1f.yaml
+++ b/releasenotes/notes/fentry-protocol-classification-ecaa3cc7936c2b1f.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Enable protocol classification (HTTP, HTTP/2, Kafka, Postgres, Redis, gRPC)
+    on the fentry eBPF tracer. This improves protocol detection reliability on
+    kernels 7.0+ where the default ``PREEMPT_LAZY`` preemption mode can cause
+    missed events with the kprobe tracer. Activate with
+    ``network_config.enable_fentry: true`` in ``system-probe.yaml``.

--- a/releasenotes/notes/fentry-protocol-classification-ecaa3cc7936c2b1f.yaml
+++ b/releasenotes/notes/fentry-protocol-classification-ecaa3cc7936c2b1f.yaml
@@ -1,8 +1,7 @@
 ---
 enhancements:
   - |
-    Enable protocol classification (HTTP, HTTP/2, Kafka, Postgres, Redis, gRPC)
-    on the fentry eBPF tracer. This improves protocol detection reliability on
-    kernels 7.0+ where the default ``PREEMPT_LAZY`` preemption mode can cause
-    missed events with the kprobe tracer. Activate with
+    Protocol classification (HTTP, HTTP/2, Kafka, Postgres, Redis, gRPC) is now
+    supported when the fentry eBPF tracer is enabled. Previously, enabling fentry
+    disabled all protocol detection. Activate with
     ``network_config.enable_fentry: true`` in ``system-probe.yaml``.


### PR DESCRIPTION
## Summary

Migrate protocol classification (HTTP, HTTP/2, Kafka, Postgres, Redis, gRPC) to work with the fentry tracer, addressing PREEMPT_LAZY preemption risks introduced in kernel 7.0.

- Add socket filter classifiers and `net_dev_queue` raw tracepoint to `tracer-fentry.c` for protocol identification and NAT correlation
- Fold `tcp_close` protocol cleanup directly into `fentry/tcp_close`, eliminating the PREEMPT_LAZY-vulnerable `tcp_close_args` pid_tgid-keyed map
- Add protocol classification maps, probes, `HeadlessSocketFilter` setup, and tail call routing to fentry Go code
- Move `ClassificationSupported()` to shared `util` package for reuse across kprobe and fentry tracers
- Remove fentry-specific protocol classification disablements in tests

TLS-encrypted protocol classification (HTTPS, encrypted Redis/Postgres/Kafka) remains on kprobes because `sockfd_lookup_light` is a static kernel function not available via BTF/fentry.

## Test plan

- [ ] CI passes (eBPF compilation, Go unit tests, linting)
- [ ] Protocol classification E2E tests pass with `DD_NETWORK_CONFIG_ENABLE_FENTRY=true`
- [ ] Verify plaintext HTTP/Kafka/Postgres/Redis detected on fentry tracer
- [ ] Verify TLS features still work via USM's kprobe path (graceful degradation)

https://claude.ai/code/session_01VskoxECPqXuRNgR84i3NxF