### PR TITLE
[AGNTLOG-604] Protect important logs from adaptive sampling

### DIFF
--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1800,6 +1800,9 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.experimental_adaptive_sampling.match_threshold", 0.9)
 	// The sampler needs a larger tokenizer window than the auto-multiline labeler.
 	config.BindEnvAndSetDefault("logs_config.experimental_adaptive_sampling.tokenizer_max_input_bytes", 2048)
+	// When true, logs containing critical severity keywords (FATAL, ERROR, PANIC, etc.)
+	// bypass the adaptive sampler and are never dropped.
+	config.BindEnvAndSetDefault("logs_config.experimental_adaptive_sampling.protect_important_logs", true)
 
 	// Enable the legacy auto multiline detection (v1)
 	config.BindEnvAndSetDefault("logs_config.force_auto_multi_line_detection_v1", false)

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -168,10 +168,11 @@ func buildLineHandler(source *sources.ReplaceableSource, multiLinePattern *regex
 	var sampler preprocessor.Sampler
 	if pkgconfigsetup.Datadog().GetBool("logs_config.experimental_adaptive_sampling.enabled") {
 		sampler = preprocessor.NewAdaptiveSampler(validateAdaptiveSamplerConfig(preprocessor.AdaptiveSamplerConfig{
-			MaxPatterns:    pkgconfigsetup.Datadog().GetInt("logs_config.experimental_adaptive_sampling.max_patterns"),
-			RateLimit:      pkgconfigsetup.Datadog().GetFloat64("logs_config.experimental_adaptive_sampling.rate_limit"),
-			BurstSize:      pkgconfigsetup.Datadog().GetFloat64("logs_config.experimental_adaptive_sampling.burst_size"),
-			MatchThreshold: pkgconfigsetup.Datadog().GetFloat64("logs_config.experimental_adaptive_sampling.match_threshold"),
+			MaxPatterns:          pkgconfigsetup.Datadog().GetInt("logs_config.experimental_adaptive_sampling.max_patterns"),
+			RateLimit:            pkgconfigsetup.Datadog().GetFloat64("logs_config.experimental_adaptive_sampling.rate_limit"),
+			BurstSize:            pkgconfigsetup.Datadog().GetFloat64("logs_config.experimental_adaptive_sampling.burst_size"),
+			MatchThreshold:       pkgconfigsetup.Datadog().GetFloat64("logs_config.experimental_adaptive_sampling.match_threshold"),
+			ProtectImportantLogs: pkgconfigsetup.Datadog().GetBool("logs_config.experimental_adaptive_sampling.protect_important_logs"),
 		}), source.UnderlyingSource().Name)
 	} else {
 		sampler = preprocessor.NewNoopSampler()

--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -132,6 +132,7 @@ func isImportant(tokens []Token) bool {
 // Returns the message if allowed, nil if dropped.
 func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message.Message {
 	if s.config.ProtectImportantLogs && isImportant(tokens) {
+		tlmAdaptiveSamplerKept.Inc(s.source)
 		tlmAdaptiveSamplerProtected.Inc(s.source)
 		return msg
 	}

--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -56,6 +56,9 @@ var tlmAdaptiveSamplerNewPatterns = telemetry.NewCounter("logs_adaptive_sampler"
 var tlmAdaptiveSamplerEvictions = telemetry.NewCounter("logs_adaptive_sampler", "evictions",
 	[]string{"source"}, "Number of pattern table evictions performed by the adaptive sampler")
 
+var tlmAdaptiveSamplerProtected = telemetry.NewCounter("logs_adaptive_sampler", "protected",
+	[]string{"source"}, "Number of important log messages that bypassed adaptive sampling")
+
 func adaptiveSamplerSampledCountTag(count int64) string {
 	return "adaptive_sampler_sampled_count:" + strconv.FormatInt(count, 10)
 }
@@ -73,6 +76,9 @@ type AdaptiveSamplerConfig struct {
 	// MatchThreshold is the fraction of tokens that must match for two logs to be
 	// considered the same pattern. Range [0, 1].
 	MatchThreshold float64
+	// ProtectImportantLogs bypasses rate limiting for logs containing critical severity
+	// keywords (FATAL, ERROR, PANIC, etc.). Protected logs are never dropped.
+	ProtectImportantLogs bool
 }
 
 // samplerEntry tracks the credit-based rate limiting state for a single log pattern.
@@ -109,9 +115,26 @@ func NewAdaptiveSampler(config AdaptiveSamplerConfig, source string) *AdaptiveSa
 	}
 }
 
+// isImportant reports whether the token sequence contains a critical severity keyword.
+// Logs matching this check are exempt from adaptive sampling and always passed through.
+func isImportant(tokens []Token) bool {
+	for _, t := range tokens {
+		switch t {
+		case Fatal, Error, Panic, Alert, Severe, Critical, Emergency, Warn,
+			Exception, Crash, Failure, Deadlock, Timeout:
+			return true
+		}
+	}
+	return false
+}
+
 // Process applies credit-based rate limiting to the message.
 // Returns the message if allowed, nil if dropped.
 func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message.Message {
+	if s.config.ProtectImportantLogs && isImportant(tokens) {
+		tlmAdaptiveSamplerProtected.Inc(s.source)
+		return msg
+	}
 	now := s.now()
 
 	for i := range s.entries {

--- a/pkg/logs/internal/decoder/preprocessor/sampler_benchmark_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_benchmark_test.go
@@ -187,3 +187,23 @@ func BenchmarkSampler_Adaptive_NewPattern_P1000_EvictFreq(b *testing.B) {
 		s.Process(msg, benchTokensINFO)
 	}
 }
+
+// BenchmarkSampler_Adaptive_ImportantBypass measures the cost of the importance
+// check short-circuiting before the pattern table scan.
+func BenchmarkSampler_Adaptive_ImportantBypass(b *testing.B) {
+	tok := NewTokenizer(0)
+	importantTokens, _ := tok.Tokenize([]byte("2024-01-15 10:30:45 ERROR [service-a] request failed id=123"))
+	s := NewAdaptiveSampler(AdaptiveSamplerConfig{
+		MaxPatterns:          1000,
+		RateLimit:            1e9,
+		BurstSize:            math.MaxFloat64 / 2,
+		MatchThreshold:       0.75,
+		ProtectImportantLogs: true,
+	}, "bench")
+	prefillSampler(s, benchFillPatterns, 100)
+	msg := benchMsg()
+	b.ResetTimer()
+	for range b.N {
+		s.Process(msg, importantTokens)
+	}
+}

--- a/pkg/logs/internal/decoder/preprocessor/sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_test.go
@@ -26,6 +26,16 @@ func newSampler(maxPatterns int, burstSize, rateLimit float64) *AdaptiveSampler 
 	}, "test")
 }
 
+func newSamplerWithProtect(maxPatterns int, burstSize, rateLimit float64, protect bool) *AdaptiveSampler {
+	return NewAdaptiveSampler(AdaptiveSamplerConfig{
+		MaxPatterns:          maxPatterns,
+		RateLimit:            rateLimit,
+		BurstSize:            burstSize,
+		MatchThreshold:       0.9,
+		ProtectImportantLogs: protect,
+	}, "test")
+}
+
 func testMsg() *message.Message {
 	return message.NewMessage([]byte("test"), nil, message.StatusInfo, 0)
 }
@@ -262,4 +272,83 @@ func TestAdaptiveSampler_EmptyTokensNewPattern(t *testing.T) {
 	out := s.Process(msg, nil)
 	assert.NotNil(t, out, "empty-token message should be allowed as new pattern")
 	require.Len(t, s.entries, 1)
+}
+
+// --- AdaptiveSampler: important log protection ---
+
+// An important log is always returned even when credits are exhausted.
+func TestAdaptiveSampler_ImportantLogBypassesRateLimit(t *testing.T) {
+	s := newSamplerWithProtect(10, 1.0, 0, true)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	importantTokens := tokenize("ERROR something went wrong")
+
+	// First message creates a pattern and consumes the burst.
+	out1 := s.Process(testMsg(), importantTokens)
+	require.NotNil(t, out1, "important log should always pass through")
+
+	// Second message would normally be dropped (burst=1, no refill).
+	out2 := s.Process(testMsg(), importantTokens)
+	require.NotNil(t, out2, "important log should bypass rate limiting")
+
+	// Third, fourth... all pass through.
+	for range 10 {
+		assert.NotNil(t, s.Process(testMsg(), importantTokens), "important log should never be dropped")
+	}
+}
+
+// Important logs bypass the pattern table entirely — no entry created.
+func TestAdaptiveSampler_ImportantLogDoesNotCreateEntry(t *testing.T) {
+	s := newSamplerWithProtect(10, 1.0, 0, true)
+	importantTokens := tokenize("FATAL: disk full")
+
+	s.Process(testMsg(), importantTokens)
+	assert.Empty(t, s.entries, "important logs should not create pattern table entries")
+}
+
+// Non-important logs are still rate-limited normally when protection is on.
+func TestAdaptiveSampler_NonImportantLogStillDropped(t *testing.T) {
+	s := newSamplerWithProtect(10, 1.0, 0, true)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	normalTokens := tokenize("info: request processed")
+
+	out1 := s.Process(testMsg(), normalTokens)
+	require.NotNil(t, out1, "first message should be allowed (new pattern)")
+	assert.Nil(t, s.Process(testMsg(), normalTokens), "second message should be dropped — burst exhausted")
+}
+
+// When ProtectImportantLogs is false, important logs are rate-limited like any other.
+func TestAdaptiveSampler_ProtectDisabled(t *testing.T) {
+	s := newSamplerWithProtect(10, 1.0, 0, false)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	importantTokens := tokenize("ERROR something went wrong")
+
+	out1 := s.Process(testMsg(), importantTokens)
+	require.NotNil(t, out1, "first message allowed (new pattern)")
+	assert.Nil(t, s.Process(testMsg(), importantTokens), "second message should be dropped — protection disabled")
+}
+
+// isImportant returns false for tokens that contain no critical keywords.
+func TestIsImportant(t *testing.T) {
+	assert.True(t, isImportant(tokenize("FATAL: disk full")))
+	assert.True(t, isImportant(tokenize("[ERROR] request failed")))
+	assert.True(t, isImportant(tokenize("WARNING: low memory")))
+	assert.True(t, isImportant(tokenize("PANIC in goroutine")))
+	assert.True(t, isImportant(tokenize("CRITICAL: service down")))
+	assert.True(t, isImportant(tokenize("EXCEPTION in handler")))
+	assert.True(t, isImportant(tokenize("DEADLOCK detected")))
+	assert.True(t, isImportant(tokenize("TIMEOUT connecting")))
+	assert.True(t, isImportant(tokenize("CRASH dump generated")))
+	assert.True(t, isImportant(tokenize("request FAILED")))
+
+	assert.False(t, isImportant(tokenize("info: all good")))
+	assert.False(t, isImportant(tokenize("debug: cache hit")))
+	assert.False(t, isImportant(tokenize("request processed successfully")))
+	assert.False(t, isImportant(nil))
+	assert.False(t, isImportant([]Token{}))
 }

--- a/pkg/logs/internal/decoder/preprocessor/tokenizer.go
+++ b/pkg/logs/internal/decoder/preprocessor/tokenizer.go
@@ -16,6 +16,10 @@ import (
 // Note: This must not exceed d10 or c10 below.
 const maxRun = 10
 
+// maxSpecialTokenLen is the maximum character run length eligible for special token
+// promotion. Longest critical keyword: "EMERGENCY" / "EXCEPTION" = 9 chars.
+const maxSpecialTokenLen = 9
+
 // tokenLookup is a 256-byte lookup table for single-byte token classification.
 // Initialized via function call to ensure it happens before other package vars use it.
 var tokenLookup = makeTokenLookup()
@@ -126,8 +130,8 @@ func (t *Tokenizer) Tokenize(input []byte) ([]Token, []int) {
 // emitToken appends a token to the output slices, checking for special tokens first.
 // Returns the updated slices.
 func (t *Tokenizer) emitToken(ts []Token, indicies []int, lastToken Token, run, idx int) ([]Token, []int) {
-	// Check for special tokens (only for C1/letter runs, length 1-4)
-	if lastToken == C1 && t.strLen > 0 && t.strLen <= 4 {
+	// Check for special tokens (only for C1/letter runs, length 1-maxSpecialTokenLen)
+	if lastToken == C1 && t.strLen > 0 && t.strLen <= maxSpecialTokenLen {
 		if t.strLen == 1 {
 			if specialToken := getSpecialShortToken(t.strBuf[0]); specialToken != End {
 				return append(ts, specialToken), append(indicies, idx)
@@ -255,10 +259,61 @@ func getSpecialLongToken(input string) Token {
 		}
 	case 4:
 		switch input {
+		case "WARN":
+			return Warn
+		case "CRIT":
+			return Critical
 		case "CEST", "NZST", "NZDT", "ACST", "ACDT",
 			"AEST", "AEDT", "AWST", "AWDT", "AKST",
 			"AKDT", "CHST", "CHDT":
 			return Zone
+		}
+	case 5:
+		switch input {
+		case "FATAL":
+			return Fatal
+		case "ERROR":
+			return Error
+		case "PANIC":
+			return Panic
+		case "ALERT":
+			return Alert
+		case "EMERG":
+			return Emergency
+		case "CRASH":
+			return Crash
+		}
+	case 6:
+		switch input {
+		case "SEVERE":
+			return Severe
+		case "FAILED":
+			return Failure
+		}
+	case 7:
+		switch input {
+		case "WARNING":
+			return Warn
+		case "CRASHED":
+			return Crash
+		case "FAILURE":
+			return Failure
+		case "TIMEOUT":
+			return Timeout
+		}
+	case 8:
+		switch input {
+		case "CRITICAL":
+			return Critical
+		case "DEADLOCK":
+			return Deadlock
+		}
+	case 9:
+		switch input {
+		case "EMERGENCY":
+			return Emergency
+		case "EXCEPTION":
+			return Exception
 		}
 	}
 	return End
@@ -341,6 +396,32 @@ func tokenToString(token Token) string {
 		return "T"
 	case Zone:
 		return "ZONE"
+	case Warn:
+		return "WARN"
+	case Fatal:
+		return "FATAL"
+	case Error:
+		return "ERROR"
+	case Panic:
+		return "PANIC"
+	case Alert:
+		return "ALERT"
+	case Severe:
+		return "SEVERE"
+	case Critical:
+		return "CRIT"
+	case Emergency:
+		return "EMERG"
+	case Exception:
+		return "EXCEPTION"
+	case Crash:
+		return "CRASH"
+	case Failure:
+		return "FAILURE"
+	case Deadlock:
+		return "DEADLOCK"
+	case Timeout:
+		return "TIMEOUT"
 	}
 	return ""
 }

--- a/pkg/logs/internal/decoder/preprocessor/tokenizer_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/tokenizer_test.go
@@ -43,6 +43,36 @@ func TestTokenizer(t *testing.T) {
 		{input: "Z0NE", expectedToken: "ZONEDCC"},
 		{input: "abc!📀🐶📊123", expectedToken: "CCC!CCCCCCCCCCDDD"},
 		{input: "!!!$$$###", expectedToken: "!$#"}, // Symobl runs get truncated
+
+		// Critical severity keyword promotion
+		{input: "FATAL", expectedToken: "FATAL"},
+		{input: "fatal", expectedToken: "FATAL"},     // case insensitive
+		{input: "Fatal", expectedToken: "FATAL"},     // mixed case
+		{input: "ERROR", expectedToken: "ERROR"},
+		{input: "PANIC", expectedToken: "PANIC"},
+		{input: "ALERT", expectedToken: "ALERT"},
+		{input: "SEVERE", expectedToken: "SEVERE"},
+		{input: "WARN", expectedToken: "WARN"},
+		{input: "WARNING", expectedToken: "WARN"},
+		{input: "CRIT", expectedToken: "CRIT"},
+		{input: "CRITICAL", expectedToken: "CRIT"},
+		{input: "EMERG", expectedToken: "EMERG"},
+		{input: "EMERGENCY", expectedToken: "EMERG"},
+		{input: "EXCEPTION", expectedToken: "EXCEPTION"},
+		{input: "CRASH", expectedToken: "CRASH"},
+		{input: "CRASHED", expectedToken: "CRASH"},
+		{input: "FAILED", expectedToken: "FAILURE"},
+		{input: "FAILURE", expectedToken: "FAILURE"},
+		{input: "DEADLOCK", expectedToken: "DEADLOCK"},
+		{input: "TIMEOUT", expectedToken: "TIMEOUT"},
+
+		// False-positive safety: longer words must NOT match
+		{input: "EXCEPTIONS", expectedToken: "CCCCCCCCCC"}, // 10 chars → C10, no match
+		{input: "FATALIZER", expectedToken: "CCCCCCCCC"},   // 9 chars, not a keyword → C9
+
+		// In-context: critical keywords separated by non-alpha chars
+		{input: "[ERROR] something", expectedToken: "[ERROR] CCCCCCCCC"},
+		{input: "FATAL: disk full", expectedToken: "FATAL: CCCC CCCC"},
 	}
 
 	tokenizer := NewTokenizer(0)

--- a/pkg/logs/internal/decoder/preprocessor/tokenizer_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/tokenizer_test.go
@@ -46,8 +46,8 @@ func TestTokenizer(t *testing.T) {
 
 		// Critical severity keyword promotion
 		{input: "FATAL", expectedToken: "FATAL"},
-		{input: "fatal", expectedToken: "FATAL"},     // case insensitive
-		{input: "Fatal", expectedToken: "FATAL"},     // mixed case
+		{input: "fatal", expectedToken: "FATAL"}, // case insensitive
+		{input: "Fatal", expectedToken: "FATAL"}, // mixed case
 		{input: "ERROR", expectedToken: "ERROR"},
 		{input: "PANIC", expectedToken: "PANIC"},
 		{input: "ALERT", expectedToken: "ALERT"},

--- a/pkg/logs/internal/decoder/preprocessor/tokens.go
+++ b/pkg/logs/internal/decoder/preprocessor/tokens.go
@@ -76,6 +76,21 @@ const (
 	Zone // Represents a timezone
 	T    // t (often `T`) denotes a time separator in many timestamp formats
 
+	// Critical severity keywords — logs containing these bypass adaptive sampling.
+	Warn      // WARN, WARNING
+	Fatal     // FATAL
+	Error     // ERROR
+	Panic     // PANIC
+	Alert     // ALERT
+	Severe    // SEVERE
+	Critical  // CRIT, CRITICAL
+	Emergency // EMERG, EMERGENCY
+	Exception // EXCEPTION
+	Crash     // CRASH, CRASHED
+	Failure   // FAILED, FAILURE
+	Deadlock  // DEADLOCK
+	Timeout   // TIMEOUT
+
 	End // Not a valid token. Used to mark the end of the token list or as a terminator.
 )
 


### PR DESCRIPTION
## Summary
- Extends the tokenizer with 13 critical severity token types (FATAL, ERROR, PANIC, WARN, CRITICAL, ALERT, SEVERE, EMERGENCY, EXCEPTION, CRASH, FAILURE, DEADLOCK, TIMEOUT)
- Adds a bypass in `AdaptiveSampler.Process()` that protects logs containing these tokens from being dropped — critical keywords are promoted during the existing tokenization pass (single-pass, no extra byte scan or regex)
- New config: `logs_config.experimental_adaptive_sampling.protect_important_logs` (default: `true`)

## Motivation
The adaptive sampler rate-limits repetitive log patterns, but has no concept of importance — a `FATAL: disk full` gets the same treatment as `[DEBUG] cache hit`. This change ensures critical logs are never dropped regardless of pattern frequency.

## Test plan
- [x] 156 unit tests passing (tokenizer + sampler)
- [x] 24 new tokenizer test cases: keyword promotion, case insensitivity, false-positive safety
- [x] 5 new sampler tests: bypass works, no entry creation, non-important still dropped, protect disabled, `isImportant` unit
- [x] New benchmark: `BenchmarkSampler_Adaptive_ImportantBypass`
- [ ] CI pipeline validates build + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)