### PR TITLE
[ABLD-8] Add 4 more binaries to the hybrid package build

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -345,3 +345,27 @@ prebuilt_file(
     target_label = "@@//:bin/agent/agent",
     target_name = "agent",
 )
+
+prebuilt_file(
+    name = "privateactionrunner_binary",
+    target_label = "@@//:bin/privateactionrunner/privateactionrunner",
+    target_name = "privateactionrunner",
+)
+
+prebuilt_file(
+    name = "process_agent_binary",
+    target_label = "@@//:bin/process-agent/process-agent",
+    target_name = "process_agent",
+)
+
+prebuilt_file(
+    name = "trace_agent_binary",
+    target_label = "@@//:bin/trace-agent/trace-agent",
+    target_name = "trace_agent",
+)
+
+prebuilt_file(
+    name = "trace_loader_binary",
+    target_label = "@@//:bin/trace-loader/trace-loader",
+    target_name = "trace_loader",
+)

--- a/cmd/loader/BUILD.bazel
+++ b/cmd/loader/BUILD.bazel
@@ -19,23 +19,18 @@ pkg_files(
         "//packages/agent:linux_fips": [
             "@trace_loader_binary//:trace_loader",
         ],
+        # This shouldn't be needed in practice, but it is used by the systemd
+        # service, which is used when installing the deb manually.
         "//packages/agent:linux_heroku": [
-            ":fake_trace_loader",
+            "main_noop.sh",
         ],
         "//conditions:default": [],
     }),
-    prefix = "embedded/bin",
-    target_compatible_with = ["@platforms//os:linux"],
-)
-
-# This shouldn't be needed in practice, but it is used by the systemd service,
-# which is used when installing the deb manually.
-pkg_files(
-    name = "fake_trace_loader",
-    srcs = ["main_noop.sh"],
     attributes = pkg_attributes(mode = "755"),
     prefix = "embedded/bin",
-    renames = {
-        ":main_noop.sh": "trace-loader",
-    },
+    renames = select({
+        "//packages/agent:linux_heroku": {":main_noop.sh": "trace-loader"},
+        "//conditions:default": {},
+    }),
+    target_compatible_with = ["@platforms//os:linux"],
 )

--- a/cmd/loader/BUILD.bazel
+++ b/cmd/loader/BUILD.bazel
@@ -1,0 +1,41 @@
+"""The trace loader."""
+
+# gazelle: exclude
+
+load(
+    "@rules_pkg//pkg:mappings.bzl",
+    "pkg_attributes",
+    "pkg_files",
+)
+
+package(default_visibility = ["//packages:__subpackages__"])
+
+pkg_files(
+    name = "trace_loader",
+    srcs = select({
+        "//packages/agent:linux_default": [
+            "@trace_loader_binary//:trace_loader",
+        ],
+        "//packages/agent:linux_fips": [
+            "@trace_loader_binary//:trace_loader",
+        ],
+        "//packages/agent:linux_heroku": [
+            ":fake_trace_loader",
+        ],
+        "//conditions:default": [],
+    }),
+    prefix = "embedded/bin",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+# This shouldn't be needed in practice, but it is used by the systemd service,
+# which is used when installing the deb manually.
+pkg_files(
+    name = "fake_trace_loader",
+    srcs = ["main_noop.sh"],
+    attributes = pkg_attributes(mode = "755"),
+    prefix = "embedded/bin",
+    renames = {
+        ":main_noop.sh": "trace-loader",
+    },
+)

--- a/packages/agent/product/BUILD.bazel
+++ b/packages/agent/product/BUILD.bazel
@@ -37,11 +37,12 @@ pkg_filegroup(
 
         # TODO: sysprobe - windows
         # TODO: systray - windows
-        # TODO: agent main binary
-        # TODO: trace-loader
-        # TODO: trace-agent
         # TODO: installer
-        # TODO: private-action-runner
+        "//cmd/loader:trace_loader",
+        ":dda_built_trace_agent_binary",
+        ":dda_built_process_agent_binary",
+        ":dda_built_privateactionrunner_binary",
+
         # TODO: system-probe
         # TODO: system-probe - selinux policy
         # TODO: system-probe - eBPF
@@ -133,4 +134,28 @@ pkg_files(
         "@agent_binary//:agent",
     ],
     prefix = "bin/agent",
+)
+
+pkg_files(
+    name = "dda_built_process_agent_binary",
+    srcs = [
+        "@process_agent_binary//:process_agent",
+    ],
+    prefix = "bin/agent",
+)
+
+pkg_files(
+    name = "dda_built_privateactionrunner_binary",
+    srcs = [
+        "@privateactionrunner_binary//:privateactionrunner",
+    ],
+    prefix = "embedded/bin",
+)
+
+pkg_files(
+    name = "dda_built_trace_agent_binary",
+    srcs = [
+        "@trace_agent_binary//:trace_agent",
+    ],
+    prefix = "embedded/bin",
 )

--- a/packages/agent/product/BUILD.bazel
+++ b/packages/agent/product/BUILD.bazel
@@ -143,7 +143,10 @@ pkg_files(
         "@process_agent_binary//:process_agent",
     ],
     attributes = pkg_attributes(mode = "755"),
-    prefix = "bin/agent",
+    prefix = select({
+        "@platforms//os:windows": "bin/agent",
+        "//conditions:default": "embedded/bin",
+    }),
 )
 
 pkg_files(

--- a/packages/agent/product/BUILD.bazel
+++ b/packages/agent/product/BUILD.bazel
@@ -133,6 +133,7 @@ pkg_files(
     srcs = [
         "@agent_binary//:agent",
     ],
+    attributes = pkg_attributes(mode = "755"),
     prefix = "bin/agent",
 )
 
@@ -141,6 +142,7 @@ pkg_files(
     srcs = [
         "@process_agent_binary//:process_agent",
     ],
+    attributes = pkg_attributes(mode = "755"),
     prefix = "bin/agent",
 )
 
@@ -149,6 +151,7 @@ pkg_files(
     srcs = [
         "@privateactionrunner_binary//:privateactionrunner",
     ],
+    attributes = pkg_attributes(mode = "755"),
     prefix = "embedded/bin",
 )
 
@@ -157,5 +160,6 @@ pkg_files(
     srcs = [
         "@trace_agent_binary//:trace_agent",
     ],
+    attributes = pkg_attributes(mode = "755"),
     prefix = "embedded/bin",
 )


### PR DESCRIPTION
### What does this PR do?

Adds privateactionrunner, process-agent, trace-agent, trace-loader to "product" pacakge.

### Motivation

- These are the next 4 sequential things in omnibus/config/software/datadog-agent.rb
- convenient review size.

### Describe how you validated your changes
- build the deb tarbal
- inspect to see the new files
```
> -rwxr-xr-x 0/0        48153656 2000-01-01 00:00 opt/datadog-agent/embedded/bin/process-agent
> -rwxr-xr-x 0/0        68297168 2000-01-01 00:00 opt/datadog-agent/embedded/bin/privateactionrunner
> -rwxr-xr-x 0/0        31554008 2000-01-01 00:00 opt/datadog-agent/embedded/bin/trace-agent
> -rwxr-xr-x 0/0         8209360 2000-01-01 00:00 opt/datadog-agent/embedded/bin/trace-loader
```

build again with heroku option `bazel build --//packages/agent:flavor=heroku //packages/agent/linux:debian`.   Look for fake trace-loader.
```
-rwxr-xr-x 0/0             220 2000-01-01 00:00 opt/datadog-agent/embedded/bin/trace-loader
```
