### PR TITLE
Bump rshell dependency from v0.0.9 to v0.0.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -977,7 +977,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/trace/traceutil v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5
-	github.com/DataDog/rshell v0.0.9
+	github.com/DataDog/rshell v0.0.10
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.64.4
 	github.com/aymerick/raymond v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/DataDog/opentelemetry-collector-contrib/extension/datadogextension v0
 github.com/DataDog/opentelemetry-collector-contrib/extension/datadogextension v0.147.1-0.20260319095942-6b90e15b61ca/go.mod h1:X2RsZAzB4956LB2UFWcz6GG9MF3X/paAZtIEnzmkL4c=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260317195537-817b91eb7dd4 h1:9+K8vjF7sQSLjVJporNyv6nw46cMg/Q8ogxbBZmrf+A=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260317195537-817b91eb7dd4/go.mod h1:KEBv+q78RzBcDPNFm1WB0V0za14gY95E/Atp3dJZ/8M=
-github.com/DataDog/rshell v0.0.9 h1:HS38O5aVK43ctHkTFm5RGTZA1JCP5oDxcD5O97NnoSc=
-github.com/DataDog/rshell v0.0.9/go.mod h1:e6IP68xHScumYqM/9dT9y5H41EmStHDVEyCZKv5mEt4=
+github.com/DataDog/rshell v0.0.10 h1:1jFuWzxxBNCv4tec1Rn1yZJrj9p3ZK7sRZEaHdxUk0Q=
+github.com/DataDog/rshell v0.0.10/go.mod h1:e6IP68xHScumYqM/9dT9y5H41EmStHDVEyCZKv5mEt4=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=
 github.com/DataDog/sketches-go v1.4.8/go.mod h1:a/wjRUqzqtGS8qRHRPDCs4EAQfmvPDZGDlMIF5mxXOE=
 github.com/DataDog/trivy v0.0.0-20260407220859-6cf8ddc1826c h1:oiwmRrkRVblZBI3SFVEnrwxkQ28W7nmwwI/VHgex0ZU=

--- a/releasenotes/notes/bump-rshell-v0.0.10-22efa9761316568e.yaml
+++ b/releasenotes/notes/bump-rshell-v0.0.10-22efa9761316568e.yaml
@@ -1,0 +1,14 @@
+---
+enhancements:
+  - |
+    Bump ``rshell`` to v0.0.10 for the Private Action Runner. Notable changes:
+
+    - Symlinks whose targets resolve within a different allowed root are now followed correctly.
+    - In containerized environments, symlink targets on host-mounted volumes are resolved
+      with the ``/host`` prefix.
+    - The ``ALLOWED_PATHS`` environment variable is now exposed inside the shell so scripts
+      can discover accessible directories.
+    - ``ls -l`` displays symlink targets (``-> target``), matching GNU ls behaviour.
+    - ``head``/``tail`` accept bare number shorthand (e.g. ``head -5``).
+    - The ``help`` builtin is no longer implicitly allowed and must be included in the
+      allowlist like any other command.

--- a/releasenotes/notes/bump-rshell-v0.0.10-22efa9761316568e.yaml
+++ b/releasenotes/notes/bump-rshell-v0.0.10-22efa9761316568e.yaml
@@ -1,14 +1,5 @@
 ---
 enhancements:
   - |
-    Bump ``rshell`` to v0.0.10 for the Private Action Runner. Notable changes:
-
-    - Symlinks whose targets resolve within a different allowed root are now followed correctly.
-    - In containerized environments, symlink targets on host-mounted volumes are resolved
-      with the ``/host`` prefix.
-    - The ``ALLOWED_PATHS`` environment variable is now exposed inside the shell so scripts
-      can discover accessible directories.
-    - ``ls -l`` displays symlink targets (``-> target``), matching GNU ls behaviour.
-    - ``head``/``tail`` accept bare number shorthand (e.g. ``head -5``).
-    - The ``help`` builtin is no longer implicitly allowed and must be included in the
-      allowlist like any other command.
+    Bump ``rshell`` to v0.0.10 for the Private Action Runner, improving symlink
+    resolution across allowed roots and in containerized environments.

--- a/releasenotes/notes/bump-rshell-v0.0.10-22efa9761316568e.yaml
+++ b/releasenotes/notes/bump-rshell-v0.0.10-22efa9761316568e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Bump ``rshell`` dependency from v0.0.9 to v0.0.10 for the Private Action Runner.

--- a/releasenotes/notes/bump-rshell-v0.0.10-22efa9761316568e.yaml
+++ b/releasenotes/notes/bump-rshell-v0.0.10-22efa9761316568e.yaml
@@ -1,5 +1,6 @@
 ---
 enhancements:
   - |
-    Bump ``rshell`` to v0.0.10 for the Private Action Runner, improving symlink
-    resolution across allowed roots and in containerized environments.
+    Bump ``rshell`` to v0.0.10 for the Private Action Runner. Shell commands now
+    follow symlinks that cross between allowed roots and resolve host-mounted
+    paths correctly in containerized deployments.

--- a/releasenotes/notes/bump-rshell-v0.0.10-22efa9761316568e.yaml
+++ b/releasenotes/notes/bump-rshell-v0.0.10-22efa9761316568e.yaml
@@ -1,4 +1,0 @@
----
-enhancements:
-  - |
-    Bump ``rshell`` dependency from v0.0.9 to v0.0.10 for the Private Action Runner.


### PR DESCRIPTION
## Summary
- Bumps `github.com/DataDog/rshell` from v0.0.9 to v0.0.10

## Test plan
- [x] CI passes with the updated dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)