### PR TITLE
Spec the adaptive sampler tie-break for matches

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
@@ -256,14 +256,12 @@ rule EmitMatchingLog {
     @guidance
         -- If prior_sampled_count > 0 the emitted message is tagged
         -- adaptive_sampler_sampled_count:<n>. If 0 no tag is added.
-        -- This models the common case where no bubbling occurs. When
-        -- the entry does bubble (see open question on aliasing), the
-        -- sampled_count read and reset target a different entry.
         --
         -- After updating, the entry is bubbled toward the front of
         -- the sorted table to maintain descending match_count order.
         -- The implementation achieves this via a swap chain (bubble
-        -- sort step), not a full sort.
+        -- sort step), not a full sort. All entry mutations complete
+        -- before bubbling to avoid pointer aliasing.
 }
 
 -- A log matches an existing pattern but credits are insufficient.
@@ -292,11 +290,6 @@ rule DropMatchingLog {
     ensures: LogDropped(message)
 
     @guidance
-        -- The sampled_count increment targets the matched entry when
-        -- no bubbling occurs. When the entry bubbles (see open
-        -- question on aliasing), the increment targets a different
-        -- entry.
-        --
         -- After updating, the entry is bubbled toward the front of
         -- the sorted table (same as EmitMatchingLog).
 }
@@ -426,9 +419,3 @@ deferred "ValidateMatchThreshold"
     -- this range (user_samples.go); the same validation needs to be
     -- added when match_threshold is wired up as user-configurable
     -- for the adaptive sampler.
-
-------------------------------------------------------------
--- Open Questions
-------------------------------------------------------------
-
-open question "After a matched entry bubbles forward in the sorted table (its incremented match_count exceeds its predecessor's), the pointer used for sampled_count operations still addresses the original array position — which now holds a different entry. In the emit path, this reads and clears the displaced entry's sampled_count instead of the matched entry's, so the adaptive_sampler_sampled_count tag may carry the wrong value or be absent when it should be present. In the drop path, the displaced entry's sampled_count is incremented instead of the matched entry's. Credit, last_seen and match_count updates are unaffected because they complete before bubbling. The bug manifests only when bubbling occurs — when two or more patterns have similar match_counts and one crosses a sort boundary. Is this intentional, or should the sampled_count operations be captured before the re-sort?"

--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
@@ -233,6 +233,8 @@ rule EmitMatchingLog {
     let matches = filter(PatternEntries, e => is_match(e.signature, incoming, config.match_threshold))
     requires: matches.count > 0
 
+    -- Among entries with equal match_count, max_by selects the
+    -- entry nearest the front of the table. See TableOrdered.
     let entry = max_by(matches, e => e.match_count)
 
     let elapsed_seconds = seconds_elapsed(entry.last_seen, now)
@@ -273,6 +275,8 @@ rule DropMatchingLog {
     let matches = filter(PatternEntries, e => is_match(e.signature, incoming, config.match_threshold))
     requires: matches.count > 0
 
+    -- Among entries with equal match_count, max_by selects the
+    -- entry nearest the front of the table. See TableOrdered.
     let entry = max_by(matches, e => e.match_count)
 
     let elapsed_seconds = seconds_elapsed(entry.last_seen, now)
@@ -391,6 +395,17 @@ invariant SampledCountNonNegative {
 
 -- Behavioural properties not expressible as state predicates
 -- but guaranteed by the rules above:
+--
+-- TableOrdered: PatternEntries is maintained in descending
+--   match_count order. Entries with equal match_count preserve
+--   their relative order (stable). Guaranteed by: new entries
+--   append at the tail with match_count = 1 (the minimum);
+--   after each match, the entry bubbles forward only when its
+--   match_count strictly exceeds its predecessor's. Because the
+--   bubble comparison is strict-less-than, equal-count entries
+--   never swap, making the ordering deterministic.
+--   This ordering is load-bearing: max_by tie-breaking in
+--   EmitMatchingLog / DropMatchingLog depends on it.
 --
 -- NewPatternsAlwaysEmitted: the first log of a never-before-seen
 --   pattern is always emitted. Guaranteed by RegisterNewPattern and

--- a/pkg/logs/internal/decoder/preprocessor/sampler.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler.go
@@ -152,11 +152,18 @@ func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message
 		e.lastSeen = now
 		e.matchCount++
 
-		// Determine outcome before bubbling: bubbling swaps entries by value, so
-		// e (= &s.entries[i]) would alias a different entry after the first swap.
+		// All mutations to e must complete before bubbling: bubbling swaps
+		// entries by value, so e (= &s.entries[i]) aliases a different
+		// entry after the first swap.
 		allow := e.credits >= 1.0
 		if allow {
 			e.credits--
+			if e.sampled > 0 {
+				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, adaptiveSamplerSampledCountTag(e.sampled))
+			}
+			e.sampled = 0
+		} else {
+			e.sampled++
 		}
 
 		// Bubble the matched entry toward the front to maintain descending order.
@@ -166,15 +173,10 @@ func (s *AdaptiveSampler) Process(msg *message.Message, tokens []Token) *message
 		}
 
 		if allow {
-			if e.sampled > 0 {
-				msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, adaptiveSamplerSampledCountTag(e.sampled))
-			}
-			e.sampled = 0
 			tlmAdaptiveSamplerKept.Inc(s.source)
 			return msg
 		}
 		tlmAdaptiveSamplerDropped.Inc(s.source)
-		e.sampled++
 		return nil
 	}
 

--- a/pkg/logs/internal/decoder/preprocessor/sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_test.go
@@ -256,6 +256,47 @@ func TestAdaptiveSampler_EvictsLeastFrequentWhenFull(t *testing.T) {
 	assert.Contains(t, counts, int64(2), "high-frequency pattern A should be retained")
 }
 
+// --- AdaptiveSampler: bubbling aliasing ---
+
+// When a matched entry's incremented matchCount exceeds its predecessor's, the
+// entry bubbles forward via value swaps. All entry mutations (including
+// sampled_count) must complete before bubbling, otherwise the pointer aliases a
+// different entry after the swap.
+func TestAdaptiveSampler_BubblingAliasesSampledCount(t *testing.T) {
+	s := newSampler(10, 1.0, 1.0) // burst=1, rate=1/sec
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	// Create A and bump its matchCount to 3.
+	s.Process(testMsg(), patternA)
+	s.now = func() time.Time { return t0.Add(1 * time.Second) }
+	s.Process(testMsg(), patternA)
+	s.now = func() time.Time { return t0.Add(2 * time.Second) }
+	s.Process(testMsg(), patternA)
+	// entries: [A(mc=3)]
+
+	// Create B and bump its matchCount to 3 (same as A).
+	s.now = func() time.Time { return t0.Add(3 * time.Second) }
+	s.Process(testMsg(), patternB)
+	s.now = func() time.Time { return t0.Add(4 * time.Second) }
+	s.Process(testMsg(), patternB)
+	s.now = func() time.Time { return t0.Add(5 * time.Second) }
+	s.Process(testMsg(), patternB)
+	// entries: [A(mc=3), B(mc=3)]
+
+	// Drop a B at the same timestamp (no credit refill). B.matchCount
+	// becomes 4, exceeding A's 3, so B bubbles past A. The pointer
+	// aliasing causes the sampled_count increment to land on A.
+	assert.Nil(t, s.Process(testMsg(), patternB), "B should be dropped (no credits)")
+
+	// Refill B's credits and emit. The emitted message should carry a tag
+	// reporting the 1 dropped message above.
+	s.now = func() time.Time { return t0.Add(6 * time.Second) }
+	out := s.Process(testMsg(), patternB)
+	require.NotNil(t, out, "B should be emitted after credit refill")
+	requireSampledCountTag(t, out, 1)
+}
+
 // --- AdaptiveSampler: misc ---
 
 func TestAdaptiveSampler_FlushReturnsNil(t *testing.T) {

--- a/pkg/logs/internal/decoder/preprocessor/sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_test.go
@@ -297,6 +297,141 @@ func TestAdaptiveSampler_BubblingAliasesSampledCount(t *testing.T) {
 	requireSampledCountTag(t, out, 1)
 }
 
+// --- AdaptiveSampler: tie-breaking determinism ---
+//
+// When multiple entries match an incoming log and share the highest
+// matchCount, the entry nearest the front of the table is selected.
+// The bubble step uses strict less-than, so equal-count entries never
+// swap and their relative order is stable.
+//
+// Tie-breaking is a structural property of scan order, determined by
+// table state (entry positions and matchCounts), not token content.
+// Fuzzing token inputs would exercise the tokenizer and IsMatch, not
+// the ordering logic, so these are table-driven tests over table states.
+//
+// The single-position-mutation trick for creating patterns that both
+// match an incoming log but don't cross-match only works for sequences
+// of length 10-15 at threshold 0.9. At length n: required = round(0.9*n),
+// 1-diff gives n-1 matches (pass), 2-diff gives n-2 matches (must fail).
+// At n >= 16, n-2 >= required and the patterns cross-match.
+//
+// These tests use a 10-token base with single-position mutations:
+// required = 9, pattern-vs-base = 9/10 (match), pattern-vs-pattern =
+// 8/10 (no match). Each pattern matches base independently, so we can
+// bump each entry's matchCount in isolation.
+func TestAdaptiveSampler_TieBreakingDeterminism(t *testing.T) {
+	base := []Token{D4, Dash, D2, Dash, D2, Space, D2, Colon, D2, Colon}
+	mutate := func(pos int) []Token {
+		out := make([]Token, len(base))
+		copy(out, base)
+		out[pos] = (base[pos] + 1) % End
+		return out
+	}
+	patX := mutate(3) // differs from base at position 3
+	patY := mutate(7) // differs from base at position 7
+	patZ := mutate(1) // differs from base at position 1
+
+	// Verify geometry: each pattern matches base, no pair cross-matches.
+	require.True(t, IsMatch(patX, base, 0.9))
+	require.True(t, IsMatch(patY, base, 0.9))
+	require.True(t, IsMatch(patZ, base, 0.9))
+	require.False(t, IsMatch(patX, patY, 0.9))
+	require.False(t, IsMatch(patX, patZ, 0.9))
+	require.False(t, IsMatch(patY, patZ, 0.9))
+
+	// Sending patX/patY/patZ to the sampler matches only the corresponding
+	// entry (no cross-match), so we can bump each entry's matchCount
+	// independently. Sending base matches all entries that are present.
+
+	t.Run("fresh tie at matchCount=1", func(t *testing.T) {
+		// Both entries start at matchCount=1 from insertion.
+		// X is at index 0, Y at index 1.
+		s := newSampler(10, 100.0, 0)
+		s.Process(testMsg(), patX)
+		s.Process(testMsg(), patY)
+
+		s.Process(testMsg(), base)
+		assert.Equal(t, int64(2), s.entries[0].matchCount,
+			"X (first in table order) should be selected")
+		assert.Equal(t, int64(1), s.entries[1].matchCount,
+			"Y should not be selected")
+	})
+
+	t.Run("evolved tie: both climb to matchCount=4 independently", func(t *testing.T) {
+		// X and Y are bumped to the same matchCount via independent hits.
+		// Because Y's matchCount never exceeds X's during the climb (we
+		// bump X first), Y never bubbles past X. Table order is preserved.
+		s := newSampler(10, 100.0, 0)
+		s.Process(testMsg(), patX) // X: mc=1
+		s.Process(testMsg(), patY) // Y: mc=1
+
+		for range 3 {
+			s.Process(testMsg(), patX) // X only
+		}
+		// Table: [X(4), Y(1)]
+		for range 3 {
+			s.Process(testMsg(), patY) // Y only; never exceeds X, no bubble
+		}
+		// Table: [X(4), Y(4)]
+		require.Equal(t, int64(4), s.entries[0].matchCount)
+		require.Equal(t, int64(4), s.entries[1].matchCount)
+
+		s.Process(testMsg(), base)
+		assert.Equal(t, int64(5), s.entries[0].matchCount,
+			"X (preserved at front through independent evolution) should be selected")
+		assert.Equal(t, int64(4), s.entries[1].matchCount,
+			"Y should not be selected")
+	})
+
+	t.Run("reversed order: Y overtakes X via bubbling, then X catches up", func(t *testing.T) {
+		// Y accumulates a higher matchCount than X, bubbles to the front.
+		// X later catches up to the same count but does NOT bubble past Y
+		// (strict-less-than comparison). Now Y is at front despite X being
+		// inserted first.
+		s := newSampler(10, 100.0, 0)
+		s.Process(testMsg(), patX) // X: mc=1
+		s.Process(testMsg(), patY) // Y: mc=1
+		// Table: [X(1), Y(1)]
+
+		// Bump Y to mc=3. First hit: Y(2) > X(1) → Y bubbles to front.
+		for range 2 {
+			s.Process(testMsg(), patY)
+		}
+		// Table: [Y(3), X(1)]
+
+		// Bump X to mc=3. X never exceeds Y's count, no bubble.
+		for range 2 {
+			s.Process(testMsg(), patX)
+		}
+		// Table: [Y(3), X(3)]
+		require.Equal(t, int64(3), s.entries[0].matchCount)
+		require.Equal(t, int64(3), s.entries[1].matchCount)
+
+		s.Process(testMsg(), base)
+		assert.Equal(t, int64(4), s.entries[0].matchCount,
+			"Y (bubbled to front when it overtook X) should be selected")
+		assert.Equal(t, int64(3), s.entries[1].matchCount,
+			"X (now behind Y) should not be selected")
+	})
+
+	t.Run("three-way tie", func(t *testing.T) {
+		// Three entries all at matchCount=1. First in table order wins.
+		s := newSampler(10, 100.0, 0)
+		s.Process(testMsg(), patX)
+		s.Process(testMsg(), patY)
+		s.Process(testMsg(), patZ)
+		require.Len(t, s.entries, 3)
+
+		s.Process(testMsg(), base)
+		assert.Equal(t, int64(2), s.entries[0].matchCount,
+			"X (first of three tied entries) should be selected")
+		assert.Equal(t, int64(1), s.entries[1].matchCount,
+			"Y should not be selected")
+		assert.Equal(t, int64(1), s.entries[2].matchCount,
+			"Z should not be selected")
+	})
+}
+
 // --- AdaptiveSampler: misc ---
 
 func TestAdaptiveSampler_FlushReturnsNil(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

When entries have equal match count on an incoming log the first
entry in descending order is selected. This behavior is deterministic
and is asserted by a new test, added here.

### Motivation

SMP forward deploy is looking to create an externally validated property test
for adaptive sampling. Scoping the problem to validation of the integration of
individually fit-for-purpose components is a tidier problem than otherwise.

### 