### PR TITLE
Clarify LogEmission invariants in spec

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
@@ -55,6 +55,16 @@ value TokenSequence {
 -- Contracts
 ------------------------------------------------------------
 
+contract LogEmission {
+    emit: (message: ByteArray, sampled_count: Integer) -> void
+
+    @invariant TagPresence
+        -- When sampled_count > 0 the emitted message carries an
+        -- adaptive_sampler_sampled_count:<n> metadata tag.
+        -- When sampled_count = 0 no tag is added. The message
+        -- content bytes are never modified.
+}
+
 contract PatternMatching {
     is_match: (a: TokenSequence, b: TokenSequence, threshold: Decimal) -> Boolean
 
@@ -256,9 +266,6 @@ rule EmitMatchingLog {
     ensures: LogEmitted(message, sampled_count: prior_sampled_count)
 
     @guidance
-        -- If prior_sampled_count > 0 the emitted message is tagged
-        -- adaptive_sampler_sampled_count:<n>. If 0 no tag is added.
-        --
         -- After updating, the entry is bubbled toward the front of
         -- the sorted table to maintain descending match_count order.
         -- The implementation achieves this via a swap chain (bubble
@@ -342,7 +349,7 @@ rule EvictAndRegisterPattern {
         match_count: 1,
         sampled_count: 0
     )
-    ensures: LogEmitted(message, sampled_count: 0)
+    ensures: LogEmitted(message)
 
     @guidance
         -- When multiple entries share the minimum match_count, the
@@ -413,8 +420,7 @@ invariant SampledCountNonNegative {
 --   burst_size >= 1 (validated at construction).
 --
 -- MessageContentIntegrity: the sampler never modifies log content
---   bytes. Emitted messages are byte-identical to their input.
---   Only metadata (adaptive_sampler_sampled_count tag) may be added.
+--   bytes. See LogEmission contract for tagging semantics.
 --
 -- SteadyStateRateBound: after burst exhaustion, a pattern emits
 --   at most rate_limit logs per second. Over interval T seconds,

--- a/pkg/logs/internal/decoder/preprocessor/sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_test.go
@@ -99,6 +99,36 @@ func TestAdaptiveSampler_NewPatternCredits(t *testing.T) {
 	assert.Equal(t, 4.0, s.entries[0].credits) // BurstSize-1 = 5-1 = 4
 }
 
+// --- AdaptiveSampler: LogEmission.TagPresence ---
+
+// When sampled_count > 0 the emitted message carries the tag.
+// When sampled_count = 0 no tag is added.
+func TestAdaptiveSampler_TagPresence(t *testing.T) {
+	s := newSampler(10, 1.0, 1.0)
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+
+	// First emit: new pattern, sampled_count = 0 → no tag.
+	out1 := s.Process(testMsg(), patternA)
+	require.NotNil(t, out1)
+	requireNoSampledCountTag(t, out1)
+
+	// Second message dropped (burst exhausted) → sampled_count increments.
+	assert.Nil(t, s.Process(testMsg(), patternA))
+
+	// Third emit after refill: sampled_count = 1 → tag present.
+	s.now = func() time.Time { return t0.Add(2 * time.Second) }
+	out2 := s.Process(testMsg(), patternA)
+	require.NotNil(t, out2)
+	requireSampledCountTag(t, out2, 1)
+
+	// Fourth emit immediately: sampled_count was reset to 0 → no tag.
+	s.now = func() time.Time { return t0.Add(3 * time.Second) }
+	out3 := s.Process(testMsg(), patternA)
+	require.NotNil(t, out3)
+	requireNoSampledCountTag(t, out3)
+}
+
 // --- AdaptiveSampler: rate limiting ---
 
 // After BurstSize messages the pattern is rate-limited.


### PR DESCRIPTION
### What does this PR do?

This commit clarifies how tag presence works. Previously this was
implicit as guidance and implied in test behavior but not explicitly
required by either the spec or test coverage

### Motivation

SMP forward deploy is looking to create an externally validated property test
for adaptive sampling. Scoping the problem to validation of the integration of
individually fit-for-purpose components is a tidier problem than otherwise.