### PR TITLE
[EBPF] gpu: bump go-nvml to latest commit 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -183,7 +183,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/Microsoft/hcsshim v0.13.0
-	github.com/NVIDIA/go-nvml v0.12.9-0
+	github.com/NVIDIA/go-nvml v0.13.0-1.0.20260414000254-c617db04ef8e
 	github.com/ProtonMail/go-crypto v1.3.0
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b

--- a/go.sum
+++ b/go.sum
@@ -288,6 +288,8 @@ github.com/Microsoft/hcsshim v0.13.0 h1:/BcXOiS6Qi7N9XqUcv27vkIuVOkBEcWstd2pMlWS
 github.com/Microsoft/hcsshim v0.13.0/go.mod h1:9KWJ/8DgU+QzYGupX4tzMhRQE8h6w90lH6HAaclpEok=
 github.com/NVIDIA/go-nvml v0.12.9-0 h1:e344UK8ZkeMeeLkdQtRhmXRxNf+u532LDZPGMtkdus0=
 github.com/NVIDIA/go-nvml v0.12.9-0/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
+github.com/NVIDIA/go-nvml v0.13.0-1.0.20260414000254-c617db04ef8e h1:sjzPY7aEDyVlahN7HBVKBdfNKXypJHND424iuUW0HGs=
+github.com/NVIDIA/go-nvml v0.13.0-1.0.20260414000254-c617db04ef8e/go.mod h1:ahi2psRYoa+wYUBIrZPRO+wJs9lcvMhxSSkjjvsJJNQ=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,6 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.13.0 h1:/BcXOiS6Qi7N9XqUcv27vkIuVOkBEcWstd2pMlWSeaA=
 github.com/Microsoft/hcsshim v0.13.0/go.mod h1:9KWJ/8DgU+QzYGupX4tzMhRQE8h6w90lH6HAaclpEok=
-github.com/NVIDIA/go-nvml v0.12.9-0 h1:e344UK8ZkeMeeLkdQtRhmXRxNf+u532LDZPGMtkdus0=
-github.com/NVIDIA/go-nvml v0.12.9-0/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
 github.com/NVIDIA/go-nvml v0.13.0-1.0.20260414000254-c617db04ef8e h1:sjzPY7aEDyVlahN7HBVKBdfNKXypJHND424iuUW0HGs=
 github.com/NVIDIA/go-nvml v0.13.0-1.0.20260414000254-c617db04ef8e/go.mod h1:ahi2psRYoa+wYUBIrZPRO+wJs9lcvMhxSSkjjvsJJNQ=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -622,7 +622,7 @@ var archNameToNVML = map[string]struct {
 	"hopper":  {nvml.DEVICE_ARCH_HOPPER, 9, 0},
 	"ada":     {nvml.DEVICE_ARCH_ADA, 8, 9},
 	"blackwell": {
-		nvml.DeviceArchitecture(10), // nvml.DEVICE_ARCH_BLACKWELL in newer go-nvml
+		nvml.DEVICE_ARCH_BLACKWELL,
 		10,
 		0,
 	},

--- a/pkg/util/gpu/nvml.go
+++ b/pkg/util/gpu/nvml.go
@@ -29,8 +29,7 @@ func ArchToString(arch nvml.DeviceArchitecture) string {
 		return "ada"
 	case nvml.DEVICE_ARCH_HOPPER:
 		return "hopper"
-	case 10: // nvml.DEVICE_ARCH_BLACKWELL in newer versions of go-nvml
-		// note: we hardcode the enum to avoid updating to an untested newer go-nvml version
+	case nvml.DEVICE_ARCH_BLACKWELL:
 		return "blackwell"
 	case nvml.DEVICE_ARCH_UNKNOWN:
 		return "unknown"


### PR DESCRIPTION
### What does this PR do?

Bumps `github.com/NVIDIA/go-nvml` to the latest upstream commit and switches the Blackwell architecture references to use the exported `nvml.DEVICE_ARCH_BLACKWELL` constant.

### Motivation

Bump to latest version, which includes new APIs and now has fixes for GPM support (https://github.com/NVIDIA/go-nvml/pull/176).

### Describe how you validated your changes

CI passing. Integration tests on GPUs with NVML also passed (existing failures were already in `main`).

### Additional Notes