### PR TITLE
Add dd-octo-sts policies for tidy workflows

### DIFF
--- a/.github/chainguard/self.cargo-bazel-tidy.push-branch.sts.yaml
+++ b/.github/chainguard/self.cargo-bazel-tidy.push-branch.sts.yaml
@@ -5,8 +5,8 @@ subject: repo:DataDog/datadog-agent:pull_request
 
 claim_pattern:
   event_name: pull_request
-  ref: refs/heads/(main|[0-9]+\.[0-9]+\.x)
-  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/cargo-bazel-tidy\.yml@refs/heads/(main|[0-9]+\.[0-9]+\.x)
+  ref: refs/pull/[0-9]+/merge
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/cargo-bazel-tidy\.yml@refs/pull/[0-9]+/merge
 
 permissions:
   contents: write

--- a/.github/chainguard/self.cargo-bazel-tidy.push-branch.sts.yaml
+++ b/.github/chainguard/self.cargo-bazel-tidy.push-branch.sts.yaml
@@ -1,0 +1,12 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-agent:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  ref: refs/heads/(main|[0-9]+\.[0-9]+\.x)
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/cargo-bazel-tidy\.yml@refs/heads/(main|[0-9]+\.[0-9]+\.x)
+
+permissions:
+  contents: write

--- a/.github/chainguard/self.go-mod-tidy.push-branch.sts.yaml
+++ b/.github/chainguard/self.go-mod-tidy.push-branch.sts.yaml
@@ -5,8 +5,8 @@ subject: repo:DataDog/datadog-agent:pull_request
 
 claim_pattern:
   event_name: pull_request
-  ref: refs/heads/(main|[0-9]+\.[0-9]+\.x)
-  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/go-mod-tidy\.yml@refs/heads/(main|[0-9]+\.[0-9]+\.x)
+  ref: refs/pull/[0-9]+/merge
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/go-mod-tidy\.yml@refs/pull/[0-9]+/merge
 
 permissions:
   contents: write

--- a/.github/chainguard/self.go-mod-tidy.push-branch.sts.yaml
+++ b/.github/chainguard/self.go-mod-tidy.push-branch.sts.yaml
@@ -1,0 +1,12 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-agent:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  ref: refs/heads/(main|[0-9]+\.[0-9]+\.x)
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/go-mod-tidy\.yml@refs/heads/(main|[0-9]+\.[0-9]+\.x)
+
+permissions:
+  contents: write


### PR DESCRIPTION
## Summary
- Add Chainguard policies for `go-mod-tidy` and `cargo-bazel-tidy` workflows
- These grant `contents: write` via dd-octo-sts App tokens
- Prerequisite for switching tidy workflows from `GITHUB_TOKEN` to dd-octo-sts (follow-up PR)

## Motivation
Commits pushed with `GITHUB_TOKEN` don't trigger downstream workflow runs (GitHub anti-recursion mechanism). This causes required checks (`CLAAssistant`, `release-note-check`, `skip-qa-check`, `team-label-check`) to never run on Renovate/Dependabot PRs after the tidy commit is pushed, blocking merge.

## Test plan
- [ ] Verify policies are synced after merge
- [ ] Follow-up PR switches workflows to use these policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)