### PR TITLE
Use dd-octo-sts in tidy workflows to trigger required checks

### DIFF
--- a/.github/workflows/cargo-bazel-tidy.yml
+++ b/.github/workflows/cargo-bazel-tidy.yml
@@ -16,9 +16,14 @@ jobs:
   repin_and_generate_licenses:
     if: ${{ github.repository == 'DataDog/datadog-agent' && github.event.pull_request.user.login == 'renovate[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-cargo') }}
     permissions:
-      contents: write
+      id-token: write # Required for dd-octo-sts OIDC token
     runs-on: ubuntu-latest
     steps:
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-agent
+          policy: self.cargo-bazel-tidy.push-branch
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
@@ -49,7 +54,7 @@ jobs:
         if: steps.commit.outputs.has_changes == 'true'
         uses: chouetz/push-signed-commits@9b123e8898e6176af65b9427b434e07aebe7f72f
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           local_branch_name: ${{ github.head_ref }}
           remote_name: "origin"
           remote_branch_name: ${{ github.head_ref }}

--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -11,9 +11,14 @@ jobs:
   mod_tidy_and_generate_licenses:
     if: ${{ github.repository == 'DataDog/datadog-agent' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]') && contains(github.event.pull_request.labels.*.name, 'dependencies-go') }}
     permissions:
-      contents: write
+      id-token: write # Required for dd-octo-sts OIDC token
     runs-on: ubuntu-latest
     steps:
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-agent
+          policy: self.go-mod-tidy.push-branch
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
@@ -53,7 +58,7 @@ jobs:
         if: steps.commit.outputs.has_changes == 'true'
         uses: chouetz/push-signed-commits@9b123e8898e6176af65b9427b434e07aebe7f72f
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           local_branch_name: ${{ github.head_ref }}
           remote_name: "origin"
           remote_branch_name: ${{ github.head_ref }}

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "minimumReleaseAge": "7 days",
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
-    "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"],
+    "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com", "200755185+dd-octo-sts[bot]@users.noreply.github.com"],
     "platformCommit": "enabled",
     "packageRules": [
       {


### PR DESCRIPTION
## Summary
- Switch `go-mod-tidy` and `cargo-bazel-tidy` workflows from `GITHUB_TOKEN` to dd-octo-sts App tokens for pushing commits
- Add `dd-octo-sts[bot]` to Renovate `gitIgnoredAuthors`

## Motivation
Commits pushed with `GITHUB_TOKEN` don't trigger downstream workflow runs ([GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow)). This causes required checks (`CLAAssistant`, `release-note-check`, `skip-qa-check`, `team-label-check`) to never run on Renovate/Dependabot PRs after the tidy commit is pushed, blocking merge.

Using an App token (via dd-octo-sts) makes the push event trigger the required workflows.

## Dependencies
- Requires #49300 to be merged first (Chainguard policies)

## Test plan
- [ ] Merge #49300 first so policies are synced
- [ ] Verify a Renovate gomod PR triggers `label-analysis` and `cla` workflows after the tidy commit is pushed
- [ ] Verify Renovate doesn't rebase over the tidy commit (gitIgnoredAuthors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)