### PR TITLE
Make compilation dir relative

### DIFF
--- a/bazel/rules/ebpf/ebpf.bzl
+++ b/bazel/rules/ebpf/ebpf.bzl
@@ -42,6 +42,7 @@ _PREBUILT_FLAGS = [
 _CORE_FLAGS = [
     "-DCOMPILE_CORE",
     "-g",
+    "-fdebug-compilation-dir=.",
 ]
 
 def _get_arch_flags(target_arch):


### PR DESCRIPTION
### What does this PR do?
The issue was reported by users with the following error message:
```shell
llvm-objdump: warning: 'kmt-deps/usama.saqib-test-sleepable-ddvm/x86_64/opt/system-probe-tests/pkg/ebpf/bytecode/build/x86_64/co-re/usm.o': failed to find source /home/ubuntu/.cache/bazel/_bazel_ubuntu/13408f4b78aee4e0b490703190dd65a3/sandbox/processwrapper-sandbox/722/execroot/_main/pkg/network/ebpf/c/protocols/http2/decoding-common.h
```

The issue was because clang was injecting an absolute build path into the produced binary that contained a bazel sandbox path that is cleaned up as soon as an action succeeds. Making the path relative makes it work in the source tree

### Describe how you validated your changes
Executed `readelf`:
```shell
readelf --debug-dump=info /root/.cache/bazel/_bazel_root/d8e9195c7180b82e81d7a40033183593/execroot/_main/bazel-out/aarch64-fastbuild/bin/pkg/ebpf/c/lock_contention.o | grep -i comp_dir

<1a>   DW_AT_comp_dir    : (indirect string, offset: 0x32): .
```
