### PR TITLE
add `SourceSecret` layer and `SourceConfigPostInit` layers

### DIFF
--- a/comp/core/settings/settingsimpl/settingsimpl_test.go
+++ b/comp/core/settings/settingsimpl/settingsimpl_test.go
@@ -311,7 +311,7 @@ func TestRuntimeSettings(t *testing.T) {
 				// simply compare strings.
 				expected := map[string]interface{}{}
 				actual := map[string]interface{}{}
-				json.Unmarshal([]byte("{\"value\":{\"Value\":\"\",\"Source\":\"\"},\"sources_value\":[{\"Source\":\"default\",\"Value\":null},{\"Source\":\"unknown\",\"Value\":null},{\"Source\":\"infra-mode\",\"Value\":null},{\"Source\":\"file\",\"Value\":null},{\"Source\":\"environment-variable\",\"Value\":null},{\"Source\":\"fleet-policies\",\"Value\":null},{\"Source\":\"agent-runtime\",\"Value\":null},{\"Source\":\"local-config-process\",\"Value\":null},{\"Source\":\"secret_backend\",\"Value\":null},{\"Source\":\"remote-config\",\"Value\":null},{\"Source\":\"cli\",\"Value\":null}]}"), &expected)
+				json.Unmarshal([]byte("{\"value\":{\"Value\":\"\",\"Source\":\"\"},\"sources_value\":[{\"Source\":\"default\",\"Value\":null},{\"Source\":\"unknown\",\"Value\":null},{\"Source\":\"infra-mode\",\"Value\":null},{\"Source\":\"file\",\"Value\":null},{\"Source\":\"environment-variable\",\"Value\":null},{\"Source\":\"fleet-policies\",\"Value\":null},{\"Source\":\"config-post-init\",\"Value\":null},{\"Source\":\"secret\",\"Value\":null},{\"Source\":\"local-config-process\",\"Value\":null},{\"Source\":\"agent-runtime\",\"Value\":null},{\"Source\":\"remote-config\",\"Value\":null},{\"Source\":\"cli\",\"Value\":null}]}"), &expected)
 				err = json.Unmarshal(body, &actual)
 
 				require.NoError(t, err, fmt.Sprintf("error loading JSON body: %s", err))

--- a/comp/core/settings/settingsimpl/settingsimpl_test.go
+++ b/comp/core/settings/settingsimpl/settingsimpl_test.go
@@ -311,7 +311,7 @@ func TestRuntimeSettings(t *testing.T) {
 				// simply compare strings.
 				expected := map[string]interface{}{}
 				actual := map[string]interface{}{}
-				json.Unmarshal([]byte("{\"value\":{\"Value\":\"\",\"Source\":\"\"},\"sources_value\":[{\"Source\":\"default\",\"Value\":null},{\"Source\":\"unknown\",\"Value\":null},{\"Source\":\"infra-mode\",\"Value\":null},{\"Source\":\"file\",\"Value\":null},{\"Source\":\"environment-variable\",\"Value\":null},{\"Source\":\"fleet-policies\",\"Value\":null},{\"Source\":\"agent-runtime\",\"Value\":null},{\"Source\":\"local-config-process\",\"Value\":null},{\"Source\":\"remote-config\",\"Value\":null},{\"Source\":\"cli\",\"Value\":null}]}"), &expected)
+				json.Unmarshal([]byte("{\"value\":{\"Value\":\"\",\"Source\":\"\"},\"sources_value\":[{\"Source\":\"default\",\"Value\":null},{\"Source\":\"unknown\",\"Value\":null},{\"Source\":\"infra-mode\",\"Value\":null},{\"Source\":\"file\",\"Value\":null},{\"Source\":\"environment-variable\",\"Value\":null},{\"Source\":\"fleet-policies\",\"Value\":null},{\"Source\":\"agent-runtime\",\"Value\":null},{\"Source\":\"local-config-process\",\"Value\":null},{\"Source\":\"secret_backend\",\"Value\":null},{\"Source\":\"remote-config\",\"Value\":null},{\"Source\":\"cli\",\"Value\":null}]}"), &expected)
 				err = json.Unmarshal(body, &actual)
 
 				require.NoError(t, err, fmt.Sprintf("error loading JSON body: %s", err))

--- a/comp/metadata/clusteragent/impl/cluster_agent.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent.go
@@ -182,7 +182,7 @@ func (dca *datadogclusteragent) getConfigs(data map[string]interface{}) {
 			}
 		}
 	}
-	if yaml, err := dca.marshalAndScrub(dca.conf.AllSettings()); err == nil {
+	if yaml, err := dca.marshalAndScrub(dca.conf.AllSettingsWithoutSecrets()); err == nil {
 		data["full_configuration"] = yaml
 	}
 }

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -497,7 +497,7 @@ func (ia *inventoryagent) getConfigs(data agentMetadata) {
 				}
 			}
 		}
-		if yaml, err := ia.marshalAndScrub(ia.conf.AllSettings()); err == nil {
+		if yaml, err := ia.marshalAndScrub(ia.conf.AllSettingsWithoutSecrets()); err == nil {
 			data["full_configuration"] = yaml
 		}
 	}

--- a/comp/trace/config/impl/config.go
+++ b/comp/trace/config/impl/config.go
@@ -188,7 +188,7 @@ func (c *cfg) GetConfigHandler() http.Handler {
 				return
 			}
 
-			runtimeConfig, err := yaml.Marshal(c.coreConfig.AllSettings())
+			runtimeConfig, err := yaml.Marshal(c.coreConfig.AllSettingsWithoutSecrets())
 			if err != nil {
 				log.Errorf("Unable to marshal runtime config response: %s", err)
 				body, _ := json.Marshal(map[string]string{"error": err.Error()})

--- a/comp/trace/config/impl/config.go
+++ b/comp/trace/config/impl/config.go
@@ -188,7 +188,7 @@ func (c *cfg) GetConfigHandler() http.Handler {
 				return
 			}
 
-			runtimeConfig, err := yaml.Marshal(c.coreConfig.AllSettingsWithoutSecrets())
+			runtimeConfig, err := yaml.Marshal(c.coreConfig.AllSettings())
 			if err != nil {
 				log.Errorf("Unable to marshal runtime config response: %s", err)
 				body, _ := json.Marshal(map[string]string{"error": err.Error()})

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -47,6 +47,8 @@ const (
 	// core-agent. This is used when side process like security-agent or trace-agent pull their configuration from
 	// the core-agent.
 	SourceLocalConfigProcess Source = "local-config-process"
+	// SourceSecretBackend are values resolved from a secrets backend (ENC[...] placeholders).
+	SourceSecretBackend Source = "secret_backend"
 	// SourceRC are the values loaded from remote-config (aka Datadog backend)
 	SourceRC Source = "remote-config"
 	// SourceFleetPolicies are the values loaded from remote-config file
@@ -67,6 +69,7 @@ var Sources = []Source{
 	SourceFleetPolicies,
 	SourceAgentRuntime,
 	SourceLocalConfigProcess,
+	SourceSecretBackend,
 	SourceRC,
 	SourceCLI,
 }
@@ -83,8 +86,9 @@ var sourcesPriority = map[Source]int{
 	SourceFleetPolicies:      5,
 	SourceAgentRuntime:       6,
 	SourceLocalConfigProcess: 7,
-	SourceRC:                 8,
-	SourceCLI:                9,
+	SourceSecretBackend:      8,
+	SourceRC:                 9,
+	SourceCLI:                10,
 }
 
 // ValueWithSource is a tuple for a source and a value, not necessarily the applied value in the main config

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -40,15 +40,17 @@ const (
 	SourceFile Source = "file"
 	// SourceEnvVar are the values loaded from the environment variables.
 	SourceEnvVar Source = "environment-variable"
-	// SourceAgentRuntime are the values configured by the agent itself. The agent can dynamically compute the best
-	// value for some settings when not set by the user.
-	SourceAgentRuntime Source = "agent-runtime"
+	// SourceConfigPostInit are values computed by the agent during initial config setup.
+	SourceConfigPostInit Source = "config-post-init"
+	// SourceSecret are values resolved from secrets (ENC[...] placeholders).
+	SourceSecret Source = "secret"
 	// SourceLocalConfigProcess are the values mirrored from the config process. The config process is the
 	// core-agent. This is used when side process like security-agent or trace-agent pull their configuration from
 	// the core-agent.
 	SourceLocalConfigProcess Source = "local-config-process"
-	// SourceSecretBackend are values resolved from a secrets backend (ENC[...] placeholders).
-	SourceSecretBackend Source = "secret_backend"
+	// SourceAgentRuntime are the values configured by the agent itself. The agent can dynamically compute the best
+	// value for some settings when not set by the user.
+	SourceAgentRuntime Source = "agent-runtime"
 	// SourceRC are the values loaded from remote-config (aka Datadog backend)
 	SourceRC Source = "remote-config"
 	// SourceFleetPolicies are the values loaded from remote-config file
@@ -67,9 +69,10 @@ var Sources = []Source{
 	SourceFile,
 	SourceEnvVar,
 	SourceFleetPolicies,
-	SourceAgentRuntime,
+	SourceConfigPostInit,
+	SourceSecret,
 	SourceLocalConfigProcess,
-	SourceSecretBackend,
+	SourceAgentRuntime,
 	SourceRC,
 	SourceCLI,
 }
@@ -84,11 +87,12 @@ var sourcesPriority = map[Source]int{
 	SourceFile:               3,
 	SourceEnvVar:             4,
 	SourceFleetPolicies:      5,
-	SourceAgentRuntime:       6,
-	SourceLocalConfigProcess: 7,
-	SourceSecretBackend:      8,
-	SourceRC:                 9,
-	SourceCLI:                10,
+	SourceConfigPostInit:     6,
+	SourceSecret:             7,
+	SourceLocalConfigProcess: 8,
+	SourceAgentRuntime:       9,
+	SourceRC:                 10,
+	SourceCLI:                11,
 }
 
 // ValueWithSource is a tuple for a source and a value, not necessarily the applied value in the main config

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -163,6 +163,10 @@ type Reader interface {
 
 	AllSettings() map[string]interface{}
 	AllSettingsWithoutDefault() map[string]interface{}
+	// AllSettingsWithoutSecrets returns all settings excluding the secrets layer.
+	AllSettingsWithoutSecrets() map[string]interface{}
+	// AllSettingsWithoutDefaultOrSecrets returns settings excluding both defaults and the secrets layer.
+	AllSettingsWithoutDefaultOrSecrets() map[string]interface{}
 	AllSettingsBySource() map[Source]interface{}
 	// AllKeysLowercased returns all config keys in the config, no matter how they are set.
 	// Note that it returns the keys lowercased.

--- a/pkg/config/nodetreemodel/compatibility_test.go
+++ b/pkg/config/nodetreemodel/compatibility_test.go
@@ -1089,12 +1089,12 @@ some:
 			assert.Equal(t, "RC_value", cfg.GetString("some.setting"))
 
 			cfg.UnsetForSource("some.setting", model.SourceRC)
-			assert.Equal(t, "process_value", cfg.GetString("some.setting"))
-
-			cfg.UnsetForSource("some.setting", model.SourceLocalConfigProcess)
 			assert.Equal(t, "runtime_value", cfg.GetString("some.setting"))
 
 			cfg.UnsetForSource("some.setting", model.SourceAgentRuntime)
+			assert.Equal(t, "process_value", cfg.GetString("some.setting"))
+
+			cfg.UnsetForSource("some.setting", model.SourceLocalConfigProcess)
 			assert.Equal(t, "file_value", cfg.GetString("some.setting"))
 
 			cfg.UnsetForSource("some.setting", model.SourceFile)

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -490,8 +490,9 @@ func (c *ntmConfig) checkKnownKey(key string) {
 	log.Warnf("config key %v is unknown", key)
 }
 
-func (c *ntmConfig) mergeAllLayers() error {
-	treeList := []*nodeImpl{
+// layerList returns all config layers in ascending priority order.
+func (c *ntmConfig) layerList() []*nodeImpl {
+	return []*nodeImpl{
 		c.defaults,
 		c.unknown,
 		c.file,
@@ -503,16 +504,33 @@ func (c *ntmConfig) mergeAllLayers() error {
 		c.remoteConfig,
 		c.cli,
 	}
+}
 
+// mergeLayers merges all layers except those in exclude.
+func (c *ntmConfig) mergeLayers(exclude ...*nodeImpl) (*nodeImpl, error) {
+	excludeSet := make(map[*nodeImpl]struct{}, len(exclude))
+	for _, e := range exclude {
+		excludeSet[e] = struct{}{}
+	}
 	merged := newInnerNode(nil)
-	for _, tree := range treeList {
+	for _, tree := range c.layerList() {
+		if _, skip := excludeSet[tree]; skip {
+			continue
+		}
 		next, err := merged.Merge(tree)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		merged = next
 	}
+	return merged, nil
+}
 
+func (c *ntmConfig) mergeAllLayers() error {
+	merged, err := c.mergeLayers()
+	if err != nil {
+		return err
+	}
 	c.root = merged
 	return nil
 }
@@ -936,6 +954,34 @@ func (c *ntmConfig) AllSettingsWithoutDefault() map[string]interface{} {
 	return c.root.dumpSettings(false)
 }
 
+// AllSettingsWithoutSecrets returns all settings excluding the secrets layer
+func (c *ntmConfig) AllSettingsWithoutSecrets() map[string]interface{} {
+	c.maybeRebuild()
+	c.RLock()
+	defer c.RUnlock()
+
+	merged, err := c.mergeLayers(c.secrets)
+	if err != nil {
+		log.Errorf("error merging config layers without secrets: %v", err)
+		return map[string]interface{}{}
+	}
+	return merged.dumpSettings(true)
+}
+
+// AllSettingsWithoutDefaultOrSecrets returns settings excluding both defaults and secrets
+func (c *ntmConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{} {
+	c.maybeRebuild()
+	c.RLock()
+	defer c.RUnlock()
+
+	merged, err := c.mergeLayers(c.defaults, c.secrets)
+	if err != nil {
+		log.Errorf("error merging config layers without defaults or secrets: %v", err)
+		return map[string]interface{}{}
+	}
+	return merged.dumpSettings(false)
+}
+
 // AllSettingsBySource returns the settings from each source (file, env vars, ...)
 func (c *ntmConfig) AllSettingsBySource() map[model.Source]interface{} {
 	c.maybeRebuild()
@@ -943,7 +989,13 @@ func (c *ntmConfig) AllSettingsBySource() map[model.Source]interface{} {
 	c.RLock()
 	defer c.RUnlock()
 
-	// We don't return include unknown settings
+	// SourceProvided excludes secrets so resolved values don't leak in metadata payloads.
+	providedWithoutSecrets, err := c.mergeLayers(c.defaults, c.secrets)
+	if err != nil {
+		log.Errorf("error building provided configuration without secrets: %v", err)
+		providedWithoutSecrets = newInnerNode(nil)
+	}
+
 	return map[model.Source]interface{}{
 		model.SourceDefault:            c.defaults.dumpSettings(true),
 		model.SourceUnknown:            c.unknown.dumpSettings(true),
@@ -953,10 +1005,9 @@ func (c *ntmConfig) AllSettingsBySource() map[model.Source]interface{} {
 		model.SourceFleetPolicies:      c.fleetPolicies.dumpSettings(true),
 		model.SourceAgentRuntime:       c.runtime.dumpSettings(true),
 		model.SourceLocalConfigProcess: c.localConfigProcess.dumpSettings(true),
-		model.SourceSecretBackend:      c.secrets.dumpSettings(true),
 		model.SourceRC:                 c.remoteConfig.dumpSettings(true),
 		model.SourceCLI:                c.cli.dumpSettings(true),
-		model.SourceProvided:           c.root.dumpSettings(false),
+		model.SourceProvided:           providedWithoutSecrets.dumpSettings(false),
 	}
 }
 

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -36,6 +36,7 @@ var sources = []model.Source{
 	model.SourceFleetPolicies,
 	model.SourceAgentRuntime,
 	model.SourceLocalConfigProcess,
+	model.SourceSecretBackend,
 	model.SourceRC,
 	model.SourceCLI,
 }
@@ -82,6 +83,8 @@ type ntmConfig struct {
 	// localConfigProcess contains the settings pulled from the config process (process owning the source of truth
 	// for the coniguration and mirrored by other processes).
 	localConfigProcess *nodeImpl
+	// secrets contains values resolved from a secrets backend (ENC[...] placeholders).
+	secrets *nodeImpl
 	// remoteConfig contains the settings pulled from Remote Config.
 	remoteConfig *nodeImpl
 	// fleetPolicies contains the settings pulled from fleetPolicies.
@@ -162,6 +165,8 @@ func (c *ntmConfig) getTreeBySource(source model.Source) (*nodeImpl, error) {
 		return c.runtime, nil
 	case model.SourceLocalConfigProcess:
 		return c.localConfigProcess, nil
+	case model.SourceSecretBackend:
+		return c.secrets, nil
 	case model.SourceRC:
 		return c.remoteConfig, nil
 	case model.SourceFleetPolicies:
@@ -494,6 +499,7 @@ func (c *ntmConfig) mergeAllLayers() error {
 		c.fleetPolicies,
 		c.runtime,
 		c.localConfigProcess,
+		c.secrets,
 		c.remoteConfig,
 		c.cli,
 	}
@@ -947,6 +953,7 @@ func (c *ntmConfig) AllSettingsBySource() map[model.Source]interface{} {
 		model.SourceFleetPolicies:      c.fleetPolicies.dumpSettings(true),
 		model.SourceAgentRuntime:       c.runtime.dumpSettings(true),
 		model.SourceLocalConfigProcess: c.localConfigProcess.dumpSettings(true),
+		model.SourceSecretBackend:      c.secrets.dumpSettings(true),
 		model.SourceRC:                 c.remoteConfig.dumpSettings(true),
 		model.SourceCLI:                c.cli.dumpSettings(true),
 		model.SourceProvided:           c.root.dumpSettings(false),
@@ -1103,6 +1110,7 @@ func NewNodeTreeConfig(name string, envPrefix string, envKeyReplacer *strings.Re
 		envs:               newInnerNode(nil),
 		runtime:            newInnerNode(nil),
 		localConfigProcess: newInnerNode(nil),
+		secrets:            newInnerNode(nil),
 		remoteConfig:       newInnerNode(nil),
 		fleetPolicies:      newInnerNode(nil),
 		cli:                newInnerNode(nil),

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -34,9 +34,10 @@ var sources = []model.Source{
 	model.SourceFile,
 	model.SourceEnvVar,
 	model.SourceFleetPolicies,
-	model.SourceAgentRuntime,
+	model.SourceConfigPostInit,
+	model.SourceSecret,
 	model.SourceLocalConfigProcess,
-	model.SourceSecretBackend,
+	model.SourceAgentRuntime,
 	model.SourceRC,
 	model.SourceCLI,
 }
@@ -78,13 +79,15 @@ type ntmConfig struct {
 	file *nodeImpl
 	// envs contains config settings created by environment variables
 	envs *nodeImpl
-	// runtime contains the settings set from the agent code itself at runtime (self configured values).
-	runtime *nodeImpl
+	// configPostInit contains values computed during initial config setup.
+	configPostInit *nodeImpl
+	// secrets contains values resolved from secrets (ENC[...] placeholders).
+	secrets *nodeImpl
 	// localConfigProcess contains the settings pulled from the config process (process owning the source of truth
 	// for the coniguration and mirrored by other processes).
 	localConfigProcess *nodeImpl
-	// secrets contains values resolved from a secrets backend (ENC[...] placeholders).
-	secrets *nodeImpl
+	// runtime contains the settings set from the agent code itself at runtime (self configured values).
+	runtime *nodeImpl
 	// remoteConfig contains the settings pulled from Remote Config.
 	remoteConfig *nodeImpl
 	// fleetPolicies contains the settings pulled from fleetPolicies.
@@ -161,12 +164,14 @@ func (c *ntmConfig) getTreeBySource(source model.Source) (*nodeImpl, error) {
 		return c.file, nil
 	case model.SourceEnvVar:
 		return c.envs, nil
-	case model.SourceAgentRuntime:
-		return c.runtime, nil
+	case model.SourceConfigPostInit:
+		return c.configPostInit, nil
+	case model.SourceSecret:
+		return c.secrets, nil
 	case model.SourceLocalConfigProcess:
 		return c.localConfigProcess, nil
-	case model.SourceSecretBackend:
-		return c.secrets, nil
+	case model.SourceAgentRuntime:
+		return c.runtime, nil
 	case model.SourceRC:
 		return c.remoteConfig, nil
 	case model.SourceFleetPolicies:
@@ -498,9 +503,10 @@ func (c *ntmConfig) layerList() []*nodeImpl {
 		c.file,
 		c.envs,
 		c.fleetPolicies,
-		c.runtime,
-		c.localConfigProcess,
+		c.configPostInit,
 		c.secrets,
+		c.localConfigProcess,
+		c.runtime,
 		c.remoteConfig,
 		c.cli,
 	}
@@ -1003,8 +1009,9 @@ func (c *ntmConfig) AllSettingsBySource() map[model.Source]interface{} {
 		model.SourceFile:               c.file.dumpSettings(true),
 		model.SourceEnvVar:             c.envs.dumpSettings(true),
 		model.SourceFleetPolicies:      c.fleetPolicies.dumpSettings(true),
-		model.SourceAgentRuntime:       c.runtime.dumpSettings(true),
+		model.SourceConfigPostInit:     c.configPostInit.dumpSettings(true),
 		model.SourceLocalConfigProcess: c.localConfigProcess.dumpSettings(true),
+		model.SourceAgentRuntime:       c.runtime.dumpSettings(true),
 		model.SourceRC:                 c.remoteConfig.dumpSettings(true),
 		model.SourceCLI:                c.cli.dumpSettings(true),
 		model.SourceProvided:           providedWithoutSecrets.dumpSettings(false),
@@ -1159,9 +1166,10 @@ func NewNodeTreeConfig(name string, envPrefix string, envKeyReplacer *strings.Re
 		unknown:            newInnerNode(nil),
 		infraMode:          newInnerNode(nil),
 		envs:               newInnerNode(nil),
-		runtime:            newInnerNode(nil),
-		localConfigProcess: newInnerNode(nil),
+		configPostInit:     newInnerNode(nil),
 		secrets:            newInnerNode(nil),
+		localConfigProcess: newInnerNode(nil),
+		runtime:            newInnerNode(nil),
 		remoteConfig:       newInnerNode(nil),
 		fleetPolicies:      newInnerNode(nil),
 		cli:                newInnerNode(nil),

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -354,16 +354,17 @@ func TestAllSettingsBySource(t *testing.T) {
 		model.SourceFile: map[string]interface{}{
 			"a": 987,
 		},
-		model.SourceEnvVar:        map[string]interface{}{},
-		model.SourceFleetPolicies: map[string]interface{}{},
+		model.SourceEnvVar:             map[string]interface{}{},
+		model.SourceFleetPolicies:      map[string]interface{}{},
+		model.SourceConfigPostInit:     map[string]interface{}{},
+		model.SourceLocalConfigProcess: map[string]interface{}{},
 		model.SourceAgentRuntime: map[string]interface{}{
 			"b": map[string]interface{}{
 				"c": 123,
 			},
 		},
-		model.SourceLocalConfigProcess: map[string]interface{}{},
-		model.SourceRC:                 map[string]interface{}{},
-		model.SourceCLI:                map[string]interface{}{},
+		model.SourceRC:  map[string]interface{}{},
+		model.SourceCLI: map[string]interface{}{},
 		model.SourceProvided: map[string]interface{}{
 			"a": 987,
 			"b": map[string]interface{}{
@@ -381,7 +382,7 @@ func TestAllSettingsWithoutSecrets(t *testing.T) {
 	cfg.BuildSchema()
 
 	cfg.Set("a", "file_value", model.SourceFile)
-	cfg.Set("a", "secret_value", model.SourceSecretBackend)
+	cfg.Set("a", "secret_value", model.SourceSecret)
 	cfg.Set("b", 42, model.SourceAgentRuntime)
 
 	// includes secrets
@@ -403,7 +404,7 @@ func TestAllSettingsWithoutDefaultOrSecrets(t *testing.T) {
 	cfg.BuildSchema()
 
 	cfg.Set("a", "file_value", model.SourceFile)
-	cfg.Set("a", "secret_value", model.SourceSecretBackend)
+	cfg.Set("a", "secret_value", model.SourceSecret)
 	cfg.Set("b", 42, model.SourceAgentRuntime)
 
 	result := cfg.AllSettingsWithoutDefaultOrSecrets()

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -362,7 +362,6 @@ func TestAllSettingsBySource(t *testing.T) {
 			},
 		},
 		model.SourceLocalConfigProcess: map[string]interface{}{},
-		model.SourceSecretBackend:      map[string]interface{}{},
 		model.SourceRC:                 map[string]interface{}{},
 		model.SourceCLI:                map[string]interface{}{},
 		model.SourceProvided: map[string]interface{}{
@@ -373,6 +372,47 @@ func TestAllSettingsBySource(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, cfg.AllSettingsBySource())
+}
+
+func TestAllSettingsWithoutSecrets(t *testing.T) {
+	cfg := NewNodeTreeConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 0)
+	cfg.SetDefault("b", 0)
+	cfg.BuildSchema()
+
+	cfg.Set("a", "file_value", model.SourceFile)
+	cfg.Set("a", "secret_value", model.SourceSecretBackend)
+	cfg.Set("b", 42, model.SourceAgentRuntime)
+
+	// includes secrets
+	all := cfg.AllSettings()
+	assert.Equal(t, "secret_value", all["a"])
+	assert.Equal(t, 42, all["b"])
+
+	// excludes secrets layer, "a" falls back to file layer value
+	withoutSecrets := cfg.AllSettingsWithoutSecrets()
+	assert.Equal(t, "file_value", withoutSecrets["a"])
+	assert.Equal(t, 42, withoutSecrets["b"])
+}
+
+func TestAllSettingsWithoutDefaultOrSecrets(t *testing.T) {
+	cfg := NewNodeTreeConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 0)
+	cfg.SetDefault("b", 0)
+	cfg.SetDefault("c", 0)
+	cfg.BuildSchema()
+
+	cfg.Set("a", "file_value", model.SourceFile)
+	cfg.Set("a", "secret_value", model.SourceSecretBackend)
+	cfg.Set("b", 42, model.SourceAgentRuntime)
+
+	result := cfg.AllSettingsWithoutDefaultOrSecrets()
+	// "a" has a fallback file value
+	assert.Equal(t, "file_value", result["a"])
+	assert.Equal(t, 42, result["b"])
+	// "c" is only a default, excluded
+	_, found := result["c"]
+	assert.False(t, found)
 }
 
 func TestIsSet(t *testing.T) {

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -362,6 +362,7 @@ func TestAllSettingsBySource(t *testing.T) {
 			},
 		},
 		model.SourceLocalConfigProcess: map[string]interface{}{},
+		model.SourceSecretBackend:      map[string]interface{}{},
 		model.SourceRC:                 map[string]interface{}{},
 		model.SourceCLI:                map[string]interface{}{},
 		model.SourceProvided: map[string]interface{}{

--- a/pkg/config/nodetreemodel/getter_test.go
+++ b/pkg/config/nodetreemodel/getter_test.go
@@ -314,11 +314,12 @@ func TestGetAllSources(t *testing.T) {
 	cfg.Set("a", 2, model.SourceInfraMode)
 	cfg.Set("a", 3, model.SourceFile)
 	cfg.Set("a", 5, model.SourceFleetPolicies)
-	cfg.Set("a", 6, model.SourceAgentRuntime)
-	cfg.Set("a", 7, model.SourceLocalConfigProcess)
-	cfg.Set("a", 8, model.SourceSecretBackend)
-	cfg.Set("a", 9, model.SourceRC)
-	cfg.Set("a", 10, model.SourceCLI)
+	cfg.Set("a", 6, model.SourceConfigPostInit)
+	cfg.Set("a", 7, model.SourceSecret)
+	cfg.Set("a", 8, model.SourceLocalConfigProcess)
+	cfg.Set("a", 9, model.SourceAgentRuntime)
+	cfg.Set("a", 10, model.SourceRC)
+	cfg.Set("a", 11, model.SourceCLI)
 
 	res := cfg.GetAllSources("a")
 	assert.Equal(t,
@@ -329,11 +330,12 @@ func TestGetAllSources(t *testing.T) {
 			{Source: model.SourceFile, Value: 3},
 			{Source: model.SourceEnvVar, Value: 4},
 			{Source: model.SourceFleetPolicies, Value: 5},
-			{Source: model.SourceAgentRuntime, Value: 6},
-			{Source: model.SourceLocalConfigProcess, Value: 7},
-			{Source: model.SourceSecretBackend, Value: 8},
-			{Source: model.SourceRC, Value: 9},
-			{Source: model.SourceCLI, Value: 10},
+			{Source: model.SourceConfigPostInit, Value: 6},
+			{Source: model.SourceSecret, Value: 7},
+			{Source: model.SourceLocalConfigProcess, Value: 8},
+			{Source: model.SourceAgentRuntime, Value: 9},
+			{Source: model.SourceRC, Value: 10},
+			{Source: model.SourceCLI, Value: 11},
 		},
 		res,
 	)

--- a/pkg/config/nodetreemodel/getter_test.go
+++ b/pkg/config/nodetreemodel/getter_test.go
@@ -316,8 +316,9 @@ func TestGetAllSources(t *testing.T) {
 	cfg.Set("a", 5, model.SourceFleetPolicies)
 	cfg.Set("a", 6, model.SourceAgentRuntime)
 	cfg.Set("a", 7, model.SourceLocalConfigProcess)
-	cfg.Set("a", 8, model.SourceRC)
-	cfg.Set("a", 9, model.SourceCLI)
+	cfg.Set("a", 8, model.SourceSecretBackend)
+	cfg.Set("a", 9, model.SourceRC)
+	cfg.Set("a", 10, model.SourceCLI)
 
 	res := cfg.GetAllSources("a")
 	assert.Equal(t,
@@ -330,8 +331,9 @@ func TestGetAllSources(t *testing.T) {
 			{Source: model.SourceFleetPolicies, Value: 5},
 			{Source: model.SourceAgentRuntime, Value: 6},
 			{Source: model.SourceLocalConfigProcess, Value: 7},
-			{Source: model.SourceRC, Value: 8},
-			{Source: model.SourceCLI, Value: 9},
+			{Source: model.SourceSecretBackend, Value: 8},
+			{Source: model.SourceRC, Value: 9},
+			{Source: model.SourceCLI, Value: 10},
 		},
 		res,
 	)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -436,8 +436,8 @@ func LoadProxyFromEnv(config pkgconfigmodel.ReaderWriter) {
 	// We have to set each value individually so both config.Get("proxy")
 	// and config.Get("proxy.http") work
 	if isSet {
-		config.Set("proxy.http", p.HTTP, pkgconfigmodel.SourceAgentRuntime)
-		config.Set("proxy.https", p.HTTPS, pkgconfigmodel.SourceAgentRuntime)
+		config.Set("proxy.http", p.HTTP, pkgconfigmodel.SourceConfigPostInit)
+		config.Set("proxy.https", p.HTTPS, pkgconfigmodel.SourceConfigPostInit)
 
 		// If this is set to an empty []string, viper will have a type conflict when merging
 		// this config during secrets resolution. It unmarshals empty yaml lists to type
@@ -446,7 +446,7 @@ func LoadProxyFromEnv(config pkgconfigmodel.ReaderWriter) {
 		for idx := range p.NoProxy {
 			noProxy[idx] = p.NoProxy[idx]
 		}
-		config.Set("proxy.no_proxy", noProxy, pkgconfigmodel.SourceAgentRuntime)
+		config.Set("proxy.no_proxy", noProxy, pkgconfigmodel.SourceConfigPostInit)
 	}
 }
 
@@ -1046,7 +1046,7 @@ func resolveSecrets(config pkgconfigmodel.Config, secretResolver secrets.Compone
 func configAssignAtPath(config pkgconfigmodel.Config, settingPath []string, newValue any) error {
 	settingName := strings.Join(settingPath, ".")
 	if config.IsKnown(settingName) {
-		config.Set(settingName, newValue, pkgconfigmodel.SourceSecretBackend)
+		config.Set(settingName, newValue, pkgconfigmodel.SourceSecret)
 		return nil
 	}
 
@@ -1160,7 +1160,7 @@ func configAssignAtPath(config pkgconfigmodel.Config, settingPath []string, newV
 		}
 	}
 
-	config.Set(settingName, startingValue, pkgconfigmodel.SourceSecretBackend)
+	config.Set(settingName, startingValue, pkgconfigmodel.SourceSecret)
 	return nil
 }
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1046,7 +1046,7 @@ func resolveSecrets(config pkgconfigmodel.Config, secretResolver secrets.Compone
 func configAssignAtPath(config pkgconfigmodel.Config, settingPath []string, newValue any) error {
 	settingName := strings.Join(settingPath, ".")
 	if config.IsKnown(settingName) {
-		config.Set(settingName, newValue, pkgconfigmodel.SourceAgentRuntime)
+		config.Set(settingName, newValue, pkgconfigmodel.SourceSecretBackend)
 		return nil
 	}
 
@@ -1160,7 +1160,7 @@ func configAssignAtPath(config pkgconfigmodel.Config, settingPath []string, newV
 		}
 	}
 
-	config.Set(settingName, startingValue, pkgconfigmodel.SourceAgentRuntime)
+	config.Set(settingName, startingValue, pkgconfigmodel.SourceSecretBackend)
 	return nil
 }
 

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1473,5 +1473,5 @@ func TestLoadProxyFromEnv(t *testing.T) {
 
 	LoadProxyFromEnv(cfg)
 	assert.Equal(t, "http://www.example.com/", cfg.Get("proxy.http"))
-	assert.Equal(t, pkgconfigmodel.SourceAgentRuntime, cfg.GetSource("proxy.http"))
+	assert.Equal(t, pkgconfigmodel.SourceConfigPostInit, cfg.GetSource("proxy.http"))
 }

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -502,6 +502,22 @@ func (t *teeConfig) AllSettingsWithoutDefault() map[string]interface{} {
 
 }
 
+// AllSettingsWithoutSecrets returns all settings excluding the secrets layer.
+func (t *teeConfig) AllSettingsWithoutSecrets() map[string]interface{} {
+	base := t.baseline.AllSettingsWithoutSecrets()
+	compare := t.compare.AllSettingsWithoutSecrets()
+	t.compareResult("", "AllSettingsWithoutSecrets", base, compare)
+	return base
+}
+
+// AllSettingsWithoutDefaultOrSecrets returns settings excluding both defaults and the secrets layer.
+func (t *teeConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{} {
+	base := t.baseline.AllSettingsWithoutDefaultOrSecrets()
+	compare := t.compare.AllSettingsWithoutDefaultOrSecrets()
+	t.compareResult("", "AllSettingsWithoutDefaultOrSecrets", base, compare)
+	return base
+}
+
 // AllSettingsBySource returns the settings from each source (file, env vars, ...)
 func (t *teeConfig) AllSettingsBySource() map[model.Source]interface{} {
 	base := t.baseline.AllSettingsBySource()

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -817,6 +817,16 @@ func (c *safeConfig) AllSettingsWithoutDefault() map[string]interface{} {
 	return c.Viper.AllSettingsWithoutDefault()
 }
 
+// AllSettingsWithoutSecrets falls back to AllSettings (viper has no secrets layer).
+func (c *safeConfig) AllSettingsWithoutSecrets() map[string]interface{} {
+	return c.AllSettings()
+}
+
+// AllSettingsWithoutDefaultOrSecrets falls back to AllSettingsWithoutDefault (viper has no secrets layer).
+func (c *safeConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{} {
+	return c.AllSettingsWithoutDefault()
+}
+
 // AllSettingsBySource returns the settings from each source (file, env vars, ...)
 func (c *safeConfig) AllSettingsBySource() map[model.Source]interface{} {
 	c.Lock()

--- a/pkg/config/viperconfig/viper_test.go
+++ b/pkg/config/viperconfig/viper_test.go
@@ -445,12 +445,12 @@ some:
 	assert.Equal(t, "RC_value", config.GetString("some.setting"))
 
 	config.UnsetForSource("some.setting", model.SourceRC)
-	assert.Equal(t, "process_value", config.GetString("some.setting"))
-
-	config.UnsetForSource("some.setting", model.SourceLocalConfigProcess)
 	assert.Equal(t, "runtime_value", config.GetString("some.setting"))
 
 	config.UnsetForSource("some.setting", model.SourceAgentRuntime)
+	assert.Equal(t, "process_value", config.GetString("some.setting"))
+
+	config.UnsetForSource("some.setting", model.SourceLocalConfigProcess)
 	assert.Equal(t, "file_value", config.GetString("some.setting"))
 
 	config.UnsetForSource("some.setting", model.SourceFile)


### PR DESCRIPTION
### What does this PR do?
adds the `SourceSecret` layer and `SourceConfigPostInit` layers and moves the `SourceAgentRuntime` layer to allow for proper layer ordering when interacting with secrets, runtimes, and config sync

### Motivation
add a secret layer and improve the layer ordering

### Describe how you validated your changes
CI, Tests

### Additional Notes
