### PR TITLE
[observer/testbench] Add log-only mode

### DIFF
--- a/cmd/observer-testbench/README.md
+++ b/cmd/observer-testbench/README.md
@@ -63,6 +63,7 @@ $ dda inv q.eval-component-workspace-report evals # This will fetch the results 
 | `--disable` | _(empty)_ | Comma-separated components to disable (overrides defaults) |
 | `--only` | _(empty)_ | Enable ONLY these components (plus extractors); disable everything else. Mutually exclusive with `--enable`/`--disable`. |
 | `--config` | _(empty)_ | Path to a JSON params file controlling enabled state and hyperparameters. Takes full precedence over `--enable`/`--disable`/`--only`. See [Params File](#params-file--config). |
+| `--logs-only` | `false` | Load only log rows from parquet scenarios; skip metric samples and trace stats. Speeds up runs focused on log anomaly detection (interactive and headless). |
 
 ### Headless Mode
 
@@ -117,6 +118,9 @@ dda inv -- q.launch-testbench --enable cusum
 
 # Run on a different port
 dda inv -- q.launch-testbench --http :9090
+
+# Log anomaly focus: skip parquet metrics and trace stats (faster)
+dda inv -- q.launch-testbench --logs-only
 ```
 
 ## Headless Mode
@@ -134,6 +138,15 @@ dda inv -- q.launch-testbench --headless-scenario <scenario-name> --profile  # w
   --headless <scenario-name> \
   --output results.json \
   --scenarios-dir ./comp/observer/scenarios
+
+# Same, but only ingest logs from parquet (ignore metrics and trace stats)
+./bin/observer-testbench \
+  --headless <scenario-name> \
+  --logs-only \
+  --output results-logs.json \
+  --scenarios-dir ./comp/observer/scenarios
+
+dda inv -- q.launch-testbench --headless-scenario <scenario-name> --logs-only
 
 # Verbose output (includes anomaly detail, member series, titles)
 ./bin/observer-testbench \

--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -41,6 +41,9 @@ type CLIParams struct {
 
 	// SendAnomalyEvent mode: run scenario and send one Datadog event per correlation
 	SendAnomalyEvent string // scenario name to run (empty = disabled)
+
+	// LogsOnly skips ingesting parquet metrics and trace stats; only log rows are loaded.
+	LogsOnly bool
 }
 
 func main() {
@@ -55,6 +58,7 @@ func main() {
 	verbose := flag.Bool("verbose", false, "Include full detail in JSON output (headless mode only)")
 	memProfile := flag.String("memprofile", "", "Write heap profile to this file after headless run (headless mode only)")
 	sendAnomalyEvent := flag.String("send-anomaly-event", "", "Run scenario and send one Datadog event per correlation, then exit")
+	logsOnly := flag.Bool("logs-only", false, "Load only log rows from scenarios; skip parquet metrics and trace stats (interactive and headless)")
 	flag.Parse()
 
 	// --config takes full precedence over --enable/--disable/--only.
@@ -108,6 +112,9 @@ func main() {
 		fmt.Printf("Observer Test Bench\n")
 		fmt.Printf("  Scenarios dir: %s\n", *scenariosDir)
 		fmt.Printf("  HTTP address:  %s\n", *httpAddr)
+		if *logsOnly {
+			fmt.Printf("  Logs-only:     true (parquet metrics and trace stats are not loaded)\n")
+		}
 		fmt.Println()
 	}
 
@@ -127,6 +134,7 @@ func main() {
 			Verbose:           *verbose,
 			MemProfile:        *memProfile,
 			SendAnomalyEvent:  *sendAnomalyEvent,
+			LogsOnly:          *logsOnly,
 		}),
 	)
 	if err != nil {
@@ -144,6 +152,7 @@ func run(recorder recorderdef.Component, cfg config.Component, logger log.Compon
 		Cfg:               cfg,
 		Logger:            logger,
 		ComponentSettings: params.ComponentSettings,
+		LogsOnly:          params.LogsOnly,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create test bench: %v\n", err)

--- a/cmd/observer-testbench/ui/src/App.tsx
+++ b/cmd/observer-testbench/ui/src/App.tsx
@@ -10,6 +10,17 @@ import type { PhaseMarker } from './components/ChartWithAnomalyDetails';
 
 type TabID = 'timeseries' | 'correlators' | 'logs' | 'reports' | 'benchmark';
 
+function LogsOnlyChip() {
+  return (
+    <span
+      className="inline-flex items-center shrink-0 rounded-full border border-amber-500/45 bg-amber-950/50 px-2.5 py-0.5 text-xs font-medium text-amber-200/95"
+      title="Started with --logs-only: parquet metrics and trace stats are not loaded; only log rows are ingested."
+    >
+      Logs only
+    </span>
+  );
+}
+
 function ConnectionStatus({ state }: { state: string }) {
   const colors: Record<string, string> = {
     disconnected: 'bg-red-500',
@@ -458,7 +469,10 @@ function App() {
       <header className="bg-slate-800 border-b border-slate-700 px-4 py-3">
         <div className="flex justify-between items-center">
           <div className="flex items-center gap-6">
-            <h1 className="text-lg font-semibold text-white">Observer Test Bench</h1>
+            <div className="flex items-center gap-3 min-w-0">
+              <h1 className="text-lg font-semibold text-white shrink-0">Observer Test Bench</h1>
+              {state.status?.serverConfig?.logsOnly ? <LogsOnlyChip /> : null}
+            </div>
             {/* Tab bar */}
             <div className="flex gap-1">
               <button

--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -7,6 +7,8 @@ export type MetricName = string & { readonly __metricNameBrand: unique symbol };
 
 export interface ServerConfig {
   components: Record<string, boolean>;
+  /** When true, scenarios load log rows only (no parquet metrics / trace stats). */
+  logsOnly?: boolean;
 }
 
 export interface EpisodePhase {

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -92,6 +92,11 @@ type TestBenchConfig struct {
 	// ComponentSettings provides per-component configuration and enabled
 	// state. Components not mentioned use their catalog defaults.
 	ComponentSettings ComponentSettings
+
+	// LogsOnly, when true, loads log rows from parquet but skips metric samples
+	// and trace stats. Use to focus on log anomaly detection without ingesting
+	// scenario metrics (faster; metric detectors see only log-derived series).
+	LogsOnly bool
 }
 
 // TestBench is the main controller for the observer test bench.
@@ -173,6 +178,7 @@ type StatusResponse struct {
 // ServerConfig exposes server-side configuration to the UI.
 type ServerConfig struct {
 	Components map[string]bool `json:"components"`
+	LogsOnly   bool            `json:"logsOnly"`
 }
 
 // NewTestBench creates a new test bench instance.
@@ -469,82 +475,86 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 
 	storage := tb.engine.Storage()
 
-	// Use batch loading - get all metrics at once
-	metrics, err := tb.config.Recorder.ReadAllMetrics(dir)
-	if err != nil {
-		return fmt.Errorf("reading parquet metrics: %w", err)
-	}
-
-	fmt.Printf("  Loading %d samples from parquet files\n", len(metrics))
-
-	byTimestampCounter := make(map[int64]int64)
-	byTimestampCardinality := make(map[int64]int64)
-
-	// Batch add all metrics to storage
-	for _, m := range metrics {
-		metricName := m.Name
-
-		// filter internal Datadog Agent telemetry
-		if strings.HasPrefix(metricName, "datadog.") {
-			continue
+	if tb.config.LogsOnly {
+		fmt.Printf("  Logs-only mode: skipping parquet metrics and trace stats\n")
+	} else {
+		// Use batch loading - get all metrics at once
+		metrics, err := tb.config.Recorder.ReadAllMetrics(dir)
+		if err != nil {
+			return fmt.Errorf("reading parquet metrics: %w", err)
 		}
 
-		byTimestampCounter[m.Timestamp]++
+		fmt.Printf("  Loading %d samples from parquet files\n", len(metrics))
 
-		if storage.Add("parquet", metricName, m.Value, m.Timestamp, m.Tags) {
-			byTimestampCardinality[m.Timestamp]++
+		byTimestampCounter := make(map[int64]int64)
+		byTimestampCardinality := make(map[int64]int64)
+
+		// Batch add all metrics to storage
+		for _, m := range metrics {
+			metricName := m.Name
+
+			// filter internal Datadog Agent telemetry
+			if strings.HasPrefix(metricName, "datadog.") {
+				continue
+			}
+
+			byTimestampCounter[m.Timestamp]++
+
+			if storage.Add("parquet", metricName, m.Value, m.Timestamp, m.Tags) {
+				byTimestampCardinality[m.Timestamp]++
+			}
 		}
-	}
 
-	// Telemetry for the number of metrics by timestamp
-	type byTimestampEntry struct {
-		Timestamp int64
-		Count     int64
-	}
-	byTimestampOrdered := make([]byTimestampEntry, 0, len(byTimestampCounter))
-	for timestamp, count := range byTimestampCounter {
-		byTimestampOrdered = append(byTimestampOrdered, byTimestampEntry{Timestamp: timestamp, Count: count})
-	}
-	sort.Slice(byTimestampOrdered, func(i, j int) bool {
-		return byTimestampOrdered[i].Timestamp < byTimestampOrdered[j].Timestamp
-	})
-	for _, entry := range byTimestampOrdered {
-		tb.handleTelemetry([]observerdef.ObserverTelemetry{newTelemetryCounter([]string{}, telemetryTbInputMetricsCount, float64(entry.Count), entry.Timestamp)}, "parquet", entry.Timestamp)
-	}
-
-	// Telemetry for cardinality (new unique series) by timestamp
-	byCardOrdered := make([]byTimestampEntry, 0, len(byTimestampCardinality))
-	for timestamp, count := range byTimestampCardinality {
-		byCardOrdered = append(byCardOrdered, byTimestampEntry{Timestamp: timestamp, Count: count})
-	}
-	sort.Slice(byCardOrdered, func(i, j int) bool {
-		return byCardOrdered[i].Timestamp < byCardOrdered[j].Timestamp
-	})
-	for _, entry := range byCardOrdered {
-		tb.handleTelemetry([]observerdef.ObserverTelemetry{newTelemetryCounter([]string{}, telemetryTbInputMetricsCardinality, float64(entry.Count), entry.Timestamp)}, "parquet", entry.Timestamp)
-	}
-
-	// Load trace stats and derive trace.* metrics via processStatsView
-	traceStats, err := tb.config.Recorder.ReadAllTraceStats(dir)
-	if err != nil {
-		return fmt.Errorf("reading parquet trace stats: %w", err)
-	}
-
-	if len(traceStats) > 0 {
-		fmt.Printf("  Loading %d trace stat rows from parquet files\n", len(traceStats))
-
-		sh := &storageHandle{namespace: "parquet", storage: storage}
-
-		// Group by (AgentHostname, AgentEnv) so each view carries the correct agent context
-		type agentKey struct{ hostname, env string }
-		groups := make(map[agentKey][]recorderdef.TraceStatsData)
-		for _, s := range traceStats {
-			key := agentKey{s.AgentHostname, s.AgentEnv}
-			groups[key] = append(groups[key], s)
+		// Telemetry for the number of metrics by timestamp
+		type byTimestampEntry struct {
+			Timestamp int64
+			Count     int64
 		}
-		for key, rows := range groups {
-			view := &parquetTraceStatsView{agentHostname: key.hostname, agentEnv: key.env, rows: rows}
-			processStatsView(sh, view)
+		byTimestampOrdered := make([]byTimestampEntry, 0, len(byTimestampCounter))
+		for timestamp, count := range byTimestampCounter {
+			byTimestampOrdered = append(byTimestampOrdered, byTimestampEntry{Timestamp: timestamp, Count: count})
+		}
+		sort.Slice(byTimestampOrdered, func(i, j int) bool {
+			return byTimestampOrdered[i].Timestamp < byTimestampOrdered[j].Timestamp
+		})
+		for _, entry := range byTimestampOrdered {
+			tb.handleTelemetry([]observerdef.ObserverTelemetry{newTelemetryCounter([]string{}, telemetryTbInputMetricsCount, float64(entry.Count), entry.Timestamp)}, "parquet", entry.Timestamp)
+		}
+
+		// Telemetry for cardinality (new unique series) by timestamp
+		byCardOrdered := make([]byTimestampEntry, 0, len(byTimestampCardinality))
+		for timestamp, count := range byTimestampCardinality {
+			byCardOrdered = append(byCardOrdered, byTimestampEntry{Timestamp: timestamp, Count: count})
+		}
+		sort.Slice(byCardOrdered, func(i, j int) bool {
+			return byCardOrdered[i].Timestamp < byCardOrdered[j].Timestamp
+		})
+		for _, entry := range byCardOrdered {
+			tb.handleTelemetry([]observerdef.ObserverTelemetry{newTelemetryCounter([]string{}, telemetryTbInputMetricsCardinality, float64(entry.Count), entry.Timestamp)}, "parquet", entry.Timestamp)
+		}
+
+		// Load trace stats and derive trace.* metrics via processStatsView
+		traceStats, err := tb.config.Recorder.ReadAllTraceStats(dir)
+		if err != nil {
+			return fmt.Errorf("reading parquet trace stats: %w", err)
+		}
+
+		if len(traceStats) > 0 {
+			fmt.Printf("  Loading %d trace stat rows from parquet files\n", len(traceStats))
+
+			sh := &storageHandle{namespace: "parquet", storage: storage}
+
+			// Group by (AgentHostname, AgentEnv) so each view carries the correct agent context
+			type agentKey struct{ hostname, env string }
+			groups := make(map[agentKey][]recorderdef.TraceStatsData)
+			for _, s := range traceStats {
+				key := agentKey{s.AgentHostname, s.AgentEnv}
+				groups[key] = append(groups[key], s)
+			}
+			for key, rows := range groups {
+				view := &parquetTraceStatsView{agentHostname: key.hostname, agentEnv: key.env, rows: rows}
+				processStatsView(sh, view)
+			}
 		}
 	}
 
@@ -693,6 +703,7 @@ func (tb *TestBench) GetStatus() StatusResponse {
 		EpisodeInfo:           tb.episodeInfo,
 		ServerConfig: ServerConfig{
 			Components: compMap,
+			LogsOnly:   tb.config.LogsOnly,
 		},
 	}
 }
@@ -1434,53 +1445,56 @@ func (tb *TestBench) loadDemoScenario() error {
 	baseTimestamp := int64(1000000)
 	const totalSeconds = 70
 
-	for t := 0; t < totalSeconds; t++ {
-		elapsed := float64(t)
-		timestamp := baseTimestamp + int64(t)
+	if !tb.config.LogsOnly {
+		for t := 0; t < totalSeconds; t++ {
+			elapsed := float64(t)
+			timestamp := baseTimestamp + int64(t)
 
-		// Heap usage (host:web-1)
-		heapValue := getDemoHeapValue(elapsed)
-		storage.Add("demo", "runtime.heap.used_mb", heapValue, timestamp, []string{"host:web-1"})
+			// Heap usage (host:web-1)
+			heapValue := getDemoHeapValue(elapsed)
+			storage.Add("demo", "runtime.heap.used_mb", heapValue, timestamp, []string{"host:web-1"})
 
-		// GC pause time (host:web-1)
-		gcValue := getDemoGCPauseValue(elapsed)
-		storage.Add("demo", "runtime.gc.pause_ms", gcValue, timestamp, []string{"host:web-1"})
+			// GC pause time (host:web-1)
+			gcValue := getDemoGCPauseValue(elapsed)
+			storage.Add("demo", "runtime.gc.pause_ms", gcValue, timestamp, []string{"host:web-1"})
 
-		// CPU usage (host:web-1)
-		cpuValue := getDemoCPUValue(elapsed)
-		storage.Add("demo", "system.cpu.user_percent", cpuValue, timestamp, []string{"host:web-1"})
+			// CPU usage (host:web-1)
+			cpuValue := getDemoCPUValue(elapsed)
+			storage.Add("demo", "system.cpu.user_percent", cpuValue, timestamp, []string{"host:web-1"})
 
-		// Request latency — two service variants
-		latencyValue := getDemoLatencyValue(elapsed)
-		storage.Add("demo", "app.request.latency_p99_ms", latencyValue*1.2, timestamp, []string{"service:api"})
-		storage.Add("demo", "app.request.latency_p99_ms", latencyValue*0.8, timestamp, []string{"service:worker"})
+			// Request latency — two service variants
+			latencyValue := getDemoLatencyValue(elapsed)
+			storage.Add("demo", "app.request.latency_p99_ms", latencyValue*1.2, timestamp, []string{"service:api"})
+			storage.Add("demo", "app.request.latency_p99_ms", latencyValue*0.8, timestamp, []string{"service:worker"})
 
-		// Error rate — two service variants
-		errorValue := getDemoErrorRateValue(elapsed)
-		storage.Add("demo", "app.request.error_rate", errorValue*1.5, timestamp, []string{"service:api"})
-		storage.Add("demo", "app.request.error_rate", errorValue*0.7, timestamp, []string{"service:worker"})
+			// Error rate — two service variants
+			errorValue := getDemoErrorRateValue(elapsed)
+			storage.Add("demo", "app.request.error_rate", errorValue*1.5, timestamp, []string{"service:api"})
+			storage.Add("demo", "app.request.error_rate", errorValue*0.7, timestamp, []string{"service:worker"})
 
-		// Throughput — two service variants
-		throughputValue := getDemoThroughputValue(elapsed)
-		storage.Add("demo", "app.request.throughput_rps", throughputValue*1.4, timestamp, []string{"service:api"})
-		storage.Add("demo", "app.request.throughput_rps", throughputValue*0.6, timestamp, []string{"service:worker"})
+			// Throughput — two service variants
+			throughputValue := getDemoThroughputValue(elapsed)
+			storage.Add("demo", "app.request.throughput_rps", throughputValue*1.4, timestamp, []string{"service:api"})
+			storage.Add("demo", "app.request.throughput_rps", throughputValue*0.6, timestamp, []string{"service:worker"})
 
-		// Correlator-targeted metrics (trigger kernel_bottleneck / network_degradation patterns)
-		// network.retransmits → analyzed as "network.retransmits:avg" — host-level
-		retransmits := getDemoNetworkRetransmitsValue(elapsed)
-		storage.Add("demo", "network.retransmits", retransmits, timestamp, []string{"host:web-1"})
+			// Correlator-targeted metrics (trigger kernel_bottleneck / network_degradation patterns)
+			// network.retransmits → analyzed as "network.retransmits:avg" — host-level
+			retransmits := getDemoNetworkRetransmitsValue(elapsed)
+			storage.Add("demo", "network.retransmits", retransmits, timestamp, []string{"host:web-1"})
 
-		// ebpf.lock_contention_ns → analyzed as "ebpf.lock_contention_ns:avg" — host-level
-		lockContention := getDemoLockContentionValue(elapsed)
-		storage.Add("demo", "ebpf.lock_contention_ns", lockContention, timestamp, []string{"host:web-1"})
+			// ebpf.lock_contention_ns → analyzed as "ebpf.lock_contention_ns:avg" — host-level
+			lockContention := getDemoLockContentionValue(elapsed)
+			storage.Add("demo", "ebpf.lock_contention_ns", lockContention, timestamp, []string{"host:web-1"})
 
-		// connection.errors → analyzed as "connection.errors:count" — two service variants
-		connErrors := getDemoConnectionErrorsValue(elapsed)
-		storage.Add("demo", "connection.errors", connErrors, timestamp, []string{"service:api"})
-		storage.Add("demo", "connection.errors", connErrors*0.6, timestamp, []string{"service:worker"})
+			// connection.errors → analyzed as "connection.errors:count" — two service variants
+			connErrors := getDemoConnectionErrorsValue(elapsed)
+			storage.Add("demo", "connection.errors", connErrors, timestamp, []string{"service:api"})
+			storage.Add("demo", "connection.errors", connErrors*0.6, timestamp, []string{"service:worker"})
+		}
+		fmt.Printf("  Generated %d seconds of demo data\n", totalSeconds)
+	} else {
+		fmt.Printf("  Logs-only mode: skipping demo metric samples\n")
 	}
-
-	fmt.Printf("  Generated %d seconds of demo data\n", totalSeconds)
 
 	// Generate demo log entries following phase-based intervals
 	logMsgIdx := 0

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -1594,6 +1594,7 @@ def launch_testbench(
     enable: str = "",
     disable: str = "",
     timeout: int = 0,
+    logs_only: bool = False,
 ):
     """
     Will launch both the observer-testbench backend and UI.
@@ -1607,6 +1608,7 @@ def launch_testbench(
         disable: Comma-separated components to disable (passed to testbench ``--disable``).
         timeout: Seconds before the headless testbench process is killed (0 = no limit;
             ignored in interactive mode).
+        logs_only: If true, pass ``--logs-only`` (load log rows only; skip parquet metrics and trace stats).
     """
     if build:
         print("Building observer-testbench...")
@@ -1615,6 +1617,8 @@ def launch_testbench(
     flags = ""
     if verbose:
         flags += " --verbose"
+    if logs_only:
+        flags += " --logs-only"
     if config:
         flags += f" --config {shlex.quote(config)}"
     else:


### PR DESCRIPTION
### What does this PR do?

To save time while testing log algorithms, this adds a log-only mode to the observer testbench.

Adds:
- Log-only mode support: parquet metrics and trace stats are not loaded; only log rows are ingested
- UI chip displaying "Logs only" status in the header when the mode is active

### Motivation

### Describe how you validated your changes

### Additional Notes