### PR TITLE
[AGTHEAL-127] feat(healthplatform): report agent high resource usage as health platform issue

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -694,7 +694,7 @@ func startAgent(
 	jmxfetch.RegisterWith(ac)
 
 	// Set up check collector
-	commonchecks.RegisterChecks(wmeta, filterStore, tagger, cfg, telemetry, rcclient, flare, snmpScanManager, traceroute)
+	commonchecks.RegisterChecks(wmeta, filterStore, tagger, cfg, telemetry, rcclient, flare, snmpScanManager, traceroute, healthplatformComp)
 	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(option.New(collectorComponent), demultiplexer, logReceiver, tagger, filterStore), true)
 
 	demultiplexer.AddAgentStartupTelemetry(version.AgentVersion)

--- a/comp/healthplatform/impl/health-platform.go
+++ b/comp/healthplatform/impl/health-platform.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	// Import issue modules to trigger their init() registration
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/agentresource"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/dockerpermissions"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/rofspermissions"

--- a/comp/healthplatform/impl/issues/agentresource/issue.go
+++ b/comp/healthplatform/impl/issues/agentresource/issue.go
@@ -34,7 +34,7 @@ func (t *AgentResourceIssue) BuildIssue(context map[string]string) (*healthplatf
 		Description: buildDescription(cpuPercent, cpuThreshold, memoryMB, memoryThresholdMB),
 		Category:    "resource",
 		Location:    "core-agent",
-		Severity:    "medium",
+		Severity:    "high",
 		Source:      "agent",
 		Remediation: buildRemediation(),
 		Tags:        []string{"cpu", "memory", "resource", "performance"},

--- a/comp/healthplatform/impl/issues/agentresource/issue.go
+++ b/comp/healthplatform/impl/issues/agentresource/issue.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package agentresource
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+)
+
+// AgentResourceIssue provides the issue template for agent high resource usage
+type AgentResourceIssue struct{}
+
+// NewAgentResourceIssue creates a new agent resource issue template
+func NewAgentResourceIssue() *AgentResourceIssue {
+	return &AgentResourceIssue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation from context.
+// Expected context keys: cpu_percent, cpu_threshold, memory_mb, memory_threshold_mb.
+func (t *AgentResourceIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	cpuPercent := context["cpu_percent"]
+	cpuThreshold := context["cpu_threshold"]
+	memoryMB := context["memory_mb"]
+	memoryThresholdMB := context["memory_threshold_mb"]
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   "agent_high_resource_usage",
+		Title:       "Agent Process High Resource Usage",
+		Description: buildDescription(cpuPercent, cpuThreshold, memoryMB, memoryThresholdMB),
+		Category:    "resource",
+		Location:    "core-agent",
+		Severity:    "medium",
+		Source:      "agent",
+		Remediation: buildRemediation(),
+		Tags:        []string{"cpu", "memory", "resource", "performance"},
+	}, nil
+}
+
+func buildDescription(cpuPercent, cpuThreshold, memoryMB, memoryThresholdMB string) string {
+	hasCPU := cpuPercent != "" && cpuThreshold != "0"
+	hasMem := memoryMB != "" && memoryThresholdMB != "0"
+
+	switch {
+	case hasCPU && hasMem:
+		return fmt.Sprintf(
+			"The Datadog Agent process is consuming high CPU (%s%%, threshold: %s%%) "+
+				"and memory (%s MB, threshold: %s MB). "+
+				"This may indicate a resource leak, a misconfigured integration, or an unexpected spike in monitored activity.",
+			cpuPercent, cpuThreshold, memoryMB, memoryThresholdMB,
+		)
+	case hasCPU:
+		return fmt.Sprintf(
+			"The Datadog Agent process is consuming high CPU (%s%%, threshold: %s%%). "+
+				"This may indicate a busy integration, an eBPF probe processing too many events, or a resource leak.",
+			cpuPercent, cpuThreshold,
+		)
+	default:
+		return fmt.Sprintf(
+			"The Datadog Agent process is consuming high memory (%s MB, threshold: %s MB). "+
+				"This may indicate a memory leak in an integration or the agent core.",
+			memoryMB, memoryThresholdMB,
+		)
+	}
+}
+
+func buildRemediation() *healthplatform.Remediation {
+	return &healthplatform.Remediation{
+		Summary: "Investigate which agent component is consuming excessive resources and consider restarting the agent",
+		Steps: []*healthplatform.RemediationStep{
+			{Order: 1, Text: "Check which integrations are running: datadog-agent check --list"},
+			{Order: 2, Text: "Review agent status and check run times: datadog-agent status"},
+			{Order: 3, Text: "Generate a diagnostic flare to capture profiles: datadog-agent flare"},
+			{Order: 4, Text: "If the issue persists, restart the agent: systemctl restart datadog-agent (Linux) or Restart-Service datadogagent (Windows)"},
+		},
+	}
+}

--- a/comp/healthplatform/impl/issues/agentresource/module.go
+++ b/comp/healthplatform/impl/issues/agentresource/module.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package agentresource provides a health platform issue module for agent high resource usage.
+// The issue is detected externally by the agentprofiling core check and reported via ReportIssue.
+package agentresource
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for agent high resource usage issues
+	IssueID = "agent-high-resource-usage"
+)
+
+// agentResourceModule implements issues.Module
+type agentResourceModule struct {
+	template *AgentResourceIssue
+}
+
+// NewModule creates a new agent resource issue module
+func NewModule(_ config.Component) issues.Module {
+	return &agentResourceModule{
+		template: NewAgentResourceIssue(),
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *agentResourceModule) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *agentResourceModule) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInCheck returns nil — this issue is reported externally by the agentprofiling core check
+func (m *agentResourceModule) BuiltInCheck() *issues.BuiltInCheck {
+	return nil
+}

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -311,7 +311,7 @@ func run(
 	// TODO Ideally we would support RC in the check subcommand,
 	//  but at the moment this is not possible - only one process can access the RC database at a time,
 	//  so the subcommand can't read the RC database if the agent is also running.
-	commonchecks.RegisterChecks(wmeta, filterStore, tagger, config, telemetry, nil, nil, nil, traceroute)
+	commonchecks.RegisterChecks(wmeta, filterStore, tagger, config, telemetry, nil, nil, nil, traceroute, nil)
 
 	common.LoadComponents(secretResolver, wmeta, tagger, filterStore, ac, pkgconfigsetup.Datadog().GetString("confd_path"))
 	ac.LoadAndRun(context.Background())

--- a/pkg/collector/corechecks/agentprofiling/agentprofiling.go
+++ b/pkg/collector/corechecks/agentprofiling/agentprofiling.go
@@ -19,6 +19,8 @@ import (
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/process"
 
+	healthplatformpayload "github.com/DataDog/agent-payload/v5/healthplatform"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -26,6 +28,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	"github.com/DataDog/datadog-agent/comp/core/flare/types"
+	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/def"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/agentresource"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -39,6 +43,9 @@ const (
 	CheckName               = "agentprofiling"
 	MB                      = 1024 * 1024
 	defaultMaxFlareAttempts = 3 // Default maximum number of flare attempts
+
+	// healthCheckID is the check ID used when reporting issues to the health platform
+	healthCheckID = "agent-resource-usage"
 )
 
 // Config is the configuration for the agentprofiling check
@@ -61,20 +68,21 @@ type Check struct {
 	nextBackoffDuration time.Duration // Cached backoff duration for current retry attempt
 	flareComponent      flare.Component
 	agentConfig         config.Component
+	healthPlatform      healthplatformdef.Component
 	lastCPUTimes        *cpu.TimesStat
 	lastCheckTime       time.Time
 	memoryThreshold     uint // Parsed memory threshold in bytes
 }
 
 // Factory creates a new instance of the agentprofiling check
-func Factory(flareComponent flare.Component, agentConfig config.Component) option.Option[func() check.Check] {
+func Factory(flareComponent flare.Component, agentConfig config.Component, healthPlatform healthplatformdef.Component) option.Option[func() check.Check] {
 	return option.New(func() check.Check {
-		return newCheck(flareComponent, agentConfig)
+		return newCheck(flareComponent, agentConfig, healthPlatform)
 	})
 }
 
 // newCheck creates a new instance of the agentprofiling check
-func newCheck(flareComponent flare.Component, agentConfig config.Component) check.Check {
+func newCheck(flareComponent flare.Component, agentConfig config.Component, healthPlatform healthplatformdef.Component) check.Check {
 	// Configure exponential backoff for flare generation retries.
 	// Flare generation is expensive, so we use a conservative backoff:
 	// - Start at 1 minute for quick retry of transient issues
@@ -96,6 +104,7 @@ func newCheck(flareComponent flare.Component, agentConfig config.Component) chec
 		backoffPolicy:  expBackoff,
 		flareComponent: flareComponent,
 		agentConfig:    agentConfig,
+		healthPlatform: healthPlatform,
 	}
 }
 
@@ -205,13 +214,9 @@ func (m *Check) getBackoffDuration(attemptNumber int) time.Duration {
 	return backoffDuration
 }
 
-// Run executes the agent profiling check, generating a flare with profiles if thresholds are exceeded
+// Run executes the agent profiling check, reporting a health platform issue and generating a flare
+// with profiles if thresholds are exceeded
 func (m *Check) Run() error {
-	// Don't run again if we've exhausted all retry attempts
-	if m.flareAttempted {
-		return nil
-	}
-
 	// Exit early if both thresholds are disabled
 	if m.memoryThreshold == 0 && m.instance.CPUThreshold <= 0 {
 		m.Warn("Memory and CPU profile thresholds are disabled, skipping check.")
@@ -257,9 +262,18 @@ func (m *Check) Run() error {
 		currentCPU = m.calculateCPUPercentage(cpuTimes)
 	}
 
+	// Always update the health platform issue regardless of flare state,
+	// so it resolves automatically when usage drops back below thresholds.
+	m.updateHealthPlatform(processMemoryMB, currentCPU)
+
 	// Exit early if usage is below thresholds
 	if processMemoryMB < float64(m.memoryThreshold)/MB && currentCPU < float64(m.instance.CPUThreshold) {
 		log.Debugf("Memory and CPU usage are below thresholds (Memory: %.2f MB < %.2f MB, CPU: %.2f%% < %d%%), skipping Agent profiling check.", processMemoryMB, float64(m.memoryThreshold)/MB, currentCPU, m.instance.CPUThreshold)
+		return nil
+	}
+
+	// Don't run flare again if we've exhausted all retry attempts
+	if m.flareAttempted {
 		return nil
 	}
 
@@ -306,6 +320,35 @@ func (m *Check) Run() error {
 	m.backoffPolicy.Reset()
 	m.nextBackoffDuration = 0
 	return nil
+}
+
+// updateHealthPlatform reports or clears a health platform issue based on current resource usage.
+// It is always called regardless of flare state so the issue resolves when usage drops.
+func (m *Check) updateHealthPlatform(processMemoryMB, currentCPU float64) {
+	if m.healthPlatform == nil {
+		return
+	}
+
+	memExceeded := m.memoryThreshold > 0 && processMemoryMB >= float64(m.memoryThreshold)/MB
+	cpuExceeded := m.instance.CPUThreshold > 0 && currentCPU >= float64(m.instance.CPUThreshold)
+
+	if memExceeded || cpuExceeded {
+		_ = m.healthPlatform.ReportIssue(
+			healthCheckID,
+			CheckName,
+			&healthplatformpayload.IssueReport{
+				IssueId: agentresource.IssueID,
+				Context: map[string]string{
+					"cpu_percent":         fmt.Sprintf("%.1f", currentCPU),
+					"cpu_threshold":       fmt.Sprintf("%d", m.instance.CPUThreshold),
+					"memory_mb":           fmt.Sprintf("%.1f", processMemoryMB),
+					"memory_threshold_mb": fmt.Sprintf("%.1f", float64(m.memoryThreshold)/MB),
+				},
+			},
+		)
+	} else {
+		m.healthPlatform.ClearIssuesForCheck(healthCheckID)
+	}
 }
 
 // terminateAgent requests graceful shutdown of the agent process after flare generation completes.

--- a/pkg/collector/corechecks/agentprofiling/agentprofiling.go
+++ b/pkg/collector/corechecks/agentprofiling/agentprofiling.go
@@ -264,10 +264,9 @@ func (m *Check) Run() error {
 
 	// Always update the health platform issue regardless of flare state,
 	// so it resolves automatically when usage drops back below thresholds.
-	m.updateHealthPlatform(processMemoryMB, currentCPU)
-
-	// Exit early if usage is below thresholds
-	if processMemoryMB < float64(m.memoryThreshold)/MB && currentCPU < float64(m.instance.CPUThreshold) {
+	// updateHealthPlatform returns true when at least one threshold is exceeded,
+	// which also drives the early-exit below — avoiding a second comparison.
+	if !m.updateHealthPlatform(processMemoryMB, currentCPU) {
 		log.Debugf("Memory and CPU usage are below thresholds (Memory: %.2f MB < %.2f MB, CPU: %.2f%% < %d%%), skipping Agent profiling check.", processMemoryMB, float64(m.memoryThreshold)/MB, currentCPU, m.instance.CPUThreshold)
 		return nil
 	}
@@ -324,31 +323,39 @@ func (m *Check) Run() error {
 
 // updateHealthPlatform reports or clears a health platform issue based on current resource usage.
 // It is always called regardless of flare state so the issue resolves when usage drops.
-func (m *Check) updateHealthPlatform(processMemoryMB, currentCPU float64) {
-	if m.healthPlatform == nil {
-		return
-	}
+// Returns true when the check should proceed to flare generation (same semantics as the original
+// threshold condition), centralising the comparison in one place.
+func (m *Check) updateHealthPlatform(processMemoryMB, currentCPU float64) bool {
+	// exceeded mirrors the original threshold condition: the check proceeds when the
+	// AND-below-thresholds guard is false, i.e. at least one value is >= its threshold.
+	exceeded := !(processMemoryMB < float64(m.memoryThreshold)/MB && currentCPU < float64(m.instance.CPUThreshold))
 
-	memExceeded := m.memoryThreshold > 0 && processMemoryMB >= float64(m.memoryThreshold)/MB
-	cpuExceeded := m.instance.CPUThreshold > 0 && currentCPU >= float64(m.instance.CPUThreshold)
+	if m.healthPlatform != nil {
+		// For the health platform we only report when a threshold that is actually
+		// configured is breached, avoiding spurious issues when one threshold is unset.
+		memExceeded := m.memoryThreshold > 0 && processMemoryMB >= float64(m.memoryThreshold)/MB
+		cpuExceeded := m.instance.CPUThreshold > 0 && currentCPU >= float64(m.instance.CPUThreshold)
 
-	if memExceeded || cpuExceeded {
-		_ = m.healthPlatform.ReportIssue(
-			healthCheckID,
-			CheckName,
-			&healthplatformpayload.IssueReport{
-				IssueId: agentresource.IssueID,
-				Context: map[string]string{
-					"cpu_percent":         fmt.Sprintf("%.1f", currentCPU),
-					"cpu_threshold":       fmt.Sprintf("%d", m.instance.CPUThreshold),
-					"memory_mb":           fmt.Sprintf("%.1f", processMemoryMB),
-					"memory_threshold_mb": fmt.Sprintf("%.1f", float64(m.memoryThreshold)/MB),
+		if memExceeded || cpuExceeded {
+			_ = m.healthPlatform.ReportIssue(
+				healthCheckID,
+				CheckName,
+				&healthplatformpayload.IssueReport{
+					IssueId: agentresource.IssueID,
+					Context: map[string]string{
+						"cpu_percent":         fmt.Sprintf("%.1f", currentCPU),
+						"cpu_threshold":       fmt.Sprintf("%d", m.instance.CPUThreshold),
+						"memory_mb":           fmt.Sprintf("%.1f", processMemoryMB),
+						"memory_threshold_mb": fmt.Sprintf("%.1f", float64(m.memoryThreshold)/MB),
+					},
 				},
-			},
-		)
-	} else {
-		m.healthPlatform.ClearIssuesForCheck(healthCheckID)
+			)
+		} else {
+			m.healthPlatform.ClearIssuesForCheck(healthCheckID)
+		}
 	}
+
+	return exceeded
 }
 
 // terminateAgent requests graceful shutdown of the agent process after flare generation completes.

--- a/pkg/collector/corechecks/agentprofiling/agentprofiling_test.go
+++ b/pkg/collector/corechecks/agentprofiling/agentprofiling_test.go
@@ -29,7 +29,7 @@ import (
 func createTestCheck(t *testing.T, memoryThreshold string, cpuThreshold int, ticketID, userEmail string, terminateAgent bool) *Check {
 	flareComp := flaremock.NewMock().Comp
 	config := configmock.NewMock(t)
-	check := newCheck(flareComp, config).(*Check)
+	check := newCheck(flareComp, config, nil).(*Check)
 
 	configData := []byte(fmt.Sprintf(`memory_threshold: "%s"
 cpu_threshold: %d

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
@@ -74,7 +75,7 @@ import (
 // RegisterChecks registers all core checks
 func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Component, tagger tagger.Component, cfg config.Component,
 	telemetry telemetry.Component, rcClient rcclient.Component, flare flare.Component, snmpScanManager snmpscanmanager.Component,
-	traceroute traceroute.Component,
+	traceroute traceroute.Component, healthPlatform healthplatformdef.Component,
 ) {
 	// Required checks
 	corecheckLoader.RegisterCheck(cpu.CheckName, cpu.Factory())
@@ -91,7 +92,7 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	corecheckLoader.RegisterCheck(containerimage.CheckName, containerimage.Factory(store, tagger))
 	corecheckLoader.RegisterCheck(containerlifecycle.CheckName, containerlifecycle.Factory(store))
 	corecheckLoader.RegisterCheck(generic.CheckName, generic.Factory(store, filterStore, tagger))
-	corecheckLoader.RegisterCheck(agentprofiling.CheckName, agentprofiling.Factory(flare, cfg))
+	corecheckLoader.RegisterCheck(agentprofiling.CheckName, agentprofiling.Factory(flare, cfg, healthPlatform))
 
 	// Flavor specific checks
 	corecheckLoader.RegisterCheck(load.CheckName, load.Factory())

--- a/pkg/commonchecks/corechecks_cluster.go
+++ b/pkg/commonchecks/corechecks_cluster.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
@@ -28,7 +29,7 @@ import (
 
 // RegisterChecks registers the checks that can run in the Cluster Agent
 func RegisterChecks(store workloadmeta.Component, _ workloadfilter.Component, tagger tagger.Component, cfg config.Component,
-	_ telemetry.Component, _ rcclient.Component, _ flare.Component, _ snmpscanmanager.Component, _ traceroute.Component) {
+	_ telemetry.Component, _ rcclient.Component, _ flare.Component, _ snmpscanmanager.Component, _ traceroute.Component, _ healthplatformdef.Component) {
 	corecheckLoader.RegisterCheck(kubernetesapiserver.CheckName, kubernetesapiserver.Factory(tagger))
 	corecheckLoader.RegisterCheck(ksm.CheckName, ksm.Factory(tagger, store))
 	corecheckLoader.RegisterCheck(helm.CheckName, helm.Factory())


### PR DESCRIPTION
### What does this PR do?

Adds a new `agentresource` health platform issue module that surfaces agent CPU/memory threshold breaches via the health platform API.

- New module at `comp/healthplatform/impl/issues/agentresource/` with issue template (title, description, remediation) parameterised by actual CPU% and memory MB values from context.
- The `agentprofiling` core check is extended to call `ReportIssue` when thresholds are exceeded and `ClearIssuesForCheck` when usage drops back below thresholds, independently of the existing flare generation logic.
- The health platform component is threaded into `RegisterChecks` and the agent run command so it reaches the check at registration time.

### Motivation

When the agent itself consumes high CPU or memory, the health platform should surface this as a queryable issue — visible via the `/health-platform/issues` API endpoint and forwarded to the Datadog intake — rather than only emitting a log line.

### Describe how you validated your changes

- `go build ./comp/healthplatform/...` — clean
- `go build ./pkg/collector/corechecks/agentprofiling/...` — clean
- `go build ./pkg/commonchecks/...` — clean
- `go build ./cmd/agent/subcommands/run/...` — clean
- `go test -tags test ./pkg/collector/corechecks/agentprofiling/...` — all pass

### Additional Notes

The issue is reported externally (no `BuiltInCheck` on the module) since the agentprofiling check already owns the measurement and threshold logic. The flare generation path is unchanged.