### PR TITLE
[EBPF-1095] gpu: Add vGPU license status

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/fields.go
@@ -184,6 +184,7 @@ var allFieldMetrics = []fieldValueMetric{
 	{name: "memory.temperature", fieldValueID: nvml.FI_DEV_MEMORY_TEMP, metricType: metrics.GaugeType},
 	{name: "pci.replay_counter", fieldValueID: nvml.FI_DEV_PCIE_REPLAY_COUNTER, metricType: metrics.GaugeType},
 	{name: "slowdown_temperature", fieldValueID: nvml.FI_DEV_PERF_POLICY_THERMAL, metricType: metrics.GaugeType},
+	{name: "vgpu.license_status", fieldValueID: nvml.FI_DEV_VGPU_LICENSE_STATUS, metricType: metrics.GaugeType},
 
 	// -- NVLink throughput --
 	// Despite NVIDIA calling these "throughput", they report cumulative bytes transferred,

--- a/pkg/collector/corechecks/gpu/nvidia/fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/fields_test.go
@@ -24,6 +24,7 @@ var mockFieldValues = map[uint32]uint32{
 	nvml.FI_DEV_MEMORY_TEMP:                       42,
 	nvml.FI_DEV_PCIE_REPLAY_COUNTER:               7,
 	nvml.FI_DEV_PERF_POLICY_THERMAL:               85,
+	nvml.FI_DEV_VGPU_LICENSE_STATUS:               1,
 	nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX:         1000,
 	nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_TX:         2000,
 	nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_RX:          3000,

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -862,6 +862,15 @@ metrics:
         mig: false
         physical: true
         vgpu: false
+  vgpu.license_status:
+    tagsets:
+      - device
+    support:
+      unsupported_architectures: []
+      device_modes:
+        mig: false
+        physical: false
+        vgpu: true
   tensor_active:
     tagsets:
       - device

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -460,7 +460,7 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 			fieldValuesCounter += 1000
 			for i := range values {
 				values[i].Timestamp = int64(time.Now().UnixMilli())
-				if opts.hasUnsupportedField(values[i].FieldId) {
+				if opts.hasUnsupportedField(values[i].FieldId) || (values[i].FieldId == nvml.FI_DEV_VGPU_LICENSE_STATUS && !opts.isVGPU()) {
 					values[i].NvmlReturn = uint32(nvml.ERROR_NOT_SUPPORTED)
 				} else {
 					values[i].NvmlReturn = uint32(nvml.SUCCESS)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"270ca0a6-cf1a-4d46-8e2f-b868da2a2d85","source":"chat","resourceId":"0c148ae9-3bc0-43dd-a4e1-7831d583709b","workflowId":"edbc5311-f26b-4456-bdbb-39e90444b816","codeChangeId":"edbc5311-f26b-4456-bdbb-39e90444b816","sourceType":"chat"} -->
### What does this PR do?
Adds support for collecting a vGPU license status metric in the GPU core check, exposed as `gpu.vgpu.license_status`.
### Motivation

Allow users to monitor licensing for vGPUs.

### Describe how you validated your changes

CI passing, manually tested on an instance with vGPUs.

### Additional Notes

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/0c148ae9-3bc0-43dd-a4e1-7831d583709b)

Comment @datadog to request changes