### PR TITLE
Tentatively fix spurious Bazel disk cache access errors on Windows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -877,8 +877,8 @@
 /tools/                                 @DataDog/agent-devx
 /tools/host-profiler/                   @DataDog/profiling-full-host
 /tools/bazel*                           @DataDog/agent-build
-/tools/ci/*bazel*                       @DataDog/agent-build
 /tools/ci                               @DataDog/agent-devx
+/tools/ci/*bazel*                       @DataDog/agent-build
 /tools/ebpf/                            @DataDog/ebpf-platform
 /tools/gdb/                             @DataDog/agent-runtimes
 /tools/go-update/                       @DataDog/agent-runtimes

--- a/tools/ci/docker-run-with-bazel-cache.ps1
+++ b/tools/ci/docker-run-with-bazel-cache.ps1
@@ -2,6 +2,15 @@ $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $true
 Set-StrictMode -Version 3.0
 
-mkdir "$env:XDG_CACHE_HOME" -Force | Out-Null
+# Allow any container user to refresh disk-cache files written by a prior job's container.
+$diskCache = Join-Path $env:XDG_CACHE_HOME "bazel\disk-cache"
+$null = New-Item $diskCache -ItemType Directory -Force
+if (-not (($acl = Get-Acl $diskCache).Access | Where-Object { -not $_.IsInherited -and $_.IdentityReference -eq 'Everyone' })) {
+    $acl.AddAccessRule([Security.AccessControl.FileSystemAccessRule]::new(
+        'Everyone', 'FullControl', 'ContainerInherit, ObjectInherit', 'None', 'Allow'))
+    Set-Acl $env:XDG_CACHE_HOME $acl
+    Set-Acl $diskCache $acl
+    Get-ChildItem $diskCache -Recurse | ForEach-Object { Set-Acl $_.FullName $acl }
+}
 & docker run --rm --env=BAZELISK_HOME --env=CI --env=XDG_CACHE_HOME --volume="${env:XDG_CACHE_HOME}:${env:XDG_CACHE_HOME}" $args
 exit $LASTEXITCODE


### PR DESCRIPTION
### What does this PR do?
Grant containers control (with inheritance) on Bazel disk cache before running `docker`.

### Motivation
The disk cache under `c:/bzl` persists across CI jobs, but it's possible that files written by one job's container are "owned" by that container's user identity, in which case a container with a different user identity would still be able to read them but would fail calling `setLastModifiedTime` on them.
This might explain why Bazel would emit permission-denied warnings during disk cache refresh and breaking GC `mtime` tracking:
```
WARNING: Remote Cache: Multiple errors during bulk transfer: C:/bzl/bazel/disk-cache/cas/62/62e8d054f201a7359667bbd9d3ca07d685b30a01adf6944c6507ecc800529edf (Permission denied)
```
([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1593374105#L185))

### Describe how you validated your changes
Best-effort.

### Additional Notes
In `CODEOWNERS`, I had to reorder:
```
/tools/ci/*bazel*                       @DataDog/agent-build
```
**after**:
```
/tools/ci                               @DataDog/agent-devx
```
... otherwise this change doesn't hit the right audience.