### PR TITLE
Add timeouts to binary build CI jobs

### DIFF
--- a/.gitlab/build/binary_build/cluster_agent.yml
+++ b/.gitlab/build/binary_build/cluster_agent.yml
@@ -1,6 +1,7 @@
 ---
 .cluster_agent-build_common:
   stage: binary_build
+  timeout: 30m
   rules:
     - !reference [.except_mergequeue]
     - when: on_success

--- a/.gitlab/build/binary_build/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/build/binary_build/cluster_agent_cloudfoundry.yml
@@ -4,6 +4,7 @@ cluster_agent_cloudfoundry-build_amd64:
     - !reference [.except_mergequeue]
     - when: on_success
   stage: binary_build
+  timeout: 25m
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]

--- a/.gitlab/build/binary_build/cws_instrumentation.yml
+++ b/.gitlab/build/binary_build/cws_instrumentation.yml
@@ -1,6 +1,7 @@
 ---
 .cws_instrumentation-build_common:
   stage: binary_build
+  timeout: 20m
   needs: []
   script:
     - dda inv -- check-go-version
@@ -41,6 +42,7 @@ cws_instrumentation-build_arm64:
 
 .cws_instrumentation-build_injector_common:
   stage: binary_build
+  timeout: 20m
   needs: []
   script:
     - dda inv -- check-go-version

--- a/.gitlab/build/binary_build/fakeintake.yml
+++ b/.gitlab/build/binary_build/fakeintake.yml
@@ -1,6 +1,7 @@
 ---
 build_fakeintake:
   stage: binary_build
+  timeout: 15m
   rules:
     - !reference [.except_mergequeue]
     - !reference [.on_fakeintake_changes]

--- a/.gitlab/build/binary_build/host_profiler.yml
+++ b/.gitlab/build/binary_build/host_profiler.yml
@@ -2,6 +2,7 @@
 .build_host_profiler_binary_common:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   stage: binary_build
+  timeout: 25m
   rules:
     - !reference [.except_mergequeue]
     - when: on_success

--- a/.gitlab/build/binary_build/linux.yml
+++ b/.gitlab/build/binary_build/linux.yml
@@ -1,6 +1,7 @@
 ---
 build_dogstatsd_static-binary_x64:
   stage: binary_build
+  timeout: 20m
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
@@ -15,6 +16,7 @@ build_dogstatsd_static-binary_x64:
 
 build_dogstatsd_static-binary_arm64:
   stage: binary_build
+  timeout: 20m
   rules:
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
@@ -31,6 +33,7 @@ build_dogstatsd_static-binary_arm64:
 
 build_dogstatsd-binary_x64:
   stage: binary_build
+  timeout: 20m
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -49,6 +52,7 @@ build_dogstatsd-binary_arm64:
     - !reference [.except_mergequeue]
     - when: on_success
   stage: binary_build
+  timeout: 20m
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
   needs: ["go_deps"]
@@ -64,6 +68,7 @@ build_dogstatsd-binary_arm64:
 # IoT Agent builds to make sure the build is not broken because of build flags
 build_iot_agent-binary_x64:
   stage: binary_build
+  timeout: 20m
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -82,6 +87,7 @@ build_iot_agent-binary_x64:
 build_iot_agent-binary_arm64:
   rules: !reference [.on_all_builds]
   stage: binary_build
+  timeout: 20m
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
   needs: ["go_deps"]

--- a/.gitlab/build/binary_build/system_probe.yml
+++ b/.gitlab/build/binary_build/system_probe.yml
@@ -1,6 +1,7 @@
 ---
 .system-probe_build_common:
   extends: .bazel:defs:cache:progressive
+  timeout: 40m
   rules:
     - when: on_success
   before_script:

--- a/.gitlab/build/source_test/ebpf.yml
+++ b/.gitlab/build/source_test/ebpf.yml
@@ -31,6 +31,7 @@
 
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
+  timeout: 20m
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   variables:


### PR DESCRIPTION
## Summary
- Add explicit `timeout` to all binary build stage jobs to prevent stuck jobs from wasting CI capacity
- Without explicit timeouts, jobs fall back to GitLab's 1h default — stuck jobs like [this one](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1591765065) ran for 2h when they should complete in ~15min
- Timeouts are set with ~2-3x headroom over expected durations:

| Jobs | Timeout |
|------|---------|
| dogstatsd (static/dynamic), iot agent, cws_instrumentation | 20m |
| cluster_agent_cloudfoundry, host_profiler | 25m |
| cluster_agent (+ fips) | 30m |
| system-probe (eBPF + bazel) | 40m |
| fakeintake | 15m |

## Test plan
- [ ] Verify CI pipeline YAML is valid (no syntax errors)
- [ ] Confirm binary build jobs pass with the new timeouts on a normal pipeline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)