### PR TITLE
CASCL-889 align autoscaling tag behavior

### DIFF
--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -87,7 +87,7 @@ func (k KubeNodeTagsProvider) getNodeInfoTags(ctx context.Context) ([]string, er
 	}
 
 	if nodeLabels[kubernetes.AutoscalingLabelKey] != "" {
-		tags = append(tags, kubernetes.ClusterAutoscalerTagName+":datadog")
+		tags = append(tags, kubernetes.ClusterAutoscalerTagName+":"+nodeLabels[kubernetes.AutoscalingLabelKey])
 	}
 
 	if nodeLabels[kubernetes.KarpenterNodePoolLabelKey] != "" {

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -86,15 +86,7 @@ func (k KubeNodeTagsProvider) getNodeInfoTags(ctx context.Context) ([]string, er
 		tags = append(tags, extractTags(nodeLabels, k.getNodeLabelsAsTags())...)
 	}
 
-	if nodeLabels[kubernetes.AutoscalingLabelKey] != "" {
-		tags = append(tags, kubernetes.ClusterAutoscalerTagName+":"+nodeLabels[kubernetes.AutoscalingLabelKey])
-	}
-
-	if nodeLabels[kubernetes.KarpenterNodePoolLabelKey] != "" {
-		tags = append(tags, kubernetes.KarpenterNodePoolTagName+":"+nodeLabels[kubernetes.KarpenterNodePoolLabelKey])
-	}
-
-	return tags, nil
+	return appendManagedNodeTags(tags, nodeLabels), nil
 }
 
 func (k KubeNodeTagsProvider) getNodeLabelsAsTags() map[string]string {
@@ -107,6 +99,18 @@ func getDefaultLabelsToTags() map[string]string {
 	return map[string]string{
 		NormalizedRoleLabel: kubernetes.KubeNodeRoleTagName,
 	}
+}
+
+func appendManagedNodeTags(tags []string, nodeLabels map[string]string) []string {
+	if nodeLabels[kubernetes.AutoscalingLabelKey] != "" {
+		tags = append(tags, kubernetes.ClusterAutoscalerTagName+":"+nodeLabels[kubernetes.AutoscalingLabelKey])
+	}
+
+	if nodeLabels[kubernetes.KarpenterNodePoolLabelKey] != "" {
+		tags = append(tags, kubernetes.KarpenterNodePoolTagName+":"+nodeLabels[kubernetes.KarpenterNodePoolLabelKey])
+	}
+
+	return tags
 }
 
 func extractTags(nodeLabels, labelsToTags map[string]string) []string {

--- a/pkg/util/kubernetes/hostinfo/tags_test.go
+++ b/pkg/util/kubernetes/hostinfo/tags_test.go
@@ -157,3 +157,59 @@ func TestExtractTags(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendManagedNodeTags(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		tags         []string
+		nodeLabels   map[string]string
+		expectedTags []string
+	}{
+		{
+			name:         "no managed labels",
+			tags:         []string{"kube_node:node-a"},
+			nodeLabels:   map[string]string{"kubernetes.io/hostname": "node-a"},
+			expectedTags: []string{"kube_node:node-a"},
+		},
+		{
+			name: "autoscaling managed label",
+			tags: []string{"kube_node:node-a"},
+			nodeLabels: map[string]string{
+				kubernetes.AutoscalingLabelKey: "true",
+			},
+			expectedTags: []string{
+				"kube_node:node-a",
+				kubernetes.ClusterAutoscalerTagName + ":true",
+			},
+		},
+		{
+			name: "karpenter nodepool label",
+			tags: []string{"kube_node:node-a"},
+			nodeLabels: map[string]string{
+				kubernetes.KarpenterNodePoolLabelKey: "pool-a",
+			},
+			expectedTags: []string{
+				"kube_node:node-a",
+				kubernetes.KarpenterNodePoolTagName + ":pool-a",
+			},
+		},
+		{
+			name: "both managed labels",
+			tags: []string{"kube_node:node-a"},
+			nodeLabels: map[string]string{
+				kubernetes.AutoscalingLabelKey:       "true",
+				kubernetes.KarpenterNodePoolLabelKey: "pool-a",
+			},
+			expectedTags: []string{
+				"kube_node:node-a",
+				kubernetes.ClusterAutoscalerTagName + ":true",
+				kubernetes.KarpenterNodePoolTagName + ":pool-a",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tags := appendManagedNodeTags(tc.tags, tc.nodeLabels)
+			assert.Equal(t, tc.expectedTags, tags)
+		})
+	}
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d6f06850-cada-4bd5-ba7b-5e6c6f371f95","source":"chat","resourceId":"7accdb32-14a9-404b-82d2-8fa556efac25","workflowId":"1bac0f1a-cad1-4f18-b960-947116fdb36c","codeChangeId":"1bac0f1a-cad1-4f18-b960-947116fdb36c","sourceType":"chat"} -->
### What does this PR do?
Updates Kubernetes host tagging so the Datadog autoscaling managed-node label is emitted using the actual node label value, aligning with how the Karpenter nodepool label is exposed. It also adds dedicated unit-test coverage for managed-node tag appending behavior.

### Motivation
For CASCL-889, we want Datadog-managed nodepool identification to follow the same label-to-tag pattern used for other Kubernetes node labels, so users can distinguish workloads on managed nodes using the underlying label value.

### Describe how you validated your changes
- Ran `Format` tool (gofmt); no additional formatting changes were required after the latest edits.
- Ran `Lint` tool; it attempted Go build/lint but failed because the required local Go version is unavailable in this environment:
  - `goenv: version '1.25.9' is not installed (set by /workspace/repo/.go-version)`

### Additional Notes
- Historical reference checked: Karpenter nodepool tagging is implemented directly in `pkg/util/kubernetes/hostinfo/tags.go` by reading `karpenter.sh/nodepool` and appending `karpenter_nodepool:<value>`.
- This PR applies the same style to autoscaling by changing `kube_cluster_autoscaler` from a hardcoded value (`datadog`) to the node label value from `autoscaling.datadoghq.com/managed`.
- Added a focused helper (`appendManagedNodeTags`) and unit tests that cover:
  - no managed labels,
  - autoscaling managed label only,
  - Karpenter nodepool label only,
  - both labels together.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7accdb32-14a9-404b-82d2-8fa556efac25)

Comment @datadog to request changes