### PR TITLE
Add pattern isolation invariant to adaptive sampling spec

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
@@ -82,6 +82,16 @@ contract PatternMatching {
         -- compared for equality. The sequences match iff
         -- positional_matches >= required_matches.
 
+    @invariant Isolation
+        -- Contrapositive of ThresholdComparison. Two sequences are
+        -- guaranteed not to match when the number of differing
+        -- positions exceeds the tolerance:
+        --   comparison_length = min(a.length, b.length)
+        --   tolerance = comparison_length - round(threshold * comparison_length)
+        --   differing_positions > tolerance implies is_match = false
+        -- This bounds the minimum edit distance required to ensure
+        -- two patterns never interfere under a given threshold.
+
     @invariant MonotonicThreshold
         -- For fixed a and b, if is_match(a, b, t1) and t2 <= t1,
         -- then is_match(a, b, t2). Lowering the threshold cannot

--- a/pkg/logs/internal/decoder/preprocessor/sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_test.go
@@ -48,8 +48,12 @@ func requireSampledCountTag(t *testing.T, msg *message.Message, want int64) {
 
 func requireNoSampledCountTag(t *testing.T, msg *message.Message) {
 	t.Helper()
+	// Use the production function with a sentinel value to derive the prefix,
+	// so this helper stays in sync if the tag name changes.
+	prefix := adaptiveSamplerSampledCountTag(0) // "adaptive_sampler_sampled_count:0"
+	prefix = prefix[:len(prefix)-1]             // strip the trailing "0"
 	for _, tag := range msg.ParsingExtra.Tags {
-		assert.NotContains(t, tag, "adaptive_sampler_sampled_count:")
+		assert.NotContains(t, tag, prefix)
 	}
 }
 

--- a/pkg/logs/internal/decoder/preprocessor/tokenizer_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/tokenizer_test.go
@@ -7,6 +7,7 @@
 package preprocessor
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -419,6 +420,46 @@ func FuzzIsMatchMonotonicity(f *testing.F) {
 				"match at thresh=%.2f must imply match at thresh=%.2f: a=%q b=%q",
 				hi, lo, inputA, inputB)
 		}
+	})
+}
+
+// PatternMatching.Isolation: two sequences differing at more than
+// tolerance = len - round(threshold * len) positions are guaranteed
+// not to match. Contrapositive of ThresholdComparison.
+func FuzzIsMatchIsolation(f *testing.F) {
+	f.Add([]byte("2024-01-15 10:30:45 INFO request"), uint8(90), uint8(0))
+	f.Add([]byte("error at line 42 in module"), uint8(75), uint8(3))
+	f.Add([]byte("GET /api/v2/users 200 42ms"), uint8(50), uint8(1))
+	f.Fuzz(func(t *testing.T, input []byte, threshPct, startPos uint8) {
+		thresh := float64(threshPct%101) / 100.0
+		tok := NewTokenizer(0)
+		tokens, _ := tok.Tokenize(input)
+		n := len(tokens)
+		if n < 2 {
+			return
+		}
+
+		required := int(math.Round(thresh * float64(n)))
+		tolerance := n - required
+
+		// Construct a mutated sequence differing at tolerance+1 positions.
+		// This should guarantee no match.
+		diffs := tolerance + 1
+		if diffs > n {
+			return // threshold so low that everything matches
+		}
+
+		mutated := make([]Token, n)
+		copy(mutated, tokens)
+		start := int(startPos) % n
+		for i := range diffs {
+			pos := (start + i) % n
+			mutated[pos] = (tokens[pos] + 1) % End
+		}
+
+		assert.False(t, IsMatch(tokens, mutated, thresh),
+			"sequences differing at %d positions (tolerance=%d) must not match: thresh=%.2f len=%d",
+			diffs, tolerance, thresh, n)
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

This commit specifies when two sequences will not match, adding a fuzz test to ensure the claim. Technically this is implied by inversion with
the pre-existing ThresholdComparison however -- belt and suspenders -- in cases where multiple inversions are possible my preference is to
specify the contrapositive.

No changes here to production code.

### Motivation

SMP forward deploy is looking to create an externally validated property test for adaptive sampling. Scoping the problem to validation of the integration of individually fit-for-purpose components is a tidier problem than otherwise.

### 