### PR TITLE
fix kmt.gen-config from ci pipeline

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -215,7 +215,7 @@ def gen_config_from_ci_pipeline(
     kmt_pipeline.retrieve_jobs()
 
     for job in kmt_pipeline.setup_jobs:
-        if (vcpu is None or memory is None) and job.status == GitlabJobStatus.SUCCESS:
+        if (vcpu is None or memory is None) and job.status == GitlabJobStatus.SUCCESS and job.component == vmconfig_template:
             info(f"[+] retrieving vmconfig from job {job.name}")
             for vmset in job.vmconfig["vmsets"]:
                 memory_list = vmset.get("memory", [])
@@ -232,7 +232,7 @@ def gen_config_from_ci_pipeline(
     failed_tests: set[str] = set()
     successful_tests: set[str] = set()
     for test_job in kmt_pipeline.test_jobs:
-        if test_job.status == GitlabJobStatus.FAILED and job.component == vmconfig_template:
+        if test_job.status == GitlabJobStatus.FAILED and test_job.component == vmconfig_template:
             vm_arch = test_job.arch
             if use_local_if_possible and vm_arch == local_arch:
                 vm_arch = "local"

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -215,7 +215,11 @@ def gen_config_from_ci_pipeline(
     kmt_pipeline.retrieve_jobs()
 
     for job in kmt_pipeline.setup_jobs:
-        if (vcpu is None or memory is None) and job.status == GitlabJobStatus.SUCCESS and job.component == vmconfig_template:
+        if (
+            (vcpu is None or memory is None)
+            and job.status == GitlabJobStatus.SUCCESS
+            and job.component == vmconfig_template
+        ):
             info(f"[+] retrieving vmconfig from job {job.name}")
             for vmset in job.vmconfig["vmsets"]:
                 memory_list = vmset.get("memory", [])


### PR DESCRIPTION
### What does this PR do?

Fixes the KMT job filter to use the correct component value.

### Motivation

Incorrect behavior due to always using the last setup job's component value.

### Describe how you validated your changes

### Additional Notes
