### PR TITLE
Strip pre-compiled bytecode from `python_win` outputs

### DIFF
--- a/deps/cpython/build_python.bat
+++ b/deps/cpython/build_python.bat
@@ -97,6 +97,7 @@ rmdir /q /s %sourcedir%\PCbuild\obj
 rmdir /q /s %sourcedir%\PCbuild\win32
 del /q %response_file%
 del /q %sourcedir%\python.bat
+for /d /r %destdir%\Lib %%d in (__pycache__) do rmdir /q /s "%%d"
 
 if %script_errorlevel% neq 0 (
    exit /b %script_errorlevel%


### PR DESCRIPTION
### What does this PR do?
Delete all `__pycache__` directories from `build/Lib` at the end of `build_python.bat`, before Bazel captures the `out_dirs` outputs.

### Motivation
`python_win` declares `build/Lib` as an `out_dir` but pre-compiled `.pyc` files get matched, [ending up in the remote and disk caches](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1594708532#L85):
```
Downloading external/+http_archive+cpython/build/Lib/__pycache__/configparser.cpython-313.opt-1.pyc, 16.0 KiB / 67.3 KiB; 1s disk-cache, remote-cache
Downloading external/+http_archive+cpython/build/Lib/__pycache__/string.cpython-313.opt-2.pyc, 10.3 KiB / 10.3 KiB; 2s disk-cache, remote-cache
Downloading external/+http_archive+cpython/build/Lib/site-packages/pip/_internal/__pycache__/main.cpython-313.pyc; 3s disk-cache, remote-cache
Downloading external/+http_archive+cpython/build/Lib/site-packages/pip/_internal/__pycache__/main.cpython-313.pyc; 7s disk-cache, remote-cache
Downloading external/+http_archive+cpython/build/Lib/site-packages/pip/_internal/models/__pycache__/__init__.cpython-313.pyc; 8s disk-cache, remote-cache
Downloading external/+http_archive+cpython/build/Lib/site-packages/pip/_vendor/idna/__pycache__/uts46data.cpython-313.pyc, 155.3 KiB / 155.3 KiB; 9s disk-cache, remote-cache
```

Those files are regenerated automatically by Python on first import and embed `co_filename`, the absolute path of the source `.py` at compile time.

In Bazel's sandbox that path includes the output base, e.g. `c:/bzl/bazel/<hash>/execroot/_main/bazel-out/.../build/Lib/configparser.py`, which is machine-specific.

Removing them therefore deflates non-reproducible artifacts.