### PR TITLE
Define `response_file` before pre-clean in `build_python.bat`

### DIFF
--- a/deps/cpython/build_python.bat
+++ b/deps/cpython/build_python.bat
@@ -6,6 +6,7 @@ for %%F in (%MSBUILD%) do set MSBUILD=%%~fF
 for %%F in (%PYTHON_FOR_BUILD%) do set PYTHON_FOR_BUILD=%%~fF
 
 set build_outdir=%sourcedir%\PCbuild\amd64
+set response_file=%sourcedir%\PCbuild\msbuild.rsp
 
 set script_errorlevel=0
 
@@ -34,7 +35,6 @@ set TCLTK_DIR=%cd%\%TCLTK_DIR%\\
 :: Note that the build.bat script only accepts 9 extra arguments that can be passed through to MSBuild,
 :: so we write the arguments to a .rsp file that will be added to msbuild calls instead to not have to worry
 :: about that
-set response_file=%sourcedir%\PCbuild\msbuild.rsp
 echo "" > %response_file%
 echo "/p:bz2Dir=%BZ2_DIR%" >> %response_file%
 echo "/p:mpdecimalDir=%MPDECIMAL_DIR%" >> %response_file%


### PR DESCRIPTION
### What does this PR do?
Move `set response_file=` next to `set build_outdir=` so the variable is defined when the pre-clean `del /q %response_file%` runs.

### Motivation
`response_file` was first set on the line that populates the file, that is **after** the pre-clean block that already tries to delete it.

As a result, `del` received an unexpanded `%response_file%` literal and [emitted](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1594708532#L113):
```
The syntax of the command is incorrect.
```
... and the file was not deleted.