### PR TITLE
[Backport 7.78.x] Address CVE-2026-1703/ pip version bump

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -36,7 +36,14 @@ build do
       " #{install_dir}/embedded/lib/libpython3.*#{sh_ext}" \
       " #{install_dir}/embedded/lib/python3.13/lib-dynload/*.so" \
       " #{install_dir}/embedded/bin/python3*"
+    python = "#{install_dir}/embedded/bin/python3"
   else
     command_on_repo_root "bazelisk run #{flavor_flag} -- @cpython//:install --destdir=#{install_dir}"
+    python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
   end
+
+  # Upgrade pip to 26.0.1 to address CVE-2026-1703 (path traversal in pip < 26.0
+  # when installing malicious wheel archives). Python 3.13 ships with pip 25.3 via
+  # ensurepip, which is vulnerable.
+  command "#{python} -m pip install pip==26.0.1"
 end


### PR DESCRIPTION
What does this PR do?
PR adds a post-install step to the Python 3 omnibus build that upgrades pip to 26.0.1 after Python is installed. The comment explains why:

▎ https://github.com/advisories/GHSA-6vgw-5pg2-w6jp — a path traversal vulnerability in pip < 26.0 when installing malicious wheel archives. Python 3.13 ships with pip 25.3 via ensurepip, which is vulnerable.

The fix handles both platforms:

Linux/macOS: uses ${install_dir}/embedded/bin/python3 -m pip install pip==26.0.1
Windows: uses the windows_safe_path equivalent
Motivation
https://datadoghq.atlassian.net/browse/VULN-59246