### PR TITLE
APM: Refactor pkg/trace/api tests to not be so slow

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -238,6 +238,9 @@ func replyWithVersion(hash string, version string, h http.Handler) http.Handler 
 }
 
 func getConfiguredRequestTimeoutDuration(conf *config.AgentConfig) time.Duration {
+	if conf.ReceiverTimeoutDuration > 0 {
+		return conf.ReceiverTimeoutDuration
+	}
 	timeout := 5 * time.Second
 	if conf.ReceiverTimeout > 0 {
 		timeout = time.Duration(conf.ReceiverTimeout) * time.Second
@@ -246,6 +249,9 @@ func getConfiguredRequestTimeoutDuration(conf *config.AgentConfig) time.Duration
 }
 
 func getConfiguredEVPRequestTimeoutDuration(conf *config.AgentConfig) time.Duration {
+	if conf.EVPProxy.ReceiverTimeoutDuration > 0 {
+		return conf.EVPProxy.ReceiverTimeoutDuration
+	}
 	timeout := 30 * time.Second
 	if conf.EVPProxy.ReceiverTimeout > 0 {
 		timeout = time.Duration(conf.EVPProxy.ReceiverTimeout) * time.Second

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -76,6 +76,10 @@ func newTestReceiverConfig() *config.AgentConfig {
 	conf.DecoderTimeout = 10000
 	conf.ReceiverTimeout = 1
 	conf.ReceiverPort = 8326 // use non-default port to avoid conflict with a running agent
+	// Reset IdleTimeout so the server uses ReadTimeout (1s) instead of the production
+	// default (60s). Without this, tests that call io.ReadAll(resp.Body) on a real server
+	// block for 60 seconds waiting for the connection to close.
+	conf.ReceiverIdleTimeout = 0
 	// Enable convert-traces by default for tests since most tests expect V1 behavior
 	if conf.Features == nil {
 		conf.Features = make(map[string]struct{})
@@ -1085,8 +1089,9 @@ func TestHandleStats(t *testing.T) {
 	})
 	t.Run("timeout", func(t *testing.T) {
 		cfg := newTestReceiverConfig()
+		cfg.ReceiverTimeoutDuration = 50 * time.Millisecond
 		rcv := newTestReceiverFromConfig(cfg)
-		mockProcessor := &mockStatsProcessor{processingLantency: 1100 * time.Millisecond}
+		mockProcessor := &mockStatsProcessor{processingLantency: 60 * time.Millisecond}
 		rcv.statsProcessor = mockProcessor
 		mux := rcv.buildMux()
 		server := httptest.NewServer(mux)
@@ -1116,8 +1121,9 @@ func TestStatsKeepaliveIdleTimeout(t *testing.T) {
 	// must be set independently to avoid "connection reset by peer" errors.
 	runTest := func(t *testing.T, idleTimeout time.Duration) (firstErr, secondErr error) {
 		cfg := newTestReceiverConfig()
+		cfg.ReceiverTimeoutDuration = 50 * time.Millisecond
 		cfg.ReceiverIdleTimeout = idleTimeout
-		readTimeout := time.Duration(cfg.ReceiverTimeout) * time.Second
+		readTimeout := cfg.ReceiverTimeoutDuration
 
 		rcv := newTestReceiverFromConfig(cfg)
 		rcv.Start()
@@ -1168,8 +1174,8 @@ func TestStatsKeepaliveIdleTimeout(t *testing.T) {
 	}
 
 	t.Run("without idle timeout", func(t *testing.T) {
-		// With no IdleTimeout, Go falls back to ReadTimeout (1s). The second request on the
-		// same connection after 2s must fail with a connection reset.
+		// With no IdleTimeout, Go falls back to ReadTimeout (50ms). The second request on the
+		// same connection after 2×ReadTimeout must fail with a connection reset.
 		firstErr, secondErr := runTest(t, 0)
 		require.NoError(t, firstErr)
 		require.Error(t, secondErr, "expected connection reset when IdleTimeout falls back to ReadTimeout")
@@ -1177,7 +1183,7 @@ func TestStatsKeepaliveIdleTimeout(t *testing.T) {
 
 	t.Run("with idle timeout", func(t *testing.T) {
 		// With IdleTimeout > ReadTimeout, the connection stays alive and both requests succeed.
-		firstErr, secondErr := runTest(t, 5*time.Second)
+		firstErr, secondErr := runTest(t, 500*time.Millisecond)
 		require.NoError(t, firstErr)
 		require.NoError(t, secondErr, "keepalive connection must survive past ReadTimeout")
 	})

--- a/pkg/trace/api/evp_proxy_test.go
+++ b/pkg/trace/api/evp_proxy_test.go
@@ -592,10 +592,10 @@ func TestE2E(t *testing.T) {
 		conf := newTestReceiverConfig()
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
-		conf.EVPProxy.ReceiverTimeout = 1 // in seconds
+		conf.EVPProxy.ReceiverTimeoutDuration = 50 * time.Millisecond
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			time.Sleep(2 * time.Second)
+			time.Sleep(100 * time.Millisecond)
 			w.Write([]byte(`OK`))
 		}))
 
@@ -612,13 +612,13 @@ func TestE2E(t *testing.T) {
 		conf := newTestReceiverConfig()
 		conf.Site = "us3.datadoghq.com"
 		conf.Endpoints[0].APIKey = "test_api_key"
-		conf.EVPProxy.ReceiverTimeout = 1 // in seconds
+		conf.EVPProxy.ReceiverTimeoutDuration = 500 * time.Millisecond
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Transfer-Encoding", "chunked")
 			w.Write([]byte(`Hello`))
 			w.(http.Flusher).Flush()
-			time.Sleep(200 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 			w.Write([]byte(`World`)) // this will be discarded if the context was cancelled
 		}))
 

--- a/pkg/trace/api/listener_test.go
+++ b/pkg/trace/api/listener_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -26,13 +25,20 @@ func (e mockNetError) Timeout() bool   { return e.timeout }
 func (e mockNetError) Temporary() bool { return !e.timeout }
 
 type mockListener struct {
-	mu  sync.RWMutex // guards below fields
-	err error        // returned error
+	mu    sync.RWMutex // guards below fields
+	err   error        // returned error
+	ready chan struct{} // closed after the first Accept call; nil means no notification needed
+	once  sync.Once
 }
 
 var _ net.Listener = (*mockListener)(nil)
 
 func (ml *mockListener) Accept() (net.Conn, error) {
+	ml.once.Do(func() {
+		if ml.ready != nil {
+			close(ml.ready)
+		}
+	})
 	ml.mu.RLock()
 	defer ml.mu.RUnlock()
 	return nil, ml.err
@@ -127,7 +133,7 @@ func TestAcceptFailure(t *testing.T) {
 	assert := assert.New(t)
 	stats := &teststatsd.Client{}
 
-	var mockln mockListener
+	mockln := mockListener{ready: make(chan struct{})}
 	mockln.SetError()
 	ln := NewMeasuredListener(&mockln, "test-metric", 5, stats).(*measuredListener)
 
@@ -139,7 +145,7 @@ func TestAcceptFailure(t *testing.T) {
 
 	expectErr := errors.New("unrecoverable error")
 	go func() {
-		time.Sleep(1 * time.Second)
+		<-mockln.ready // wait until srv.Serve has entered the accept loop
 		mockln.SetArbitraryError(expectErr)
 	}()
 

--- a/pkg/trace/api/listener_test.go
+++ b/pkg/trace/api/listener_test.go
@@ -25,8 +25,8 @@ func (e mockNetError) Timeout() bool   { return e.timeout }
 func (e mockNetError) Temporary() bool { return !e.timeout }
 
 type mockListener struct {
-	mu    sync.RWMutex // guards below fields
-	err   error        // returned error
+	mu    sync.RWMutex  // guards below fields
+	err   error         // returned error
 	ready chan struct{} // closed after the first Accept call; nil means no notification needed
 	once  sync.Once
 }

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -389,19 +389,19 @@ type AgentConfig struct {
 	ErrorTrackingStandalone bool
 
 	// Receiver
-	ReceiverEnabled     bool // specifies whether Receiver listeners are enabled. Unless OTLPReceiver is used, this should always be true.
-	ReceiverHost        string
-	ReceiverPort        int
-	ReceiverSocket      string // if not empty, UDS will be enabled on unix://<receiver_socket>
-	ConnectionLimit     int    // for rate-limiting, how many unique connections to allow in a lease period (30s)
+	ReceiverEnabled         bool // specifies whether Receiver listeners are enabled. Unless OTLPReceiver is used, this should always be true.
+	ReceiverHost            string
+	ReceiverPort            int
+	ReceiverSocket          string // if not empty, UDS will be enabled on unix://<receiver_socket>
+	ConnectionLimit         int    // for rate-limiting, how many unique connections to allow in a lease period (30s)
 	ReceiverTimeout         int
 	ReceiverTimeoutDuration time.Duration // overrides ReceiverTimeout when non-zero; allows sub-second values in tests
 	ReceiverIdleTimeout     time.Duration // idle timeout for keepalive connections.
-	MaxRequestBytes     int64         // specifies the maximum allowed request size for incoming trace payloads
-	TraceBuffer         int           // specifies the number of traces to buffer before blocking.
-	Decoders            int           // specifies the number of traces that can be concurrently decoded.
-	MaxConnections      int           // specifies the maximum number of concurrent incoming connections allowed.
-	DecoderTimeout      int           // specifies the maximum time in milliseconds that the decoders will wait for a turn to accept a payload before returning 429
+	MaxRequestBytes         int64         // specifies the maximum allowed request size for incoming trace payloads
+	TraceBuffer             int           // specifies the number of traces to buffer before blocking.
+	Decoders                int           // specifies the number of traces that can be concurrently decoded.
+	MaxConnections          int           // specifies the maximum number of concurrent incoming connections allowed.
+	DecoderTimeout          int           // specifies the maximum time in milliseconds that the decoders will wait for a turn to accept a payload before returning 429
 
 	WindowsPipeName        string
 	PipeBufferSize         int

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -285,6 +285,8 @@ type EVPProxy struct {
 	MaxPayloadSize int64
 	// ReceiverTimeout indicates the maximum time an EVPProxy request can take. Value in seconds.
 	ReceiverTimeout int
+	// ReceiverTimeoutDuration overrides ReceiverTimeout when non-zero; allows sub-second values in tests.
+	ReceiverTimeoutDuration time.Duration
 }
 
 // OpenLineageProxy contains the settings for the OpenLineageProxy proxy.
@@ -392,8 +394,9 @@ type AgentConfig struct {
 	ReceiverPort        int
 	ReceiverSocket      string // if not empty, UDS will be enabled on unix://<receiver_socket>
 	ConnectionLimit     int    // for rate-limiting, how many unique connections to allow in a lease period (30s)
-	ReceiverTimeout     int
-	ReceiverIdleTimeout time.Duration // idle timeout for keepalive connections.
+	ReceiverTimeout         int
+	ReceiverTimeoutDuration time.Duration // overrides ReceiverTimeout when non-zero; allows sub-second values in tests
+	ReceiverIdleTimeout     time.Duration // idle timeout for keepalive connections.
 	MaxRequestBytes     int64         // specifies the maximum allowed request size for incoming trace payloads
 	TraceBuffer         int           // specifies the number of traces to buffer before blocking.
 	Decoders            int           // specifies the number of traces that can be concurrently decoded.


### PR DESCRIPTION
### What does this PR do?
The pkg/trace/api tests were taking nearly 3 minutes to run all together in CI causing some PRs to flake here. Investigated these slow tests with Claude and came up with some refactors that should cut down on sleep/wait time in these tests.

There's a few different changes here, but the biggest impact one was setting the `conf.ReceiverIdleTimeout = 0` in the tests, this immediately brought a speedup of 2 minutes as there were 2 tests that were using `io.ReadAll` and waiting the full default of 60s 😭 

Outside that also added `ReceiverTimeoutDuration` options for a few endpoints to override the longer default timeout for tests that verify this behavior.

Locally this went from 2m3s to 4.5s, a 40x speedup 😎
Looks like in CI it's down to 44s which is still an excellent improvement and should prevent flaky timeouts at the 3m cutoff

### Motivation
Slow and flaky tests are no good

### Describe how you validated your changes
Run all the tests, those should well cover these changes.

### Additional Notes
