### PR TITLE
Fix OpenSSL DLL loading and error propagation in CPython PGO build

### DIFF
--- a/deps/cpython/0003-propagate-pgo-test-exit-code.patch
+++ b/deps/cpython/0003-propagate-pgo-test-exit-code.patch
@@ -1,0 +1,23 @@
+diff --git a/PCbuild/build.bat b/PCbuild/build.bat
+--- a/PCbuild/build.bat
++++ b/PCbuild/build.bat
+@@ -142,14 +142,19 @@
+ rem %VARS% are evaluated eagerly, which would lose the ERRORLEVEL
+ rem value if we didn't split it out here.
+ if "%do_pgo%"=="true" if ERRORLEVEL 1 exit /B %ERRORLEVEL%
+ if "%do_pgo%"=="true" (
+     del /s "%dir%\*.pgc"
+     del /s "%dir%\..\Lib\*.pyc"
+     echo on
+     call "%dir%\..\python.bat" %pgo_job%
+     @echo off
++)
++rem Split out as above, this time to save PGO test result.
++set pgo_errorlevel=%ERRORLEVEL%
++if "%do_pgo%"=="true" (
+     call :Kill
++    if %pgo_errorlevel% NEQ 0 exit /B %pgo_errorlevel%
+     set conf=PGUpdate
+     set target=Build
+ )
+ goto :Build

--- a/deps/cpython/build_python.bat
+++ b/deps/cpython/build_python.bat
@@ -48,6 +48,9 @@ echo "/p:TclVersion=%TCL_VERSION%" >> %response_file%
 :: We disable copying around of the OpenSSL libraries (as defined in openssl.props)
 :: This simplifies the requirements on the input files and their names and gives us more control
 echo "/p:SkipCopySSLDLL=1" >> %response_file%
+:: but _hashlib.pyd needs OPENSSL_DIR registered as a DLL search directory for PGO tests.
+echo import os; os.add_dll_directory(r'%OPENSSL_DIR%') >sitecustomize.py
+set "PYTHONPATH=%cd%;%PYTHONPATH%"
 
 :: -e flag would normally also fetch external dependencies, but we have a patch inhibiting that;
 :: the flag is still needed because otherwise modules depending on some of those external dependencies

--- a/deps/cpython/cpython.MODULE.bazel
+++ b/deps/cpython/cpython.MODULE.bazel
@@ -13,6 +13,7 @@ http_archive(
     patches = [
         "//deps/cpython:0001-customize-windows-build-script.patch",
         "//deps/cpython:0002-Set-the-install-name-to-use-rpath-instead-of-absolut.patch",
+        "//deps/cpython:0003-propagate-pgo-test-exit-code.patch",
     ],
     sha256 = "12e7cb170ad2d1a69aee96a1cc7fc8de5b1e97a2bdac51683a3db016ec9a2996",
     strip_prefix = "Python-{}".format(PYTHON_VERSION),


### PR DESCRIPTION
### What does this PR do?
- add a patch for CPython's `PCbuild/build.bat` that propagates the PGO test exit code to prevent failing tests from being unnoticed,
- fix the failing test by means of an adhoc `sitecustomize.py` that adds the OpenSSL directory to the DLL search path.

### Motivation
A failure in the CPython PGO Windows build went unnoticed.

`SkipCopySSLDLL=1` indeed prevents MSBuild from placing the OpenSSL DLLs alongside `python.exe`, and the manual `xcopy` only runs after the PGO step.
As a result `test_hashlib` [fails](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1594708532#L1243) during PGO test execution:
```
0:03:33 load avg: 0.00 [20/43] test_hashlib failed (uncaught exception)
Total test files: run=43/43 failed=1
```
... and the exit code is swallowed.

### Describe how you validated your changes
Local VM and CI.

Without the fix, the error is now properly propagated thanks to the patch: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1601046520#L1765

### Additional Notes
The patch only consists in repeating the pattern established a few lines earlier in the script.

Upstream issue:
- python/cpython#148644.