### PR TITLE
Replace outdated S3 mirror for OpenSSL 3.5.6

### DIFF
--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -118,7 +118,7 @@ http_archive(
     sha256 = "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736",
     strip_prefix = "openssl-3.5.6",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/openssl-3.5.6.tar.gz",
+        "https://github.com/openssl/openssl/releases/download/openssl-3.5.6/openssl-3.5.6.tar.gz",
         "https://www.openssl.org/source/openssl-3.5.6.tar.gz",
     ],
 )


### PR DESCRIPTION
### What does this PR do?
Replace the primary download URL for the OpenSSL 3.5.6 `http_archive` with the GitHub releases URL.
The S3 mirror (dd-agent-omnibus.s3.amazonaws.com) returns HTTP 404 for this version since it couldn't be populated when #48948 bumped OpenSSL to 3.5.6.

### Motivation
Every Bazel invocation that needs OpenSSL [emits a warning](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1596207323#L61) and incurs extra latency from the failed S3 request before falling back to the secondary URL:
> WARNING: Download from https://dd-agent-omnibus.s3.amazonaws.com/bazel/openssl-3.5.6.tar.gz failed: class java.io.FileNotFoundException GET returned 404 Not Found

The GitHub releases tarball and the openssl.org tarball both produce the same sha256 already declared in the stanza, so no integrity change is needed.

### Describe how you validated your changes
Downloaded both tarballs independently and verified they produce the same sha256.