### PR TITLE
bazel: rules: centralize symlink permissions setting

### DIFF
--- a/bazel/rules/so_symlink.bzl
+++ b/bazel/rules/so_symlink.bzl
@@ -1,4 +1,4 @@
-load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files", "pkg_mklink")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mklink")
 
 _SPECS = [
     struct(os = "linux", prefix = "lib/", format = "{}.so{}"),
@@ -10,6 +10,7 @@ def _gen_targets(base_name, src, libname, version, prefix, spec, attributes):
     name = "{}_{}".format(base_name, spec.os)
     platform = "@platforms//os:{}".format(spec.os)
     dest_prefix = (prefix + "/" + spec.prefix) if prefix else spec.prefix
+    attributes = attributes or pkg_attributes(mode = "0644")
 
     # Windows: no symlinks, no renaming - just copy the DLL as-is
     if spec.os == "windows":


### PR DESCRIPTION
### What does this PR do?

Ensure all our symlinks are generated with the same default permissions

### Motivation

While working on https://github.com/DataDog/datadog-agent/pull/49309, I realized that some symlinks end up being created with different permissions depending on the context.
We can make this uniform from the rule and stop having to think about this

### Describe how you validated your changes

File inventory checking will do the heavy lifting here

### Additional Notes

I went with the path of least resistance:
* defaulting to 755 causes 37 files to be modified
* defaulting to 644 causes no file to be modified
-> Default to 0644 it is