### PR TITLE
[CWS] Adjust configuration when SBOM resolver is enabled

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -96,6 +96,8 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 			evm.RegisterEventConsumer(usage)
 			log.Info("event monitoring usage consumer initialized")
 		}
+
+		opts.ProbeOpts.PathResolutionEnabled = true
 	}
 
 	netconfig := netconfig.New()

--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	emconfig "github.com/DataDog/datadog-agent/pkg/eventmonitor/config"
 	gpuconfig "github.com/DataDog/datadog-agent/pkg/gpu/config"
@@ -67,7 +68,7 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 	}
 
 	cwsEnabled := secconfig.RuntimeSecurity.IsRuntimeEnabled()
-	runtimeUsageEnabled := secconfig.RuntimeSecurity.SBOMResolverEnabled
+	runtimeUsageEnabled := pkgconfigsetup.Datadog().GetBool("sbom.enrichment.usage.enabled")
 
 	if cwsEnabled || runtimeUsageEnabled {
 		stopChan := make(chan struct{})

--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -44,12 +44,7 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 	opts.ProbeOpts.FilterStore = deps.FilterStore
 	secmoduleOpts := secmodule.Opts{}
 
-	// adapt options
-	if secconfig.RuntimeSecurity.IsRuntimeEnabled() {
-		secmodule.UpdateEventMonitorOpts(&opts, secconfig)
-	} else {
-		secmodule.DisableRuntimeSecurity(secconfig)
-	}
+	secmodule.UpdateEventMonitorOpts(&opts, secconfig)
 
 	hostname, err := deps.Hostname.Get(context.Background())
 	if err != nil {
@@ -96,8 +91,6 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 			evm.RegisterEventConsumer(usage)
 			log.Info("event monitoring usage consumer initialized")
 		}
-
-		opts.ProbeOpts.PathResolutionEnabled = true
 	}
 
 	netconfig := netconfig.New()

--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -373,7 +373,7 @@ func (s *streamHandler) IsEnabled() bool {
 	}
 
 	sbomEnrichmentEnabled := s.agentConfig.GetBool("sbom.enrichment.usage.enabled")
-	runtimeSecuritySBOMDisabled := s.systemProbeConfig.IsConfigured("runtime_security_config.sbom.enabled") && s.systemProbeConfig.GetBool("runtime_security_config.sbom.enabled") == false
+	runtimeSecuritySBOMDisabled := s.systemProbeConfig.IsConfigured("runtime_security_config.sbom.enabled") && !s.systemProbeConfig.GetBool("runtime_security_config.sbom.enabled")
 
 	return sbomEnrichmentEnabled && !runtimeSecuritySBOMDisabled
 }

--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -80,7 +80,8 @@ func (s *stream) Recv() (interface{}, error) {
 }
 
 type streamHandler struct {
-	model.Reader
+	agentConfig       model.Reader
+	systemProbeConfig model.Reader
 }
 
 // workloadmetaEventFromSBOMEventSet converts the given SBOM message into a workloadmeta event
@@ -318,7 +319,7 @@ func NewCollector(ipc ipc.Component) (workloadmeta.CollectorProvider, error) {
 		Collector: &remote.GenericCollector{
 			CollectorID: collectorID,
 			// TODO(components): make sure StreamHandler uses the config component not pkg/config
-			StreamHandler: &streamHandler{Reader: pkgconfigsetup.SystemProbe()},
+			StreamHandler: &streamHandler{agentConfig: pkgconfigsetup.Datadog(), systemProbeConfig: pkgconfigsetup.SystemProbe()},
 			Catalog:       workloadmeta.NodeAgent,
 			IPC:           ipc,
 		},
@@ -341,13 +342,13 @@ func (s *streamHandler) Port() int {
 
 func (s *streamHandler) Address() string {
 	// SBOM collector service is on the command socket, not the main runtime security socket
-	cmdSocket := s.GetString("runtime_security_config.cmd_socket")
+	cmdSocket := s.systemProbeConfig.GetString("runtime_security_config.cmd_socket")
 	if cmdSocket != "" {
 		return cmdSocket
 	}
 
 	// If cmd_socket not explicitly set, derive it from main socket (adds "cmd-" prefix)
-	mainSocket := s.GetString("runtime_security_config.socket")
+	mainSocket := s.systemProbeConfig.GetString("runtime_security_config.socket")
 	if mainSocket == "" {
 		return ""
 	}
@@ -371,10 +372,10 @@ func (s *streamHandler) IsEnabled() bool {
 		return false
 	}
 
-	runtimeSecurityEnabled := s.Reader.GetBool("runtime_security_config.enabled")
-	runtimeSecuritySBOMEnabled := s.Reader.GetBool("runtime_security_config.sbom.enabled")
+	sbomEnrichmentEnabled := s.agentConfig.GetBool("sbom.enrichment.usage.enabled")
+	runtimeSecuritySBOMDisabled := s.systemProbeConfig.IsConfigured("runtime_security_config.sbom.enabled") && s.systemProbeConfig.GetBool("runtime_security_config.sbom.enabled") == false
 
-	return runtimeSecurityEnabled && runtimeSecuritySBOMEnabled
+	return sbomEnrichmentEnabled && !runtimeSecuritySBOMDisabled
 }
 
 func (s *streamHandler) NewClient(cc grpc.ClientConnInterface) remote.GrpcClient {

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -801,6 +801,9 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("sbom.host.analyzers", []string{"os"})
 	config.BindEnvAndSetDefault("sbom.host.additional_directories", []string{})
 
+	// SBOM enrichment configuration
+	config.BindEnvAndSetDefault("sbom.enrichment.usage.enabled", false)
+
 	// Service discovery configuration
 	bindEnvAndSetLogsConfigKeys(config, "service_discovery.forwarder.")
 

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -586,7 +586,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		},
 
 		// SBOM resolver
-		SBOMResolverEnabled:            pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.enabled"),
+		SBOMResolverEnabled:            pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.enabled") || pkgconfigsetup.Datadog().GetBool("sbom.enrichment.usage.enabled"),
 		SBOMResolverWorkloadsCacheSize: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.sbom.workloads_cache_size"),
 		SBOMResolverEnrichmentTicker:   pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sbom.enrichment_ticker"),
 		SBOMResolverHostEnabled:        pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.host.enabled"),
@@ -709,7 +709,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 
 // IsRuntimeEnabled returns true if any feature is enabled. Has to be applied in config package too
 func (c *RuntimeSecurityConfig) IsRuntimeEnabled() bool {
-	return c.RuntimeEnabled || c.FIMEnabled || c.SBOMResolverEnabled
+	return c.RuntimeEnabled || c.FIMEnabled
 }
 
 // IsSysctlEventEnabled returns whether the sysctl event is enabled

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -709,7 +709,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 
 // IsRuntimeEnabled returns true if any feature is enabled. Has to be applied in config package too
 func (c *RuntimeSecurityConfig) IsRuntimeEnabled() bool {
-	return c.RuntimeEnabled || c.FIMEnabled
+	return c.RuntimeEnabled || c.FIMEnabled || c.SBOMResolverEnabled
 }
 
 // IsSysctlEventEnabled returns whether the sysctl event is enabled

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -69,6 +69,9 @@ func (c *CommandServer) Start() error {
 
 // Stop stops the command server
 func (c *CommandServer) Stop() {
+	if !c.started {
+		return
+	}
 	c.grpcCmdServer.Stop()
 	c.started = false
 }

--- a/pkg/security/module/cws_linux.go
+++ b/pkg/security/module/cws_linux.go
@@ -6,6 +6,7 @@
 package module
 
 import (
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
@@ -13,10 +14,17 @@ import (
 
 // UpdateEventMonitorOpts adapt the event monitor options
 func UpdateEventMonitorOpts(opts *eventmonitor.Opts, config *config.Config) {
-	opts.ProbeOpts.PathResolutionEnabled = true
-	opts.ProbeOpts.TTYFallbackEnabled = true
-	opts.ProbeOpts.SyscallsMonitorEnabled = config.Probe.SyscallsMonitorEnabled
-	opts.ProbeOpts.EBPFLessEnabled = config.RuntimeSecurity.EBPFLessEnabled
+	if config.RuntimeSecurity.IsRuntimeEnabled() {
+		opts.ProbeOpts.PathResolutionEnabled = true
+		opts.ProbeOpts.TTYFallbackEnabled = true
+		opts.ProbeOpts.SyscallsMonitorEnabled = config.Probe.SyscallsMonitorEnabled
+		opts.ProbeOpts.EBPFLessEnabled = config.RuntimeSecurity.EBPFLessEnabled
+	} else {
+		DisableRuntimeSecurity(config)
+		if pkgconfigsetup.Datadog().GetBool("sbom.enrichment.usage.enabled") {
+			opts.ProbeOpts.PathResolutionEnabled = true
+		}
+	}
 }
 
 // DisableRuntimeSecurity disables all the runtime security features

--- a/pkg/security/module/usage_consumer.go
+++ b/pkg/security/module/usage_consumer.go
@@ -48,11 +48,15 @@ func (u *UsageConsumer) ID() string {
 
 // Start starts the usage consumer
 func (u *UsageConsumer) Start() error {
+	if err := u.CommandServer.Start(); err != nil {
+		return err
+	}
 	seclog.Infof("usage consumer started")
 	return nil
 }
 
 // Stop stops the usage consumer
 func (u *UsageConsumer) Stop() {
+	u.CommandServer.Stop()
 	seclog.Infof("usage consumer stopped")
 }

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -699,7 +699,7 @@ func (r *Resolver) ResolvePackage(pc *model.ProcessContext, file *model.FileEven
 	// replay any file accesses that arrived before the SBOM was ready
 	r.processPendingFileEvents(sbom)
 
-	seclog.Debugf("file '%s' accessed by '%s' in container '%s'", file.PathnameStr, pc.Process.Comm, sbom.ContainerID)
+	seclog.Tracef("file '%s' accessed by '%s' in container '%s'", file.PathnameStr, pc.Process.Comm, sbom.ContainerID)
 
 	pkg := sbom.data.files.queryFile(file.PathnameStr)
 	if pkg != nil {

--- a/pkg/system-probe/config/adjust_security.go
+++ b/pkg/system-probe/config/adjust_security.go
@@ -39,6 +39,10 @@ func adjustSecurity(cfg model.Config) {
 		cfg.Set(secNS("security_profile.enabled"), false, model.SourceAgentRuntime)
 	}
 
+	if cfg.GetBool(secNS("sbom.enabled")) {
+		cfg.Set(secNS("event_sampling.open.enabled"), true, model.SourceAgentRuntime)
+	}
+
 	// further adjustments done in RuntimeSecurityConfig.sanitize
 	// because it requires access to security packages
 }

--- a/pkg/system-probe/config/adjust_security.go
+++ b/pkg/system-probe/config/adjust_security.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 func adjustSecurity(cfg model.Config) {
@@ -39,7 +40,7 @@ func adjustSecurity(cfg model.Config) {
 		cfg.Set(secNS("security_profile.enabled"), false, model.SourceAgentRuntime)
 	}
 
-	if cfg.GetBool(secNS("sbom.enabled")) {
+	if pkgconfigsetup.Datadog().GetBool("sbom.enrichment.usage.enabled") {
 		cfg.Set(secNS("event_sampling.open.enabled"), true, model.SourceAgentRuntime)
 	}
 

--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -140,7 +140,7 @@ func load() (*types.Config, error) {
 	}
 	if csmEnabled ||
 		cfg.GetBool(secNS("fim_enabled")) ||
-		cfg.GetBool(secNS("sbom.enabled")) ||
+		coreCfg.GetBool("sbom.enrichment.usage.enabled") ||
 		(usmEnabled && cfg.GetBool(smNS("enable_event_stream"))) ||
 		(c.ModuleIsEnabled(NetworkTracerModule) && cfg.GetBool(evNS("network_process.enabled"))) ||
 		gpuEnabled ||


### PR DESCRIPTION
### What does this PR do?

Force path resolution and event sampling when SBOM resolver is enabled.

### Motivation

If `runtime_security_config.enabled` is not set, path may not be resolved, therefore causing matching against SBOM impossible.
In addition to that, event sampling had to be abled manually.

### Describe how you validated your changes

### Additional Notes
