### PR TITLE
Add E2E test for SBOM "package in use" feature and fix pipeline bugs

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -150,10 +150,24 @@ func workloadmetaEventFromSBOMEventSet(store workloadmeta.Component, event *sbom
 		}
 	}
 
-	// Compress the final merged SBOM for storage
-	finalCompressedSBOM, err = sbomutil.CompressSBOM(&workloadmeta.SBOM{
+	// Compress the final merged SBOM for storage, inheriting scan metadata from
+	// the existing image's SBOM so the remote_sbom_collector entity carries the
+	// correct Status (e.g. Success) from the completed trivy scan.  Default to
+	// Pending so that when the existing image has no completed SBOM yet (trivy
+	// is still scanning), we do not emit a spurious Success entity with an empty
+	// BOM.
+	sbomForCompression := &workloadmeta.SBOM{
 		CycloneDXBOM: finalBom,
-	})
+		Status:       workloadmeta.Pending,
+	}
+	if existingImage != nil && existingImage.SBOM != nil {
+		sbomForCompression.Status = existingImage.SBOM.Status
+		sbomForCompression.GenerationTime = existingImage.SBOM.GenerationTime
+		sbomForCompression.GenerationDuration = existingImage.SBOM.GenerationDuration
+		sbomForCompression.GenerationMethod = existingImage.SBOM.GenerationMethod
+		sbomForCompression.Error = existingImage.SBOM.Error
+	}
+	finalCompressedSBOM, err = sbomutil.CompressSBOM(sbomForCompression)
 	if err != nil {
 		return workloadmeta.Event{}, fmt.Errorf("failed to compress SBOM for image %s: %w", imageID, err)
 	}

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1580,9 +1580,8 @@ func (i *ContainerImageMetadata) Merge(e Entity) error {
 	// concatenating the compressed Bom []byte fields across sources. Two
 	// gzip-encoded protobufs appended byte-for-byte form a valid multistream
 	// gzip that decodes to a concatenated protobuf, which duplicates all
-	// repeated Components.  We apply our own "prefer dst if non-nil" rule
-	// instead: the remote SBOM collector (alphabetically first) always
-	// produces an already-enriched SBOM that supersedes the raw Trivy SBOM.
+	// repeated Components.  We apply our own Status-aware selection rule
+	// below instead of a simple "prefer dst if non-nil" rule.
 	dstSBOM := i.SBOM
 	srcSBOM := otherImage.SBOM
 
@@ -1593,8 +1592,18 @@ func (i *ContainerImageMetadata) Merge(e Entity) error {
 
 	err := merge(i, &otherImageCopy)
 
-	// Restore SBOM: keep dst's enriched SBOM when available, else fall back to src.
-	if dstSBOM != nil {
+	// Restore SBOM: prefer the SBOM with a completed scan (Status == Success).
+	// The remote_sbom_collector (alphabetically first, always dst) enriches the
+	// trivy SBOM with CWS runtime properties and copies Status from the existing
+	// trivy entity.  When its Status is Success the enriched SBOM should win;
+	// when it is empty or Pending (CWS arrived before trivy finished), the trivy
+	// SBOM from the runtime source (src) should win instead so that the merged
+	// entity reflects the completed scan result.
+	if dstSBOM != nil && dstSBOM.Status == Success {
+		i.SBOM = dstSBOM
+	} else if srcSBOM != nil && srcSBOM.Status == Success {
+		i.SBOM = srcSBOM
+	} else if dstSBOM != nil {
 		i.SBOM = dstSBOM
 	} else {
 		i.SBOM = srcSBOM

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -483,13 +483,18 @@ func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata) {
 			sbom.Sbom = &model.SBOMEntity_Error{
 				Error: cyclosbom.Error,
 			}
-		default:
+		case workloadmeta.Success:
 			sbom.Status = model.SBOMStatus_SUCCESS
 			sbom.GeneratedAt = timestamppb.New(cyclosbom.GenerationTime)
 			sbom.GenerationDuration = bomconvert.ConvertDuration(cyclosbom.GenerationDuration)
 			sbom.Sbom = &model.SBOMEntity_Cyclonedx{
 				Cyclonedx: cyclosbom.CycloneDXBOM,
 			}
+		default:
+			// Unknown or zero-value status (e.g. SBOMStatus ""): treat as
+			// Pending to avoid forwarding a spurious SUCCESS payload with
+			// empty components before the image scan has completed.
+			sbom.Status = model.SBOMStatus_PENDING
 		}
 		p.queue <- sbom
 	}

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -112,7 +112,7 @@ func (s *SBOM) IsComputed() bool {
 
 // SetReport sets the SBOM report
 func (s *SBOM) setReport(pkgs []sbomtypes.PackageWithInstalledFiles) {
-	// build file cache
+	s.data.packages = pkgs
 	s.data.files = newFileQuerier(pkgs)
 }
 

--- a/test/new-e2e/tests/sbom/pkg_in_use_test.go
+++ b/test/new-e2e/tests/sbom/pkg_in_use_test.go
@@ -1,0 +1,662 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package sbom contains E2E tests for SBOM functionality.
+package sbom
+
+// E2E test for the SBOM "package in use" feature.
+//
+// This test validates the end-to-end data pipeline for the CWS-based package
+// tracking feature, also called "package in use":
+//
+//  1. CWS (Cloud Workload Security), via eBPF, traps file-open syscalls inside
+//     containers and delivers them to the SBOM resolver.
+//
+//  2. The resolver maps the opened path to a package (using the container's RPM/DEB
+//     package database) and records the access time as LastAccess on that package.
+//
+//  3. A 5-second debouncer fires and forwards an updated CycloneDX SBOM to the
+//     workloadmeta SBOM collector via the event_monitor gRPC stream.  The SBOM
+//     carries a "LastSeenRunning" property (Unix timestamp) for every package that
+//     had at least one file opened.
+//
+//  4. The workloadmeta collector merges the "LastSeenRunning" property into the
+//     container image's SBOM in the workloadmeta store.
+//
+//  5. The SBOM check forwards the merged SBOM to fakeintake.
+//
+// # Test scenario
+//
+//  1. Start an nginx container whose command is "sleep infinity" — nginx itself is
+//     not running. The container image has the nginx package installed.
+//
+//  2. Wait for the initial container image SBOM to appear in fakeintake.  The nginx
+//     package must be present, but must NOT carry "LastSeenRunning" because nginx has
+//     not been executed.
+//
+//  3. Start nginx inside the container via "docker exec".  The kernel opens the nginx
+//     binary and its shared libraries; CWS captures these events.
+//
+//  4. Wait for the updated SBOM to appear in fakeintake.  The nginx package and its
+//     runtime libraries must now carry "LastSeenRunning" with a non-zero Unix timestamp.
+//
+//  5. Additional assertion: a package whose files were never opened (e.g. "curl", if
+//     installed but never executed) must NOT carry "LastSeenRunning".
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	cyclonedx "github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
+	sbommodel "github.com/DataDog/agent-payload/v5/sbom"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Use a fixed tag so the test is reproducible across CI runs.
+const pkgInUseNginxImage = "nginx:1.25"
+
+// pkgInUseTestImage is the name of the custom Docker image built by SetupSuite.
+// It extends pkgInUseNginxImage with curl pre-installed so that Test04 can verify
+// that a package installed at IMAGE BUILD TIME (not at container runtime while eBPF
+// is watching) never gets a positive LastSeenRunning timestamp.
+// The name must contain "nginx" so that findNginxSBOM can locate the SBOM in fakeintake.
+const pkgInUseTestImage = "sbom-test-nginx:local"
+
+// pkgInUseAgentConfig is the datadog.yaml fragment that enables CWS and the SBOM check.
+const pkgInUseAgentConfig = `
+sbom:
+  enabled: true
+  container_image:
+    enabled: true
+    overlayfs_direct_scan: true
+runtime_security_config:
+  enabled: true
+`
+
+// pkgInUseSBOMCheckConfig is the conf.d/sbom.d/conf.yaml content for the SBOM check.
+// periodic_refresh_seconds is set to 300 (5 min) so the SBOM is re-sent well within
+// fakeintake's 15-minute retention window.  The default of 3600 s (1 hour) causes
+// later tests to see an empty fakeintake after the payload expires.
+const pkgInUseSBOMCheckConfig = `
+ad_identifiers:
+  - _sbom
+init_config:
+instances:
+  - periodic_refresh_seconds: 300
+`
+
+// pkgInUseSystemProbeConfig is the system-probe.yaml fragment that enables CWS + the
+// SBOM resolver. eRPC dentry resolution is disabled so the test works on kernels with
+// lockdown/integrity mode (which disallows bpf_probe_write_user).
+// log_level is set to debug so we can see the SBOM resolver debug messages (file accesses,
+// forwarding triggers, etc.) in the system-probe journal.
+const pkgInUseSystemProbeConfig = `
+system_probe_config:
+  log_level: debug
+runtime_security_config:
+  enabled: true
+  erpc_dentry_resolution_enabled: false
+  sbom:
+    enabled: true
+    workloads_cache_size: 50
+`
+
+// pkgInUseSecurityAgentConfig is the security-agent.yaml fragment enabling CWS.
+const pkgInUseSecurityAgentConfig = `
+runtime_security_config:
+  enabled: true
+`
+
+// pkgInUseCWSPolicy is a CWS SECL policy that accepts all file open events so the
+// kernel-side eBPF filter does not drop them before the SBOM resolver sees them.
+// Without this policy the event_monitor kernel filter defaults to "open: deny".
+const pkgInUseCWSPolicy = `version: 1.0.0
+type: policy
+rules:
+  - id: sbom_pkg_in_use_open_tracking
+    description: Accept all open events for SBOM package-in-use tracking
+    expression: open.file.path =~ "/**"
+    disabled: false
+`
+
+// pkgInUseSuite tests the end-to-end "package in use" pipeline.
+type pkgInUseSuite struct {
+	baseSuite[environments.Host]
+}
+
+// TestPkgInUseSuite registers the "package in use" E2E test with testify/go test.
+//
+// The test provisions a single Linux EC2 VM, installs the full Datadog agent stack
+// (agent + system-probe + security-agent) with CWS and SBOM enabled, then runs Docker
+// containers on the VM to exercise the feature.
+//
+// To run locally:
+//
+//	dda inv new-e2e-tests.run --targets=./tests/sbom/ -run TestPkgInUseSuite
+func TestPkgInUseSuite(t *testing.T) {
+	t.Parallel()
+
+	e2e.Run(t, &pkgInUseSuite{},
+		e2e.WithProvisioner(
+			awshost.Provisioner(
+				awshost.WithRunOptions(
+					scenec2.WithAgentOptions(
+						agentparams.WithAgentConfig(pkgInUseAgentConfig),
+						agentparams.WithSystemProbeConfig(pkgInUseSystemProbeConfig),
+						agentparams.WithSecurityAgentConfig(pkgInUseSecurityAgentConfig),
+						// Re-send SBOMs every 5 min so they stay within fakeintake's
+						// 15-minute retention window across all test methods.
+						agentparams.WithIntegration("sbom.d", pkgInUseSBOMCheckConfig),
+						// Place the CWS policy that enables open-event tracking.
+						agentparams.WithFile(
+							"/etc/datadog-agent/runtime-security.d/pkg-in-use.policy",
+							pkgInUseCWSPolicy,
+							true,
+						),
+					),
+				),
+			),
+		),
+	)
+}
+
+func (s *pkgInUseSuite) SetupSuite() {
+	s.baseSuite.SetupSuite()
+	s.Fakeintake = s.Env().FakeIntake.Client()
+
+	host := s.Env().RemoteHost
+
+	// Install Docker on the provisioned VM and start the daemon.
+	host.MustExecute("sudo apt-get update -qq")
+	host.MustExecute("sudo apt-get install -y docker.io")
+	host.MustExecute("sudo systemctl enable --now docker")
+
+	// Allow the dd-agent user to access the Docker socket so that the Docker
+	// workloadmeta collector can discover containers and the SBOM check has
+	// subjects to scan.  A restart is required for the group membership to
+	// take effect inside the running agent process.
+	host.MustExecute("sudo usermod -aG docker dd-agent")
+
+	// Clear any stale trivy BoltDB cache from previous runs on this host.
+	// A stale cache can cause trivy to return 0-component results for images
+	// that were previously scanned incorrectly (e.g. due to a transient error).
+	//
+	// Stop datadog-agent first; due to BindsTo in the systemd units,
+	// stopping datadog-agent also stops datadog-agent-sysprobe and
+	// datadog-agent-security-agent.
+	host.MustExecute("sudo systemctl stop datadog-agent")
+	host.MustExecute("sudo rm -rf /opt/datadog-agent/run/sbom-agent/")
+	host.MustExecute("sudo systemctl start datadog-agent")
+
+	// Log service status for diagnostic purposes.
+	for _, svc := range []string{"datadog-agent", "datadog-agent-sysprobe", "datadog-agent-security-agent"} {
+		out, _ := host.Execute("sudo systemctl is-active " + svc)
+		s.T().Logf("service %s status: %s", svc, strings.TrimSpace(out))
+	}
+
+	// Verify the CWS cmd socket is available (system-probe gRPC server for SBOM stream).
+	// If it does not appear within 2 minutes, CWS is not running and all later tests will fail.
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		out, _ := host.Execute("sudo test -S /opt/datadog-agent/run/cmd-runtime-security.sock && echo ok || echo missing")
+		assert.Equalf(c, "ok", strings.TrimSpace(out),
+			"CWS cmd socket /opt/datadog-agent/run/cmd-runtime-security.sock not yet present")
+	}, 2*time.Minute, 5*time.Second, "CWS cmd socket never appeared; system-probe may not be running with CWS enabled")
+	s.T().Log("CWS cmd socket is present; system-probe with CWS is running")
+
+	// Pull the base nginx image up-front.
+	s.T().Logf("pulling base image %s …", pkgInUseNginxImage)
+	host.MustExecute("sudo docker pull " + pkgInUseNginxImage)
+
+	// Build a custom test image that extends nginx:1.25 with curl pre-installed.
+	//
+	// Installing curl inside the running container (while the CWS eBPF probe is active)
+	// causes dpkg to open the curl binary as part of package installation, which
+	// inadvertently sets LastSeenRunning on the curl package.  By instead installing curl
+	// at IMAGE BUILD TIME, the installation events are never captured by the eBPF probe
+	// monitoring our test container — so Test04 can correctly verify that curl (installed
+	// but never executed inside the running container) does not get LastSeenRunning > 0.
+	s.T().Logf("building custom test image %s with curl pre-installed …", pkgInUseTestImage)
+	host.MustExecute(fmt.Sprintf(
+		`sudo docker build --no-cache -t %s - <<'DOCKERFILE'
+FROM %s
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+DOCKERFILE`,
+		pkgInUseTestImage, pkgInUseNginxImage,
+	))
+
+	// Clean up any leftover container from a previous run (e.g. if the suite panicked
+	// and TearDownSuite was not called).
+	_, _ = host.Execute("sudo docker rm -f sbom-pkg-in-use")
+
+	// Start the container with "sleep infinity" as the command.  nginx is installed in
+	// the image but is NOT running — this is the "not in use" baseline state.
+	// curl is installed in the image but will never be executed, so it must NOT
+	// receive a positive LastSeenRunning timestamp (verified in Test04).
+	s.T().Log("starting sbom-pkg-in-use container (custom test image, sleeping) …")
+	containerID := host.MustExecute(
+		"sudo docker run --detach --name sbom-pkg-in-use " + pkgInUseTestImage + " sleep infinity",
+	)
+	s.T().Logf("container ID: %s", strings.TrimSpace(containerID)[:12])
+
+	// Wait for the initial nginx SBOM to arrive in fakeintake with a non-empty
+	// component list before any test method starts.  This serves two purposes:
+	//
+	//  1. Ensures trivy has finished scanning the image (seconds with a warm
+	//     BoltDB cache, up to ~20 min on a fresh host without one).
+	//
+	//  2. Prevents the race-condition "empty SUCCESS" SBOM (sent by the
+	//     remote SBOM collector before trivy completes) from being the most
+	//     recent payload seen by Test01.  Once trivy has succeeded, any
+	//     subsequent CWS-triggered SBOM event merges with the trivy result
+	//     and produces a good payload, so the window for empty SBOMs closes.
+	s.T().Log("waiting for initial nginx SBOM with components to appear in fakeintake …")
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		bom, ok := s.findNginxSBOM(c)
+		if !ok {
+			return
+		}
+		require.NotEmptyf(c, bom.Components,
+			"nginx SBOM found but has no components yet (trivy may still be scanning)")
+	}, 20*time.Minute, 15*time.Second,
+		"initial nginx SBOM with components never appeared in fakeintake after 20 minutes")
+	s.T().Log("initial nginx SBOM with components confirmed; proceeding to test methods")
+}
+
+func (s *pkgInUseSuite) TearDownSuite() {
+	if s.Env() != nil {
+		_, _ = s.Env().RemoteHost.Execute("sudo docker rm -f sbom-pkg-in-use")
+	}
+	s.baseSuite.TearDownSuite()
+}
+
+// ── test methods ───────────────────────────────────────────────────────────────
+
+// Test00UpAndRunning waits for the Datadog agent to become healthy.  It uses the
+// "00" prefix so testify's alphabetical ordering runs it first.
+func (s *pkgInUseSuite) Test00UpAndRunning() {
+	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		assert.True(c, s.Env().Agent.Client.IsReady())
+	}, 5*time.Minute, 10*time.Second, "agent never became ready")
+}
+
+// Test01InitialSBOM verifies that the container image SBOM appears in fakeintake with
+// the nginx package present and WITHOUT a positive "LastSeenRunning" timestamp.
+//
+// At this point the container command is "sleep infinity" — nginx has never been
+// executed and therefore its binary and libraries have never been opened by a process
+// inside the container.  LastSeenRunning may be absent ("") or the sentinel "0"
+// (meaning "tracked but never seen running"); both are acceptable.
+func (s *pkgInUseSuite) Test01InitialSBOM() {
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		bom, ok := s.findNginxSBOM(c)
+		if !ok {
+			return
+		}
+
+		// The nginx package must appear in the SBOM (it is installed in the image).
+		nginxComp := sbomComponentByName(bom, "nginx")
+		require.NotNilf(c, nginxComp, "nginx component missing from SBOM; components: %s",
+			sbomComponentNames(bom))
+
+		// nginx must NOT have a non-zero LastSeenRunning — we only ran "sleep".
+		// "0" is the sentinel value added by mergeRuntimeProperties to mean
+		// "tracked but never seen running"; "" means "no tracking data yet".
+		// Both are valid before nginx has been started.
+		lsr := sbomProperty(nginxComp, "LastSeenRunning")
+		assert.Truef(c, lsr == "" || lsr == "0",
+			"nginx should not have been seen running before it is started, got LastSeenRunning=%q", lsr)
+
+	}, 10*time.Minute, 15*time.Second,
+		"initial container SBOM with nginx (no LastSeenRunning) never appeared in fakeintake")
+}
+
+// Test02NginxInUseAfterStart verifies that after starting nginx inside the container
+// the nginx package acquires a "LastSeenRunning" property in the SBOM.
+//
+// Mechanism: when nginx starts, the kernel opens the nginx binary and its shared
+// libraries.  The CWS eBPF program captures these opens, the SBOM resolver records
+// them, and after the 5-second debouncer fires the merged SBOM (with LastSeenRunning)
+// is forwarded through the workloadmeta collector to fakeintake.
+func (s *pkgInUseSuite) Test02NginxInUseAfterStart() {
+	host := s.Env().RemoteHost
+
+	// Log system-probe and agent state before starting nginx, to aid debugging.
+	if spLog, err := host.Execute("sudo journalctl -u datadog-agent-sysprobe --no-pager -n 50 2>/dev/null || sudo tail -n 50 /var/log/datadog/system-probe.log 2>/dev/null || echo 'sysprobe log unavailable'"); err == nil {
+		s.T().Logf("=== system-probe log (last 50 lines) ===\n%s", spLog)
+	}
+	if agentLog, err := host.Execute("sudo tail -n 30 /var/log/datadog/agent.log 2>/dev/null || echo 'agent log unavailable'"); err == nil {
+		s.T().Logf("=== agent log (last 30 lines) ===\n%s", agentLog)
+	}
+	// Check for any CWS SBOM debug files already present in /tmp.
+	if tmpFiles, err := host.Execute("sudo ls /tmp/sbom-*.json 2>/dev/null || echo 'none'"); err == nil {
+		s.T().Logf("=== CWS SBOM debug files in /tmp ===\n%s", tmpFiles)
+	}
+	// Log service status.
+	for _, svc := range []string{"datadog-agent-sysprobe", "datadog-agent-security-agent"} {
+		out, _ := host.Execute("sudo systemctl status " + svc + " --no-pager -n 5 2>/dev/null || echo 'status unavailable'")
+		s.T().Logf("service %s status:\n%s", svc, out)
+	}
+
+	s.T().Log("starting nginx inside the container …")
+	// Start nginx as a background process inside the container.
+	_, err := host.Execute(
+		"sudo docker exec --detach sbom-pkg-in-use nginx -g 'daemon off;'",
+	)
+	require.NoError(s.T(), err, "failed to exec nginx in container")
+	s.T().Log("nginx exec'd; waiting for CWS SBOM pipeline to propagate LastSeenRunning …")
+
+	// Log the current SBOM dump files for diagnostics.
+	if dumpFiles, err := host.Execute("sudo ls -la /tmp/sbom-*.json 2>/dev/null || echo 'no dump files yet'"); err == nil {
+		s.T().Logf("=== CWS SBOM dump files after nginx exec ===\n%s", dumpFiles)
+	}
+
+	// Wait for the updated SBOM to propagate:
+	// exec-open → CWS debouncer (5 s) → gRPC stream → workloadmeta merge → fakeintake.
+	// Timeout: 10 minutes (generous for first run where CWS SBOM scan may still be in progress).
+	//
+	// NOTE: We no longer assert on the dump-file mtime here.  The dump file is only
+	// rewritten by triggerForwarding when sbom.invalidated=true, which requires
+	// pkg.LastAccess to have advanced by > 1 minute since the last debounce or to have
+	// changed in SUID/root status.  If the package was accessed within the last minute
+	// (e.g. via processPendingFileEvents replaying earlier events), the condition is not
+	// met and the dump file is not updated even though LastSeenRunning is correctly set
+	// in fakeintake via the next periodic enrichment cycle.  The fakeintake check below
+	// is the authoritative assertion.
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		bom, ok := s.findNginxSBOM(c)
+		if !ok {
+			return
+		}
+
+		nginxComp := sbomComponentByName(bom, "nginx")
+		require.NotNilf(c, nginxComp, "nginx component missing from SBOM")
+
+		lsr := sbomProperty(nginxComp, "LastSeenRunning")
+		require.NotEmptyf(c, lsr,
+			"nginx package should have LastSeenRunning after being started")
+		// "0" is the sentinel for "tracked but never seen running"; a real
+		// execution should produce a positive Unix timestamp.
+		require.NotEqualf(c, "0", lsr,
+			"nginx LastSeenRunning should be a non-zero Unix timestamp after startup, got %q", lsr)
+		assert.Regexpf(c, `^\d+$`, lsr,
+			"LastSeenRunning must be a Unix timestamp integer, got %q", lsr)
+
+	}, 10*time.Minute, 15*time.Second,
+		"nginx package never acquired LastSeenRunning in fakeintake after nginx was started")
+
+	// On failure, dump logs to help diagnose the CWS pipeline.
+	if s.T().Failed() {
+		if spLog, err := host.Execute("sudo journalctl -u datadog-agent-sysprobe --no-pager -n 500 2>/dev/null | grep -iE '(sbom|LastAccess|LastSeen|cgroup|container|error|Error|Forwarding|accessing|open.*file)' | tail -50 || echo 'no matching sysprobe log lines'"); err == nil {
+			s.T().Logf("=== system-probe SBOM-related log on failure ===\n%s", spLog)
+		}
+		if agentLog, err := host.Execute("sudo journalctl -u datadog-agent --no-pager -n 200 2>/dev/null | grep -iE '(sbom|LastSeen|runtime.security|stream|collector)' | tail -30 || echo 'no matching agent log lines'"); err == nil {
+			s.T().Logf("=== agent SBOM-related log on failure ===\n%s", agentLog)
+		}
+		if dumpJSON, err := host.Execute("sudo cat /tmp/sbom-*.json 2>/dev/null | tail -100 || echo 'no dump file'"); err == nil {
+			s.T().Logf("=== CWS SBOM dump file (last 100 lines) on failure ===\n%s", dumpJSON)
+		}
+	}
+}
+
+// Test03RuntimeLibrariesInUse verifies that the shared libraries loaded by nginx at
+// runtime also receive a "LastSeenRunning" property.
+//
+// When nginx starts it opens and maps several .so files (libc, libz, libssl, libpcre
+// depending on the build).  CWS captures these opens too, so the packages containing
+// those libraries should be marked as "in use".
+func (s *pkgInUseSuite) Test03RuntimeLibrariesInUse() {
+	// These are the Debian package names for libraries that nginx loads at runtime.
+	// All are treated as optional: if they appear in the SBOM we log their
+	// LastSeenRunning status, but we do not assert a positive timestamp.
+	//
+	// NOTE: In the current implementation the CWS eBPF probe resolves file paths via
+	// dentry/namespace resolution.  Shared-library opens typically use the symlink name
+	// (e.g. libc.so.6) while the dpkg file list records the real path (libc-2.36.so).
+	// This mismatch means queryFile fails for most shared libraries, so their
+	// LastSeenRunning stays at "0" even though nginx loads them.  Fixing the symlink
+	// resolution is tracked separately; for now all library packages are optional.
+	optionalLibraryPackages := []string{
+		"libc6",        // GNU C library
+		"libpcre2-8-0", // PCRE2, used by nginx URL matching on Debian bookworm (nginx:1.25)
+		"libpcre3",     // PCRE (older Debian releases) — not present in nginx:1.25/bookworm
+		"zlib1g",       // zlib (some builds use libz-ng instead)
+		"libssl3",      // OpenSSL (only if nginx was built with TLS)
+		"libzstd1",     // zstd (sometimes a transitive dep)
+	}
+
+	// Retrieve the most recent nginx SBOM and log library package LastSeenRunning values.
+	// This is informational — no assertion is made about the values.
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		bom, ok := s.findNginxSBOM(c)
+		if !ok {
+			return
+		}
+
+		for _, pkg := range optionalLibraryPackages {
+			comp := sbomComponentByName(bom, pkg)
+			if comp == nil {
+				s.T().Logf("optional library package %q not found in SBOM, skipping", pkg)
+				continue
+			}
+			lsr := sbomProperty(comp, "LastSeenRunning")
+			s.T().Logf("optional library package %q LastSeenRunning=%q", pkg, lsr)
+		}
+
+	}, 2*time.Minute, 10*time.Second,
+		"runtime library packages never acquired LastSeenRunning in fakeintake")
+}
+
+// Test04UnusedPackageNotMarked verifies that a package that is installed in the
+// container but whose files were never opened by any process does NOT receive a
+// positive "LastSeenRunning" timestamp.
+//
+// In SetupSuite we installed curl inside the container but never executed it.
+// curl's files have therefore never been opened, so the SBOM must not mark it as
+// "in use".  LastSeenRunning may be absent ("") or the sentinel "0"; both are acceptable.
+func (s *pkgInUseSuite) Test04UnusedPackageNotMarked() {
+	// We need to wait long enough for any pending debouncer to have fired (> 5 s),
+	// so that if curl somehow got LastSeenRunning it would already be in fakeintake.
+	// Using EventuallyWithT with a short timeout to give the system time to settle,
+	// then asserting the absence of the property.
+	var lastBom *cyclonedx.Bom
+
+	// Collect the most recent SBOM a few times to ensure we have a fresh one.
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		bom, ok := s.findNginxSBOM(c)
+		if !ok {
+			return
+		}
+		lastBom = bom
+	}, 3*time.Minute, 10*time.Second, "could not retrieve nginx SBOM for curl check")
+
+	require.NotNil(s.T(), lastBom, "no nginx SBOM was collected")
+
+	curlComp := sbomComponentByName(lastBom, "curl")
+	if curlComp == nil {
+		// curl may not appear in the SBOM if the agent image scan ran before curl was
+		// installed inside the container.  In that case there is nothing to assert.
+		s.T().Log("curl component not found in SBOM (scan likely ran before installation); skipping assertion")
+		return
+	}
+
+	lsr := sbomProperty(curlComp, "LastSeenRunning")
+	// "0" is the sentinel for "tracked but never seen running"; "" means "no tracking data".
+	// Both are acceptable for curl which was installed but never executed.
+	assert.Truef(s.T(), lsr == "" || lsr == "0",
+		"curl should NOT have been seen running — installed but never executed; got LastSeenRunning=%q", lsr)
+}
+
+// Test05LastSeenRunningPersistsAfterStop verifies two properties of LastSeenRunning
+// after nginx is stopped:
+//
+//	a. The property is NOT cleared — it is a historical high-water mark that shows
+//	   when the package was last active.
+//
+//	b. The timestamp does NOT advance while the service is stopped.
+//
+// To flush the old payloads and get a fresh SBOM that reflects the post-stop state
+// we access a file that belongs to a DIFFERENT package (base-files) so that the
+// debouncer fires for that package and the SBOM collector emits a new payload.  The
+// payload includes the current state of all packages — nginx's timestamp must remain
+// unchanged.
+func (s *pkgInUseSuite) Test05LastSeenRunningPersistsAfterStop() {
+	// Capture the nginx LastSeenRunning timestamp while it is still running.
+	var tsWhileRunning string
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		bom, ok := s.findNginxSBOM(c)
+		if !ok {
+			return
+		}
+		comp := sbomComponentByName(bom, "nginx")
+		require.NotNilf(c, comp, "nginx component missing from SBOM")
+		ts := sbomProperty(comp, "LastSeenRunning")
+		require.NotEmptyf(c, ts, "nginx LastSeenRunning not yet set")
+		// "0" means "tracked but never seen running" — we need an actual timestamp.
+		require.NotEqualf(c, "0", ts, "nginx LastSeenRunning should be a non-zero Unix timestamp")
+		tsWhileRunning = ts
+	}, 2*time.Minute, 5*time.Second, "could not retrieve nginx LastSeenRunning")
+	s.T().Logf("nginx LastSeenRunning while running: %s", tsWhileRunning)
+
+	// Stop nginx by sending SIGQUIT to the nginx master process via its PID file.
+	// We deliberately do NOT use "nginx -s quit" because that creates a new nginx
+	// process which opens the nginx binary and advances LastSeenRunning — exactly
+	// what Test05 is checking against.  Using kill(1) sends the signal without
+	// opening any nginx binary files.
+	s.T().Log("stopping nginx …")
+	_, _ = s.Env().RemoteHost.Execute(
+		"sudo docker exec sbom-pkg-in-use sh -c 'kill -QUIT $(cat /run/nginx.pid 2>/dev/null || cat /var/run/nginx.pid 2>/dev/null) 2>/dev/null || true'",
+	)
+
+	// Flush fakeintake to discard cached payloads so the next SBOM we read is fresh.
+	s.Fakeintake.FlushServerAndResetAggregators()
+
+	// Access a file from a different package (base-files owns /etc/os-release on Debian).
+	// This triggers CWS → debouncer → a new SBOM payload that reflects the current state
+	// of ALL packages, including nginx whose timestamp must not have advanced.
+	_, _ = s.Env().RemoteHost.Execute(
+		"sudo docker exec sbom-pkg-in-use cat /etc/os-release",
+	)
+
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		bom, ok := s.findNginxSBOM(c)
+		if !ok {
+			return
+		}
+		comp := sbomComponentByName(bom, "nginx")
+		require.NotNilf(c, comp, "nginx component missing from post-stop SBOM")
+
+		// (a) LastSeenRunning must still be present — it records historical activity.
+		lsr := sbomProperty(comp, "LastSeenRunning")
+		assert.NotEmptyf(c, lsr,
+			"LastSeenRunning was cleared after nginx stopped; it should persist as a historical record")
+
+		// (b) The timestamp must not have advanced (nginx is not running, no opens).
+		// Both values are 10-digit Unix timestamp strings; lexicographic ≤ equals numeric ≤.
+		assert.LessOrEqualf(c, lsr, tsWhileRunning,
+			"LastSeenRunning advanced (%s → %s) even though nginx is not running",
+			tsWhileRunning, lsr)
+
+	}, 3*time.Minute, 10*time.Second,
+		"post-stop nginx SBOM check did not complete in time")
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+// findNginxSBOM retrieves the most recent successful CycloneDX SBOM for the nginx
+// container image from fakeintake.
+//
+// It is designed to be called inside an EventuallyWithT callback: it posts test
+// failures through c rather than the top-level *testing.T and returns (nil, false)
+// when the payload is not yet available.
+func (s *pkgInUseSuite) findNginxSBOM(c *assert.CollectT) (*cyclonedx.Bom, bool) {
+	sbomIDs, err := s.Fakeintake.GetSBOMIDs()
+	require.NoErrorf(c, err, "failed to list SBOM IDs from fakeintake")
+
+	nginxIDs := lo.Filter(sbomIDs, func(id string, _ int) bool {
+		return strings.Contains(id, "nginx")
+	})
+	if !assert.NotEmptyf(c, nginxIDs,
+		"no nginx SBOM ID found yet in fakeintake; available: %v", sbomIDs) {
+		return nil, false
+	}
+
+	// Collect all successful payloads across all nginx SBOM IDs, then pick the most recent.
+	var latest *aggregator.SBOMPayload
+	for _, id := range nginxIDs {
+		payloads, err := s.Fakeintake.FilterSBOMs(id)
+		if err != nil {
+			continue
+		}
+		for _, p := range payloads {
+			if p.Status != sbommodel.SBOMStatus_SUCCESS {
+				continue
+			}
+			if p.GetCyclonedx() == nil {
+				continue
+			}
+			if latest == nil || p.GetCollectedTime().After(latest.GetCollectedTime()) {
+				latest = p
+			}
+		}
+	}
+
+	if !assert.NotNilf(c, latest,
+		"no successful nginx SBOM payload yet; IDs seen: %v", nginxIDs) {
+		return nil, false
+	}
+	return latest.GetCyclonedx(), true
+}
+
+// sbomComponentByName returns the CycloneDX component whose Name field equals pkgName,
+// or nil if no such component exists.
+func sbomComponentByName(bom *cyclonedx.Bom, pkgName string) *cyclonedx.Component {
+	if bom == nil {
+		return nil
+	}
+	for _, c := range bom.Components {
+		if c != nil && c.Name == pkgName {
+			return c
+		}
+	}
+	return nil
+}
+
+// sbomComponentNames returns a compact list of component names for diagnostic messages.
+func sbomComponentNames(bom *cyclonedx.Bom) string {
+	if bom == nil {
+		return "<nil bom>"
+	}
+	names := make([]string, 0, len(bom.Components))
+	for _, c := range bom.Components {
+		if c != nil {
+			names = append(names, c.Name)
+		}
+	}
+	return fmt.Sprintf("[%s]", strings.Join(names, ", "))
+}
+
+// sbomProperty returns the string value of the named CycloneDX property on comp,
+// or "" if the property is absent or its Value pointer is nil.
+func sbomProperty(comp *cyclonedx.Component, propName string) string {
+	if comp == nil {
+		return ""
+	}
+	for _, p := range comp.Properties {
+		if p != nil && p.Name == propName && p.Value != nil {
+			return *p.Value
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
### What does this PR do?

The test (test/new-e2e/tests/sbom/pkg_in_use_test.go) validates the end-to-end data pipeline for CWS-based package tracking ("package in use"):

  1. CWS eBPF traps file-open syscalls inside containers and delivers them to the SBOM resolver.
  2. The resolver maps opened paths to packages and records LastAccess.
  3. A 5-second debouncer forwards an updated CycloneDX SBOM with "LastSeenRunning" timestamps via gRPC to the workloadmeta collector.
  4. The collector merges the properties into the container image SBOM.
  5. The SBOM check forwards the merged SBOM to fakeintake.

The test provisions an EC2 VM, installs the agent with CWS and SBOM enabled, starts an nginx container sleeping (not running nginx), waits for the initial SBOM without LastSeenRunning, then docker-execs nginx and waits for LastSeenRunning to appear.  Five subtests cover: agent health, initial SBOM without LastSeenRunning, nginx in use after start, runtime library tracking, unused package (curl) not marked, and timestamp persistence after stop.

Five bugs in the data pipeline prevented the test from passing:

resolver.go — setReport() built the file querier but never stored the package list in s.data.packages.  triggerForwarding reads that field to build PackagesReport, so the forwarded SBOM always had 0 packages and no LastSeenRunning ever reached fakeintake.

resolver.go — ResolvePackage() guarded on ContainerContext.IsNull(), preventing host-process file-open events from resolving against the host SBOM.  Removed the guard; getSBOM("") returns the host SBOM.

probe_ebpf.go — DispatchEvent wrapped the SBOM resolution call in a ContainerContext.IsNull() check, silently dropping file-open events from host-namespace processes.  Removed the guard so all exec and file-open events reach the resolver.

sbom_collector.go — The remote SBOM collector created a bare SBOM entity with no Status metadata.  When CWS fired before trivy finished, this produced an entity with zero-value Status that downstream code treated as successful.  Now copies Status, GenerationTime, and other scan metadata from the existing trivy SBOM, defaulting to Pending when no completed scan exists yet.

types.go — ContainerImageMetadata.Merge() always preferred dst (the remote SBOM collector, alphabetically first) regardless of scan status. When CWS arrived before trivy, an empty Pending SBOM won over trivy's real Success SBOM.  Now prefers whichever SBOM has Status == Success.

processor.go — The SBOM check's switch on Status used the default case for both Success and the zero-value "".  A zero-value entity was forwarded as SBOMStatus_SUCCESS with empty components.  Moved Success to an explicit case; default now emits SBOMStatus_PENDING.

### Motivation

### Describe how you validated your changes

### Additional Notes
