### PR TITLE
Drop unnecessary local tag from go test target

### DIFF
--- a/pkg/util/hostinfo/BUILD.bazel
+++ b/pkg/util/hostinfo/BUILD.bazel
@@ -92,7 +92,6 @@ go_test(
     embed = [":hostinfo"],
     env_inherit = ["PATH"],  # test invokes system utilities (e.g. ioreg on macOS) requiring the host PATH
     gotags = ["test"],
-    tags = ["local"],
     deps = select({
         "@rules_go//go/platform:aix": [
             "//pkg/util/cache",


### PR DESCRIPTION
### What does this PR do?

Drops the `local` tag from hostinfo test to prevent bazel from removing sandboxing for this target.

### Motivation

This tag caused problems when trying to move to a hermetic toolchain on macos (https://github.com/DataDog/datadog-agent/pull/42894). The tag turns out to not really be needed (as providing the PATH is enough for what the test actually needs).

### Describe how you validated your changes

Passing tests.

### Additional Notes
