### PR TITLE
[tagger] Add telemetry for tag completeness delay

### DIFF
--- a/comp/core/tagger/tagstore/tagstore.go
+++ b/comp/core/tagger/tagstore/tagstore.go
@@ -40,6 +40,10 @@ type TagStore struct {
 	store     *genericstore.ObjectStore[EntityTags]
 	telemetry map[string]map[string]float64
 
+	// incompleteEntities tracks when entities were first seen in an incomplete
+	// state, so we can measure the delay until they become complete.
+	incompleteEntities map[types.EntityID]time.Time
+
 	subscriptionManager subscriber.SubscriptionManager
 
 	clock clock.Clock
@@ -56,6 +60,7 @@ func newTagStoreWithClock(clock clock.Clock, telemetryStore *telemetry.Store) *T
 	return &TagStore{
 		telemetry:           make(map[string]map[string]float64),
 		store:               genericstore.NewObjectStore[EntityTags](),
+		incompleteEntities:  make(map[types.EntityID]time.Time),
 		subscriptionManager: subscriber.NewSubscriptionManager(telemetryStore),
 		clock:               clock,
 		// telemetryStore is optional. If it is nil, we will not collect
@@ -156,6 +161,8 @@ func (s *TagStore) ProcessTagInfo(tagInfos []*types.TagInfo) {
 		}
 		storedTags.setIsComplete(info.IsComplete)
 
+		s.trackCompletenessDelay(info.EntityID, eventType, info.IsComplete)
+
 		events = append(events, types.EntityEvent{
 			EventType: eventType,
 			Entity:    storedTags.toEntity(),
@@ -241,6 +248,7 @@ func (s *TagStore) Prune() {
 			if s.telemetryStore != nil {
 				s.telemetryStore.PrunedEntities.Inc()
 			}
+			delete(s.incompleteEntities, eid)
 			s.store.Unset(eid)
 			events = append(events, types.EntityEvent{
 				EventType: types.EventTypeDeleted,
@@ -324,6 +332,32 @@ func (s *TagStore) GetEntity(entityID types.EntityID) (*types.Entity, error) {
 
 	entity := tags.toEntity()
 	return &entity, nil
+}
+
+func (s *TagStore) trackCompletenessDelay(entityID types.EntityID, eventType types.EventType, isComplete bool) {
+	if s.telemetryStore == nil {
+		return
+	}
+
+	prefix := string(entityID.GetPrefix())
+
+	if eventType == types.EventTypeAdded {
+		if isComplete {
+			s.telemetryStore.TagCompletenessDelay.Observe(0, prefix)
+		} else {
+			s.incompleteEntities[entityID] = s.clock.Now()
+		}
+		return
+	}
+
+	// Existing entity became complete
+	if eventType == types.EventTypeModified && isComplete {
+		if firstSeen, ok := s.incompleteEntities[entityID]; ok {
+			delay := s.clock.Now().Sub(firstSeen).Seconds()
+			s.telemetryStore.TagCompletenessDelay.Observe(delay, prefix)
+			delete(s.incompleteEntities, entityID)
+		}
+	}
 }
 
 func (s *TagStore) getEntityTags(entityID types.EntityID) (EntityTags, error) {

--- a/comp/core/tagger/tagstore/tagstore_test.go
+++ b/comp/core/tagger/tagstore/tagstore_test.go
@@ -536,6 +536,66 @@ func TestProcessTagInfo_IsComplete(t *testing.T) {
 	}
 }
 
+func TestProcessTagInfo_CompletenessDelay(t *testing.T) {
+	entityID := types.NewEntityID(types.ContainerID, "test")
+	prefix := string(types.ContainerID)
+
+	t.Run("entity arrives already complete emits 0 delay", func(t *testing.T) {
+		telemetryComponent := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
+		telemetryStore := taggerTelemetry.NewStore(telemetryComponent)
+		tagStore := NewTagStore(telemetryStore)
+
+		tagStore.ProcessTagInfo([]*types.TagInfo{
+			{
+				Source:      "source",
+				EntityID:    entityID,
+				LowCardTags: []string{"low"},
+				IsComplete:  true,
+			},
+		})
+
+		hist := telemetryStore.TagCompletenessDelay.WithValues(prefix).Get()
+		assert.Equal(t, uint64(1), hist.Count)
+		assert.Equal(t, 0.0, hist.Sum)
+	})
+
+	t.Run("entity arrives incomplete then becomes complete emits delay", func(t *testing.T) {
+		telemetryComponent := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
+		telemetryStore := taggerTelemetry.NewStore(telemetryComponent)
+		clk := clock.NewMock()
+		clk.Add(time.Since(time.Unix(0, 0)))
+		tagStore := newTagStoreWithClock(clk, telemetryStore)
+
+		tagStore.ProcessTagInfo([]*types.TagInfo{
+			{
+				Source:      "source",
+				EntityID:    entityID,
+				LowCardTags: []string{"low"},
+				IsComplete:  false,
+			},
+		})
+
+		// No observation yet because entity is incomplete
+		hist := telemetryStore.TagCompletenessDelay.WithValues(prefix).Get()
+		assert.Equal(t, uint64(0), hist.Count)
+
+		clk.Add(3 * time.Second)
+
+		tagStore.ProcessTagInfo([]*types.TagInfo{
+			{
+				Source:      "source",
+				EntityID:    entityID,
+				LowCardTags: []string{"low", "extra"},
+				IsComplete:  true,
+			},
+		})
+
+		hist = telemetryStore.TagCompletenessDelay.WithValues(prefix).Get()
+		assert.Equal(t, uint64(1), hist.Count)
+		assert.Equal(t, 3.0, hist.Sum)
+	})
+}
+
 func TestSubscribe(t *testing.T) {
 	tel := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
 	telemetryStore := taggerTelemetry.NewStore(tel)

--- a/comp/core/tagger/telemetry/telemetry.go
+++ b/comp/core/tagger/telemetry/telemetry.go
@@ -61,6 +61,10 @@ type Store struct {
 	// to generate a container ID from Origin Info.
 	OriginInfoRequests telemetry.Counter
 
+	// TagCompletenessDelay tracks the delay (seconds) from when an entity's
+	// tags first appear until the tag set is considered complete.
+	TagCompletenessDelay telemetry.Histogram
+
 	LowCardinalityQueries          CardinalityTelemetry
 	OrchestratorCardinalityQueries CardinalityTelemetry
 	HighCardinalityQueries         CardinalityTelemetry
@@ -127,6 +131,15 @@ func NewStore(telemetryComp telemetry.Component) *Store {
 		OriginInfoRequests: telemetryComp.NewCounterWithOpts(subsystem, "origin_info_requests",
 			[]string{"status"}, "Number of requests to the tagger to generate a container ID from origin info.",
 			commonOpts),
+
+		TagCompletenessDelay: telemetryComp.NewHistogramWithOpts(
+			subsystem,
+			"tag_completeness_delay",
+			[]string{"prefix"},
+			"Delay before all expected collectors reported for an entity (in seconds).",
+			[]float64{0, 1, 2.5, 5, 10, 30, 60, 120}, // 0 is here because we want to know when there's no delay
+			commonOpts,
+		),
 
 		LowCardinalityQueries:          newCardinalityTelemetry(queries, types.LowCardinalityString),
 		OrchestratorCardinalityQueries: newCardinalityTelemetry(queries, types.OrchestratorCardinalityString),


### PR DESCRIPTION
### What does this PR do?

This PR adds a new telemetry metric in the tagger: `tagger.tag_completeness_delay`. It tracks how long it takes from when an entity's tags first show up until the full tag set is considered complete.


### Describe how you validated your changes

Unit tests plus manual testing in a local kind cluster. I ran two scenarios to check the new metric:
- Deployed with default config and created workloads behind Kubernetes services. The metric showed delays of tens of seconds, which is expected because the `kube_service` tag comes from the kubemetadata collector, which only pulls every 60s.
- Deployed with `DD_KUBERNETES_METADATA_STREAMING=true` which lets the agent get the `kube_service` tag much faster. The new metric confirmed this.



