### PR TITLE
Update OTel v0.150.0 release note per review feedback

### DIFF
--- a/releasenotes/notes/upgrade-otel-collector-v0.150.0-f341e91566fe9075.yaml
+++ b/releasenotes/notes/upgrade-otel-collector-v0.150.0-f341e91566fe9075.yaml
@@ -17,6 +17,13 @@ enhancements:
       topology view.
     - Fix for use-after-free bug in quantile sketches when exporting
       ExponentialHistogram metrics with multiple attribute sets.
+    - OTTL context setters (used by ``transform``, ``filter``, and ``tailsampling``
+      processors) now validate value types and return errors on type mismatches
+      instead of silently ignoring them.
+      Users with ``error_mode: propagate`` (the default for the transform
+      processor) may see new errors if their OTTL statements had pre-existing
+      type mismatches. Switch to ``error_mode: ignore`` to preserve the previous
+      behavior while fixing the statements.
 
     See the full upstream changelogs:
     `collector-contrib v0.150.0 <https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.150.0>`_,


### PR DESCRIPTION
### What does this PR do?

Updates the OTel v0.150.0 release note to address review feedback from @RiantZ on PR #48796.

### Motivation

The release note was merged without incorporating all feedback from RiantZ's review. This follow-up adds the missing items.

### Describe how you validated your changes

Release note only — no code changes.

### Additional Notes

Based on RiantZ's review comment on PR #48796 and the proposed release note at https://github.com/DataDog/datadog-agent/blob/bd805062df1470334692342fdcf98505ffc0d852/releasenotes/notes/upgrade-otel-collector-v0.150.0-f341e91566fe9075.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)