### PR TITLE
[CWS] Fix agent container created_at to serialize as RFC3339 timestamp

### DIFF
--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 const (
@@ -88,7 +89,7 @@ const (
 // AgentContainerContext is like model.ContainerContext, but without event based resolvers
 type AgentContainerContext struct {
 	ContainerID containerutils.ContainerID `json:"id,omitempty"`
-	CreatedAt   uint64                     `json:"created_at"`
+	CreatedAt   *utils.EasyjsonTime        `json:"created_at,omitempty"`
 }
 
 // CustomEventCommonFields represents the fields common to all custom events

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -10,6 +10,7 @@ import (
 	events "github.com/DataDog/datadog-agent/pkg/security/events"
 	containerutils "github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	serializers "github.com/DataDog/datadog-agent/pkg/security/serializers"
+	utils "github.com/DataDog/datadog-agent/pkg/security/utils"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
@@ -140,8 +141,18 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in *jle
 		case "created_at":
 			if in.IsNull() {
 				in.Skip()
+				out.CreatedAt = nil
 			} else {
-				out.CreatedAt = uint64(in.Uint64())
+				if out.CreatedAt == nil {
+					out.CreatedAt = new(utils.EasyjsonTime)
+				}
+				if in.IsNull() {
+					in.Skip()
+				} else {
+					if data := in.Raw(); in.Ok() {
+						in.AddError((*out.CreatedAt).UnmarshalJSON(data))
+					}
+				}
 			}
 		default:
 			in.SkipRecursive()
@@ -163,7 +174,7 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out *jw
 		out.RawString(prefix[1:])
 		out.String(string(in.ContainerID))
 	}
-	{
+	if in.CreatedAt != nil {
 		const prefix string = ",\"created_at\":"
 		if first {
 			first = false
@@ -171,7 +182,7 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out *jw
 		} else {
 			out.RawString(prefix)
 		}
-		out.Uint64(uint64(in.CreatedAt))
+		(*in.CreatedAt).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -7,6 +7,8 @@
 package probe
 
 import (
+	"time"
+
 	gopsutilProcess "github.com/shirou/gopsutil/v4/process"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
@@ -103,7 +105,7 @@ func NewAgentContainerContext() (*events.AgentContainerContext, error) {
 		return nil, err
 	}
 	acc := &events.AgentContainerContext{
-		CreatedAt: uint64(createTime),
+		CreatedAt: utils.NewEasyjsonTimeIfNotZero(time.UnixMilli(createTime)),
 	}
 
 	cfs := utils.DefaultCGroupFS()

--- a/pkg/security/rules/monitor/policy_monitor_easyjson.go
+++ b/pkg/security/rules/monitor/policy_monitor_easyjson.go
@@ -9,6 +9,7 @@ import (
 	eval "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	containerutils "github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	rules "github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	utils "github.com/DataDog/datadog-agent/pkg/security/utils"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
@@ -239,8 +240,18 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityEvents(in *jle
 		case "created_at":
 			if in.IsNull() {
 				in.Skip()
+				out.CreatedAt = nil
 			} else {
-				out.CreatedAt = uint64(in.Uint64())
+				if out.CreatedAt == nil {
+					out.CreatedAt = new(utils.EasyjsonTime)
+				}
+				if in.IsNull() {
+					in.Skip()
+				} else {
+					if data := in.Raw(); in.Ok() {
+						in.AddError((*out.CreatedAt).UnmarshalJSON(data))
+					}
+				}
 			}
 		default:
 			in.SkipRecursive()
@@ -262,7 +273,7 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out *jw
 		out.RawString(prefix[1:])
 		out.String(string(in.ContainerID))
 	}
-	{
+	if in.CreatedAt != nil {
 		const prefix string = ",\"created_at\":"
 		if first {
 			first = false
@@ -270,7 +281,7 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityEvents(out *jw
 		} else {
 			out.RawString(prefix)
 		}
-		out.Uint64(uint64(in.CreatedAt))
+		(*in.CreatedAt).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
The `created_at` field in `AgentContainerContext` was previously a raw `uint64` nanosecond epoch value. Change it to `*utils.EasyjsonTime` so it serializes as a human-readable RFC3339 timestamp in custom security events, consistent with other time fields in the model. The field is now omitted when zero. Regenerate affected easyjson files.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
