### PR TITLE
[CWS] Populate pid_ignored map with kworkers during process snapshot (#49241)

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/network/pid_resolver.h
+++ b/pkg/security/ebpf/c/include/helpers/network/pid_resolver.h
@@ -50,6 +50,9 @@ __attribute__((always_inline)) void resolve_pid_from_flow_pid(struct packet_t *p
 }
 
 __attribute__((always_inline)) void resolve_pid(struct __sk_buff *skb, struct packet_t *pkt) {
+    pkt->pid = 0;
+    pkt->cgroup_id = 0;
+
     // pid from socket cookie
     u64 cookie = bpf_get_socket_cookie(skb);
     u32 *pid = bpf_map_lookup_elem(&sock_cookie_pid, &cookie);
@@ -65,6 +68,13 @@ __attribute__((always_inline)) void resolve_pid(struct __sk_buff *skb, struct pa
             u64 pid_tgid = bpf_get_current_pid_tgid();
             pkt->pid = pid_tgid >> 32;
         }
+    }
+
+    // check if the pid is a kworker pid, if so let the resolve_pid_from_flow_pid do the job
+    u32 pid_val = (u32)pkt->pid;
+    void *ignored = bpf_map_lookup_elem(&pid_ignored, &pid_val);
+    if (ignored) {
+        pkt->pid = 0;
     }
 
     // pid from flow pid

--- a/pkg/security/ebpf/c/include/helpers/process.h
+++ b/pkg/security/ebpf/c/include/helpers/process.h
@@ -81,7 +81,7 @@ static struct proc_cache_t *__attribute__((always_inline)) fill_process_context_
 
     u32 pid = data->pid;
     // consider kworker a pid which is ignored
-    u32 *is_ignored = bpf_map_lookup_elem(&pid_ignored, &pid);
+    void *is_ignored = bpf_map_lookup_elem(&pid_ignored, &pid);
     if (is_ignored) {
         data->is_kworker = 1;
     }

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -131,7 +131,7 @@ SEC("tracepoint/module/module_load")
 int module_load(struct tracepoint_module_module_load_t *args) {
     // check if the tracepoint is hit by a kworker
     u32 pid = bpf_get_current_pid_tgid();
-    u32 *is_kworker = bpf_map_lookup_elem(&pid_ignored, &pid);
+    void *is_kworker = bpf_map_lookup_elem(&pid_ignored, &pid);
     if (!is_kworker) {
         return 0;
     }

--- a/pkg/security/ebpf/c/include/hooks/network/tc.h
+++ b/pkg/security/ebpf/c/include/hooks/network/tc.h
@@ -100,13 +100,8 @@ int classifier_raw_packet_egress(struct __sk_buff *skb) {
     }
     resolve_pid(skb, pkt);
 
-    pkt->cgroup_id = get_cgroup_id(pkt->pid);
-    if (!pkt->cgroup_id) {
-        u64 sched_cls_has_current_cgroup_id_helper = 0;
-        LOAD_CONSTANT("sched_cls_has_current_cgroup_id_helper", sched_cls_has_current_cgroup_id_helper);
-        if (sched_cls_has_current_cgroup_id_helper) {
-            pkt->cgroup_id = bpf_get_current_cgroup_id();
-        }
+    if (pkt->pid) {
+        pkt->cgroup_id = get_cgroup_id(pkt->pid);
     }
 
     if (!prepare_raw_packet_event(skb, pkt)) {

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -73,7 +73,7 @@ BPF_LRU_MAP(tgid_fd_map_id, struct bpf_tgid_fd_t, u32, 4096)
 BPF_LRU_MAP(tgid_fd_prog_id, struct bpf_tgid_fd_t, u32, 4096)
 BPF_LRU_MAP(proc_cache, u64, struct proc_cache_t, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(pid_cache, u32, struct pid_cache_t, 1) // max entries will be overridden at runtime
-BPF_LRU_MAP(pid_ignored, u32, u32, 16738)
+BPF_LRU_MAP(pid_ignored, u32, u8, 16738)
 BPF_LRU_MAP(exec_pid_transfer, u32, u64, 512)
 BPF_LRU_MAP(netns_cache, u32, u32, 40960)
 BPF_LRU_MAP(mntns_cache, u32, u32, 40960)

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1098,7 +1098,7 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 
 	event.ProcessContext = &event.ProcessCacheEntry.ProcessContext
 
-	if process.IsKThread(event.ProcessContext.PPid, event.ProcessContext.Pid) {
+	if process.IsKworker(event.ProcessContext.PPid, event.ProcessContext.Pid) {
 		return false
 	}
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -79,11 +79,12 @@ type EBPFResolver struct {
 	envVarsResolver     *envvars.Resolver
 	userSessionResolver *usersessions.Resolver
 
-	inodeFileMap ebpf.Map
-	procCacheMap ebpf.Map
-	pidCacheMap  ebpf.Map
-	pathIDMap    ebpf.Map
-	opts         ResolverOpts
+	inodeFileMap  ebpf.Map
+	procCacheMap  ebpf.Map
+	pidCacheMap   ebpf.Map
+	pathIDMap     ebpf.Map
+	pidIgnoredMap ebpf.Map
+	opts          ResolverOpts
 
 	// stats
 	hitsStats                 map[string]*atomic.Int64
@@ -297,7 +298,7 @@ func (p *EBPFResolver) AddForkEntry(event *model.Event, cgroupContext model.CGro
 	if event.ProcessCacheEntry.Pid == 0 {
 		return errors.New("no pid")
 	}
-	if IsKThread(event.ProcessCacheEntry.PPid, event.ProcessCacheEntry.Pid) {
+	if IsKworker(event.ProcessCacheEntry.PPid, event.ProcessCacheEntry.Pid) {
 		return errors.New("process is kthread")
 	}
 
@@ -964,8 +965,8 @@ func (p *EBPFResolver) resolveFromProcfs(pid uint32, inode uint64, maxDepth int,
 		return nil
 	}
 
-	// ignore kthreads
-	if IsKThread(uint32(filledProc.Ppid), uint32(filledProc.Pid)) {
+	// ignore kworker/kthreads
+	if IsKworker(uint32(filledProc.Ppid), uint32(filledProc.Pid)) {
 		return nil
 	}
 
@@ -1250,6 +1251,10 @@ func (p *EBPFResolver) Start(ctx context.Context) error {
 		return err
 	}
 
+	if p.pidIgnoredMap, err = managerhelper.Map(p.manager, "pid_ignored"); err != nil {
+		return err
+	}
+
 	go p.cacheFlush(ctx)
 
 	return nil
@@ -1288,14 +1293,21 @@ func (p *EBPFResolver) cacheFlush(ctx context.Context) {
 
 // SyncCache snapshots /proc for the provided pid.
 func (p *EBPFResolver) SyncCache(proc *process.Process) {
-	// Only a R lock is necessary to check if the entry exists, but if it exists, we'll update it, so a RW lock is
-	// required.
 	p.Lock()
 	defer p.Unlock()
 
 	filledProc, err := utils.GetFilledProcess(proc)
 	if err != nil {
 		seclog.Tracef("unable to get a filled process for %d: %v", proc.Pid, err)
+		return
+	}
+
+	// ignore kworker/kthreads
+	if IsKworker(uint32(filledProc.Ppid), uint32(filledProc.Pid)) {
+		value := uint8(1)
+		if err = p.pidIgnoredMap.Put(uint32(filledProc.Pid), value); err != nil {
+			seclog.Errorf("couldn't push pid_ignored entry to kernel space: %s", err)
+		}
 		return
 	}
 
@@ -1360,8 +1372,6 @@ func (p *EBPFResolver) newEntryFromProcfs(proc *process.Process, filledProc *uti
 			p.inodeErrStats[inodeErrTagProcfsMismatch].Inc()
 		}
 	}
-
-	entry.IsKworker = filledProc.Ppid == 0 && filledProc.Pid != 1
 
 	parent := p.entryCache[entry.PPid]
 	if parent != nil {

--- a/pkg/security/resolvers/process/resolver_linux.go
+++ b/pkg/security/resolvers/process/resolver_linux.go
@@ -15,8 +15,8 @@ import (
 
 const memfdPrefix = "memfd:"
 
-// IsKThread returns whether given pids are from kthreads
-func IsKThread(ppid, pid uint32) bool {
+// IsKworker returns whether given pids are from kworker/kthreads
+func IsKworker(ppid, pid uint32) bool {
 	return ppid == 2 || pid == 2
 }
 

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -315,17 +315,6 @@ func (r *EBPFResolvers) snapshot() error {
 	r.NamespaceResolver.SyncCache()
 
 	for _, proc := range processes {
-		ppid, err := proc.Ppid()
-		if err != nil {
-			continue
-		}
-
-		pid := uint32(proc.Pid)
-
-		if process.IsKThread(uint32(ppid), pid) {
-			continue
-		}
-
 		// Sync the process cache
 		r.ProcessResolver.SyncCache(proc)
 	}


### PR DESCRIPTION
During the /proc snapshot (startup or cache refresh), kworker/kthread processes were skipped in userspace only. Kernel-side eBPF probes had no knowledge of these PIDs until they generated a fork/exec event, leaving a window where events from kworkers could be processed.

Move the kworker filtering inside SyncCache so any kworker/kthread found during the snapshot is explicitly inserted into the pid_ignored eBPF map, ensuring kernel probes ignore them immediately.

Additional changes:
- Rename IsKThread → IsKworker to better reflect it detects both kworkers and kthreads (ppid == 2 || pid == 2)
- Change pid_ignored map value type from u32 to u8 to reduce memory usage; fix bpf_map_lookup_elem return type from u32* to void*
- Remove redundant IsKworker field assignment in newEntryFromProcfs since kworkers are now filtered out before entry creation

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes


(cherry picked from commit 141f12062790e3dad23eb89c0bab3d3554851bda)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
