### PR TITLE
[Backport 7.78.x] Fix built-in profile reconciliation drift by adding explicit fallback policy

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/profile/builtin.go
+++ b/pkg/clusteragent/autoscaling/workload/profile/builtin.go
@@ -76,6 +76,16 @@ var (
 							},
 						},
 					},
+					// Currently this is defaulted in CRD Def, we need to keep it here to not break hash-based reconciliation
+					Fallback: &datadoghq.DatadogFallbackPolicy{
+						Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
+							Enabled:   true,
+							Direction: datadoghq.DatadogPodAutoscalerFallbackDirectionScaleUp,
+							Triggers: datadoghq.HorizontalFallbackTriggers{
+								StaleRecommendationThresholdSeconds: 600,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -119,6 +129,16 @@ var (
 							},
 						},
 					},
+					// Currently this is defaulted in CRD Def, we need to keep it here to not break hash-based reconciliation
+					Fallback: &datadoghq.DatadogFallbackPolicy{
+						Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
+							Enabled:   true,
+							Direction: datadoghq.DatadogPodAutoscalerFallbackDirectionScaleUp,
+							Triggers: datadoghq.HorizontalFallbackTriggers{
+								StaleRecommendationThresholdSeconds: 600,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -159,6 +179,16 @@ var (
 									Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 									Utilization: pointer.Ptr[int32](60),
 								},
+							},
+						},
+					},
+					// Currently this is defaulted in CRD Def, we need to keep it here to not break hash-based reconciliation
+					Fallback: &datadoghq.DatadogFallbackPolicy{
+						Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
+							Enabled:   true,
+							Direction: datadoghq.DatadogPodAutoscalerFallbackDirectionScaleUp,
+							Triggers: datadoghq.HorizontalFallbackTriggers{
+								StaleRecommendationThresholdSeconds: 600,
 							},
 						},
 					},


### PR DESCRIPTION
Backport 33f038414690aebaea10c261b1226b80113b711a from #49269.

 ___

### What does this PR do?

Adds the explicit `Fallback` policy to the built-in profiles definition to match what the CRD defaults.

### Motivation

The CRD definition defaults the fallback policy fields (horizontal fallback enabled, scale-up direction, 600s stale recommendation threshold). Since the built-in profile definition in Go code did not include these fields, the hash computed from the in-cluster object (which has the defaults applied) differed from the hash of the hardcoded definition. This caused the hash-based reconciliation to detect drift on every cycle and issue unnecessary update calls.

### Describe how you validated your changes

Logs like `"Updated built-in profile (drift detected)` should not be present anymore.

### Additional Notes