### PR TITLE
[CWS] Register endpoint log config keys in system-probe config

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -332,6 +332,9 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 
 	cfg.BindEnvAndSetDefault("compliance_config.database_benchmarks.enabled", false)
 
+	// CSPM - former security-agent config
+	bindEnvAndSetLogsConfigKeys(cfg, "compliance_config.endpoints.")
+
 	// enable/disable use of root net namespace
 	cfg.BindEnvAndSetDefault("network_config.enable_root_netns", true)
 

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -56,6 +56,10 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.exclude_pause_container", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.cmd_socket", "")
 
+	// CWS - former security-agent config
+	bindEnvAndSetLogsConfigKeys(cfg, "runtime_security_config.endpoints.")
+	bindEnvAndSetLogsConfigKeys(cfg, "runtime_security_config.activity_dump.remote_storage.endpoints.")
+
 	cfg.SetDefault("runtime_security_config.windows_filename_cache_max", 16384)
 	cfg.SetDefault("runtime_security_config.windows_registry_cache_max", 4096)
 	// windows specific channel size for etw events


### PR DESCRIPTION
### What does this PR do?

Registers the endpoint log config keys (`compliance_config.endpoints.*`, `runtime_security_config.endpoints.*`, `runtime_security_config.activity_dump.remote_storage.endpoints.*`) in the system-probe config.

### Motivation

Endpoint communication for CWS and CSPM is being migrated from security-agent to system-probe. These keys were only registered in the core agent config (`initCoreAgentFull`) but not in the system-probe config (`InitSystemProbeConfig`), causing error logs at startup:

```
Key 'runtime_security_config.activity_dump.remote_storage.endpoints' is partial path of a setting. 'Set' does not allow configuring multiple settings at once using maps
Key 'compliance_config.endpoints' is partial path of a setting. 'Set' does not allow configuring multiple settings at once using maps
```

### Describe how you validated your changes

Verified the config setup package compiles and existing system-probe config tests pass.

### Additional Notes

The `bindEnvAndSetLogsConfigKeys` calls mirror those already present in `initCoreAgentFull` in `common_settings.go`.