### PR TITLE
[tagger] Mark static global tags as complete

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -138,6 +138,7 @@ func (c *WorkloadMetaCollector) collectStaticGlobalTags(ctx context.Context, dat
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,
 			StandardTags:         standard,
+			IsComplete:           true,
 		},
 	})
 }

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -3113,6 +3113,7 @@ func TestNoGlobalTags(t *testing.T) {
 		OrchestratorCardTags: []string{},
 		LowCardTags:          []string{},
 		StandardTags:         []string{},
+		IsComplete:           true,
 	}
 
 	var actualStaticSourceEvent *types.TagInfo
@@ -3128,6 +3129,28 @@ func TestNoGlobalTags(t *testing.T) {
 		"Global Entity should be set with no tags:\nexpected: %v\nfound: %v ",
 		expectedEmptyEvent, actualStaticSourceEvent,
 	)
+}
+
+func TestCollectStaticGlobalTags_SetsIsComplete(t *testing.T) {
+	mockConfig := configmock.New(t)
+	tagInfosCh := make(chan []*types.TagInfo, 10)
+
+	wmetaCollector := NewWorkloadMetaCollector(context.TODO(), mockConfig, nil, &fakeProcessor{tagInfosCh})
+	wmetaCollector.collectStaticGlobalTags(context.TODO(), mockConfig)
+
+	tagInfos := <-tagInfosCh
+
+	var actualStaticSourceEvent *types.TagInfo
+	for _, event := range tagInfos {
+		if event.Source == staticSource {
+			actualStaticSourceEvent = event
+			break
+		}
+	}
+
+	require.NotNil(t, actualStaticSourceEvent)
+	assert.Equal(t, types.GetGlobalEntityID(), actualStaticSourceEvent.EntityID)
+	assert.True(t, actualStaticSourceEvent.IsComplete)
 }
 
 func TestParseJSONValue(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This PR fixes a minor problem in the tagger. `collectStaticGlobalTags()` was emitting a TagInfo without IsComplete, which defaulted to false. This is not correct and can affect the telemetry. This was an oversight because all the other TagInfo objects generated in the tagger (see `comp/core/tagger/collectors/workloadmeta_extract.go`) correctly set `IsComplete`.

This bug doesn't affect any released versions.

### Describe how you validated your changes

Unit tests.