### PR TITLE
Store sourceID as a uint8 instead of model.Source in NTM nodes

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -260,7 +260,7 @@ func (c *ntmConfig) insertValueIntoTree(key string, value interface{}, source mo
 	}
 
 	parts := splitKey(key)
-	err = tree.setAt(parts, value, source)
+	err = tree.setAt(parts, value, sourceIDFromSource(source))
 	return tree, err
 }
 
@@ -294,7 +294,7 @@ func (c *ntmConfig) SetDefault(key string, value interface{}) {
 
 func (c *ntmConfig) setDefault(key string, value interface{}) {
 	parts := splitKey(key)
-	_ = c.defaults.setAt(parts, value, model.SourceDefault)
+	_ = c.defaults.setAt(parts, value, sourceIDDefault)
 }
 
 func (c *ntmConfig) findPreviousSourceNode(key string, source model.Source) (*nodeImpl, error) {
@@ -574,7 +574,7 @@ func (c *ntmConfig) insertNodeFromString(curr *nodeImpl, key string, envval stri
 		}
 	}
 	parts := splitKeyFunc(key)
-	return curr.setAt(parts, actualValue, model.SourceEnvVar)
+	return curr.setAt(parts, actualValue, sourceIDEnvVar)
 }
 
 // ParseEnvAsStringSlice registers a transform function to parse an environment variable as a []string.
@@ -857,7 +857,7 @@ func (c *ntmConfig) MergeConfig(in io.Reader) error {
 	}
 
 	other := newInnerNode(nil)
-	if err = c.readConfigurationContent(other, model.SourceFile, content); err != nil {
+	if err = c.readConfigurationContent(other, sourceIDFile, content); err != nil {
 		return err
 	}
 
@@ -897,7 +897,7 @@ func (c *ntmConfig) MergeFleetPolicy(configPath string) error {
 	}
 
 	other := newInnerNode(nil)
-	if err = c.readConfigurationContent(other, model.SourceFleetPolicies, content); err != nil {
+	if err = c.readConfigurationContent(other, sourceIDFleetPolicies, content); err != nil {
 		return err
 	}
 

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -522,7 +522,7 @@ logs_config:
 
 func TestMapGetChildNotFound(t *testing.T) {
 	m := map[string]interface{}{"a": "apple", "b": "banana"}
-	n, err := newNodeTree(m, model.SourceDefault)
+	n, err := newNodeTree(m, sourceIDDefault)
 	assert.NoError(t, err)
 
 	val, err := n.GetChild("a")

--- a/pkg/config/nodetreemodel/helpers.go
+++ b/pkg/config/nodetreemodel/helpers.go
@@ -13,7 +13,6 @@ import (
 	"unicode"
 
 	"github.com/DataDog/datadog-agent/pkg/config/helper"
-	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/mohae/deepcopy"
 	"github.com/spf13/cast"
 )
@@ -122,7 +121,7 @@ func mapToMapString(m reflect.Value) map[string]interface{} {
 }
 
 // newNodeTree will recursively create nodes from the input value to construct a tree
-func newNodeTree(v interface{}, source model.Source) (*nodeImpl, error) {
+func newNodeTree(v interface{}, source sourceID) (*nodeImpl, error) {
 	if helper.IsNilValue(v) {
 		// nil as a value acts as the zero value, and the cast library will correctly
 		// convert it to zero values for the types we handle
@@ -154,7 +153,7 @@ func newNodeTree(v interface{}, source model.Source) (*nodeImpl, error) {
 	return node, err
 }
 
-func makeChildNodeTrees(input map[string]interface{}, source model.Source) (map[string]*nodeImpl, error) {
+func makeChildNodeTrees(input map[string]interface{}, source sourceID) (map[string]*nodeImpl, error) {
 	children := make(map[string]*nodeImpl)
 	for k, v := range input {
 		node, err := newNodeTree(v, source)

--- a/pkg/config/nodetreemodel/inner_node_test.go
+++ b/pkg/config/nodetreemodel/inner_node_test.go
@@ -8,7 +8,6 @@ package nodetreemodel
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +24,7 @@ func TestMergeToEmpty(t *testing.T) {
 		},
 	}
 
-	src, err := newNodeTree(obj, model.SourceFile)
+	src, err := newNodeTree(obj, sourceIDFile)
 	require.NoError(t, err)
 	require.True(t, src.IsInnerNode())
 
@@ -36,14 +35,14 @@ func TestMergeToEmpty(t *testing.T) {
 
 	expected := &nodeImpl{
 		children: map[string]*nodeImpl{
-			"a": {val: "apple", source: model.SourceFile},
-			"b": {val: 123, source: model.SourceFile},
+			"a": {val: "apple", source: sourceIDFile},
+			"b": {val: 123, source: sourceIDFile},
 			"c": {
 				children: map[string]*nodeImpl{
-					"d": {val: true, source: model.SourceFile},
+					"d": {val: true, source: sourceIDFile},
 					"e": {
 						children: map[string]*nodeImpl{
-							"f": {val: 456, source: model.SourceFile},
+							"f": {val: 456, source: sourceIDFile},
 						},
 					},
 				},
@@ -77,11 +76,11 @@ func TestMergeTwoTree(t *testing.T) {
 		},
 	}
 
-	base, err := newNodeTree(obj, model.SourceFile)
+	base, err := newNodeTree(obj, sourceIDFile)
 	require.NoError(t, err)
 	require.True(t, base.IsInnerNode())
 
-	overwrite, err := newNodeTree(obj2, model.SourceEnvVar)
+	overwrite, err := newNodeTree(obj2, sourceIDEnvVar)
 	require.NoError(t, err)
 	require.True(t, overwrite.IsInnerNode())
 
@@ -90,16 +89,16 @@ func TestMergeTwoTree(t *testing.T) {
 
 	expected := &nodeImpl{
 		children: map[string]*nodeImpl{
-			"a": {val: "orange", source: model.SourceEnvVar},
-			"b": {val: 123, source: model.SourceFile},
-			"z": {val: 987, source: model.SourceEnvVar},
+			"a": {val: "orange", source: sourceIDEnvVar},
+			"b": {val: 123, source: sourceIDFile},
+			"z": {val: 987, source: sourceIDEnvVar},
 			"c": {
 				children: map[string]*nodeImpl{
-					"d": {val: false, source: model.SourceEnvVar},
+					"d": {val: false, source: sourceIDEnvVar},
 					"e": {
 						children: map[string]*nodeImpl{
-							"f": {val: 456, source: model.SourceEnvVar},
-							"g": {val: "kiwi", source: model.SourceEnvVar},
+							"f": {val: 456, source: sourceIDEnvVar},
+							"g": {val: "kiwi", source: sourceIDEnvVar},
 						},
 					},
 				},
@@ -118,11 +117,11 @@ func TestMergeErrorLeafToNode(t *testing.T) {
 		"a": map[string]interface{}{},
 	}
 
-	base, err := newNodeTree(obj, model.SourceFile)
+	base, err := newNodeTree(obj, sourceIDFile)
 	require.NoError(t, err)
 	require.True(t, base.IsInnerNode())
 
-	overwrite, err := newNodeTree(obj2, model.SourceEnvVar)
+	overwrite, err := newNodeTree(obj2, sourceIDEnvVar)
 	require.NoError(t, err)
 	require.True(t, overwrite.IsInnerNode())
 

--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -19,7 +19,7 @@ import (
 var ErrNotFound = errors.New("not found")
 
 // missingLeafImpl is a none-object representing when a child node is missing
-var missingLeaf = &nodeImpl{source: model.SourceUnknown}
+var missingLeaf = &nodeImpl{source: sourceIDUnknown}
 
 // Node is a inner or leaf node in the config tree
 type Node interface {
@@ -32,7 +32,7 @@ type Node interface {
 type nodeImpl struct {
 	children map[string]*nodeImpl
 	val      interface{}
-	source   model.Source
+	source   sourceID
 }
 
 var _ Node = (*nodeImpl)(nil)
@@ -44,7 +44,7 @@ func newInnerNode(children map[string]*nodeImpl) *nodeImpl {
 	return &nodeImpl{children: children}
 }
 
-func newLeafNode(v interface{}, source model.Source) *nodeImpl {
+func newLeafNode(v interface{}, source sourceID) *nodeImpl {
 	return &nodeImpl{val: v, source: source}
 }
 
@@ -106,7 +106,7 @@ func (n *nodeImpl) Merge(that *nodeImpl) (*nodeImpl, error) {
 
 		if ourIsLeaf && theirIsLeaf {
 			// both are leafs, check the priority by source
-			if ourChild.Source() == theirChild.Source() || theirChild.SourceGreaterThan(ourChild.Source()) {
+			if ourChild.source == theirChild.source || theirChild.source.IsGreaterThan(ourChild.source) {
 				newChildren[name] = theirChild
 			} else {
 				newChildren[name] = ourChild
@@ -147,7 +147,7 @@ func (n *nodeImpl) ChildrenKeys() []string {
 // The key parts should already be lowercased.
 //
 // This method should only be called on the root of a tree, not on an inner node with parents.
-func (n *nodeImpl) setAt(key []string, value interface{}, source model.Source) error {
+func (n *nodeImpl) setAt(key []string, value interface{}, source sourceID) error {
 	if len(key) == 0 {
 		return errors.New("empty key given to Set")
 	}
@@ -161,7 +161,7 @@ func (n *nodeImpl) setAt(key []string, value interface{}, source model.Source) e
 // setNodeAtPath allocates a new branch, ending in a leaf at the given path of fields, with the
 // given value, and returns the root of that branch. If a leaf already exists at that path,
 // instead it is modified and no branch is allocated and this returns nil
-func setNodeAtPath(n *nodeImpl, fields []string, value interface{}, source model.Source) (*nodeImpl, error) {
+func setNodeAtPath(n *nodeImpl, fields []string, value interface{}, source sourceID) (*nodeImpl, error) {
 	if len(fields) == 0 {
 		return newLeafNode(value, source), nil
 	}
@@ -225,7 +225,7 @@ func (n *nodeImpl) dumpSettings(includeDefaults bool) map[string]interface{} {
 	for _, k := range n.ChildrenKeys() {
 		child, _ := n.GetChild(k)
 		if child.IsLeafNode() {
-			if child.Source() == model.SourceDefault && !includeDefaults {
+			if child.source == sourceIDDefault && !includeDefaults {
 				continue
 			}
 			res[k] = child.Get()
@@ -243,7 +243,7 @@ func (n *nodeImpl) dumpSettings(includeDefaults bool) map[string]interface{} {
 
 // SourceGreaterThan returns true if the source of the current node is greater than the one given as a
 // parameter
-func (n *nodeImpl) SourceGreaterThan(source model.Source) bool {
+func (n *nodeImpl) SourceGreaterThan(source sourceID) bool {
 	return n.source.IsGreaterThan(source)
 }
 
@@ -273,5 +273,5 @@ func (n *nodeImpl) ReplaceValue(v interface{}) error {
 
 // Source returns the source for this leaf
 func (n *nodeImpl) Source() model.Source {
-	return n.source
+	return n.source.toSource()
 }

--- a/pkg/config/nodetreemodel/node_test.go
+++ b/pkg/config/nodetreemodel/node_test.go
@@ -8,7 +8,6 @@ package nodetreemodel
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +21,7 @@ func TestNewNodeAndNodeMethods(t *testing.T) {
 		},
 	}
 
-	nodeTree, err := newNodeTree(obj, model.SourceDefault)
+	nodeTree, err := newNodeTree(obj, sourceIDDefault)
 	assert.NoError(t, err)
 
 	assert.True(t, nodeTree.IsInnerNode())

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -86,7 +86,7 @@ func (c *ntmConfig) ReadConfig(in io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if err := c.readConfigurationContent(c.file, model.SourceFile, content); err != nil {
+	if err := c.readConfigurationContent(c.file, sourceIDFile, content); err != nil {
 		return err
 	}
 	return c.mergeAllLayers()
@@ -97,10 +97,10 @@ func (c *ntmConfig) readInConfig(filePath string) error {
 	if err != nil {
 		return model.NewConfigFileNotFoundError(err) // nolint: forbidigo // constructing proper error
 	}
-	return c.readConfigurationContent(c.file, model.SourceFile, content)
+	return c.readConfigurationContent(c.file, sourceIDFile, content)
 }
 
-func (c *ntmConfig) readConfigurationContent(target *nodeImpl, source model.Source, content []byte) error {
+func (c *ntmConfig) readConfigurationContent(target *nodeImpl, source sourceID, content []byte) error {
 	var inData map[string]interface{}
 
 	if strictErr := yaml.UnmarshalStrict(content, &inData); strictErr != nil {
@@ -132,7 +132,7 @@ var valuelessLeaf = &nodeImpl{}
 
 // loadYamlInto traverses input data parsed from YAML, checking if each node is defined by the schema.
 // If found, the value from the YAML blob is imported into the 'dest' tree. Otherwise, a warning will be created.
-func loadYamlInto(dest *nodeImpl, source model.Source, inData map[string]interface{}, atPath string, schema *nodeImpl, knownKeys map[string]bool, unknownKeys map[string]struct{}) []error {
+func loadYamlInto(dest *nodeImpl, source sourceID, inData map[string]interface{}, atPath string, schema *nodeImpl, knownKeys map[string]bool, unknownKeys map[string]struct{}) []error {
 	warnings := []error{}
 	for key, value := range inData {
 		key = strings.ToLower(key)

--- a/pkg/config/nodetreemodel/read_config_file_test.go
+++ b/pkg/config/nodetreemodel/read_config_file_test.go
@@ -176,10 +176,10 @@ c:
 
 	expected := &nodeImpl{
 		children: map[string]*nodeImpl{
-			"a": {val: "orange", source: model.SourceFile},
+			"a": {val: "orange", source: sourceIDFile},
 			"c": {
 				children: map[string]*nodeImpl{
-					"d": {val: 1234, source: model.SourceFile},
+					"d": {val: 1234, source: sourceIDFile},
 				},
 			},
 		},
@@ -211,11 +211,11 @@ c:
 
 	expected := &nodeImpl{
 		children: map[string]*nodeImpl{
-			"a": {val: "orange", source: model.SourceFile},
+			"a": {val: "orange", source: sourceIDFile},
 			"c": {
 				children: map[string]*nodeImpl{
-					"d":       {val: 1234, source: model.SourceFile},
-					"unknown": {val: "key", source: model.SourceFile},
+					"d":       {val: 1234, source: sourceIDFile},
+					"unknown": {val: "key", source: sourceIDFile},
 				},
 			},
 		},

--- a/pkg/config/nodetreemodel/reflection_node.go
+++ b/pkg/config/nodetreemodel/reflection_node.go
@@ -9,8 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-
-	"github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
 var (
@@ -37,7 +35,7 @@ func asReflectionNode(v interface{}) (*nodeImpl, error) {
 			item := rv.Index(i).Interface()
 			elems = append(elems, item)
 		}
-		return newLeafNode(elems, model.SourceUnknown), nil
+		return newLeafNode(elems, sourceIDUnknown), nil
 	} else if rv.Kind() == reflect.Map {
 		res := make(map[string]interface{}, rv.Len())
 		mapkeys := rv.MapKeys()
@@ -50,7 +48,7 @@ func asReflectionNode(v interface{}) (*nodeImpl, error) {
 			}
 			res[kstr] = rv.MapIndex(mk).Interface()
 		}
-		return newLeafNode(res, model.SourceUnknown), nil
+		return newLeafNode(res, sourceIDUnknown), nil
 	}
 	return nil, errUnknownConversion
 }

--- a/pkg/config/nodetreemodel/sourceid.go
+++ b/pkg/config/nodetreemodel/sourceid.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package nodetreemodel
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+type sourceID uint8
+
+const (
+	sourceIDDefault sourceID = iota
+	sourceIDUnknown
+	sourceIDInfraMode
+	sourceIDFile
+	sourceIDEnvVar
+	sourceIDFleetPolicies
+	sourceIDAgentRuntime
+	sourceIDLocalConfigProcess
+	sourceIDRC
+	sourceIDCLI
+)
+
+func sourceIDFromSource(s model.Source) sourceID {
+	switch s {
+	case model.SourceDefault:
+		return sourceIDDefault
+	case model.SourceUnknown:
+		return sourceIDUnknown
+	case model.SourceInfraMode:
+		return sourceIDInfraMode
+	case model.SourceFile:
+		return sourceIDFile
+	case model.SourceEnvVar:
+		return sourceIDEnvVar
+	case model.SourceFleetPolicies:
+		return sourceIDFleetPolicies
+	case model.SourceAgentRuntime:
+		return sourceIDAgentRuntime
+	case model.SourceLocalConfigProcess:
+		return sourceIDLocalConfigProcess
+	case model.SourceRC:
+		return sourceIDRC
+	case model.SourceCLI:
+		return sourceIDCLI
+	default:
+		return sourceIDUnknown
+	}
+}
+
+func (s sourceID) toSource() model.Source {
+	switch s {
+	case sourceIDDefault:
+		return model.SourceDefault
+	case sourceIDUnknown:
+		return model.SourceUnknown
+	case sourceIDInfraMode:
+		return model.SourceInfraMode
+	case sourceIDFile:
+		return model.SourceFile
+	case sourceIDEnvVar:
+		return model.SourceEnvVar
+	case sourceIDFleetPolicies:
+		return model.SourceFleetPolicies
+	case sourceIDAgentRuntime:
+		return model.SourceAgentRuntime
+	case sourceIDLocalConfigProcess:
+		return model.SourceLocalConfigProcess
+	case sourceIDRC:
+		return model.SourceRC
+	case sourceIDCLI:
+		return model.SourceCLI
+	default:
+		return model.SourceUnknown
+	}
+}
+
+func (s sourceID) IsGreaterThan(other sourceID) bool {
+	return s > other
+}


### PR DESCRIPTION
### What does this PR do?

Store sourceID as a uint8 instead of model.Source in NTM nodes

### Motivation

Performance improvement

### Describe how you validated your changes

### Additional Notes
