### PR TITLE
chore(renovate): prioritize internal updates and remove dead protobuf rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "minimumReleaseAge": "7 days",
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
+    "prPriority": -1,
     "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com", "200755185+dd-octo-sts[bot]@users.noreply.github.com"],
     "platformCommit": "enabled",
     "packageRules": [
@@ -37,11 +38,8 @@
       },
       {
         "matchManagers": ["custom.regex"],
-        "minimumReleaseAge": null
-      },
-      {
-        "matchDepNames": ["protocolbuffers/protobuf"],
-        "minimumReleaseAge": "7 days"
+        "minimumReleaseAge": null,
+        "prPriority": 10
       },
       {
         "matchManagers": ["github-actions"],


### PR DESCRIPTION
### What does this PR do?

- Adds global `prPriority: -1` so all Renovate updates default to low priority
- Sets `prPriority: 10` on `custom.regex` managers so internal dependency updates (CI images, dda, omnibus-ruby, integrations-core) are always created first and never rate-limited
- Removes the dead `protocolbuffers/protobuf` package rule — its custom regex manager was already removed in #48970 when protobuf tooling moved to hermetic Bazel-managed binaries

### Motivation

Internal dependency updates (CI images, integrations-core, etc.) should always generate PRs regardless of Renovate's rate limits (`prHourlyLimit`, `prConcurrentLimit`). By giving them high priority and everything else low priority, internal updates are created first within each rate-limit window.

The protobuf rule cleanup is a follow-up to #48970 which removed the `.protoc-version` file and the associated custom manager but left behind the now-orphaned package rule.

### Describe how you validated your changes

Config-only change. Validated that:
- The `prPriority` field is supported at both global and packageRule level per [Renovate docs](https://docs.renovatebot.com/configuration-options/#prpriority)
- The protobuf custom manager no longer exists (removed in #48970), confirming the package rule matches nothing

### Additional Notes

N/A