### PR TITLE
packages: don't install nfsiostat & gstatus from omnibus

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
@@ -42,8 +42,5 @@ if linux_target?
         + " '#{install_dir}/embedded/msodbcsql/lib64/libmsodbcsql-18.3.so.3.1'"
     end
 
-    # gstatus binary used by the glusterfs integration
-    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //deps/gstatus:install --destdir='#{install_dir}'"
-    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //deps/nfsiostat:install --destdir='#{install_dir}'"
   end
 end

--- a/packages/agent/dependencies/BUILD.bazel
+++ b/packages/agent/dependencies/BUILD.bazel
@@ -4,7 +4,6 @@ Gathering spot for all the various dependencies which are shipped as part of the
 This replaces datadog-agent-dependencies.rb.
 """
 
-load("//bazel/rules/dd_packaging:dd_collect_dependencies.bzl", "dd_collect_dependencies")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 load("//bazel/rules/dd_packaging:dd_collect_dependencies.bzl", "dd_collect_dependencies")

--- a/packages/agent/dependencies/BUILD.bazel
+++ b/packages/agent/dependencies/BUILD.bazel
@@ -23,6 +23,7 @@ pkg_filegroup(
         "@platforms//os:linux": [
             # dependency curl
             "@systemd//:all_files",
+            "//deps/gstatus:all_files",
             ":collected_libs",
         ],
         "//conditions:default": [],
@@ -34,9 +35,11 @@ pkg_filegroup(
             # dependency datadog_agent_data_plane
             # This is really part of system-probe
             "@libpcap//:all_files",
+            "//deps/nfsiostat:all_files",
         ],
         "//packages/agent:linux_fips": [
             "//deps/compile_policy:all_files",
+            "//deps/nfsiostat:all_files",
             "//deps/security_agent_policies:all_files",
             "@libpcap//:all_files",
         ],

--- a/packages/agent/dependencies/BUILD.bazel
+++ b/packages/agent/dependencies/BUILD.bazel
@@ -4,6 +4,7 @@ Gathering spot for all the various dependencies which are shipped as part of the
 This replaces datadog-agent-dependencies.rb.
 """
 
+load("//bazel/rules/dd_packaging:dd_collect_dependencies.bzl", "dd_collect_dependencies")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 load("//bazel/rules/dd_packaging:dd_collect_dependencies.bzl", "dd_collect_dependencies")

--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -52,7 +52,6 @@ pkg_filegroup(
     name = "transitive_deps",
     srcs = [
         "//deps/msodbcsql18:all_files",
-        "//deps/nfsiostat:all_files",
         "//deps/openscap:all_files",
         "@nghttp2//:all_files",
         "@xz//:all_files",

--- a/packages/install_dir/BUILD.bazel
+++ b/packages/install_dir/BUILD.bazel
@@ -8,10 +8,7 @@ pkg_filegroup(
     name = "embedded",
     srcs = [
         "//packages/install_dir/embedded:all_files",
-    ] + select({
-        "@platforms//os:linux": ["//deps/gstatus:all_files"],
-        "//conditions:default": [],
-    }),
+    ],
 )
 
 # This is a placeholder for an eventual group containg (the future) top level binaries
@@ -29,7 +26,6 @@ filegroup(
         "@zlib//:z",
     ] + select({
         "//packages/agent:linux_default": [
-            "//deps/nfsiostat:all_files",
             "//deps/openscap:all_deps",
             "@curl//:all_files",
             "@gpg-error",
@@ -37,7 +33,6 @@ filegroup(
             "@nghttp2",
         ],
         "//packages/agent:linux_fips": [
-            "//deps/nfsiostat:all_files",
             "//deps/openscap:all_deps",
             "@curl//:all_files",
             "@gpg-error",


### PR DESCRIPTION
### What does this PR do?

Remove a couple manual installation of dependencies from omnibus

### Motivation

Keep on migrating away from omnibus

### Describe how you validated your changes

### Additional Notes

Based on top of https://github.com/DataDog/datadog-agent/pull/49377