### PR TITLE
SGC image build pipeline

### DIFF
--- a/.gitlab/.ci-linters.yml
+++ b/.gitlab/.ci-linters.yml
@@ -13,6 +13,8 @@ needs-rules:
     - deploy_mutable_image_tags
     - deploy_cws_instrumentation
     - deploy_cws_instrumentation_mutable_tags
+    - deploy_secret_generic_connector
+    - deploy_secret_generic_connector_mutable_tags
 
   allowed-jobs:
     - build_clang_arm64

--- a/.gitlab/.pre/common/container_publish_job_templates.yml
+++ b/.gitlab/.pre/common/container_publish_job_templates.yml
@@ -6,6 +6,7 @@
   SRC_CWS_INSTRUMENTATION: registry.ddbuild.io/ci/datadog-agent/cws-instrumentation
   SRC_OTEL_AGENT: registry.ddbuild.io/ci/datadog-agent/otel-agent
   SRC_DDOT_EBPF: registry.ddbuild.io/ci/datadog-agent/ddot-ebpf
+  SRC_SGC: registry.ddbuild.io/ci/datadog-agent/secret-generic-connector
 
 .docker_publish_job_definition:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
@@ -16,13 +17,13 @@
     IMG_SIGNING: "false"
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - |
-      if [[ "$BUCKET_BRANCH" == "nightly" && ( "$IMG_SOURCES" =~ "$SRC_AGENT" || "$IMG_SOURCES" =~ "$SRC_OTEL_AGENT" || "$IMG_SOURCES" =~ "$SRC_DDOT_EBPF" || "$IMG_SOURCES" =~ "$SRC_DCA" || "$IMG_SOURCES" =~ "$SRC_CWS_INSTRUMENTATION" || "$IMG_VARIABLES" =~ "$SRC_AGENT" || "$IMG_VARIABLES" =~ "$SRC_DDOT_EBPF" || "$IMG_VARIABLES" =~ "$SRC_DCA" || "$IMG_VARIABLES" =~ "$SRC_CWS_INSTRUMENTATION" ) ]]; then
+      if [[ "$BUCKET_BRANCH" == "nightly" && ( "$IMG_SOURCES" =~ "$SRC_AGENT" || "$IMG_SOURCES" =~ "$SRC_OTEL_AGENT" || "$IMG_SOURCES" =~ "$SRC_DDOT_EBPF" || "$IMG_SOURCES" =~ "$SRC_DCA" || "$IMG_SOURCES" =~ "$SRC_CWS_INSTRUMENTATION" || "$IMG_SOURCES" =~ "$SRC_SGC" || "$IMG_VARIABLES" =~ "$SRC_AGENT" || "$IMG_VARIABLES" =~ "$SRC_DDOT_EBPF" || "$IMG_VARIABLES" =~ "$SRC_DCA" || "$IMG_VARIABLES" =~ "$SRC_CWS_INSTRUMENTATION" || "$IMG_VARIABLES" =~ "$SRC_SGC" ) ]]; then
         export ECR_RELEASE_SUFFIX="-nightly"
       else
         export ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
       fi
-    - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_OTEL_AGENT}|${SRC_DDOT_EBPF}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
-    - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_OTEL_AGENT}|${SRC_DDOT_EBPF}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
+    - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_OTEL_AGENT}|${SRC_DDOT_EBPF}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION}|${SRC_SGC})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
+    - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_OTEL_AGENT}|${SRC_DDOT_EBPF}|${SRC_DSD}|${SRC_DCA}|${SRC_CWS_INSTRUMENTATION}|${SRC_SGC})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
     - "dda inv pipeline.trigger-child-pipeline --project-name DataDog/public-images --git-ref main --timeout 1800
       --variable IMG_VARIABLES
       --variable IMG_REGISTRIES

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -41,6 +41,7 @@ cluster_agent_cloudfoundry-build*    @Datadog/agent-integrations
 cluster_agent-build*                 @DataDog/container-integrations
 cluster_agent_fips-build*            @DataDog/container-integrations
 cws_instrumentation-build*           @DataDog/agent-security
+secret_generic_connector-build*      @DataDog/agent-configuration
 build_windows_container_entrypoint   @DataDog/windows-products
 generate_config_schema-linux         @DataDog/agent-configuration
 generate_config_schema-macos         @DataDog/agent-configuration
@@ -143,11 +144,15 @@ deploy_containers*                     @Datadog/agent-delivery
 deploy_latest_rc_only                  @Datadog/agent-delivery
 deploy_mutable_image_tags*             @Datadog/agent-delivery
 deploy_mutable_cws_instrumentation_tags*     @Datadog/agent-delivery
+deploy_mutable_secret_generic_connector_tags*  @Datadog/agent-delivery
 deploy_mutable_dca_tags*               @Datadog/agent-delivery
 deploy_mutable_ot_standalone_tags*     @Datadog/agent-delivery
 
 # Deploy CWS instrumentation
 deploy_containers-cws-instrumentation* @DataDog/agent-security
+
+# Deploy Secret Generic Connector
+deploy_containers-secret-generic-connector* @DataDog/agent-configuration
 
 # Trigger release
 trigger_manual_prod_release*            @DataDog/agent-delivery

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -50,6 +50,7 @@ cluster_agent_cloudfoundry-build*    @Datadog/agent-integrations
 cluster_agent-build*                 @DataDog/container-integrations
 cluster_agent_fips-build*            @DataDog/container-integrations
 cws_instrumentation-build*           @DataDog/agent-security
+secret_generic_connector-build*      @DataDog/agent-configuration
 build_windows_container_entrypoint   @DataDog/windows-products
 generate_config_schema-linux         @DataDog/agent-configuration
 generate_config_schema-macos         @DataDog/agent-configuration
@@ -153,11 +154,15 @@ deploy_containers*                     @Datadog/agent-delivery
 deploy_latest_rc_only                  @Datadog/agent-delivery
 deploy_mutable_image_tags*             @Datadog/agent-delivery
 deploy_mutable_cws_instrumentation_tags*     @Datadog/agent-delivery
+deploy_mutable_secret_generic_connector_tags*  @Datadog/agent-delivery
 deploy_mutable_dca_tags*               @Datadog/agent-delivery
 deploy_mutable_ot_standalone_tags*     @Datadog/agent-delivery
 
 # Deploy CWS instrumentation
 deploy_containers-cws-instrumentation* @DataDog/agent-security
+
+# Deploy Secret Generic Connector
+deploy_containers-secret-generic-connector* @DataDog/agent-configuration
 
 # Trigger release
 trigger_manual_prod_release*            @DataDog/agent-delivery

--- a/.gitlab/build/binary_build/secret_generic_connector.yml
+++ b/.gitlab/build/binary_build/secret_generic_connector.yml
@@ -1,0 +1,38 @@
+---
+.secret_generic_connector-build_common:
+  stage: binary_build
+  needs: []
+  script:
+    - dda inv -- check-go-version
+    - dda inv -- -e secret-generic-connector.build --arch-suffix
+  artifacts:
+    paths:
+      - $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.$ARCH
+
+.secret_generic_connector_amd64:
+  rules:
+    - when: on_success
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  tags: ["arch:amd64", "specific:true"]
+  needs: ["go_deps"]
+  variables:
+    ARCH: amd64
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+
+.secret_generic_connector_arm64:
+  rules:
+    - when: on_success
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  tags: ["arch:arm64", "specific:true"]
+  needs: ["go_deps"]
+  variables:
+    ARCH: arm64
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+
+secret_generic_connector-build_amd64:
+  extends: [.secret_generic_connector-build_common, .secret_generic_connector_amd64]
+
+secret_generic_connector-build_arm64:
+  extends: [.secret_generic_connector-build_common, .secret_generic_connector_arm64]

--- a/.gitlab/deploy/conditions.yml
+++ b/.gitlab/deploy/conditions.yml
@@ -59,6 +59,7 @@
       OTEL_AGENT_REPOSITORY: ddot-collector
       DSD_REPOSITORY: dogstatsd
       CWS_INSTRUMENTATION_REPOSITORY: cws-instrumentation
+      SECRET_GENERIC_CONNECTOR_REPOSITORY: secret-generic-connector
       IMG_REGISTRIES: public
 
 # Same as on_deploy_manual, except the job would not run on pipelines
@@ -82,6 +83,7 @@
       OTEL_AGENT_REPOSITORY: ddot-collector
       DSD_REPOSITORY: dogstatsd
       CWS_INSTRUMENTATION_REPOSITORY: cws-instrumentation
+      SECRET_GENERIC_CONNECTOR_REPOSITORY: secret-generic-connector
       IMG_REGISTRIES: public
 
 # This is used for image vulnerability scanning. Because agent 6
@@ -98,6 +100,7 @@
       OTEL_AGENT_REPOSITORY: ci/datadog-agent/otel-agent-release
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       CWS_INSTRUMENTATION_REPOSITORY: ci/datadog-agent/cws-instrumentation-release
+      SECRET_GENERIC_CONNECTOR_REPOSITORY: ci/datadog-agent/secret-generic-connector-release
       IMG_REGISTRIES: internal-aws-ddbuild
 
 # Same as on_deploy_manual_final, except the job is used to publish images
@@ -115,6 +118,7 @@
       CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       CWS_INSTRUMENTATION_REPOSITORY: ci/datadog-agent/cws-instrumentation-release
+      SECRET_GENERIC_CONNECTOR_REPOSITORY: ci/datadog-agent/secret-generic-connector-release
       IMG_REGISTRIES: internal-aws-ddbuild
 
 .on_deploy_stable_or_beta_repo_branch_manual:

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -6,7 +6,7 @@
     - BUILD_ARG=${BUILD_ARG:-}
     - EXTRA_BUILD_CONTEXT=${ARTIFACTS_BUILD_CONTEXT:+"--build-context artifacts=$ARTIFACTS_BUILD_CONTEXT"}
     - |
-      if [[ "$BUCKET_BRANCH" == "nightly" && ( "$IMAGE" =~ "ci/datadog-agent/agent" || "$IMAGE" =~ "ci/datadog-agent/cluster-agent" || "$IMAGE" =~ "ci/datadog-agent/cws-instrumentation"  || "$IMAGE" =~ "ci/datadog-agent/otel-agent" || "$IMAGE" =~ "ci/datadog-agent/ddot-ebpf" ) ]]; then
+      if [[ "$BUCKET_BRANCH" == "nightly" && ( "$IMAGE" =~ "ci/datadog-agent/agent" || "$IMAGE" =~ "ci/datadog-agent/cluster-agent" || "$IMAGE" =~ "ci/datadog-agent/cws-instrumentation" || "$IMAGE" =~ "ci/datadog-agent/secret-generic-connector" || "$IMAGE" =~ "ci/datadog-agent/otel-agent" || "$IMAGE" =~ "ci/datadog-agent/ddot-ebpf" ) ]]; then
         export ECR_RELEASE_SUFFIX="-nightly"
       else
         export ECR_RELEASE_SUFFIX=${CI_COMMIT_TAG+-release}

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -516,6 +516,33 @@ docker_build_cws_instrumentation_arm64:
   variables:
     STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_cws_instrumentation_arm64"
 
+# build the secret-generic-connector image
+.docker_build_secret_generic_connector:
+  extends: .docker_build_job_definition
+  rules:
+    - when: on_success
+  variables:
+    IMAGE: registry.ddbuild.io/ci/datadog-agent/secret-generic-connector
+    BUILD_CONTEXT: Dockerfiles/secret-generic-connector
+  before_script:
+    - cp $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} $BUILD_CONTEXT/
+
+docker_build_secret_generic_connector_amd64:
+  extends: [.docker_build_secret_generic_connector, .docker_build_amd64]
+  needs:
+    - job: secret_generic_connector-build_amd64
+      artifacts: true
+  variables:
+    STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_secret_generic_connector_amd64"
+
+docker_build_secret_generic_connector_arm64:
+  extends: [.docker_build_secret_generic_connector, .docker_build_arm64]
+  needs:
+    - job: secret_generic_connector-build_arm64
+      artifacts: true
+  variables:
+    STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_secret_generic_connector_arm64"
+
 # build the dogstatsd image
 .docker_build_dogstatsd:
   extends: [.docker_build_job_definition, .docker_build_s3]

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -518,6 +518,33 @@ docker_build_cws_instrumentation_arm64:
   variables:
     STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_cws_instrumentation_arm64"
 
+# build the secret-generic-connector image
+.docker_build_secret_generic_connector:
+  extends: .docker_build_job_definition
+  rules:
+    - when: on_success
+  variables:
+    IMAGE: registry.ddbuild.io/ci/datadog-agent/secret-generic-connector
+    BUILD_CONTEXT: Dockerfiles/secret-generic-connector
+  before_script:
+    - cp $SECRET_GENERIC_CONNECTOR_BINARIES_DIR/secret-generic-connector.${ARCH} $BUILD_CONTEXT/
+
+docker_build_secret_generic_connector_amd64:
+  extends: [.docker_build_secret_generic_connector, .docker_build_amd64]
+  needs:
+    - job: secret_generic_connector-build_amd64
+      artifacts: true
+  variables:
+    STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_secret_generic_connector_amd64"
+
+docker_build_secret_generic_connector_arm64:
+  extends: [.docker_build_secret_generic_connector, .docker_build_arm64]
+  needs:
+    - job: secret_generic_connector-build_arm64
+      artifacts: true
+  variables:
+    STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_secret_generic_connector_arm64"
+
 # build the dogstatsd image
 .docker_build_dogstatsd:
   extends: [.docker_build_job_definition, .docker_build_s3]

--- a/.gitlab/distribute/deploy_secret_generic_connector.yml
+++ b/.gitlab/distribute/deploy_secret_generic_connector.yml
@@ -1,0 +1,19 @@
+---
+#
+# Secret Generic Connector image tagging & manifest publication
+#
+
+.deploy_containers-secret-generic-connector-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_secret_generic_connector
+  before_script:
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(dda inv agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?; fi
+    - if [[ "$SECRET_GENERIC_CONNECTOR_REPOSITORY" == "" ]]; then export SECRET_GENERIC_CONNECTOR_REPOSITORY="secret-generic-connector"; fi
+    - export IMG_BASE_SRC="${SRC_SGC}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
+    - export IMG_DESTINATIONS="${SECRET_GENERIC_CONNECTOR_REPOSITORY}:${VERSION}"
+
+deploy_containers-secret-generic-connector:
+  extends: .deploy_containers-secret-generic-connector-base
+  rules: !reference [.on_deploy_manual_auto_on_rc]
+  needs: []

--- a/.gitlab/distribute/deploy_secret_generic_connector_mutable_tags.yml
+++ b/.gitlab/distribute/deploy_secret_generic_connector_mutable_tags.yml
@@ -1,0 +1,28 @@
+# deploy mutable secret generic connector tags stage
+# Contains jobs which deploy SGC related mutable image tags to the registries. That means - not uploading the image, but only creating the tags.
+
+.deploy_mutable_secret_generic_connector_tags-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_secret_generic_connector_mutable_tags
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - export IMG_TAG_REFERENCE=${SECRET_GENERIC_CONNECTOR_REPOSITORY}:${VERSION}
+
+deploy_mutable_secret_generic_connector_tags-rc:
+  extends: .deploy_mutable_secret_generic_connector_tags-base
+  rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-secret-generic-connector
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc
+
+deploy_mutable_secret_generic_connector_tags-latest:
+  extends: .deploy_mutable_secret_generic_connector_tags-base
+  rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-secret-generic-connector
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest

--- a/.gitlab/distribution.yml
+++ b/.gitlab/distribution.yml
@@ -5,6 +5,8 @@ stages:
   - deploy_packages
   - deploy_cws_instrumentation
   - deploy_cws_instrumentation_mutable_tags
+  - deploy_secret_generic_connector
+  - deploy_secret_generic_connector_mutable_tags
   - deploy_dca
   - deploy_dca_mutable_tags
   - trigger_release

--- a/Dockerfiles/secret-generic-connector/Dockerfile
+++ b/Dockerfiles/secret-generic-connector/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+ARG TARGETARCH
+COPY --chmod=0755 ./secret-generic-connector.$TARGETARCH /secret-generic-connector
+USER 1000

--- a/tasks/secret_generic_connector.py
+++ b/tasks/secret_generic_connector.py
@@ -3,12 +3,13 @@ secret_generic_connector namespaced tasks
 """
 
 import os
+import platform
 
 from invoke import task
 
 from tasks.build_tags import get_default_build_tags
 from tasks.flavor import AgentFlavor
-from tasks.libs.common.constants import REPO_PATH
+from tasks.libs.common.constants import CONTAINER_PLATFORM_MAPPING, REPO_PATH
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import bin_name
 from tasks.libs.releasing.version import get_version
@@ -29,6 +30,7 @@ def build(
     output_bin=None,
     strip_binary=True,
     fips_mode=False,
+    arch_suffix=False,
 ):
     """
     Build the secret-generic-connector binary.
@@ -60,6 +62,10 @@ def build(
         build="secret-generic-connector", flavor=AgentFlavor.fips if fips_mode else AgentFlavor.base
     )
     bin_path = output_bin or BIN_PATH
+
+    if arch_suffix:
+        arch = CONTAINER_PLATFORM_MAPPING.get(platform.machine().lower())
+        bin_path = f'{bin_path}.{arch}'
 
     go_build(
         ctx,


### PR DESCRIPTION
### What does this PR do?
Adds a standalone build-and-publish pipeline for the secret-generic-connector (SGC) binary. Produces a public multi-arch Docker image (datadog/secret-generic-connector) on Docker Hub and also a binary on registry.ddbuild.io

### Motivation
Multiple teams need the SGC binary independently of the agent the. This gives any consumer a simple way to consume the binary such as:
`COPY --from=datadog/secret-generic-connector:7.x.y /secret-generic-connector /secret-generic-connector`

### Describe how you validated your changes
- `dda inv -- -e secret-generic-connector.build --arch-suffix` produces arch-suffixed binary
- `dda inv linter.gitlab-ci` passes
- CI

### Additional Notes
No FIPS or Windows variants for now
