### PR TITLE
Configsync can assign a tree of config data using SetTree

### DIFF
--- a/comp/core/configsync/configsyncimpl/sync.go
+++ b/comp/core/configsync/configsyncimpl/sync.go
@@ -13,6 +13,7 @@ import (
 
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipchttp "github.com/DataDog/datadog-agent/comp/core/ipc/httphelpers"
+	"github.com/DataDog/datadog-agent/pkg/config/helper"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
@@ -59,7 +60,7 @@ func (cs *configSync) updater() error {
 				cs.Config.Set(key, typedValues, pkgconfigmodel.SourceLocalConfigProcess)
 			}
 		} else {
-			cs.Config.Set(key, value, pkgconfigmodel.SourceLocalConfigProcess)
+			helper.SetTree(cs.Config, key, value, pkgconfigmodel.SourceLocalConfigProcess)
 		}
 	}
 	return nil

--- a/comp/core/configsync/go.mod
+++ b/comp/core/configsync/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/log/mock v0.70.0
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.76.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/create v0.76.0-devel
+	github.com/DataDog/datadog-agent/pkg/config/helper v0.76.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.76.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/model v0.77.2
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.76.0-devel
@@ -34,7 +35,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/buildschema v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.76.0-devel // indirect
-	github.com/DataDog/datadog-agent/pkg/config/helper v0.76.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.76.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect

--- a/pkg/config/buildschema/config.go
+++ b/pkg/config/buildschema/config.go
@@ -257,7 +257,7 @@ func (b *builder) IsKnown(_ string) bool {
 	return false
 }
 
-func (b *builder) IsLeafSetting(_ string) bool {
+func (b *builder) IsSetting(_ string) bool {
 	b.notImplemented()
 	return false
 }

--- a/pkg/config/buildschema/config.go
+++ b/pkg/config/buildschema/config.go
@@ -257,6 +257,11 @@ func (b *builder) IsKnown(_ string) bool {
 	return false
 }
 
+func (b *builder) IsLeafSetting(key string) bool {
+	b.notImplemented()
+	return false
+}
+
 func (b *builder) GetKnownKeysLowercased() map[string]interface{} {
 	b.notImplemented()
 	return nil

--- a/pkg/config/buildschema/config.go
+++ b/pkg/config/buildschema/config.go
@@ -257,7 +257,7 @@ func (b *builder) IsKnown(_ string) bool {
 	return false
 }
 
-func (b *builder) IsLeafSetting(key string) bool {
+func (b *builder) IsLeafSetting(_ string) bool {
 	b.notImplemented()
 	return false
 }

--- a/pkg/config/create/go.mod
+++ b/pkg/config/create/go.mod
@@ -17,7 +17,6 @@ require gopkg.in/yaml.v3 v3.0.1 // indirect
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/helper v0.73.0-devel.0.20251030121902-cd89eab046d6 // indirect
 	github.com/DataDog/datadog-agent/pkg/template v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.72.2 // indirect
 	github.com/DataDog/viper v1.15.1 // indirect

--- a/pkg/config/helper/BUILD.bazel
+++ b/pkg/config/helper/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "helper",
-    srcs = ["get_combine.go"],
+    srcs = [
+        "get_combine.go",
+        "set_tree.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/config/helper",
     visibility = ["//visibility:public"],
     deps = ["//pkg/config/model"],

--- a/pkg/config/helper/BUILD.bazel
+++ b/pkg/config/helper/BUILD.bazel
@@ -13,10 +13,15 @@ go_library(
 
 go_test(
     name = "helper_test",
-    srcs = ["get_combine_test.go"],
+    srcs = [
+        "get_combine_test.go",
+        "set_tree_test.go",
+    ],
     embed = [":helper"],
     gotags = ["test"],
     deps = [
+        "//pkg/config/model",
+        "//pkg/config/nodetreemodel",
         "//pkg/config/viperconfig",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/config/helper/go.mod
+++ b/pkg/config/helper/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.72.2
+	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.72.2
 	github.com/stretchr/testify v1.11.1
 )

--- a/pkg/config/helper/set_tree.go
+++ b/pkg/config/helper/set_tree.go
@@ -16,8 +16,8 @@ func SetTree(cfg model.ReaderWriter, key string, value interface{}, source model
 		cfg.Set(key, value, source)
 		return
 	}
-	if cfg.IsLeafSetting(key) {
-		// the value is a map, but the config says the setting is a leaf
+	if cfg.IsSetting(key) {
+		// the value is a map, but the config says this key is a setting
 		cfg.Set(key, value, source)
 		return
 	}

--- a/pkg/config/helper/set_tree.go
+++ b/pkg/config/helper/set_tree.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package helper
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+func SetTree(cfg model.ReaderWriter, key string, value interface{}, source model.Source) {
+	valueMap, ok := value.(map[string]interface{})
+	if !ok {
+		// not a map, assign to the leaf setting
+		cfg.Set(key, value, source)
+		return
+	}
+	if cfg.IsLeafSetting(key) {
+		// the value is a map, but the config says the setting is a leaf
+		cfg.Set(key, value, source)
+		return
+	}
+	// otherwise recursively assign subfield settings
+	for k, v := range valueMap {
+		subkey := key + "." + k
+		SetTree(cfg, subkey, v, source)
+	}
+}

--- a/pkg/config/helper/set_tree_test.go
+++ b/pkg/config/helper/set_tree_test.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package helper
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/config/nodetreemodel"
+	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
+)
+
+func constructBothConfigs(content string, setupFunc func(model.Setup)) (model.BuildableConfig, model.BuildableConfig) {
+	viperConf := viperconfig.NewViperConfig("datadog", "DD", strings.NewReplacer(".", "_"))    // nolint: forbidigo // legit use case
+	ntmConf := nodetreemodel.NewNodeTreeConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+
+	if setupFunc != nil {
+		setupFunc(viperConf)
+		setupFunc(ntmConf)
+	}
+
+	viperConf.BuildSchema()
+	ntmConf.BuildSchema()
+
+	if len(content) > 0 {
+		viperConf.SetConfigType("yaml")
+		viperConf.ReadConfig(bytes.NewBuffer([]byte(content)))
+
+		ntmConf.SetConfigType("yaml")
+		ntmConf.ReadConfig(bytes.NewBuffer([]byte(content)))
+	} else {
+		viperConf.ReadInConfig()
+		ntmConf.ReadInConfig()
+	}
+
+	return viperConf, ntmConf
+}
+
+func TestSetTree(t *testing.T) {
+	// One setting comes from the yaml file
+	configData := `network_path:
+  collector:
+    input_chan_size: 23456
+    workers: 8
+`
+	viperCfg, ntmCfg := constructBothConfigs(configData, func(cfg model.Setup) {
+		cfg.BindEnvAndSetDefault("network_path.collector.input_chan_size", 0)
+		cfg.BindEnvAndSetDefault("network_path.collector.workers", 0)
+	})
+
+	SetTree(viperCfg, "network_path.collector", map[string]interface{}{
+		"input_chan_size": 65432,
+		"workers":         16,
+	}, model.SourceLocalConfigProcess)
+
+	assert.Equal(t, 65432, viperCfg.GetInt("network_path.collector.input_chan_size"))
+	assert.Equal(t, 16, viperCfg.GetInt("network_path.collector.workers"))
+
+	SetTree(ntmCfg, "network_path.collector", map[string]interface{}{
+		"input_chan_size": 65432,
+		"workers":         16,
+	}, model.SourceLocalConfigProcess)
+
+	assert.Equal(t, 65432, ntmCfg.GetInt("network_path.collector.input_chan_size"))
+	assert.Equal(t, 16, ntmCfg.GetInt("network_path.collector.workers"))
+}

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -189,6 +189,8 @@ type Reader interface {
 
 	// IsKnown returns whether this key is known
 	IsKnown(key string) bool
+	// IsLeafSetting returns whether the setting is a leaf in the tree
+	IsLeafSetting(key string) bool
 
 	// GetKnownKeysLowercased returns all the keys that meet at least one of these criteria:
 	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -189,8 +189,8 @@ type Reader interface {
 
 	// IsKnown returns whether this key is known
 	IsKnown(key string) bool
-	// IsLeafSetting returns whether the setting is a leaf in the tree
-	IsLeafSetting(key string) bool
+	// IsSetting returns whether the key identifies a setting (and not a section)
+	IsSetting(key string) bool
 
 	// GetKnownKeysLowercased returns all the keys that meet at least one of these criteria:
 	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()

--- a/pkg/config/nodetreemodel/BUILD.bazel
+++ b/pkg/config/nodetreemodel/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/basic",
-        "//pkg/config/helper",
         "//pkg/config/model",
         "//pkg/util/log",
         "@com_github_mohae_deepcopy//:deepcopy",

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -435,8 +435,8 @@ func (c *ntmConfig) IsKnown(key string) bool {
 	return c.isKnownKey(key)
 }
 
-// IsLeafSetting returns true for leaf nodes
-func (c *ntmConfig) IsLeafSetting(key string) bool {
+// IsSetting returns true for leaf nodes
+func (c *ntmConfig) IsSetting(key string) bool {
 	n, err := c.GetNode(key)
 	if err != nil {
 		return false

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -435,6 +435,15 @@ func (c *ntmConfig) IsKnown(key string) bool {
 	return c.isKnownKey(key)
 }
 
+// IsLeafSetting returns true for leaf nodes
+func (c *ntmConfig) IsLeafSetting(key string) bool {
+	n, err := c.GetNode(key)
+	if err != nil {
+		return false
+	}
+	return n.IsLeafNode()
+}
+
 // isKnownKey returns whether the key is known.
 // Must be called with the lock read-locked.
 func (c *ntmConfig) isKnownKey(key string) bool {

--- a/pkg/config/nodetreemodel/helpers.go
+++ b/pkg/config/nodetreemodel/helpers.go
@@ -8,11 +8,11 @@ package nodetreemodel
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 	"unicode"
 
-	"github.com/DataDog/datadog-agent/pkg/config/helper"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/mohae/deepcopy"
 	"github.com/spf13/cast"
@@ -121,9 +121,27 @@ func mapToMapString(m reflect.Value) map[string]interface{} {
 	return res
 }
 
+// valid kinds to call IsNil on
+// duplicated from pkg/config/helper in order to avoid import cycle
+var nillableKinds = []reflect.Kind{reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice}
+
+// isNilValue returns true if a is nil, or a is an interface with nil data
+// duplicated from pkg/config/helper in order to avoid import cycle
+func isNilValue(a interface{}) bool {
+	if a == nil {
+		return true
+	}
+	rv := reflect.ValueOf(a)
+	// check if IsNil may be called in order to avoid a panic
+	if slices.Contains(nillableKinds, rv.Kind()) {
+		return reflect.ValueOf(a).IsNil()
+	}
+	return false
+}
+
 // newNodeTree will recursively create nodes from the input value to construct a tree
 func newNodeTree(v interface{}, source model.Source) (*nodeImpl, error) {
-	if helper.IsNilValue(v) {
+	if isNilValue(v) {
 		// nil as a value acts as the zero value, and the cast library will correctly
 		// convert it to zero values for the types we handle
 		return newLeafNode(nil, source), nil

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -116,6 +116,11 @@ func (t *teeConfig) IsKnown(key string) bool {
 	return base
 }
 
+func (t *teeConfig) IsLeafSetting(key string) bool {
+	// viper and nodetreemodel don't agree on this functionality, no point in logging differences
+	return t.baseline.IsKnown(key)
+}
+
 // GetKnownKeysLowercased returns all the keys that meet at least one of these criteria:
 // 1) have a default, 2) have an environment variable binded or 3) have been SetKnown()
 // Note that it returns the keys lowercased.

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -118,7 +118,7 @@ func (t *teeConfig) IsKnown(key string) bool {
 
 func (t *teeConfig) IsLeafSetting(key string) bool {
 	// viper and nodetreemodel don't agree on this functionality, no point in logging differences
-	return t.baseline.IsKnown(key)
+	return t.baseline.IsLeafSetting(key)
 }
 
 // GetKnownKeysLowercased returns all the keys that meet at least one of these criteria:

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -116,9 +116,9 @@ func (t *teeConfig) IsKnown(key string) bool {
 	return base
 }
 
-func (t *teeConfig) IsLeafSetting(key string) bool {
+func (t *teeConfig) IsSetting(key string) bool {
 	// viper and nodetreemodel don't agree on this functionality, no point in logging differences
-	return t.baseline.IsLeafSetting(key)
+	return t.baseline.IsSetting(key)
 }
 
 // GetKnownKeysLowercased returns all the keys that meet at least one of these criteria:

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -208,7 +208,7 @@ func (c *safeConfig) IsKnown(key string) bool {
 }
 
 // IsLeafSetting always returns true for Viper, because it doesn't know the difference
-func (c *safeConfig) IsLeafSetting(key string) bool {
+func (c *safeConfig) IsLeafSetting(_ string) bool {
 	return true
 }
 

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -207,6 +207,11 @@ func (c *safeConfig) IsKnown(key string) bool {
 	return c.Viper.IsKnown(key)
 }
 
+// IsLeafSetting always returns true for Viper, because it doesn't know the difference
+func (c *safeConfig) IsLeafSetting(key string) bool {
+	return true
+}
+
 // checkKnownKey checks if a key is known, and if not logs a warning
 // Only a single warning will be logged per unknown key.
 //

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -207,8 +207,8 @@ func (c *safeConfig) IsKnown(key string) bool {
 	return c.Viper.IsKnown(key)
 }
 
-// IsLeafSetting always returns true for Viper, because it doesn't know the difference
-func (c *safeConfig) IsLeafSetting(_ string) bool {
+// IsSetting always returns true for Viper, because it doesn't have a way to tell
+func (c *safeConfig) IsSetting(_ string) bool {
 	return true
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix a bug in configsync so that it assigns trees of data using the helper method `SetTree`.

### Motivation

With nodetreemodel, assigning a group of settings at once using `config.Set("my_section", map[string]...)` doesn't work anymore. This helper method fixes the implementation of configsync which needs to assign such data under certain circumstances.

### Describe how you validated your changes

### Additional Notes
