### PR TITLE
[workloadmeta/ecs] Set container Owner to parent ECS task in v1 and v2 parsers

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
@@ -108,6 +108,10 @@ func (c *collector) parseTaskContainers(
 				EntityMeta: workloadmeta.EntityMeta{
 					Name: container.DockerName,
 				},
+				Owner: &workloadmeta.EntityID{
+					Kind: workloadmeta.KindECSTask,
+					ID:   task.Arn,
+				},
 				State: workloadmeta.ContainerState{
 					Status: workloadmeta.ContainerStatusUnknown,
 					Health: workloadmeta.ContainerHealthUnknown,

--- a/comp/core/workloadmeta/collectors/internal/ecs/v1parser_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v1parser_test.go
@@ -97,6 +97,15 @@ func TestPullWithV1Parser(t *testing.T) {
 			taskTags := c.resourceTags[entityID].tags
 			assert.Equal(t, taskTags, test.expectedTags)
 
+			// Verify the container event has the Owner set to the parent ECS task
+			store := c.store.(*fakeWorkloadmetaStore)
+			require.NotEmpty(t, store.notifiedEvents)
+			container, ok := store.notifiedEvents[0].Entity.(*workloadmeta.Container)
+			require.True(t, ok)
+			require.NotNil(t, container.Owner)
+			assert.Equal(t, workloadmeta.KindECSTask, container.Owner.Kind)
+			assert.Equal(t, entityID, container.Owner.ID)
+
 			// This is only needed because of the workaround about the empty
 			// runtime documented in the parseTaskContainers function. Remove
 			// this when the workaround is no longer needed.

--- a/comp/core/workloadmeta/collectors/internal/ecs/v2parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v2parser.go
@@ -158,6 +158,10 @@ func (c *collector) parseV2TaskContainers(
 					Name:   container.DockerName,
 					Labels: container.Labels,
 				},
+				Owner: &workloadmeta.EntityID{
+					Kind: workloadmeta.KindECSTask,
+					ID:   task.TaskARN,
+				},
 				Image:      image,
 				Runtime:    containerRuntime,
 				NetworkIPs: ips,

--- a/comp/core/workloadmeta/collectors/internal/ecs/v2parser_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v2parser_test.go
@@ -239,6 +239,10 @@ func TestParseV2TaskContainers(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, workloadmeta.ContainerRuntimeECSFargate, container.Runtime)
 
+		require.NotNil(t, container.Owner)
+		assert.Equal(t, workloadmeta.KindECSTask, container.Owner.Kind)
+		assert.Equal(t, task.TaskARN, container.Owner.ID)
+
 		// Check network IPs
 		if container.ID == "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946" {
 			assert.Equal(t, "10.0.2.106", container.NetworkIPs["awsvpc"])


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue in the ECS workloadmeta collector.

The collector was setting the `Owner` field for containers with the parent ECS task when the v4 parser is used. However, it was not setting them when using v1 or v2.

It's not clear to me that this causes a problem for existing consumers of container entities that come from the ECS collectors, but codex caught this in a PR of mine that relies on this `Owner` field (https://github.com/DataDog/datadog-agent/pull/49174#discussion_r3085862053).


### Describe how you validated your changes

Unit tests.
