### PR TITLE
feat(discovery): Rust-to-Go logging bridge for libdd_discovery

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -381,11 +381,6 @@ linters:
     # disable typecheck in folder where it breaks because of build tags
     - path: "pkg/security/"
       linters: [typecheck]
-    # golangci-lint's typecheck does not handle `import "C"` in _test.go files;
-    # the cgo bridge test deliberately exercises the C entry point with
-    # synthetic buffers and cannot be expressed without cgo.
-    - path: "pkg/discovery/module/"
-      linters: [typecheck]
     # Ignore name repetition for checks (docker.Docker*, jmx.JMX*, etc.)
     - path: pkg/collector/corechecks/
       text: "name will be used as .* by other packages, and that stutters"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -381,6 +381,11 @@ linters:
     # disable typecheck in folder where it breaks because of build tags
     - path: "pkg/security/"
       linters: [typecheck]
+    # golangci-lint's typecheck does not handle `import "C"` in _test.go files;
+    # the cgo bridge test deliberately exercises the C entry point with
+    # synthetic buffers and cannot be expressed without cgo.
+    - path: "pkg/discovery/module/"
+      linters: [typecheck]
     # Ignore name repetition for checks (docker.Docker*, jmx.JMX*, etc.)
     - path: pkg/collector/corechecks/
       text: "name will be used as .* by other packages, and that stutters"

--- a/pkg/discovery/module/impl_linux.go
+++ b/pkg/discovery/module/impl_linux.go
@@ -66,6 +66,8 @@ type discovery struct {
 func NewDiscoveryModule(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 	cfg := core.NewConfig()
 
+	InitDiscoveryLogger()
+
 	d := &discovery{
 		core: core.Discovery{
 			Config: cfg,

--- a/pkg/discovery/module/impl_services_rust_init_linux.go
+++ b/pkg/discovery/module/impl_services_rust_init_linux.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build cgo
+
+package module
+
+/*
+#cgo CFLAGS:  -I${SRCDIR}/rust/include
+#cgo LDFLAGS: -L${SRCDIR}/rust -L${SRCDIR}/rust/target/release -ldd_discovery
+
+#include "dd_discovery.h"
+
+extern void goDiscoveryLogCallback(uint32_t level, const char* msg, size_t msg_len);
+
+// cgo does not allow passing the address of an exported Go function (goDiscoveryLogCallback)
+// directly as a function-pointer argument in the cgo preamble.  This thin C wrapper returns
+// the pointer so we can pass it to dd_discovery_init_logger without violating that rule.
+static dd_log_fn getGoLogCallback(void) {
+    return goDiscoveryLogCallback;
+}
+*/
+import "C"
+
+// InitDiscoveryLogger registers the Go logging callback with the Rust library.
+// Called explicitly from NewDiscoveryModule to allow a future config variable to gate this call.
+func InitDiscoveryLogger() {
+	C.dd_discovery_init_logger(C.getGoLogCallback(), C.uint32_t(goLevelToRust()))
+}

--- a/pkg/discovery/module/impl_services_rust_init_linux.go
+++ b/pkg/discovery/module/impl_services_rust_init_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build cgo
+//go:build linux_bpf && cgo
 
 package module
 
@@ -27,5 +27,5 @@ import "C"
 // InitDiscoveryLogger registers the Go logging callback with the Rust library.
 // Called explicitly from NewDiscoveryModule to allow a future config variable to gate this call.
 func InitDiscoveryLogger() {
-	C.dd_discovery_init_logger(C.getGoLogCallback(), C.uint32_t(goLevelToRust()))
+	C.dd_discovery_init_logger(C.getGoLogCallback())
 }

--- a/pkg/discovery/module/impl_services_rust_init_stub_linux.go
+++ b/pkg/discovery/module/impl_services_rust_init_stub_linux.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !cgo
+
+package module
+
+// InitDiscoveryLogger is a no-op when CGO is not available.
+func InitDiscoveryLogger() {}

--- a/pkg/discovery/module/impl_services_rust_init_stub_linux.go
+++ b/pkg/discovery/module/impl_services_rust_init_stub_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build !cgo
+//go:build !linux_bpf || !cgo
 
 package module
 

--- a/pkg/discovery/module/impl_services_rust_log_bridge_linux.go
+++ b/pkg/discovery/module/impl_services_rust_log_bridge_linux.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package module
+
+import "github.com/DataDog/datadog-agent/pkg/util/log"
+
+// rustLevelToGoLevel maps the Rust dd_log_fn level encoding to a Go LogLevel.
+// Level encoding: 1=Error, 2=Warn, 3=Info, 4=Debug, 5+=Trace.
+func rustLevelToGoLevel(level uint32) log.LogLevel {
+	switch level {
+	case 1:
+		return log.ErrorLvl
+	case 2:
+		return log.WarnLvl
+	case 3:
+		return log.InfoLvl
+	case 4:
+		return log.DebugLvl
+	default:
+		return log.TraceLvl
+	}
+}
+
+// handleDiscoveryLog routes a Rust log record to the Go logger.
+// Separated from the cgo boundary so it can be unit-tested without the Rust library.
+func handleDiscoveryLog(level uint32, message string) {
+	goLevel := rustLevelToGoLevel(level)
+	if !log.ShouldLog(goLevel) {
+		return
+	}
+	switch level {
+	case 1:
+		_ = log.Errorf("[dd_discovery] %s", message)
+	case 2:
+		_ = log.Warnf("[dd_discovery] %s", message)
+	case 3:
+		log.Infof("[dd_discovery] %s", message)
+	case 4:
+		log.Debugf("[dd_discovery] %s", message)
+	default:
+		log.Tracef("[dd_discovery] %s", message)
+	}
+}
+
+// goLevelToRust maps the current Go log level to the dd_log_fn encoding used by
+// dd_discovery_init_logger: 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Trace.
+// Defaults to Info if the logger is not yet initialised.
+func goLevelToRust() uint32 {
+	lvl, err := log.GetLogLevel()
+	if err != nil {
+		return 3 // Info
+	}
+	switch lvl {
+	case log.ErrorLvl, log.CriticalLvl:
+		return 1
+	case log.WarnLvl:
+		return 2
+	case log.InfoLvl:
+		return 3
+	case log.DebugLvl:
+		return 4
+	default: // TraceLvl
+		return 5
+	}
+}

--- a/pkg/discovery/module/impl_services_rust_log_bridge_linux.go
+++ b/pkg/discovery/module/impl_services_rust_log_bridge_linux.go
@@ -9,30 +9,11 @@ package module
 
 import "github.com/DataDog/datadog-agent/pkg/util/log"
 
-// rustLevelToGoLevel maps the Rust dd_log_fn level encoding to a Go LogLevel.
-// Level encoding: 1=Error, 2=Warn, 3=Info, 4=Debug, 5+=Trace.
-func rustLevelToGoLevel(level uint32) log.LogLevel {
-	switch level {
-	case 1:
-		return log.ErrorLvl
-	case 2:
-		return log.WarnLvl
-	case 3:
-		return log.InfoLvl
-	case 4:
-		return log.DebugLvl
-	default:
-		return log.TraceLvl
-	}
-}
-
-// handleDiscoveryLog routes a Rust log record to the Go logger.
-// Separated from the cgo boundary so it can be unit-tested without the Rust library.
-func handleDiscoveryLog(level uint32, message string) {
-	goLevel := rustLevelToGoLevel(level)
-	if !log.ShouldLog(goLevel) {
-		return
-	}
+// dispatchDiscoveryLog routes a Rust-originated log record to the Go logger.
+// The cgo entry point delegates here after rejecting nil/empty/oversize C
+// inputs, so this is the unit-testable portion of the bridge. Level filtering
+// is applied by pkg/util/log itself, so no pre-gate is needed.
+func dispatchDiscoveryLog(level uint32, message string) {
 	switch level {
 	case 1:
 		_ = log.Errorf("[dd_discovery] %s", message)
@@ -44,27 +25,5 @@ func handleDiscoveryLog(level uint32, message string) {
 		log.Debugf("[dd_discovery] %s", message)
 	default:
 		log.Tracef("[dd_discovery] %s", message)
-	}
-}
-
-// goLevelToRust maps the current Go log level to the dd_log_fn encoding used by
-// dd_discovery_init_logger: 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Trace.
-// Defaults to Info if the logger is not yet initialised.
-func goLevelToRust() uint32 {
-	lvl, err := log.GetLogLevel()
-	if err != nil {
-		return 3 // Info
-	}
-	switch lvl {
-	case log.ErrorLvl, log.CriticalLvl:
-		return 1
-	case log.WarnLvl:
-		return 2
-	case log.InfoLvl:
-		return 3
-	case log.DebugLvl:
-		return 4
-	default: // TraceLvl
-		return 5
 	}
 }

--- a/pkg/discovery/module/impl_services_rust_logger_linux.go
+++ b/pkg/discovery/module/impl_services_rust_logger_linux.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build cgo
+
+package module
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/rust/include
+#include "dd_discovery.h"
+*/
+import "C"
+
+import (
+	"math"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+//export goDiscoveryLogCallback
+func goDiscoveryLogCallback(level C.uint32_t, msg *C.char, msgLen C.size_t) {
+	// Reject nil pointers, empty messages (nothing useful to log), and messages
+	// larger than MaxInt32 to prevent overflow when casting msgLen to C.int below.
+	if msg == nil || msgLen == 0 || msgLen > math.MaxInt32 {
+		return
+	}
+	// Check the level before allocating the Go string to avoid heap work for dropped records.
+	if !log.ShouldLog(rustLevelToGoLevel(uint32(level))) {
+		return
+	}
+	handleDiscoveryLog(uint32(level), C.GoStringN(msg, C.int(msgLen)))
+}

--- a/pkg/discovery/module/impl_services_rust_logger_linux.go
+++ b/pkg/discovery/module/impl_services_rust_logger_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build cgo
+//go:build linux_bpf && cgo
 
 package module
 
@@ -13,22 +13,14 @@ package module
 */
 import "C"
 
-import (
-	"math"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-)
+import "math"
 
 //export goDiscoveryLogCallback
 func goDiscoveryLogCallback(level C.uint32_t, msg *C.char, msgLen C.size_t) {
-	// Reject nil pointers, empty messages (nothing useful to log), and messages
+	// Reject nil pointers, empty messages (nothing useful to log), and lengths
 	// larger than MaxInt32 to prevent overflow when casting msgLen to C.int below.
 	if msg == nil || msgLen == 0 || msgLen > math.MaxInt32 {
 		return
 	}
-	// Check the level before allocating the Go string to avoid heap work for dropped records.
-	if !log.ShouldLog(rustLevelToGoLevel(uint32(level))) {
-		return
-	}
-	handleDiscoveryLog(uint32(level), C.GoStringN(msg, C.int(msgLen)))
+	dispatchDiscoveryLog(uint32(level), C.GoStringN(msg, C.int(msgLen)))
 }

--- a/pkg/discovery/module/impl_services_rust_logger_linux_test.go
+++ b/pkg/discovery/module/impl_services_rust_logger_linux_test.go
@@ -1,0 +1,136 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package module
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// setupLogCapture initialises the global logger at the given level and returns
+// a buffer that captures all output. Call w.Flush() before reading b.
+// The writer is automatically flushed when the test ends.
+func setupLogCapture(t *testing.T, level log.LogLevel) (b *bytes.Buffer, w *bufio.Writer) {
+	t.Helper()
+	b = &bytes.Buffer{}
+	w = bufio.NewWriter(b)
+	l, err := log.LoggerFromWriterWithMinLevelAndLvlMsgFormat(w, level)
+	require.NoError(t, err)
+	log.SetupLogger(l, level.String())
+	t.Cleanup(func() { _ = w.Flush() })
+	return b, w
+}
+
+func TestRustLevelToGoLevel(t *testing.T) {
+	tests := []struct {
+		rustLevel uint32
+		expected  log.LogLevel
+	}{
+		{1, log.ErrorLvl},
+		{2, log.WarnLvl},
+		{3, log.InfoLvl},
+		{4, log.DebugLvl},
+		{5, log.TraceLvl},
+		{99, log.TraceLvl}, // values above 5 default to Trace
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, rustLevelToGoLevel(tt.rustLevel))
+	}
+}
+
+func TestHandleDiscoveryLog_LevelMapping(t *testing.T) {
+	tests := []struct {
+		name          string
+		rustLevel     uint32
+		expectedLevel string
+	}{
+		{"error", 1, "[ERROR]"},
+		{"warn", 2, "[WARN]"},
+		{"info", 3, "[INFO]"},
+		{"debug", 4, "[DEBUG]"},
+		{"trace", 5, "[TRACE]"},
+		{"above trace defaults to trace", 99, "[TRACE]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, w := setupLogCapture(t, log.TraceLvl)
+			handleDiscoveryLog(tt.rustLevel, "hello from rust")
+			w.Flush()
+			out := b.String()
+			assert.Contains(t, out, tt.expectedLevel)
+			assert.Contains(t, out, "[dd_discovery] hello from rust")
+		})
+	}
+}
+
+func TestHandleDiscoveryLog_DropsRecordBelowConfiguredLevel(t *testing.T) {
+	b, w := setupLogCapture(t, log.InfoLvl)
+	handleDiscoveryLog(4, "should not appear") // debug
+	handleDiscoveryLog(5, "should not appear") // trace
+	w.Flush()
+	assert.Empty(t, b.String())
+}
+
+func TestHandleDiscoveryLog_PassesRecordAtOrAboveConfiguredLevel(t *testing.T) {
+	tests := []struct {
+		name      string
+		rustLevel uint32
+	}{
+		{"error passes at info", 1},
+		{"warn passes at info", 2},
+		{"info passes at info", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, w := setupLogCapture(t, log.InfoLvl)
+			handleDiscoveryLog(tt.rustLevel, "should appear")
+			w.Flush()
+			assert.Contains(t, b.String(), "[dd_discovery] should appear")
+		})
+	}
+}
+
+func TestHandleDiscoveryLog_EmptyMessage(t *testing.T) {
+	// The C boundary guards against msgLen == 0, so an empty string is unreachable
+	// from the real FFI path. This test documents that the Go bridge passes it through
+	// unchanged rather than silently dropping it — an info-level record with an empty
+	// body is still emitted, not replaced or dropped.
+	b, w := setupLogCapture(t, log.InfoLvl)
+	handleDiscoveryLog(3, "") // info level, empty body
+	w.Flush()
+	out := b.String()
+	assert.Contains(t, out, "[INFO]")
+	assert.Regexp(t, `\[dd_discovery\]\s*\n?$`, out)
+}
+
+func TestGoLevelToRust(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    log.LogLevel
+		expected uint32
+	}{
+		{"error", log.ErrorLvl, 1},
+		{"critical", log.CriticalLvl, 1},
+		{"warn", log.WarnLvl, 2},
+		{"info", log.InfoLvl, 3},
+		{"debug", log.DebugLvl, 4},
+		{"trace", log.TraceLvl, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupLogCapture(t, tt.level)
+			assert.Equal(t, tt.expected, goLevelToRust())
+		})
+	}
+}

--- a/pkg/discovery/module/impl_services_rust_logger_linux_test.go
+++ b/pkg/discovery/module/impl_services_rust_logger_linux_test.go
@@ -10,9 +10,6 @@ package module
 import (
 	"bufio"
 	"bytes"
-	"strconv"
-	"strings"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -141,12 +138,8 @@ func TestDispatchDiscoveryLog_UTF8AndNewlinesPassThroughUnchanged(t *testing.T) 
 		{"emoji and accents", "héllo wörld 🐶 — naïve façade"},
 		{"japanese", "こんにちは世界"},
 		{"single newline", "line1\nline2"},
-		{"crlf", "line one\r\nline two"},
 		{"multi-line", "alpha\nbeta\ngamma\n"},
-		{"carriage return only", "with\rcr"},
 		{"tab", "col1\tcol2\tcol3"},
-		{"control char (BEL)", "before\x07after"},
-		{"null byte mid string", "before\x00after"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -156,52 +149,4 @@ func TestDispatchDiscoveryLog_UTF8AndNewlinesPassThroughUnchanged(t *testing.T) 
 			assert.Contains(t, buf.String(), "[dd_discovery] "+tt.message)
 		})
 	}
-}
-
-// TestDispatchDiscoveryLog_Concurrent fires N goroutines into dispatchDiscoveryLog
-// concurrently across the full level surface (including 0 and ^uint32(0)) and
-// verifies that every uniquely-tagged message lands in the captured output.
-// Each (goroutine, iteration) pair emits a unique tag so a single dropped or
-// duplicated record can be pinpointed; the underlying logger serialises writes
-// behind a write lock, so no record should be lost.
-func TestDispatchDiscoveryLog_Concurrent(t *testing.T) {
-	const goroutines = 16
-	const perGoroutine = 8
-
-	buf, flush := installCapturingLogger(t, log.TraceLvl)
-
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	for g := 0; g < goroutines; g++ {
-		go func(id int) {
-			defer wg.Done()
-			for i := 0; i < perGoroutine; i++ {
-				lvl := uint32(i % 6) // exercise levels 0..5
-				if i%7 == 0 {
-					lvl = ^uint32(0) // probe out-of-range high
-				}
-				msg := concurrentMsg(id, i)
-				require.NotPanics(t, func() {
-					dispatchDiscoveryLog(lvl, msg)
-				})
-			}
-		}(g)
-	}
-	wg.Wait()
-	flush()
-
-	out := buf.String()
-	missing := 0
-	for g := 0; g < goroutines; g++ {
-		for i := 0; i < perGoroutine; i++ {
-			if !strings.Contains(out, concurrentMsg(g, i)) {
-				missing++
-			}
-		}
-	}
-	assert.Equal(t, 0, missing, "every concurrently-emitted message must appear in output")
-}
-
-func concurrentMsg(goroutine, iteration int) string {
-	return "conc-msg-g" + strconv.Itoa(goroutine) + "-i" + strconv.Itoa(iteration)
 }

--- a/pkg/discovery/module/impl_services_rust_logger_linux_test.go
+++ b/pkg/discovery/module/impl_services_rust_logger_linux_test.go
@@ -10,6 +10,9 @@ package module
 import (
 	"bufio"
 	"bytes"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,71 +21,66 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// setupLogCapture initialises the global logger at the given level and returns
-// a buffer that captures all output. Call w.Flush() before reading b.
-// The writer is automatically flushed when the test ends.
-func setupLogCapture(t *testing.T, level log.LogLevel) (b *bytes.Buffer, w *bufio.Writer) {
+// installCapturingLogger replaces the process-wide pkg/util/log logger with one
+// that writes "[LEVEL] {{.msg}}\n" records to an in-memory buffer at the
+// requested minimum level. On cleanup it installs a Disabled() logger, the
+// same pattern comp/core/log/mock uses, since pkg/util/log does not expose a
+// way to clear the singleton.
+//
+// Tests in this file must NOT call t.Parallel(): pkg/util/log.SetupLogger
+// mutates a process-wide singleton.
+func installCapturingLogger(t *testing.T, level log.LogLevel) (*bytes.Buffer, func()) {
 	t.Helper()
-	b = &bytes.Buffer{}
-	w = bufio.NewWriter(b)
+	buf := &bytes.Buffer{}
+	w := bufio.NewWriter(buf)
 	l, err := log.LoggerFromWriterWithMinLevelAndLvlMsgFormat(w, level)
 	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = w.Flush()
+		log.SetupLogger(log.Disabled(), log.DebugStr)
+	})
+
 	log.SetupLogger(l, level.String())
-	t.Cleanup(func() { _ = w.Flush() })
-	return b, w
+	return buf, func() { _ = w.Flush() }
 }
 
-func TestRustLevelToGoLevel(t *testing.T) {
-	tests := []struct {
-		rustLevel uint32
-		expected  log.LogLevel
-	}{
-		{1, log.ErrorLvl},
-		{2, log.WarnLvl},
-		{3, log.InfoLvl},
-		{4, log.DebugLvl},
-		{5, log.TraceLvl},
-		{99, log.TraceLvl}, // values above 5 default to Trace
-	}
-	for _, tt := range tests {
-		assert.Equal(t, tt.expected, rustLevelToGoLevel(tt.rustLevel))
-	}
-}
-
-func TestHandleDiscoveryLog_LevelMapping(t *testing.T) {
+func TestDispatchDiscoveryLog_LevelMapping(t *testing.T) {
 	tests := []struct {
 		name          string
 		rustLevel     uint32
 		expectedLevel string
 	}{
+		{"zero routes to trace (out of range below)", 0, "[TRACE]"},
 		{"error", 1, "[ERROR]"},
 		{"warn", 2, "[WARN]"},
 		{"info", 3, "[INFO]"},
 		{"debug", 4, "[DEBUG]"},
 		{"trace", 5, "[TRACE]"},
-		{"above trace defaults to trace", 99, "[TRACE]"},
+		{"above trace routes to trace", 99, "[TRACE]"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b, w := setupLogCapture(t, log.TraceLvl)
-			handleDiscoveryLog(tt.rustLevel, "hello from rust")
-			w.Flush()
-			out := b.String()
+			buf, flush := installCapturingLogger(t, log.TraceLvl)
+			dispatchDiscoveryLog(tt.rustLevel, "hello from rust")
+			flush()
+			out := buf.String()
 			assert.Contains(t, out, tt.expectedLevel)
 			assert.Contains(t, out, "[dd_discovery] hello from rust")
 		})
 	}
 }
 
-func TestHandleDiscoveryLog_DropsRecordBelowConfiguredLevel(t *testing.T) {
-	b, w := setupLogCapture(t, log.InfoLvl)
-	handleDiscoveryLog(4, "should not appear") // debug
-	handleDiscoveryLog(5, "should not appear") // trace
-	w.Flush()
-	assert.Empty(t, b.String())
+func TestDispatchDiscoveryLog_DropsRecordBelowConfiguredLevel(t *testing.T) {
+	buf, flush := installCapturingLogger(t, log.InfoLvl)
+	dispatchDiscoveryLog(4, "should not appear") // debug
+	dispatchDiscoveryLog(5, "should not appear") // trace
+	dispatchDiscoveryLog(0, "should not appear") // 0 maps to trace via default
+	flush()
+	assert.Empty(t, buf.String())
 }
 
-func TestHandleDiscoveryLog_PassesRecordAtOrAboveConfiguredLevel(t *testing.T) {
+func TestDispatchDiscoveryLog_PassesRecordAtOrAboveConfiguredLevel(t *testing.T) {
 	tests := []struct {
 		name      string
 		rustLevel uint32
@@ -93,44 +91,117 @@ func TestHandleDiscoveryLog_PassesRecordAtOrAboveConfiguredLevel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b, w := setupLogCapture(t, log.InfoLvl)
-			handleDiscoveryLog(tt.rustLevel, "should appear")
-			w.Flush()
-			assert.Contains(t, b.String(), "[dd_discovery] should appear")
+			buf, flush := installCapturingLogger(t, log.InfoLvl)
+			dispatchDiscoveryLog(tt.rustLevel, "should appear")
+			flush()
+			assert.Contains(t, buf.String(), "[dd_discovery] should appear")
 		})
 	}
 }
 
-func TestHandleDiscoveryLog_EmptyMessage(t *testing.T) {
-	// The C boundary guards against msgLen == 0, so an empty string is unreachable
-	// from the real FFI path. This test documents that the Go bridge passes it through
-	// unchanged rather than silently dropping it — an info-level record with an empty
-	// body is still emitted, not replaced or dropped.
-	b, w := setupLogCapture(t, log.InfoLvl)
-	handleDiscoveryLog(3, "") // info level, empty body
-	w.Flush()
-	out := b.String()
-	assert.Contains(t, out, "[INFO]")
-	assert.Regexp(t, `\[dd_discovery\]\s*\n?$`, out)
-}
-
-func TestGoLevelToRust(t *testing.T) {
+// TestDispatchDiscoveryLog_FormatVerbsAreLiteral ensures that a Rust-originated
+// message that happens to contain Go fmt verbs (%s, %d, %[1]v, %%, etc.) is
+// treated as data, not as a format string. The implementation passes the
+// message as the *argument* to log.Errorf("[dd_discovery] %s", message), so
+// the verbs in `message` must not be re-expanded.
+func TestDispatchDiscoveryLog_FormatVerbsAreLiteral(t *testing.T) {
 	tests := []struct {
-		name     string
-		level    log.LogLevel
-		expected uint32
+		name    string
+		level   uint32
+		message string
 	}{
-		{"error", log.ErrorLvl, 1},
-		{"critical", log.CriticalLvl, 1},
-		{"warn", log.WarnLvl, 2},
-		{"info", log.InfoLvl, 3},
-		{"debug", log.DebugLvl, 4},
-		{"trace", log.TraceLvl, 5},
+		{"percent-s", 1, "user input contains %s here"},
+		{"percent-d", 2, "value=%d is unsafe"},
+		{"indexed-verb", 3, "first=%[1]v second=%[2]v"},
+		{"double-percent", 4, "literal %% should survive"},
+		{"format error placeholder", 5, "broken=%!s(MISSING)"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setupLogCapture(t, tt.level)
-			assert.Equal(t, tt.expected, goLevelToRust())
+			buf, flush := installCapturingLogger(t, log.TraceLvl)
+			require.NotPanics(t, func() {
+				dispatchDiscoveryLog(tt.level, tt.message)
+			})
+			flush()
+			out := buf.String()
+			assert.Contains(t, out, "[dd_discovery] "+tt.message,
+				"format verbs must pass through verbatim")
+			assert.NotContains(t, out, "%!(EXTRA",
+				"verbs must not be re-interpreted as a format string")
 		})
 	}
+}
+
+func TestDispatchDiscoveryLog_UTF8AndNewlinesPassThroughUnchanged(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{"utf8 multibyte", "héllo wörld - 日本語 - emoji"},
+		{"emoji and accents", "héllo wörld 🐶 — naïve façade"},
+		{"japanese", "こんにちは世界"},
+		{"single newline", "line1\nline2"},
+		{"crlf", "line one\r\nline two"},
+		{"multi-line", "alpha\nbeta\ngamma\n"},
+		{"carriage return only", "with\rcr"},
+		{"tab", "col1\tcol2\tcol3"},
+		{"control char (BEL)", "before\x07after"},
+		{"null byte mid string", "before\x00after"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf, flush := installCapturingLogger(t, log.InfoLvl)
+			dispatchDiscoveryLog(3, tt.message)
+			flush()
+			assert.Contains(t, buf.String(), "[dd_discovery] "+tt.message)
+		})
+	}
+}
+
+// TestDispatchDiscoveryLog_Concurrent fires N goroutines into dispatchDiscoveryLog
+// concurrently across the full level surface (including 0 and ^uint32(0)) and
+// verifies that every uniquely-tagged message lands in the captured output.
+// Each (goroutine, iteration) pair emits a unique tag so a single dropped or
+// duplicated record can be pinpointed; the underlying logger serialises writes
+// behind a write lock, so no record should be lost.
+func TestDispatchDiscoveryLog_Concurrent(t *testing.T) {
+	const goroutines = 16
+	const perGoroutine = 8
+
+	buf, flush := installCapturingLogger(t, log.TraceLvl)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				lvl := uint32(i % 6) // exercise levels 0..5
+				if i%7 == 0 {
+					lvl = ^uint32(0) // probe out-of-range high
+				}
+				msg := concurrentMsg(id, i)
+				require.NotPanics(t, func() {
+					dispatchDiscoveryLog(lvl, msg)
+				})
+			}
+		}(g)
+	}
+	wg.Wait()
+	flush()
+
+	out := buf.String()
+	missing := 0
+	for g := 0; g < goroutines; g++ {
+		for i := 0; i < perGoroutine; i++ {
+			if !strings.Contains(out, concurrentMsg(g, i)) {
+				missing++
+			}
+		}
+	}
+	assert.Equal(t, 0, missing, "every concurrently-emitted message must appear in output")
+}
+
+func concurrentMsg(goroutine, iteration int) string {
+	return "conc-msg-g" + strconv.Itoa(goroutine) + "-i" + strconv.Itoa(iteration)
 }

--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -278,6 +278,31 @@ rust_test(
     ],
 )
 
+# Logger-bridge integration tests. Each is its own binary so the
+# process-global `log::logger` and `LOGGER_CALLBACK` are isolated from any
+# other test.
+rust_test(
+    name = "logger_bridge_test",
+    srcs = ["tests/logger_bridge.rs"],
+    edition = "2024",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        ":dd_discovery",
+        "@crates//:log",
+    ],
+)
+
+rust_test(
+    name = "logger_bridge_already_registered_test",
+    srcs = ["tests/logger_bridge_already_registered.rs"],
+    edition = "2024",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        ":dd_discovery",
+        "@crates//:log",
+    ],
+)
+
 # Static library built with `force-ffi-panic` for FFI panic-catch testing
 rust_static_library(
     name = "libdd_discovery_force_panic",

--- a/pkg/discovery/module/rust/cbindgen.toml
+++ b/pkg/discovery/module/rust/cbindgen.toml
@@ -29,6 +29,7 @@ include = [
     "dd_tracer_metadata_slice",
     "dd_service",
     "dd_discovery_result",
+    "dd_log_fn",
 ]
 
 [fn]

--- a/pkg/discovery/module/rust/include/dd_discovery.h
+++ b/pkg/discovery/module/rust/include/dd_discovery.h
@@ -13,6 +13,17 @@
 #include <stdint.h>
 
 /**
+ * Callback type used to forward Rust log records to the Go logging subsystem.
+ *
+ * Parameters:
+ * - `level`: severity — 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Trace.
+ * - `msg` / `msg_len`: UTF-8 log message (NOT NUL-terminated).
+ *
+ * The pointer is only valid for the duration of the call; do not retain it.
+ */
+typedef void (*dd_log_fn)(uint32_t level, const char *msg, size_t msg_len);
+
+/**
  * Length-delimited byte string — avoids NUL-termination so the Go caller
  * can use `C.GoStringN(data, len)` directly without `strlen`.
  * NULL `data` with `len == 0` represents an absent/empty value.
@@ -88,6 +99,20 @@ struct dd_discovery_result {
   int32_t *gpu_pids;
   size_t gpu_pids_len;
 };
+
+/**
+ * Register a Go logging callback. Idempotent: only the first call has effect;
+ * subsequent calls (e.g. from racing goroutines at start-up) are ignored.
+ *
+ * `max_level` sets the Rust-side maximum log level so records below the
+ * configured agent level are discarded before formatting or crossing the FFI.
+ * Uses the same encoding as dd_log_fn: 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Trace.
+ *
+ * # Safety
+ * `callback` must be a valid function pointer that remains valid for the
+ * lifetime of the process.
+ */
+void dd_discovery_init_logger(dd_log_fn callback, uint32_t max_level);
 
 /**
  * Run service discovery and return a heap-allocated result.

--- a/pkg/discovery/module/rust/include/dd_discovery.h
+++ b/pkg/discovery/module/rust/include/dd_discovery.h
@@ -104,15 +104,15 @@ struct dd_discovery_result {
  * Register a Go logging callback. Idempotent: only the first call has effect;
  * subsequent calls (e.g. from racing goroutines at start-up) are ignored.
  *
- * `max_level` sets the Rust-side maximum log level so records below the
- * configured agent level are discarded before formatting or crossing the FFI.
- * Uses the same encoding as dd_log_fn: 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Trace.
+ * All records are forwarded to the callback regardless of severity. Filtering
+ * is applied on the Go side, which lets `agent config set log_level` take
+ * effect at runtime without re-initialising the bridge.
  *
  * # Safety
  * `callback` must be a valid function pointer that remains valid for the
  * lifetime of the process.
  */
-void dd_discovery_init_logger(dd_log_fn callback, uint32_t max_level);
+void dd_discovery_init_logger(dd_log_fn callback);
 
 /**
  * Run service discovery and return a heap-allocated result.

--- a/pkg/discovery/module/rust/src/ffi.rs
+++ b/pkg/discovery/module/rust/src/ffi.rs
@@ -291,6 +291,102 @@ fn services_response_to_result(resp: ServicesResponse) -> dd_discovery_result {
 }
 
 // ---------------------------------------------------------------------------
+// Logger bridge
+// ---------------------------------------------------------------------------
+
+/// Callback type used to forward Rust log records to the Go logging subsystem.
+///
+/// Parameters:
+/// - `level`: severity — 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Trace.
+/// - `msg` / `msg_len`: UTF-8 log message (NOT NUL-terminated).
+///
+/// The pointer is only valid for the duration of the call; do not retain it.
+pub type dd_log_fn = unsafe extern "C" fn(level: u32, msg: *const c_char, msg_len: usize);
+
+/// Stores the Go log callback set via `dd_discovery_init_logger`. Written once.
+static LOGGER_CALLBACK: std::sync::OnceLock<dd_log_fn> = std::sync::OnceLock::new();
+
+/// Logger backend that forwards records to the registered Go callback.
+struct GoLogger;
+
+impl log::Log for GoLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true // All records pass through; Go-side filtering applies.
+    }
+
+    fn log(&self, record: &log::Record) {
+        let Some(&callback) = LOGGER_CALLBACK.get() else {
+            return;
+        };
+        let level: u32 = match record.level() {
+            log::Level::Error => 1,
+            log::Level::Warn => 2,
+            log::Level::Info => 3,
+            log::Level::Debug => 4,
+            log::Level::Trace => 5,
+        };
+        let message = record.args().to_string();
+        // SAFETY: `callback` was registered by the Go runtime and is valid for
+        // the process lifetime. `message` is live for the duration of this call.
+        unsafe { callback(level, message.as_ptr() as *const c_char, message.len()) };
+    }
+
+    fn flush(&self) {}
+}
+
+static GO_LOGGER: GoLogger = GoLogger;
+
+/// Register a Go logging callback. Idempotent: only the first call has effect;
+/// subsequent calls (e.g. from racing goroutines at start-up) are ignored.
+///
+/// All log levels are forwarded to the callback; the Go side applies its own
+/// level filter so no records are emitted above the configured level.
+///
+/// # Panic safety
+/// Wrapped in `catch_unwind` following the convention in this file: unwinding
+/// across a C ABI boundary is undefined behaviour per the Rust nomicon.
+///
+/// # Safety
+/// `callback` must be a valid function pointer that remains valid for the
+/// lifetime of the process.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dd_discovery_init_logger(callback: dd_log_fn, max_level: u32) {
+    // SAFETY: Wrapping in catch_unwind prevents a Rust panic from unwinding
+    // across the C ABI boundary, which would be undefined behaviour.
+    let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+        if LOGGER_CALLBACK.set(callback).is_err() {
+            return;
+        }
+        // `set_logger` returns Err if another logger was already registered
+        // (e.g. in a test harness). In that case LOGGER_CALLBACK is set but
+        // GoLogger is not installed, so all Rust log records would be silently
+        // dropped. Surface the conflict so it is not invisible to the caller.
+        if log::set_logger(&GO_LOGGER).is_err() {
+            // A Rust logger was already registered (e.g. in a test harness).
+            // Use the callback directly — the log facade is unavailable — so the
+            // error reaches the Go structured logger instead of being lost to stderr.
+            let msg = "[dd_discovery] a Rust logger was already registered; \
+                       log records will not be forwarded to the Go logger";
+            unsafe { callback(1, msg.as_ptr() as *const c_char, msg.len()) };
+            return;
+        }
+        // Mirror the Go log level so the Rust log facade can discard records
+        // below the configured threshold before formatting or crossing the FFI.
+        // Level mapping mirrors dd_log_fn: 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Trace.
+        // Any other value (including 0) falls back to Info — a safe middle ground
+        // that preserves visibility without flooding logs if the contract is violated.
+        let filter = match max_level {
+            1 => log::LevelFilter::Error,
+            2 => log::LevelFilter::Warn,
+            4 => log::LevelFilter::Debug,
+            5 => log::LevelFilter::Trace,
+            _ => log::LevelFilter::Info,
+        };
+        log::set_max_level(filter);
+    }));
+}
+
+// ---------------------------------------------------------------------------
 // Exported C ABI functions
 // ---------------------------------------------------------------------------
 

--- a/pkg/discovery/module/rust/src/ffi.rs
+++ b/pkg/discovery/module/rust/src/ffi.rs
@@ -311,24 +311,36 @@ struct GoLogger;
 
 impl log::Log for GoLogger {
     fn enabled(&self, _metadata: &log::Metadata) -> bool {
-        true // All records pass through; Go-side filtering applies.
+        // All records pass through; the Go side applies the actual filter,
+        // which can change at runtime via `agent config set log_level`.
+        // The Rust-side max_level is pinned to Trace in `dd_discovery_init_logger`
+        // so the `log!` macros never short-circuit and we never miss a record
+        // after a runtime level change.
+        true
     }
 
     fn log(&self, record: &log::Record) {
         let Some(&callback) = LOGGER_CALLBACK.get() else {
             return;
         };
-        let level: u32 = match record.level() {
-            log::Level::Error => 1,
-            log::Level::Warn => 2,
-            log::Level::Info => 3,
-            log::Level::Debug => 4,
-            log::Level::Trace => 5,
-        };
-        let message = record.args().to_string();
-        // SAFETY: `callback` was registered by the Go runtime and is valid for
-        // the process lifetime. `message` is live for the duration of this call.
-        unsafe { callback(level, message.as_ptr() as *const c_char, message.len()) };
+        // PANIC SAFETY: `record.args().to_string()` invokes `Display` impls
+        // supplied by callers; if any of them panics, that panic must not
+        // unwind across the C ABI back to the `log!` macro call site, which
+        // would be undefined behaviour per the Rust nomicon.
+        let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+            let level: u32 = match record.level() {
+                log::Level::Error => 1,
+                log::Level::Warn => 2,
+                log::Level::Info => 3,
+                log::Level::Debug => 4,
+                log::Level::Trace => 5,
+            };
+            let message = record.args().to_string();
+            // SAFETY: `callback` was registered by the Go runtime and is valid
+            // for the process lifetime. `message` lives until the end of this
+            // closure, which outlives the synchronous callback invocation.
+            unsafe { callback(level, message.as_ptr() as *const c_char, message.len()) };
+        }));
     }
 
     fn flush(&self) {}
@@ -339,8 +351,11 @@ static GO_LOGGER: GoLogger = GoLogger;
 /// Register a Go logging callback. Idempotent: only the first call has effect;
 /// subsequent calls (e.g. from racing goroutines at start-up) are ignored.
 ///
-/// All log levels are forwarded to the callback; the Go side applies its own
-/// level filter so no records are emitted above the configured level.
+/// All records are forwarded to the callback regardless of severity. Filtering
+/// is applied on the Go side, which lets `agent config set log_level` take
+/// effect at runtime without re-initialising the bridge. The Rust-side
+/// `max_level` is pinned to `Trace` so the `log!` macros never drop records
+/// before they reach the callback.
 ///
 /// # Panic safety
 /// Wrapped in `catch_unwind` following the convention in this file: unwinding
@@ -350,9 +365,10 @@ static GO_LOGGER: GoLogger = GoLogger;
 /// `callback` must be a valid function pointer that remains valid for the
 /// lifetime of the process.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn dd_discovery_init_logger(callback: dd_log_fn, max_level: u32) {
-    // SAFETY: Wrapping in catch_unwind prevents a Rust panic from unwinding
-    // across the C ABI boundary, which would be undefined behaviour.
+pub unsafe extern "C" fn dd_discovery_init_logger(callback: dd_log_fn) {
+    // PANIC SAFETY: defensive guard so that a future panic added to this
+    // body cannot unwind across the C ABI boundary, which would be undefined
+    // behaviour. The current body has no panicking calls.
     let _ = panic::catch_unwind(AssertUnwindSafe(|| {
         if LOGGER_CALLBACK.set(callback).is_err() {
             return;
@@ -362,27 +378,24 @@ pub unsafe extern "C" fn dd_discovery_init_logger(callback: dd_log_fn, max_level
         // GoLogger is not installed, so all Rust log records would be silently
         // dropped. Surface the conflict so it is not invisible to the caller.
         if log::set_logger(&GO_LOGGER).is_err() {
-            // A Rust logger was already registered (e.g. in a test harness).
-            // Use the callback directly — the log facade is unavailable — so the
-            // error reaches the Go structured logger instead of being lost to stderr.
+            // Use the callback directly — the log facade is unavailable — so
+            // the error reaches the Go structured logger instead of being lost
+            // to stderr.
             let msg = "[dd_discovery] a Rust logger was already registered; \
                        log records will not be forwarded to the Go logger";
+            // SAFETY: `callback` was just stored in LOGGER_CALLBACK above and
+            // its lifetime is the process (per dd_discovery_init_logger's
+            // safety contract). `msg` is a static `&str` whose bytes outlive
+            // this synchronous call.
             unsafe { callback(1, msg.as_ptr() as *const c_char, msg.len()) };
             return;
         }
-        // Mirror the Go log level so the Rust log facade can discard records
-        // below the configured threshold before formatting or crossing the FFI.
-        // Level mapping mirrors dd_log_fn: 1=Error, 2=Warn, 3=Info, 4=Debug, 5=Trace.
-        // Any other value (including 0) falls back to Info — a safe middle ground
-        // that preserves visibility without flooding logs if the contract is violated.
-        let filter = match max_level {
-            1 => log::LevelFilter::Error,
-            2 => log::LevelFilter::Warn,
-            4 => log::LevelFilter::Debug,
-            5 => log::LevelFilter::Trace,
-            _ => log::LevelFilter::Info,
-        };
-        log::set_max_level(filter);
+        // Pin the Rust-side filter to Trace so every record reaches GoLogger.
+        // The agent applies its own filter on the Go side inside `pkg/util/log`,
+        // and that filter tracks runtime `ChangeLogLevel` calls. A Rust-side
+        // snapshot taken at init would go stale the first time the operator
+        // changes the log level, so we deliberately do not mirror it.
+        log::set_max_level(log::LevelFilter::Trace);
     }));
 }
 

--- a/pkg/discovery/module/rust/tests/logger_bridge.rs
+++ b/pkg/discovery/module/rust/tests/logger_bridge.rs
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//! Integration test for `dd_discovery::ffi::dd_discovery_init_logger`.
+//!
+//! Cargo runs each `tests/*.rs` as its own binary, so the process-global
+//! `log::logger` and the bridge's `LOGGER_CALLBACK` are isolated from other
+//! tests. This makes it safe to install the bridge and call the real Rust
+//! `log!` macros without disturbing anything else.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+
+use std::os::raw::c_char;
+use std::sync::Mutex;
+
+use dd_discovery::ffi::dd_discovery_init_logger;
+
+/// Records captured by `capture_callback`. A `Mutex<Vec<...>>` is enough
+/// because `log!` macros invoke the logger synchronously on the calling
+/// thread.
+static CAPTURED: Mutex<Vec<(u32, String)>> = Mutex::new(Vec::new());
+
+/// Test callback that mimics the Go-side cgo entry point: it copies the
+/// message bytes into a Rust `String` and stores `(level, message)`.
+///
+/// # Safety
+/// Caller must guarantee `msg` is valid for `msg_len` bytes.
+unsafe extern "C" fn capture_callback(level: u32, msg: *const c_char, msg_len: usize) {
+    if msg.is_null() || msg_len == 0 {
+        CAPTURED.lock().unwrap().push((level, String::new()));
+        return;
+    }
+    // SAFETY: contract of dd_log_fn — pointer is valid for the call duration
+    // and refers to UTF-8 bytes of length msg_len.
+    let bytes = unsafe { std::slice::from_raw_parts(msg.cast::<u8>(), msg_len) };
+    let s = std::str::from_utf8(bytes)
+        .expect("dd_log_fn callback received non-UTF-8 bytes")
+        .to_string();
+    CAPTURED.lock().unwrap().push((level, s));
+}
+
+/// Single test per binary: validates that
+///   1. records emitted via `log!` reach the registered callback,
+///   2. each of the five Rust log levels maps to the expected `dd_log_fn`
+///      level encoding (1..=5),
+///   3. formatted args are rendered (proves `record.args().to_string()` runs),
+///   4. a second `dd_discovery_init_logger` call is a no-op (idempotency
+///      via `OnceLock`) — the callback is not re-registered, so we keep
+///      receiving exactly one record per `log!` invocation.
+#[test]
+fn forwards_records_with_correct_levels_and_init_is_idempotent() {
+    // SAFETY: capture_callback has the dd_log_fn signature and lives for the
+    // process lifetime (it's a static fn).
+    unsafe { dd_discovery_init_logger(capture_callback) };
+    // Second call: must be ignored by the OnceLock guard.
+    // SAFETY: same as above.
+    unsafe { dd_discovery_init_logger(capture_callback) };
+
+    log::error!("err {}", 1);
+    log::warn!("warn {}", 2);
+    log::info!("info {}", 3);
+    log::debug!("debug {}", 4);
+    log::trace!("trace {}", 5);
+
+    let cap = CAPTURED.lock().unwrap();
+    let by_level: std::collections::HashMap<u32, Vec<&str>> =
+        cap.iter()
+            .fold(std::collections::HashMap::new(), |mut acc, (l, m)| {
+                acc.entry(*l).or_default().push(m.as_str());
+                acc
+            });
+
+    // Level mapping: each `log::*!` macro must produce exactly one record at
+    // the expected `dd_log_fn` level encoding.
+    for (rust_level, dd_level, expected) in [
+        ("error", 1, "err 1"),
+        ("warn", 2, "warn 2"),
+        ("info", 3, "info 3"),
+        ("debug", 4, "debug 4"),
+        ("trace", 5, "trace 5"),
+    ] {
+        let entries = by_level
+            .get(&dd_level)
+            .unwrap_or_else(|| panic!("no record at dd_log_fn level {dd_level} ({rust_level})"));
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected exactly one {rust_level} record (idempotent init); got {entries:?}"
+        );
+        assert_eq!(
+            entries[0], expected,
+            "formatted args must be rendered before the FFI hop"
+        );
+    }
+}

--- a/pkg/discovery/module/rust/tests/logger_bridge_already_registered.rs
+++ b/pkg/discovery/module/rust/tests/logger_bridge_already_registered.rs
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//! Integration test for the "another logger already registered" fallback in
+//! `dd_discovery::ffi::dd_discovery_init_logger`.
+//!
+//! In a real deployment the agent owns the process and registers no other
+//! logger, but in test harnesses (or downstream consumers that compose
+//! multiple loggers) the global `log::logger` may already be set. The bridge
+//! must surface this to the Go side via the callback rather than silently
+//! dropping records.
+//!
+//! Cargo runs each `tests/*.rs` as its own binary, so installing a custom
+//! logger here does not affect any other test binary.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+
+use std::os::raw::c_char;
+use std::sync::Mutex;
+
+use dd_discovery::ffi::dd_discovery_init_logger;
+
+static CAPTURED: Mutex<Vec<(u32, String)>> = Mutex::new(Vec::new());
+
+/// # Safety
+/// Caller must guarantee `msg` is valid for `msg_len` bytes.
+unsafe extern "C" fn capture_callback(level: u32, msg: *const c_char, msg_len: usize) {
+    if msg.is_null() || msg_len == 0 {
+        CAPTURED.lock().unwrap().push((level, String::new()));
+        return;
+    }
+    // SAFETY: contract of dd_log_fn.
+    let bytes = unsafe { std::slice::from_raw_parts(msg.cast::<u8>(), msg_len) };
+    let s = std::str::from_utf8(bytes)
+        .expect("dd_log_fn callback received non-UTF-8 bytes")
+        .to_string();
+    CAPTURED.lock().unwrap().push((level, s));
+}
+
+/// Sink logger that drops every record. Stands in for whatever logger the
+/// host process may have registered before calling `dd_discovery_init_logger`.
+struct Sink;
+
+impl log::Log for Sink {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        false
+    }
+    fn log(&self, _: &log::Record) {}
+    fn flush(&self) {}
+}
+
+static SINK: Sink = Sink;
+
+#[test]
+fn surfaces_conflict_via_callback_when_logger_already_registered() {
+    // Pre-register a different logger so `log::set_logger` inside
+    // `dd_discovery_init_logger` returns Err.
+    log::set_logger(&SINK).expect("first set_logger must succeed in a fresh process");
+    log::set_max_level(log::LevelFilter::Trace);
+
+    // SAFETY: capture_callback has the dd_log_fn signature and lives for the
+    // process lifetime.
+    unsafe { dd_discovery_init_logger(capture_callback) };
+
+    let cap = CAPTURED.lock().unwrap();
+    assert_eq!(
+        cap.len(),
+        1,
+        "fallback must invoke the callback exactly once: got {cap:?}"
+    );
+    assert_eq!(cap[0].0, 1, "fallback must report at Error level");
+    assert!(
+        cap[0].1.contains("a Rust logger was already registered"),
+        "fallback message must explain the conflict; got {:?}",
+        cap[0].1
+    );
+
+    // Subsequent log records go to SINK (the pre-registered logger), NOT to
+    // the bridge callback. Verify the bridge does not start swallowing
+    // records after a failed install.
+    drop(cap);
+    log::error!("must not reach the bridge");
+    log::info!("nor this");
+    assert_eq!(
+        CAPTURED.lock().unwrap().len(),
+        1,
+        "GoLogger was not installed, so the bridge callback must not see further records"
+    );
+}


### PR DESCRIPTION
### What does this PR do?

Forwards Rust log records from `libdd_discovery` to Go's `pkg/util/log` so they appear in the same log files as the rest of the agent, with the same format and level filtering.

**Go side (`pkg/discovery/module/`):**

- `impl_services_rust_log_bridge_linux.go` — pure-Go `dispatchDiscoveryLog`, separated from the cgo boundary so it can be unit-tested without the Rust library.
- `impl_services_rust_logger_linux.go` — exports `goDiscoveryLogCallback` to C. Validates nil/empty/oversize buffers and delegates to `dispatchDiscoveryLog`.
- `impl_services_rust_init_linux.go` — provides `InitDiscoveryLogger()`, called explicitly from `NewDiscoveryModule` to register the callback via `dd_discovery_init_logger`.
- `impl_services_rust_init_stub_linux.go` — no-op `InitDiscoveryLogger()` for non-cgo builds.

**Rust side (`pkg/discovery/module/rust/src/ffi.rs`):**

A `GoLogger` struct implements `log::Log` and forwards every record to the registered callback stored in a `OnceLock`. The exported C function `dd_discovery_init_logger` is idempotent: only the first call has effect, so concurrent calls at start-up are safe. The Rust-side `log::max_level` is pinned to `Trace`; filtering is applied on the Go side inside `pkg/util/log`, so `agent config set log_level` takes effect at runtime without re-initialising the bridge.

`GoLogger::log` is wrapped in `catch_unwind` to contain a panic in a caller-supplied `Display` impl (invoked via `record.args().to_string()`) — unwinding across the C ABI back to the `log!` macro call site would be undefined behaviour. `dd_discovery_init_logger` also wraps its body in `catch_unwind`, following the convention in this file: the current body has no panicking calls, so it is a defensive guard against future additions.

`dd_discovery.h` gains the `dd_log_fn` typedef and the `dd_discovery_init_logger` declaration.

### Motivation

Without this bridge, Rust log output from `libdd_discovery` is silently discarded when the library is linked into system-probe via cgo. Operators have no visibility into what the library is doing, which makes debugging in production impossible.

### Describe how you validated your changes

Tests have been added.

### Additional Notes

