### PR TITLE
[OTAGENT-986] Fix dogtelextension liveness metric: add periodic heartbeat

### DIFF
--- a/comp/otelcol/dogtelextension/impl/extension.go
+++ b/comp/otelcol/dogtelextension/impl/extension.go
@@ -54,6 +54,9 @@ type dogtelExtension struct {
 	taggerServer     *grpc.Server
 	taggerServerPort int
 	taggerListener   net.Listener
+
+	// Liveness metric heartbeat
+	stopLiveness chan struct{}
 }
 
 // Start implements extension.Extension
@@ -95,12 +98,31 @@ func (e *dogtelExtension) Start(_ context.Context, _ component.Host) error {
 	e.log.Infof("dogtelextension started successfully (tagger_port=%d, metadata_enabled=%t)",
 		e.taggerServerPort, metadataEnabled)
 
-	// Send liveness metric to indicate the extension is running
+	// Send an initial liveness metric immediately, then continue sending
+	// periodically so test aggregators that flush state can still observe it.
+	e.stopLiveness = make(chan struct{})
 	if err := e.sendLivenessMetric(context.Background()); err != nil {
 		e.log.Warnf("Failed to send liveness metric: %v", err)
 	}
+	go e.livenessMetricLoop()
 
 	return nil
+}
+
+// livenessMetricLoop periodically re-emits the liveness metric until Shutdown.
+func (e *dogtelExtension) livenessMetricLoop() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := e.sendLivenessMetric(context.Background()); err != nil {
+				e.log.Warnf("Failed to send periodic liveness metric: %v", err)
+			}
+		case <-e.stopLiveness:
+			return
+		}
+	}
 }
 
 // sendLivenessMetric sends a gauge metric indicating the extension is running.
@@ -128,6 +150,11 @@ func (e *dogtelExtension) sendLivenessMetric(ctx context.Context) error {
 // Shutdown implements extension.Extension
 func (e *dogtelExtension) Shutdown(_ context.Context) error {
 	e.log.Info("Shutting down dogtelextension")
+
+	// Stop the liveness heartbeat goroutine
+	if e.stopLiveness != nil {
+		close(e.stopLiveness)
+	}
 
 	// Stop tagger server gracefully
 	e.stopTaggerServer()

--- a/comp/otelcol/dogtelextension/impl/extension_test.go
+++ b/comp/otelcol/dogtelextension/impl/extension_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -80,6 +81,7 @@ func TestStart_StandaloneMode_TaggerDisabled(t *testing.T) {
 	err := ext.Start(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Nil(t, ext.taggerServer)
+	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
 }
 
 // TestShutdown_NoTaggerServer verifies Shutdown does not panic when no server is running.
@@ -206,5 +208,79 @@ func TestStart_StandaloneMode_NoopSecretsWarning(t *testing.T) {
 
 	// Start should succeed; the warning is logged but not fatal.
 	err := ext.Start(context.Background(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ext.Shutdown(context.Background()) })
+}
+
+// TestLivenessLoop_ExitsOnStop verifies that livenessMetricLoop returns promptly
+// when stopLiveness is closed, without waiting for the 30-second ticker.
+func TestLivenessLoop_ExitsOnStop(t *testing.T) {
+	ext := &dogtelExtension{
+		log:          logmock.New(t),
+		stopLiveness: make(chan struct{}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ext.livenessMetricLoop()
+	}()
+
+	close(ext.stopLiveness)
+
+	select {
+	case <-done:
+		// goroutine exited promptly — correct
+	case <-time.After(time.Second):
+		t.Fatal("livenessMetricLoop did not exit after stopLiveness was closed")
+	}
+}
+
+// TestShutdown_ClosesLivenessChannel verifies that Shutdown closes the stopLiveness
+// channel, which signals the heartbeat goroutine to stop.
+func TestShutdown_ClosesLivenessChannel(t *testing.T) {
+	ext := newTestExtension(t, nil, nil)
+	ext.stopLiveness = make(chan struct{})
+
+	err := ext.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	// A closed channel always returns immediately with the zero value and ok=false.
+	select {
+	case _, ok := <-ext.stopLiveness:
+		assert.False(t, ok, "stopLiveness should be closed after Shutdown")
+	default:
+		t.Fatal("stopLiveness channel was not closed by Shutdown")
+	}
+}
+
+// TestStart_StandaloneMode_InitializesLivenessChannel verifies that Start in
+// standalone mode sets up the stopLiveness channel used by the heartbeat goroutine.
+func TestStart_StandaloneMode_InitializesLivenessChannel(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.EnableTaggerServer = false
+
+	hostname, _ := hostnameinterface.NewMock("test-host")
+	sz := serializermock.NewMetricSerializer(t)
+	sz.On("SendIterableSeries", mock.Anything).Return(nil)
+
+	ext := &dogtelExtension{
+		config:     cfg,
+		log:        logmock.New(t),
+		coreConfig: configmock.NewMockWithOverrides(t, map[string]interface{}{"otel_standalone": true}),
+		serializer: sz,
+		hostname:   hostname,
+		telemetry:  noopsimpl.GetCompatComponent(),
+		ipc:        ipcmock.New(t),
+	}
+
+	assert.Nil(t, ext.stopLiveness)
+
+	err := ext.Start(context.Background(), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, ext.stopLiveness, "Start must initialize stopLiveness for the heartbeat goroutine")
+
+	// Shutdown stops the goroutine cleanly.
+	err = ext.Shutdown(context.Background())
 	require.NoError(t, err)
 }


### PR DESCRIPTION
### What does this PR do?
The liveness metric (otel.dogtel_extension.running) was sent exactly once at Start() and never again. When fakeintake aggregators are flushed (between test cases or during normal intake cycles), the metric disappeared permanently — causing TestDogtelLivenessMetric to timeout and failing in production Datadog after the first intake flush cycle.

Fix: introduce a stopLiveness channel and a livenessMetricLoop goroutine that re-emits the metric every 30 seconds. The goroutine starts immediately after the initial send in Start() and is stopped in Shutdown() by closing the channel.

Unit tests added:
- TestLivenessLoop_ExitsOnStop: loop goroutine exits promptly on channel close
- TestShutdown_ClosesLivenessChannel: Shutdown closes the channel
- TestStart_StandaloneMode_InitializesLivenessChannel: Start sets up the channel
- Fix existing Start tests to call Shutdown via t.Cleanup (goroutine leak)

### Motivation
Standalone DDOT

### Describe how you validated your changes
new unit tests

### Additional Notes
