### PR TITLE
[netflow] Agent-side eBPF connection enrichment for NetFlow records

### DIFF
--- a/comp/netflow/config/config.go
+++ b/comp/netflow/config/config.go
@@ -37,6 +37,9 @@ type NetflowConfig struct {
 	PrometheusListenerEnabled bool   `mapstructure:"prometheus_listener_enabled"`
 
 	ReverseDNSEnrichmentEnabled bool `mapstructure:"reverse_dns_enrichment_enabled"`
+
+	ConnectionEnrichmentEnabled      bool `mapstructure:"connection_enrichment_enabled"`
+	ConnectionEnrichmentPollInterval int  `mapstructure:"connection_enrichment_poll_interval"`
 }
 
 // ListenerConfig contains configuration for a single flow listener
@@ -137,6 +140,10 @@ func (mainConfig *NetflowConfig) SetDefaults(namespace string, logger log.Compon
 
 	if mainConfig.PrometheusListenerAddress == "" {
 		mainConfig.PrometheusListenerAddress = common.DefaultPrometheusListenerAddress
+	}
+
+	if mainConfig.ConnectionEnrichmentPollInterval == 0 {
+		mainConfig.ConnectionEnrichmentPollInterval = 30
 	}
 
 	return nil

--- a/comp/netflow/flowaggregator/aggregator.go
+++ b/comp/netflow/flowaggregator/aggregator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/integrations"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/comp/netflow/format"
 	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/def"
@@ -58,8 +59,9 @@ type FlowAggregator struct {
 	lastSequencePerExporter   map[sequenceDeltaKey]uint32
 	lastSequencePerExporterMu sync.Mutex
 
-	flowFilter FlowFlushFilter
-	logger     log.Component
+	flowFilter   FlowFlushFilter
+	connEnricher *ConnEnricher
+	logger       log.Component
 }
 
 type sequenceDeltaKey struct {
@@ -88,7 +90,7 @@ var maxNegativeSequenceDiffToReset = map[common.FlowType]int{
 }
 
 // NewFlowAggregator returns a new FlowAggregator
-func NewFlowAggregator(sender sender.Sender, epForwarder eventplatform.Forwarder, config *config.NetflowConfig, hostname string, logger log.Component, rdnsQuerier rdnsquerier.Component) *FlowAggregator {
+func NewFlowAggregator(sender sender.Sender, epForwarder eventplatform.Forwarder, config *config.NetflowConfig, hostname string, logger log.Component, rdnsQuerier rdnsquerier.Component, taggerComp tagger.Component, sysprobeSocketPath string) *FlowAggregator {
 	flushConfig := common.FlushConfig{
 		FlowCollectionDuration: time.Duration(config.AggregatorFlushInterval) * time.Second,
 		FlushTickFrequency:     flushFlowsToSendInterval,
@@ -105,9 +107,20 @@ func NewFlowAggregator(sender sender.Sender, epForwarder eventplatform.Forwarder
 
 	flowContextTTL := time.Duration(config.AggregatorFlowContextTTL) * time.Second
 	rollupTrackerRefreshInterval := time.Duration(config.AggregatorRollupTrackerRefreshInterval) * time.Second
+
+	var enricher *ConnEnricher
+	if config.ConnectionEnrichmentEnabled && taggerComp != nil && sysprobeSocketPath != "" {
+		pollInterval := time.Duration(config.ConnectionEnrichmentPollInterval) * time.Second
+		enricher = NewConnEnricher(sysprobeSocketPath, pollInterval, logger, taggerComp)
+		logger.Infof("Connection enrichment enabled (poll_interval=%s)", pollInterval)
+	}
+
+	flowAcc := newFlowAccumulator(flushConfig, flowScheduler, flowContextTTL, config.AggregatorPortRollupThreshold, config.AggregatorPortRollupDisabled, logger, rdnsQuerier)
+	flowAcc.connEnricher = enricher
+
 	return &FlowAggregator{
 		flowIn:                       make(chan *common.Flow, config.AggregatorBufferSize),
-		flowAcc:                      newFlowAccumulator(flushConfig, flowScheduler, flowContextTTL, config.AggregatorPortRollupThreshold, config.AggregatorPortRollupDisabled, logger, rdnsQuerier),
+		flowAcc:                      flowAcc,
 		FlushConfig:                  flushConfig,
 		rollupTrackerRefreshInterval: rollupTrackerRefreshInterval,
 		sender:                       sender,
@@ -124,12 +137,16 @@ func NewFlowAggregator(sender sender.Sender, epForwarder eventplatform.Forwarder
 		lastSequencePerExporter:      make(map[sequenceDeltaKey]uint32),
 		logger:                       logger,
 		flowFilter:                   topNFilter,
+		connEnricher:                 enricher,
 	}
 }
 
 // Start will start the FlowAggregator worker
 func (agg *FlowAggregator) Start() {
 	agg.logger.Info("Flow Aggregator started")
+	if agg.connEnricher != nil {
+		agg.connEnricher.Start()
+	}
 	go agg.run()
 	agg.flushLoop() // blocking call
 }
@@ -139,6 +156,9 @@ func (agg *FlowAggregator) Stop() {
 	close(agg.stopChan)
 	<-agg.flushLoopDone
 	<-agg.runDone
+	if agg.connEnricher != nil {
+		agg.connEnricher.Stop()
+	}
 }
 
 // GetFlowInChan returns flow input chan

--- a/comp/netflow/flowaggregator/aggregator_test.go
+++ b/comp/netflow/flowaggregator/aggregator_test.go
@@ -172,7 +172,7 @@ func TestAggregator(t *testing.T) {
 	logger := logmock.New(t)
 	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier, nil, "")
 	aggregator.FlushConfig.FlushTickFrequency = 1 * time.Second
 	aggregator.TimeNowFunction = func() time.Time {
 		return flushTime
@@ -288,7 +288,7 @@ func TestAggregator_withMockPayload(t *testing.T) {
 
 	logger := logmock.New(t)
 	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier, nil, "")
 	aggregator.FlushConfig.FlushTickFrequency = 1 * time.Second
 	aggregator.TimeNowFunction = func() time.Time {
 		return flushTime
@@ -388,7 +388,7 @@ func TestFlowAggregator_flush_submitCollectorMetrics_error(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	epForwarder := eventplatformimpl.NewMockEventPlatformForwarder(ctrl)
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier, nil, "")
 	aggregator.goflowPrometheusGatherer = prometheus.GathererFunc(func() ([]*promClient.MetricFamily, error) {
 		return nil, errors.New("some prometheus gatherer error")
 	})
@@ -429,7 +429,7 @@ func TestFlowAggregator_submitCollectorMetrics(t *testing.T) {
 	logger := logmock.New(t)
 	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier, nil, "")
 	aggregator.goflowPrometheusGatherer = prometheus.GathererFunc(func() ([]*promClient.MetricFamily, error) {
 		return []*promClient.MetricFamily{
 			{
@@ -506,7 +506,7 @@ func TestFlowAggregator_submitCollectorMetrics_error(t *testing.T) {
 	logger := logmock.New(t)
 	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier, nil, "")
 	aggregator.goflowPrometheusGatherer = prometheus.GathererFunc(func() ([]*promClient.MetricFamily, error) {
 		return nil, errors.New("some prometheus gatherer error")
 	})
@@ -541,7 +541,7 @@ func TestFlowAggregator_sendExporterMetadata_multiplePayloads(t *testing.T) {
 	logger := logmock.New(t)
 	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier, nil, "")
 
 	var flows []*common.Flow
 	for i := 1; i <= 250; i++ {
@@ -627,7 +627,7 @@ func TestFlowAggregator_sendExporterMetadata_noPayloads(t *testing.T) {
 	logger := logmock.New(t)
 	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier, nil, "")
 
 	var flows []*common.Flow
 	now := time.Unix(1681295467, 0)
@@ -660,7 +660,7 @@ func TestFlowAggregator_sendExporterMetadata_invalidIPIgnored(t *testing.T) {
 
 	logger := logmock.New(t)
 	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier, nil, "")
 
 	now := time.Unix(1681295467, 0)
 	flows := []*common.Flow{
@@ -746,7 +746,7 @@ func TestFlowAggregator_sendExporterMetadata_multipleNamespaces(t *testing.T) {
 
 	logger := logmock.New(t)
 	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier, nil, "")
 
 	now := time.Unix(1681295467, 0)
 	flows := []*common.Flow{
@@ -852,7 +852,7 @@ func TestFlowAggregator_sendExporterMetadata_singleExporterIpWithMultipleFlowTyp
 	logger := logmock.New(t)
 	rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger, rdnsQuerier, nil, "")
 
 	now := time.Unix(1681295467, 0)
 	flows := []*common.Flow{
@@ -1205,7 +1205,7 @@ func TestFlowAggregator_getSequenceDelta(t *testing.T) {
 				AggregatorPortRollupThreshold:          10,
 				AggregatorRollupTrackerRefreshInterval: 3600,
 			}
-			agg := NewFlowAggregator(sender, nil, &conf, "my-hostname", logger, rdnsQuerier)
+			agg := NewFlowAggregator(sender, nil, &conf, "my-hostname", logger, rdnsQuerier, nil, "")
 			for roundNum, testRound := range tt.rounds {
 				assert.Equal(t, testRound.expectedSequenceDelta, agg.getSequenceDelta(testRound.flowsToFlush), fmt.Sprintf("Test Round %d", roundNum))
 			}
@@ -1250,7 +1250,7 @@ func TestAggregatorFlushing(t *testing.T) {
 		logger := logmock.New(t)
 		rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
-		aggregator := NewFlowAggregator(sender, epForwarder, &conf, "test-hostname", logger, rdnsQuerier)
+		aggregator := NewFlowAggregator(sender, epForwarder, &conf, "test-hostname", logger, rdnsQuerier, nil, "")
 		aggregator.TimeNowFunction = func() time.Time {
 			return flushTime
 		}
@@ -1353,7 +1353,7 @@ func TestAggregatorFlushing(t *testing.T) {
 		logger := logmock.New(t)
 		rdnsQuerier := fxutil.Test[rdnsquerier.Component](t, rdnsquerierfxmock.MockModule())
 
-		aggregator := NewFlowAggregator(sender, epForwarder, &conf, "test-hostname", logger, rdnsQuerier)
+		aggregator := NewFlowAggregator(sender, epForwarder, &conf, "test-hostname", logger, rdnsQuerier, nil, "")
 		aggregator.TimeNowFunction = func() time.Time {
 			return startTime
 		}

--- a/comp/netflow/flowaggregator/connenricher.go
+++ b/comp/netflow/flowaggregator/connenricher.go
@@ -1,0 +1,421 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package flowaggregator
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/comp/netflow/common"
+	netEncoding "github.com/DataDog/datadog-agent/pkg/network/encoding/unmarshal"
+	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
+	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
+)
+
+const netflowEnricherClientID = "netflow-enricher"
+
+// connKey is a lookup key for the connection index.
+// IPs are stored as 16-byte arrays (IPv4 addresses are v4-mapped-v6).
+type connKey struct {
+	SrcIP    [16]byte
+	DstIP    [16]byte
+	SrcPort  uint16
+	DstPort  uint16
+	Protocol uint8
+}
+
+// connMeta holds enrichment metadata for a matched connection.
+type connMeta struct {
+	SrcContainerID string
+	DstContainerID string
+	SrcService     string
+	DstService     string
+	SrcTags        []string
+	DstTags        []string
+	Direction      string
+}
+
+// ConnEnricher periodically polls system-probe's /connections endpoint and
+// builds an in-memory lookup index for enriching NetFlow records with eBPF
+// connection metadata (container IDs, service names, tags).
+type ConnEnricher struct {
+	mu         sync.RWMutex
+	exactIndex map[connKey]*connMeta // exact 5-tuple match
+	noSrcPort  map[connKey]*connMeta // wildcard SrcPort=0 for ephemeral rollup
+	noDstPort  map[connKey]*connMeta // wildcard DstPort=0 for ephemeral rollup
+
+	httpClient   *http.Client
+	tagger       tagger.Component
+	pollInterval time.Duration
+	logger       log.Component
+	stopChan     chan struct{}
+	doneChan     chan struct{}
+	registered   bool
+}
+
+// NewConnEnricher creates a new ConnEnricher that polls system-probe for connection data.
+func NewConnEnricher(sysprobeSocketPath string, pollInterval time.Duration, logger log.Component, taggerComp tagger.Component) *ConnEnricher {
+	return &ConnEnricher{
+		exactIndex:   make(map[connKey]*connMeta),
+		noSrcPort:    make(map[connKey]*connMeta),
+		noDstPort:    make(map[connKey]*connMeta),
+		httpClient:   sysprobeclient.Get(sysprobeSocketPath),
+		tagger:       taggerComp,
+		pollInterval: pollInterval,
+		logger:       logger,
+		stopChan:     make(chan struct{}),
+		doneChan:     make(chan struct{}),
+	}
+}
+
+// Start begins background polling of system-probe connections.
+func (e *ConnEnricher) Start() {
+	e.logger.Info("ConnEnricher starting")
+	go e.pollLoop()
+}
+
+// Stop signals the poll loop to stop and waits for it to finish.
+func (e *ConnEnricher) Stop() {
+	e.logger.Info("ConnEnricher stopping")
+	close(e.stopChan)
+	<-e.doneChan
+}
+
+func (e *ConnEnricher) pollLoop() {
+	defer close(e.doneChan)
+
+	// Do an initial poll immediately
+	e.doPoll()
+
+	ticker := time.NewTicker(e.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-e.stopChan:
+			return
+		case <-ticker.C:
+			e.doPoll()
+		}
+	}
+}
+
+func (e *ConnEnricher) doPoll() {
+	if !e.registered {
+		if err := e.register(); err != nil {
+			e.logger.Debugf("ConnEnricher: failed to register with system-probe: %v", err)
+			return
+		}
+		e.registered = true
+	}
+
+	conns, err := e.getConnections()
+	if err != nil {
+		e.logger.Debugf("ConnEnricher: failed to get connections from system-probe: %v", err)
+		return
+	}
+
+	e.buildIndex(conns)
+	e.logger.Debugf("ConnEnricher: indexed %d connections (%d exact, %d noSrcPort, %d noDstPort)",
+		len(conns.Conns), len(e.exactIndex), len(e.noSrcPort), len(e.noDstPort))
+}
+
+func (e *ConnEnricher) register() error {
+	url := sysprobeclient.ModuleURL(sysconfig.NetworkTracerModule, "/register?client_id="+netflowEnricherClientID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("register request failed: status code: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (e *ConnEnricher) getConnections() (*model.Connections, error) {
+	url := sysprobeclient.ModuleURL(sysconfig.NetworkTracerModule, "/connections?client_id="+netflowEnricherClientID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/protobuf")
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("connections request failed: status code: %d", resp.StatusCode)
+	}
+
+	body, err := sysprobeclient.ReadAllResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	contentType := resp.Header.Get("Content-type")
+	return netEncoding.GetUnmarshaler(contentType).Unmarshal(body)
+}
+
+func (e *ConnEnricher) buildIndex(conns *model.Connections) {
+	exact := make(map[connKey]*connMeta, len(conns.Conns))
+	noSrc := make(map[connKey]*connMeta, len(conns.Conns))
+	noDst := make(map[connKey]*connMeta, len(conns.Conns))
+
+	for _, conn := range conns.Conns {
+		if conn.Laddr == nil || conn.Raddr == nil {
+			continue
+		}
+
+		srcIP := normalizeIP(conn.Laddr.Ip)
+		dstIP := normalizeIP(conn.Raddr.Ip)
+		proto := connectionTypeToProtocol(conn.Type)
+
+		meta := &connMeta{
+			SrcContainerID: conn.Laddr.GetContainerId(),
+			DstContainerID: conn.Raddr.GetContainerId(),
+			Direction:      directionString(conn.Direction),
+		}
+
+		// Resolve tags for source container
+		if meta.SrcContainerID != "" {
+			meta.SrcService, meta.SrcTags = e.resolveServiceTags(meta.SrcContainerID)
+		}
+		// Resolve tags for destination container
+		if meta.DstContainerID != "" {
+			meta.DstService, meta.DstTags = e.resolveServiceTags(meta.DstContainerID)
+		}
+
+		// Skip connections with no useful metadata
+		if meta.SrcContainerID == "" && meta.DstContainerID == "" {
+			continue
+		}
+
+		srcPort := uint16(conn.Laddr.Port)
+		dstPort := uint16(conn.Raddr.Port)
+
+		// Exact 5-tuple
+		exactKey := connKey{
+			SrcIP:    srcIP,
+			DstIP:    dstIP,
+			SrcPort:  srcPort,
+			DstPort:  dstPort,
+			Protocol: proto,
+		}
+		exact[exactKey] = meta
+
+		// Wildcard with SrcPort=0 (for ephemeral source port rollup)
+		noSrcKey := connKey{
+			SrcIP:    srcIP,
+			DstIP:    dstIP,
+			SrcPort:  0,
+			DstPort:  dstPort,
+			Protocol: proto,
+		}
+		noSrc[noSrcKey] = meta
+
+		// Wildcard with DstPort=0 (for ephemeral dest port rollup)
+		noDstKey := connKey{
+			SrcIP:    srcIP,
+			DstIP:    dstIP,
+			SrcPort:  srcPort,
+			DstPort:  0,
+			Protocol: proto,
+		}
+		noDst[noDstKey] = meta
+	}
+
+	// Swap under write lock
+	e.mu.Lock()
+	e.exactIndex = exact
+	e.noSrcPort = noSrc
+	e.noDstPort = noDst
+	e.mu.Unlock()
+}
+
+func (e *ConnEnricher) resolveServiceTags(containerID string) (string, []string) {
+	entityID := taggertypes.NewEntityID(taggertypes.ContainerID, containerID)
+	tags, err := e.tagger.Tag(entityID, taggertypes.LowCardinality)
+	if err != nil {
+		e.logger.Debugf("ConnEnricher: failed to get tags for container %s: %v", containerID, err)
+		return "", nil
+	}
+
+	service := ""
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, "service:") {
+			service = tag[len("service:"):]
+			break
+		}
+	}
+	return service, tags
+}
+
+// Lookup looks up eBPF connection metadata for a given flow tuple.
+// srcPort/dstPort use -1 to indicate ephemeral port rollup.
+func (e *ConnEnricher) Lookup(srcIP, dstIP []byte, srcPort, dstPort int32, ipProtocol uint32) *connMeta {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	normalizedSrc := normalizeIPBytes(srcIP)
+	normalizedDst := normalizeIPBytes(dstIP)
+	proto := uint8(ipProtocol)
+
+	// Try exact match first (when neither port is ephemeral)
+	if srcPort >= 0 && dstPort >= 0 {
+		key := connKey{
+			SrcIP:    normalizedSrc,
+			DstIP:    normalizedDst,
+			SrcPort:  uint16(srcPort),
+			DstPort:  uint16(dstPort),
+			Protocol: proto,
+		}
+		if meta, ok := e.exactIndex[key]; ok {
+			return meta
+		}
+	}
+
+	// Ephemeral source port (-1): look up with SrcPort=0
+	if srcPort == -1 {
+		key := connKey{
+			SrcIP:    normalizedSrc,
+			DstIP:    normalizedDst,
+			SrcPort:  0,
+			DstPort:  uint16(dstPort),
+			Protocol: proto,
+		}
+		if meta, ok := e.noSrcPort[key]; ok {
+			return meta
+		}
+	}
+
+	// Ephemeral dest port (-1): look up with DstPort=0
+	if dstPort == -1 {
+		key := connKey{
+			SrcIP:    normalizedSrc,
+			DstIP:    normalizedDst,
+			SrcPort:  uint16(srcPort),
+			DstPort:  0,
+			Protocol: proto,
+		}
+		if meta, ok := e.noDstPort[key]; ok {
+			return meta
+		}
+	}
+
+	return nil
+}
+
+// normalizeIP parses an IP string and returns a 16-byte representation.
+func normalizeIP(ipStr string) [16]byte {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return [16]byte{}
+	}
+	ip = ip.To16()
+	if ip == nil {
+		return [16]byte{}
+	}
+	var result [16]byte
+	copy(result[:], ip)
+	return result
+}
+
+// normalizeIPBytes converts a raw IP byte slice to a 16-byte representation.
+func normalizeIPBytes(ipBytes []byte) [16]byte {
+	var result [16]byte
+	switch len(ipBytes) {
+	case 4:
+		// IPv4 → v4-mapped-v6
+		result[10] = 0xff
+		result[11] = 0xff
+		copy(result[12:], ipBytes)
+	case 16:
+		copy(result[:], ipBytes)
+	}
+	return result
+}
+
+// connectionTypeToProtocol converts model.ConnectionType to an IP protocol number.
+func connectionTypeToProtocol(connType model.ConnectionType) uint8 {
+	switch connType {
+	case model.ConnectionType_tcp:
+		return 6 // TCP
+	case model.ConnectionType_udp:
+		return 17 // UDP
+	default:
+		return 0
+	}
+}
+
+// directionString converts model.ConnectionDirection to a human-readable string.
+func directionString(dir model.ConnectionDirection) string {
+	switch dir {
+	case model.ConnectionDirection_incoming:
+		return "incoming"
+	case model.ConnectionDirection_outgoing:
+		return "outgoing"
+	case model.ConnectionDirection_local:
+		return "local"
+	default:
+		return "unspecified"
+	}
+}
+
+// addConnEnrichment enriches a flow with eBPF connection metadata.
+func addConnEnrichment(flow *common.Flow, enricher *ConnEnricher) {
+	if enricher == nil {
+		return
+	}
+
+	meta := enricher.Lookup(flow.SrcAddr, flow.DstAddr, flow.SrcPort, flow.DstPort, flow.IPProtocol)
+	if meta == nil {
+		return
+	}
+
+	if flow.AdditionalFields == nil {
+		flow.AdditionalFields = make(common.AdditionalFields)
+	}
+
+	flow.AdditionalFields["ebpf.matched"] = true
+	if meta.SrcService != "" {
+		flow.AdditionalFields["ebpf.src.service"] = meta.SrcService
+	}
+	if meta.DstService != "" {
+		flow.AdditionalFields["ebpf.dst.service"] = meta.DstService
+	}
+	if meta.SrcContainerID != "" {
+		flow.AdditionalFields["ebpf.src.container_id"] = meta.SrcContainerID
+	}
+	if meta.DstContainerID != "" {
+		flow.AdditionalFields["ebpf.dst.container_id"] = meta.DstContainerID
+	}
+	if len(meta.SrcTags) > 0 {
+		flow.AdditionalFields["ebpf.src.tags"] = strings.Join(meta.SrcTags, ",")
+	}
+	if len(meta.DstTags) > 0 {
+		flow.AdditionalFields["ebpf.dst.tags"] = strings.Join(meta.DstTags, ",")
+	}
+	if meta.Direction != "" {
+		flow.AdditionalFields["ebpf.direction"] = meta.Direction
+	}
+}

--- a/comp/netflow/flowaggregator/connenricher_test.go
+++ b/comp/netflow/flowaggregator/connenricher_test.go
@@ -1,0 +1,278 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test
+
+package flowaggregator
+
+import (
+	"net"
+	"testing"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/stretchr/testify/assert"
+
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/comp/netflow/common"
+)
+
+func TestNormalizeIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected [16]byte
+	}{
+		{
+			name:  "IPv4",
+			input: "192.168.1.1",
+			expected: [16]byte{
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff,
+				192, 168, 1, 1,
+			},
+		},
+		{
+			name:  "IPv6",
+			input: "::1",
+			expected: [16]byte{
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+			},
+		},
+		{
+			name:     "invalid",
+			input:    "not-an-ip",
+			expected: [16]byte{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeIP(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeIPBytes(t *testing.T) {
+	// IPv4 bytes
+	ipv4 := net.ParseIP("10.0.0.1").To4()
+	result := normalizeIPBytes(ipv4)
+	expected := [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 10, 0, 0, 1}
+	assert.Equal(t, expected, result)
+
+	// IPv6 bytes
+	ipv6 := net.ParseIP("::1").To16()
+	result = normalizeIPBytes(ipv6)
+	expected = [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	assert.Equal(t, expected, result)
+}
+
+func TestConnectionTypeToProtocol(t *testing.T) {
+	assert.Equal(t, uint8(6), connectionTypeToProtocol(model.ConnectionType_tcp))
+	assert.Equal(t, uint8(17), connectionTypeToProtocol(model.ConnectionType_udp))
+	assert.Equal(t, uint8(0), connectionTypeToProtocol(model.ConnectionType(99)))
+}
+
+func TestDirectionString(t *testing.T) {
+	assert.Equal(t, "incoming", directionString(model.ConnectionDirection_incoming))
+	assert.Equal(t, "outgoing", directionString(model.ConnectionDirection_outgoing))
+	assert.Equal(t, "local", directionString(model.ConnectionDirection_local))
+	assert.Equal(t, "unspecified", directionString(model.ConnectionDirection_unspecified))
+}
+
+func TestConnEnricherBuildIndexAndLookup(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	fakeTagger.SetTags(
+		taggertypes.NewEntityID(taggertypes.ContainerID, "abc123"),
+		"test",
+		[]string{"service:trainer", "env:testbed"},
+		nil, nil, nil,
+	)
+	fakeTagger.SetTags(
+		taggertypes.NewEntityID(taggertypes.ContainerID, "def456"),
+		"test",
+		[]string{"service:pokedex", "env:testbed"},
+		nil, nil, nil,
+	)
+
+	enricher := &ConnEnricher{
+		exactIndex: make(map[connKey]*connMeta),
+		noSrcPort:  make(map[connKey]*connMeta),
+		noDstPort:  make(map[connKey]*connMeta),
+		tagger:     fakeTagger,
+		logger:     logmock.New(t),
+	}
+
+	conns := &model.Connections{
+		Conns: []*model.Connection{
+			{
+				Pid: 1234,
+				Laddr: &model.Addr{
+					Ip:          "172.20.0.10",
+					Port:        45678,
+					ContainerId: "abc123",
+				},
+				Raddr: &model.Addr{
+					Ip:          "172.21.0.10",
+					Port:        8080,
+					ContainerId: "def456",
+				},
+				Type:      model.ConnectionType_tcp,
+				Direction: model.ConnectionDirection_outgoing,
+			},
+		},
+	}
+
+	enricher.buildIndex(conns)
+
+	assert.Len(t, enricher.exactIndex, 1)
+	assert.Len(t, enricher.noSrcPort, 1)
+	assert.Len(t, enricher.noDstPort, 1)
+
+	// Exact lookup
+	srcIP := net.ParseIP("172.20.0.10").To4()
+	dstIP := net.ParseIP("172.21.0.10").To4()
+	meta := enricher.Lookup(srcIP, dstIP, 45678, 8080, 6)
+	assert.NotNil(t, meta)
+	assert.Equal(t, "abc123", meta.SrcContainerID)
+	assert.Equal(t, "def456", meta.DstContainerID)
+	assert.Equal(t, "trainer", meta.SrcService)
+	assert.Equal(t, "pokedex", meta.DstService)
+	assert.Equal(t, "outgoing", meta.Direction)
+	assert.Contains(t, meta.SrcTags, "service:trainer")
+	assert.Contains(t, meta.DstTags, "service:pokedex")
+
+	// Ephemeral source port lookup
+	meta = enricher.Lookup(srcIP, dstIP, -1, 8080, 6)
+	assert.NotNil(t, meta)
+	assert.Equal(t, "abc123", meta.SrcContainerID)
+
+	// Ephemeral dest port lookup
+	meta = enricher.Lookup(srcIP, dstIP, 45678, -1, 6)
+	assert.NotNil(t, meta)
+	assert.Equal(t, "def456", meta.DstContainerID)
+
+	// Lookup miss
+	otherIP := net.ParseIP("10.0.0.1").To4()
+	meta = enricher.Lookup(otherIP, dstIP, 45678, 8080, 6)
+	assert.Nil(t, meta)
+}
+
+func TestConnEnricherSkipsEmptyContainers(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+
+	enricher := &ConnEnricher{
+		exactIndex: make(map[connKey]*connMeta),
+		noSrcPort:  make(map[connKey]*connMeta),
+		noDstPort:  make(map[connKey]*connMeta),
+		tagger:     fakeTagger,
+		logger:     logmock.New(t),
+	}
+
+	conns := &model.Connections{
+		Conns: []*model.Connection{
+			{
+				Laddr: &model.Addr{Ip: "1.2.3.4", Port: 1111},
+				Raddr: &model.Addr{Ip: "5.6.7.8", Port: 2222},
+				Type:  model.ConnectionType_tcp,
+			},
+		},
+	}
+
+	enricher.buildIndex(conns)
+	assert.Len(t, enricher.exactIndex, 0)
+}
+
+func TestAddConnEnrichment(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	fakeTagger.SetTags(
+		taggertypes.NewEntityID(taggertypes.ContainerID, "src-container"),
+		"test",
+		[]string{"service:web", "env:prod"},
+		nil, nil, nil,
+	)
+
+	enricher := &ConnEnricher{
+		exactIndex: make(map[connKey]*connMeta),
+		noSrcPort:  make(map[connKey]*connMeta),
+		noDstPort:  make(map[connKey]*connMeta),
+		tagger:     fakeTagger,
+		logger:     logmock.New(t),
+	}
+
+	conns := &model.Connections{
+		Conns: []*model.Connection{
+			{
+				Laddr: &model.Addr{
+					Ip:          "172.20.0.10",
+					Port:        45678,
+					ContainerId: "src-container",
+				},
+				Raddr: &model.Addr{
+					Ip:          "172.21.0.10",
+					Port:        8080,
+					ContainerId: "dst-container",
+				},
+				Type:      model.ConnectionType_tcp,
+				Direction: model.ConnectionDirection_outgoing,
+			},
+		},
+	}
+	enricher.buildIndex(conns)
+
+	flow := &common.Flow{
+		SrcAddr:    net.ParseIP("172.20.0.10").To4(),
+		DstAddr:    net.ParseIP("172.21.0.10").To4(),
+		SrcPort:    45678,
+		DstPort:    8080,
+		IPProtocol: 6,
+	}
+
+	addConnEnrichment(flow, enricher)
+
+	assert.NotNil(t, flow.AdditionalFields)
+	assert.Equal(t, true, flow.AdditionalFields["ebpf.matched"])
+	assert.Equal(t, "src-container", flow.AdditionalFields["ebpf.src.container_id"])
+	assert.Equal(t, "dst-container", flow.AdditionalFields["ebpf.dst.container_id"])
+	assert.Equal(t, "web", flow.AdditionalFields["ebpf.src.service"])
+	assert.Equal(t, "outgoing", flow.AdditionalFields["ebpf.direction"])
+}
+
+func TestAddConnEnrichmentNilEnricher(t *testing.T) {
+	flow := &common.Flow{
+		SrcAddr:    net.ParseIP("172.20.0.10").To4(),
+		DstAddr:    net.ParseIP("172.21.0.10").To4(),
+		SrcPort:    45678,
+		DstPort:    8080,
+		IPProtocol: 6,
+	}
+
+	addConnEnrichment(flow, nil)
+	assert.Nil(t, flow.AdditionalFields)
+}
+
+func TestAddConnEnrichmentNoMatch(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+
+	enricher := &ConnEnricher{
+		exactIndex: make(map[connKey]*connMeta),
+		noSrcPort:  make(map[connKey]*connMeta),
+		noDstPort:  make(map[connKey]*connMeta),
+		tagger:     fakeTagger,
+		logger:     logmock.New(t),
+	}
+
+	flow := &common.Flow{
+		SrcAddr:    net.ParseIP("172.20.0.10").To4(),
+		DstAddr:    net.ParseIP("172.21.0.10").To4(),
+		SrcPort:    45678,
+		DstPort:    8080,
+		IPProtocol: 6,
+	}
+
+	addConnEnrichment(flow, enricher)
+	assert.Nil(t, flow.AdditionalFields)
+}

--- a/comp/netflow/flowaggregator/flowaccumulator.go
+++ b/comp/netflow/flowaggregator/flowaccumulator.go
@@ -42,8 +42,9 @@ type flowAccumulator struct {
 
 	hashCollisionFlowCount *atomic.Uint64
 
-	logger      log.Component
-	rdnsQuerier rdnsquerier.Component
+	logger       log.Component
+	rdnsQuerier  rdnsquerier.Component
+	connEnricher *ConnEnricher
 }
 
 func newFlowAccumulator(flushConfig common.FlushConfig, flowScheduler FlowScheduler, aggregatorFlowContextTTL time.Duration, portRollupThreshold int, portRollupDisabled bool, logger log.Component, rdnsQuerier rdnsquerier.Component) *flowAccumulator {
@@ -147,12 +148,14 @@ func (f *flowAccumulator) add(flowToAdd *common.Flow) {
 			nextFlush: nextFlush,
 		}
 		f.addRDNSEnrichment(aggHash, flowToAdd.SrcAddr, flowToAdd.DstAddr)
+		addConnEnrichment(flowToAdd, f.connEnricher)
 		return
 	}
 	if aggFlow.flow == nil {
 		// flowToAdd is for the same hash as an aggregated flow that has been flushed
 		aggFlow.flow = flowToAdd
 		f.addRDNSEnrichment(aggHash, flowToAdd.SrcAddr, flowToAdd.DstAddr)
+		addConnEnrichment(flowToAdd, f.connEnricher)
 	} else {
 		// use go routine for hash collision detection to avoid blocking critical path
 		go f.detectHashCollision(aggHash, *aggFlow.flow, *flowToAdd)

--- a/comp/netflow/server/server.go
+++ b/comp/netflow/server/server.go
@@ -15,9 +15,11 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
+	agentconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/status"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder"
 	nfconfig "github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/DataDog/datadog-agent/comp/netflow/flowaggregator"
@@ -28,11 +30,13 @@ import (
 type dependencies struct {
 	fx.In
 	Config        nfconfig.Component
+	AgentConfig   agentconfig.Component
 	Logger        log.Component
 	Demultiplexer demultiplexer.Component
 	Forwarder     forwarder.Component
 	Hostname      hostname.Component
 	RDNSQuerier   rdnsquerier.Component
+	Tagger        tagger.Component
 }
 
 type provides struct {
@@ -63,7 +67,8 @@ func newServer(lc fx.Lifecycle, deps dependencies) (provides, error) {
 		deps.Logger.Infof("Reverse DNS Enrichment is disabled for NDM NetFlow")
 	}
 
-	flowAgg := flowaggregator.NewFlowAggregator(sender, deps.Forwarder, conf, deps.Hostname.GetSafe(context.Background()), deps.Logger, rdnsQuerier)
+	sysprobeSocketPath := deps.AgentConfig.GetString("system_probe_config.sysprobe_socket")
+	flowAgg := flowaggregator.NewFlowAggregator(sender, deps.Forwarder, conf, deps.Hostname.GetSafe(context.Background()), deps.Logger, rdnsQuerier, deps.Tagger, sysprobeSocketPath)
 
 	server := &Server{
 		config:  conf,

--- a/comp/netflow/server/server.go
+++ b/comp/netflow/server/server.go
@@ -24,6 +24,7 @@ import (
 	nfconfig "github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/DataDog/datadog-agent/comp/netflow/flowaggregator"
 	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/def"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	rdnsquerierimplnone "github.com/DataDog/datadog-agent/comp/rdnsquerier/impl-none"
 )
 
@@ -68,6 +69,9 @@ func newServer(lc fx.Lifecycle, deps dependencies) (provides, error) {
 	}
 
 	sysprobeSocketPath := deps.AgentConfig.GetString("system_probe_config.sysprobe_socket")
+	if sysprobeSocketPath == "" {
+		sysprobeSocketPath = pkgconfigsetup.DefaultSystemProbeAddress
+	}
 	flowAgg := flowaggregator.NewFlowAggregator(sender, deps.Forwarder, conf, deps.Hostname.GetSafe(context.Background()), deps.Logger, rdnsQuerier, deps.Tagger, sysprobeSocketPath)
 
 	server := &Server{

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -246,6 +246,8 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_devices.netflow.enabled", false)
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.netflow.forwarder.")
 	config.BindEnvAndSetDefault("network_devices.netflow.reverse_dns_enrichment_enabled", false)
+	config.BindEnvAndSetDefault("network_devices.netflow.connection_enrichment_enabled", false)
+	config.SetKnown("network_devices.netflow.connection_enrichment_poll_interval") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 
 	// Network Path
 	config.BindEnvAndSetDefault("network_path.connections_monitoring.enabled", false)


### PR DESCRIPTION
## Summary
- Adds a new `ConnEnricher` component that polls system-probe's `/connections` endpoint and builds an in-memory lookup index keyed by IP 5-tuple (with ephemeral port rollup support)
- Enriches NetFlow records with container IDs, service names, and tags from the eBPF connection table before sending to the backend
- Resolves container→service mapping via the agent's tagger component (service, env, team tags)

Enriched fields flow through as `AdditionalFields` (`@ebpf.src.service`, `@ebpf.dst.service`, `@ebpf.src.container_id`, etc.) into the ndmflow Husky index.

Disabled by default. Enable with:
```yaml
network_devices:
  netflow:
    connection_enrichment_enabled: true
```

## Motivation
CNM (eBPF) and NetFlow (NDM) see the same network traffic from different vantage points but have zero correlation today. This enables filtering NetFlow by service name and cross-referencing with CNM data — the agent-side implementation of the M1+ approach from the CNM + NetFlow Flow Consolidation Strategy.

## Test plan
- [x] Unit tests for ConnEnricher (IP normalization, index building, exact/wildcard lookup, flow enrichment)
- [x] All existing flowaggregator tests pass unchanged
- [ ] Deploy to porygon-testbed: trainer→pokedex through FRR router, verify `@ebpf.src.service=trainer` appears in NetFlow UI
- [ ] Verify overlay topology (VXLAN) correctly shows no match (validates M1 limitation)


🤖 Generated with [Claude Code](https://claude.com/claude-code)