### PR TITLE
Add context timeout to RC backend HTTP fetches to prevent agent liveness failures

### DIFF
--- a/pkg/config/remote/service/BUILD.bazel
+++ b/pkg/config/remote/service/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     srcs = [
         "clients_test.go",
         "service_test.go",
+        "service_timeout_test.go",
         "subscriptions_test.go",
         "tracer_predicates_test.go",
         "util_test.go",

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -57,6 +57,7 @@ const (
 	maxFetchConfigsUntilLogLevelErrors = 5
 	// Number of /status calls where we get 503 or 504 errors until the log level is increased to ERROR
 	maxFetchOrgStatusUntilLogLevelErrors = 5
+	defaultFetchTimeout                  = 10 * time.Second
 )
 
 // Constraints on the maximum backoff time when errors occur
@@ -134,6 +135,9 @@ type CoreAgentService struct {
 	startupTime           time.Time
 	disableConfigPollLoop bool
 
+	// Maximum duration for a single HTTP fetch to the RC backend.
+	// Prevents indefinite hangs when the backend is degraded.
+	fetchTimeout time.Duration
 	// The backoff policy used for retries when errors are encountered
 	backoffPolicy backoff.Policy
 	// Used to report metrics on cache bypass requests
@@ -245,6 +249,7 @@ type RcTelemetryReporter interface {
 // orgStatusPoller handles periodic polling of the organization status from the remote config backend
 type orgStatusPoller struct {
 	refreshInterval time.Duration
+	fetchTimeout    time.Duration
 	stopChan        chan struct{}
 
 	mu struct {
@@ -256,9 +261,10 @@ type orgStatusPoller struct {
 	}
 }
 
-func newOrgStatusPoller(refreshInterval time.Duration) *orgStatusPoller {
+func newOrgStatusPoller(refreshInterval time.Duration, fetchTimeout time.Duration) *orgStatusPoller {
 	p := &orgStatusPoller{
 		refreshInterval: refreshInterval,
+		fetchTimeout:    fetchTimeout,
 		stopChan:        make(chan struct{}),
 	}
 	return p
@@ -296,7 +302,9 @@ func (p *orgStatusPoller) getPreviousStatus() *pbgo.OrgStatusResponse {
 
 // poll fetches and processes the current organization status
 func (p *orgStatusPoller) poll(apiClient api.API, rcType string) {
-	response, err := apiClient.FetchOrgStatus(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), p.fetchTimeout)
+	defer cancel()
+	response, err := apiClient.FetchOrgStatus(ctx)
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -372,6 +380,7 @@ type options struct {
 	clientTTL                      time.Duration
 	disableConfigPollLoop          bool
 	orgStatusRefreshInterval       time.Duration
+	fetchTimeout                   time.Duration
 	// for mocking creating db instance in test
 	uptaneFactory func(md *uptane.Metadata) (coreAgentUptaneClient, error)
 	// The allowed products for each subscription products value. Overridable
@@ -408,6 +417,7 @@ var defaultOptions = options{
 	clientTTL:                           defaultClientsTTL,
 	disableConfigPollLoop:               false,
 	orgStatusRefreshInterval:            defaultRefreshInterval,
+	fetchTimeout:                        defaultFetchTimeout,
 	subscriptionProductMappings:         defaultSubscriptionProductMappings,
 	maxConcurrentSubscriptions:          defaultMaxConcurrentSubscriptions,
 	maxTrackedRuntimeIDsPerSubscription: defaultMaxTrackedRuntimeIDsPerSubscription,
@@ -495,6 +505,13 @@ func WithMaxBackoffInterval(interval time.Duration, cfgPath string) func(s *opti
 	return func(s *options) {
 		s.maxBackoff = interval
 	}
+}
+
+// WithFetchTimeout sets the maximum duration for a single HTTP fetch to the RC backend.
+// This prevents indefinite hangs when the backend is degraded (e.g. returning 503/504),
+// which can stall the agent during startup and prevent it from passing liveness probes.
+func WithFetchTimeout(timeout time.Duration) func(s *options) {
+	return func(s *options) { s.fetchTimeout = timeout }
 }
 
 // WithRcKey sets the service remote configuration key
@@ -670,7 +687,8 @@ func NewService(cfg model.Reader, rcType, baseRawURL, hostname string, tagsGette
 		subscriptionProductMappings:         options.subscriptionProductMappings,
 		maxConcurrentSubscriptions:          options.maxConcurrentSubscriptions,
 		maxTrackedRuntimeIDsPerSubscription: options.maxTrackedRuntimeIDsPerSubscription,
-		orgStatusPoller:                     newOrgStatusPoller(options.orgStatusRefreshInterval),
+		fetchTimeout:                        options.fetchTimeout,
+		orgStatusPoller:                     newOrgStatusPoller(options.orgStatusRefreshInterval, options.fetchTimeout),
 	}
 	cas.mu.subscriptions = newSubscriptions(
 		options.subscriptionProductMappings,
@@ -862,7 +880,8 @@ func (s *CoreAgentService) refresh() error {
 	func() {
 		s.mu.Unlock()
 		defer s.mu.Lock()
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), s.fetchTimeout)
+		defer cancel()
 		response, err = s.api.Fetch(ctx, request)
 	}()
 	s.mu.lastUpdateErr = nil

--- a/pkg/config/remote/service/service_timeout_test.go
+++ b/pkg/config/remote/service/service_timeout_test.go
@@ -1,0 +1,214 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package service
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config/remote/uptane"
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+)
+
+// hangingAPI simulates a degraded RC backend (e.g. rc-delivery behind rc-edge
+// returning DeadlineExceeded) by blocking all Fetch and FetchOrgStatus calls
+// until the context is cancelled or the test ends.
+//
+// This reproduces the production scenario from incident 52759: during a rolling
+// update, freshly-started agents call refresh() which issues Fetch() with no
+// context timeout. When the backend is degraded, the goroutine blocks
+// indefinitely, preventing the agent from initializing and passing liveness
+// probes.
+type hangingAPI struct {
+	fetchCalls     atomic.Int64
+	orgStatusCalls atomic.Int64
+	stopCh         chan struct{}
+}
+
+func newHangingAPI() *hangingAPI {
+	return &hangingAPI{stopCh: make(chan struct{})}
+}
+
+func (h *hangingAPI) Fetch(ctx context.Context, _ *pbgo.LatestConfigsRequest) (*pbgo.LatestConfigsResponse, error) {
+	h.fetchCalls.Add(1)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-h.stopCh:
+		return nil, context.Canceled
+	}
+}
+
+func (h *hangingAPI) FetchOrgData(ctx context.Context) (*pbgo.OrgDataResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-h.stopCh:
+		return nil, context.Canceled
+	}
+}
+
+func (h *hangingAPI) FetchOrgStatus(ctx context.Context) (*pbgo.OrgStatusResponse, error) {
+	h.orgStatusCalls.Add(1)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-h.stopCh:
+		return nil, context.Canceled
+	}
+}
+
+func (h *hangingAPI) UpdatePARJWT(_ string) {}
+func (h *hangingAPI) UpdateAPIKey(_ string) {}
+
+func (h *hangingAPI) stop() { close(h.stopCh) }
+
+// newTestServiceWithHangingAPI creates a fresh CoreAgentService (simulating a
+// post-rolling-update startup) wired to a hanging backend. The fetchTimeout
+// parameter controls whether the fix is applied (short timeout) or not (very
+// large timeout to simulate the pre-fix behavior).
+func newTestServiceWithHangingAPI(t *testing.T, fetchTimeout time.Duration) (*CoreAgentService, *hangingAPI) {
+	t.Helper()
+	hangingBackend := newHangingAPI()
+	uptaneClient := &mockCoreAgentUptane{}
+	clk := clock.NewMock()
+
+	opts := []Option{
+		WithFetchTimeout(fetchTimeout),
+	}
+	service := newTestService(t, &mockAPI{}, uptaneClient, clk, opts...)
+	service.api = hangingBackend
+
+	uptaneClient.On("StoredOrgUUID").Return("abcdef", nil)
+	uptaneClient.On("TUFVersionState").Return(uptane.TUFVersions{}, nil)
+	uptaneClient.On("TargetsCustom").Return([]byte{}, nil)
+	uptaneClient.On("Update").Return(nil)
+	uptaneClient.On("UnsafeTargetsMeta").Return([]byte(`{}`), nil)
+	uptaneClient.On("TimestampExpires").Return(time.Now().Add(time.Hour), nil)
+
+	return service, hangingBackend
+}
+
+// TestStartupRefreshBlocksOnHangingBackend reproduces the root cause of
+// incident 52759. When a fresh service calls refresh() and the backend hangs,
+// refresh() blocks indefinitely because it uses context.Background() with no
+// timeout. This prevents the poll loop goroutine from advancing, which in
+// production means the service cannot serve ClientGetConfigs and contributes
+// to the liveness probe failure cascade.
+//
+// The test uses a very large fetchTimeout (simulating pre-fix behavior) and
+// verifies that refresh() does NOT return within a reasonable window.
+func TestStartupRefreshBlocksOnHangingBackend(t *testing.T) {
+	service, hangingBackend := newTestServiceWithHangingAPI(t, 10*time.Minute)
+	defer hangingBackend.stop()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- service.refresh()
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("refresh() returned when it should have blocked indefinitely with a hanging backend and no effective timeout")
+	case <-time.After(3 * time.Second):
+		// Expected: refresh() is still blocked after 3s because the backend
+		// hangs and there is no short timeout to bail out.
+	}
+
+	require.Greater(t, hangingBackend.fetchCalls.Load(), int64(0),
+		"Fetch should have been called at least once")
+}
+
+// TestStartupRefreshTimesOutOnHangingBackend proves the fix works: with a
+// short fetchTimeout, refresh() returns an error within the timeout window
+// even when the backend hangs. This allows the poll loop to advance, apply
+// backoff, and keep the service responsive during agent startup.
+func TestStartupRefreshTimesOutOnHangingBackend(t *testing.T) {
+	fetchTimeout := 500 * time.Millisecond
+	service, hangingBackend := newTestServiceWithHangingAPI(t, fetchTimeout)
+	defer hangingBackend.stop()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- service.refresh()
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "refresh() should return an error when the backend times out")
+		assert.Contains(t, err.Error(), "context deadline exceeded",
+			"error should indicate the fetch was cancelled by the timeout")
+	case <-time.After(5 * time.Second):
+		t.Fatal("refresh() did not return within 5s — timeout fix is not working")
+	}
+}
+
+// TestOrgStatusPollerTimesOutOnHangingBackend proves the fix applies to the
+// orgStatusPoller path as well. During startup, orgStatusPoller fires
+// immediately (timer initialized to 0) and can also hang indefinitely on a
+// degraded backend. With the fix, it times out and returns.
+func TestOrgStatusPollerTimesOutOnHangingBackend(t *testing.T) {
+	fetchTimeout := 500 * time.Millisecond
+	service, hangingBackend := newTestServiceWithHangingAPI(t, fetchTimeout)
+	defer hangingBackend.stop()
+
+	done := make(chan struct{}, 1)
+	go func() {
+		service.orgStatusPoller.poll(service.api, service.rcType)
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+		// poll() returned — the timeout worked
+	case <-time.After(5 * time.Second):
+		t.Fatal("orgStatusPoller.poll() did not return within 5s — timeout fix is not working")
+	}
+
+	require.Greater(t, hangingBackend.orgStatusCalls.Load(), int64(0),
+		"FetchOrgStatus should have been called")
+}
+
+// TestServiceResponsiveAfterTimeoutDuringStartup proves that after the first
+// refresh() times out on a hanging backend, the service is still responsive.
+// In the pre-fix world, a hanging refresh() would block the poll loop
+// goroutine, making it unable to service bypass requests from
+// ClientGetConfigs. With the fix, the poll loop advances past the failed
+// refresh, applies backoff, and remains responsive.
+func TestServiceResponsiveAfterTimeoutDuringStartup(t *testing.T) {
+	fetchTimeout := 500 * time.Millisecond
+	service, hangingBackend := newTestServiceWithHangingAPI(t, fetchTimeout)
+	defer hangingBackend.stop()
+
+	// Call refresh() directly to simulate the first startup call.
+	// With the timeout, this should return quickly.
+	err := service.refresh()
+	require.Error(t, err, "first refresh should fail due to timeout")
+
+	// Verify backoff was applied
+	service.mu.Lock()
+	backoffCount := service.mu.backoffErrorCount
+	lastErr := service.mu.lastUpdateErr
+	service.mu.Unlock()
+
+	assert.Greater(t, backoffCount, 0,
+		"backoff error count should be incremented after a failed refresh")
+	assert.NotNil(t, lastErr,
+		"lastUpdateErr should be set after a failed refresh")
+
+	// Verify the service can still calculate a refresh interval (not wedged)
+	interval := service.calculateRefreshInterval()
+	assert.Greater(t, interval, time.Duration(0),
+		"refresh interval should be positive after a failed refresh")
+	assert.Greater(t, interval, service.mu.defaultRefreshInterval,
+		"refresh interval should include backoff time after error")
+}


### PR DESCRIPTION
## Summary

During [incident 52759](https://app.datadoghq.com/incidents/52759), a degraded `rc-delivery` caused `rc-edge` to return 503/504 errors to agents. This triggered a **fleet-wide CrashLoopBackOff spiral** in the stripe staging cluster: **5,254 probe failure/kill events**, hosts accumulating **9–15 restart cycles**. We confirmed the root cause by **reproducing the issue**: degrading `rc-delivery` again caused the same container restart spike.

Full investigation and reproduction details:
[Investigation context & rough notes](https://ddstaging.datadoghq.com/notebook/14291693/container-restarts-due-to-degraded-rc-delivery)
[rc-delivery scale-down → agent restarts notebook](https://ddstaging.datadoghq.com/notebook/14293622/rc-delivery-scale-down-agent-restarts?cell_id=b3zlcodl)

This PR adds a **context timeout** (default 10s) to the RC service's HTTP fetch calls, preventing indefinite hangs when the backend is degraded.

## Root Cause Analysis

### The causal chain

```
rc-delivery degraded (scaled down / WPA unable to meet demand)
            ↓
rc-edge can't reach rc-delivery (GetLatestConfigs → DeadlineExceeded, 503/504)
            ↓
Agents get RC errors on startup
            ↓
RC HTTP fetch calls block indefinitely (context.Background() with no deadline)
            ↓
Poll loop goroutine stuck on first refresh() — never enters steady-state loop
            ↓
Agent startup delayed past liveness probe window
            ↓
collector-queue-300s goes unhealthy → /live returns HTTP 500
            ↓
Kubelet kills container → restart → same RC failures → CrashLoopBackOff
```

This was **confirmed by reproduction**: degrading `rc-delivery` again caused the same agent restart spike, proving that RC backend degradation alone is sufficient to trigger the cascade — no DaemonSet config change required.

### What we know for certain

1. **Two goroutines block indefinitely**: The RC service has exactly two goroutines making backend calls — the main poll loop (`startWithAgentPollLoop` → `refresh()`) and the `orgStatusPoller` (→ `poll()`). Both call the backend using `context.Background()` with no deadline. When the backend is degraded, these two goroutines hang forever. No additional goroutines are spawned — the refresh bypass mechanism puts a sentinel on a channel (size=1) that nudges the existing poll loop, it does not create new goroutines.

2. **The poll loop blocks on first refresh()**: `startWithAgentPollLoop` calls `s.refresh()` synchronously at line 742 *before* entering the `for` loop. If `refresh()` hangs, the poll loop goroutine never reaches steady state. This means refresh bypass requests from `ClientGetConfigs` cannot be consumed from the `refreshBypassRequests` channel, though `ClientGetConfigs` itself has its own timeout (`newClientBlockTTL`) so it doesn't block the caller.

3. **RC is NOT a liveness component**: `pkg/config/remote` does not call `health.RegisterLiveness()` — the link from RC to liveness failure is indirect.

4. **Disabling RC broke the loop**: without RC trying to reach the degraded backend, agents initialized fast enough to pass liveness probes.

5. **First healthcheck failure**: `Healthcheck failed on: [collector-queue-300s]` — a single component, on host `i-01c8c9471c9036218` at 07:15 UTC. Subsequent failures showed 20+ components simultaneously — consistent with cold-start after kubelet kill.

### What remains under investigation

The exact mechanism by which 2 blocked RC goroutines delay overall agent startup past the liveness probe window is not fully understood. Possible contributing factors:

- Interaction with the Fx component lifecycle during agent startup (whether other components wait on RC readiness signals)
- Whether the `s.mu` lock held during `refresh()` (before/after the fetch, not during) creates contention with other startup paths
- Whether the combination of a degraded network (affecting RC) also slows other agent components that make outbound calls during startup

Regardless of the cascade mechanism, the fix is correct: **unbounded HTTP calls with `context.Background()` are a bug**, and adding a timeout is a basic defensive practice that allows the poll loop to advance and apply backoff.

## Changes

### `pkg/config/remote/service/service.go`

- Added `defaultFetchTimeout = 10s` constant
- Added `fetchTimeout` field to `CoreAgentService` and `orgStatusPoller`
- Added `WithFetchTimeout()` option for configurability
- **Key fix**: replaced `context.Background()` with `context.WithTimeout()` in:
  - `refresh()` (line 880) — the main config fetch path
  - `orgStatusPoller.poll()` (line 302) — the org status fetch path

### `pkg/config/remote/service/service_timeout_test.go`

Four tests proving the root cause and fix:

| Test | What it proves |
|------|---------------|
| `TestStartupRefreshBlocksOnHangingBackend` | **Reproduces root cause**: fresh service + hanging backend → `refresh()` blocks indefinitely |
| `TestStartupRefreshTimesOutOnHangingBackend` | **Proves fix**: `refresh()` returns with error within timeout |
| `TestOrgStatusPollerTimesOutOnHangingBackend` | **Proves fix for second path**: `poll()` also fails fast |
| `TestServiceResponsiveAfterTimeoutDuringStartup` | Service applies backoff and remains responsive after timeout |

## What this PR does NOT cover

These are follow-up items, not blockers:

- **Investigate the exact cascade mechanism**: Understand precisely how 2 blocked RC goroutines delay agent startup past the liveness probe window
- **Add `http.Client.Timeout`** as defense-in-depth on the RC HTTP client
- **E2E test** covering the full chain (degraded rc-delivery + liveness probe + container restart)
- **Probe tuning** (startup probe or higher `failureThreshold`) as a safety net

## Test plan

- [x] `TestStartupRefreshBlocksOnHangingBackend` — reproduces pre-fix behavior
- [x] `TestStartupRefreshTimesOutOnHangingBackend` — verifies fix
- [x] `TestOrgStatusPollerTimesOutOnHangingBackend` — verifies fix for org status path
- [x] `TestServiceResponsiveAfterTimeoutDuringStartup` — verifies service recovery
- [x] All existing `pkg/config/remote/service` tests pass (no regressions)