### PR TITLE
[OTELS-985] omit hostname field from JSON payload when empty

### DIFF
--- a/pkg/logs/processor/encoder_test.go
+++ b/pkg/logs/processor/encoder_test.go
@@ -269,6 +269,70 @@ func TestJsonEncoder(t *testing.T) {
 	})
 }
 
+func TestJsonEncoderHostnameOmitted(t *testing.T) {
+	logsConfig := &config.LogsConfig{Source: "Source"}
+	source := sources.NewLogSource("", logsConfig)
+
+	t.Run("empty hostname is omitted from JSON", func(t *testing.T) {
+		msg := newMessage([]byte("log message"), source, message.StatusInfo)
+		msg.State = message.StateRendered
+
+		err := JSONEncoder.Encode(msg, "")
+		assert.Nil(t, err)
+
+		var parsed map[string]any
+		assert.Nil(t, json.Unmarshal(msg.GetContent(), &parsed))
+		_, hasHostname := parsed["hostname"]
+		assert.False(t, hasHostname, "hostname key should be absent when hostname is empty")
+	})
+
+	t.Run("non-empty hostname is present in JSON", func(t *testing.T) {
+		msg := newMessage([]byte("log message"), source, message.StatusInfo)
+		msg.State = message.StateRendered
+
+		err := JSONEncoder.Encode(msg, "my-host")
+		assert.Nil(t, err)
+
+		var parsed map[string]any
+		assert.Nil(t, json.Unmarshal(msg.GetContent(), &parsed))
+		hostname, hasHostname := parsed["hostname"]
+		assert.True(t, hasHostname, "hostname key should be present when hostname is non-empty")
+		assert.Equal(t, "my-host", hostname)
+	})
+}
+
+func TestJsonServerlessInitEncoderHostnameOmitted(t *testing.T) {
+	logsConfig := &config.LogsConfig{Source: "Source"}
+	source := sources.NewLogSource("", logsConfig)
+
+	t.Run("empty hostname is omitted from JSON", func(t *testing.T) {
+		msg := newMessage([]byte("log message"), source, message.StatusInfo)
+		msg.State = message.StateRendered
+
+		err := JSONServerlessInitEncoder.Encode(msg, "")
+		assert.Nil(t, err)
+
+		var parsed map[string]any
+		assert.Nil(t, json.Unmarshal(msg.GetContent(), &parsed))
+		_, hasHostname := parsed["hostname"]
+		assert.False(t, hasHostname, "hostname key should be absent when hostname is empty")
+	})
+
+	t.Run("non-empty hostname is present in JSON", func(t *testing.T) {
+		msg := newMessage([]byte("log message"), source, message.StatusInfo)
+		msg.State = message.StateRendered
+
+		err := JSONServerlessInitEncoder.Encode(msg, "my-host")
+		assert.Nil(t, err)
+
+		var parsed map[string]any
+		assert.Nil(t, json.Unmarshal(msg.GetContent(), &parsed))
+		hostname, hasHostname := parsed["hostname"]
+		assert.True(t, hasHostname, "hostname key should be present when hostname is non-empty")
+		assert.Equal(t, "my-host", hostname)
+	})
+}
+
 func TestEncoderToValidUTF8(t *testing.T) {
 	// valid utf-8
 	assert.Equal(t, "", toValidUtf8(nil))

--- a/pkg/logs/processor/json.go
+++ b/pkg/logs/processor/json.go
@@ -30,7 +30,7 @@ type jsonPayload struct {
 	Message   ValidUtf8Bytes `json:"message"`
 	Status    string         `json:"status"`
 	Timestamp int64          `json:"timestamp"`
-	Hostname  string         `json:"hostname"`
+	Hostname  string         `json:"hostname,omitempty"`
 	Service   string         `json:"service"`
 	Source    string         `json:"ddsource"`
 	Tags      string         `json:"ddtags"`

--- a/pkg/logs/processor/json_serverless_init.go
+++ b/pkg/logs/processor/json_serverless_init.go
@@ -29,7 +29,7 @@ type jsonServerlessInitPayload struct {
 	Message   ValidUtf8Bytes `json:"message"`
 	Status    string         `json:"status"`
 	Timestamp int64          `json:"timestamp"`
-	Hostname  string         `json:"hostname"`
+	Hostname  string         `json:"hostname,omitempty"`
 	Service   string         `json:"service,omitempty"`
 	Source    string         `json:"ddsource"`
 	Tags      string         `json:"ddtags"`

--- a/releasenotes/notes/fix-otel-logs-empty-hostname-fargate-6b2fdadda066a5ab.yaml
+++ b/releasenotes/notes/fix-otel-logs-empty-hostname-fargate-6b2fdadda066a5ab.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix OTel logs sent via the Datadog exporter on ECS Fargate showing an empty
+    string for the ``host`` reserved attribute instead of no host. The hostname
+    field is now omitted from the log payload when no hostname applies (e.g.
+    serverless/Fargate environments), so logs appear without a host rather than
+    with a blank one.


### PR DESCRIPTION
### What does this PR do?
When the OTel collector runs in ECS Fargate, the hostname service returns "" (intentionally — Fargate tasks have no host). Previously the jsonPayload and jsonServerlessInitPayload structs had no omitempty on the Hostname field, so an empty hostname was serialized as "hostname":"" and sent to the Datadog intake, causing the host reserved attribute to appear as an empty string instead of being absent.

Adding omitempty ensures the hostname key is omitted from the JSON payload when empty, which is the correct behavior for serverless environments.

### Motivation
https://datadoghq.atlassian.net/browse/OTELS-985

### Describe how you validated your changes
new unit tests

### Additional Notes
