### PR TITLE
Bump rshell to v0.0.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -969,7 +969,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.64.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5
-	github.com/DataDog/rshell v0.0.10
+	github.com/DataDog/rshell v0.0.11
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8
 	github.com/aymerick/raymond v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2598,8 +2598,8 @@ github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816 h1:8diKw2aLYE6LsjWfYxD
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816/go.mod h1:7cPuErOAt7k/oVWAVJnxqAC6mwArrAazkvk0RXiih2A=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260317195537-817b91eb7dd4 h1:9+K8vjF7sQSLjVJporNyv6nw46cMg/Q8ogxbBZmrf+A=
 github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260317195537-817b91eb7dd4/go.mod h1:KEBv+q78RzBcDPNFm1WB0V0za14gY95E/Atp3dJZ/8M=
-github.com/DataDog/rshell v0.0.10 h1:1jFuWzxxBNCv4tec1Rn1yZJrj9p3ZK7sRZEaHdxUk0Q=
-github.com/DataDog/rshell v0.0.10/go.mod h1:e6IP68xHScumYqM/9dT9y5H41EmStHDVEyCZKv5mEt4=
+github.com/DataDog/rshell v0.0.11 h1:VXs219rmbACRWiCSp3jM1rGcA62Bn/tcSZ1NNmjZElI=
+github.com/DataDog/rshell v0.0.11/go.mod h1:e6IP68xHScumYqM/9dT9y5H41EmStHDVEyCZKv5mEt4=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=
 github.com/DataDog/sketches-go v1.4.8/go.mod h1:a/wjRUqzqtGS8qRHRPDCs4EAQfmvPDZGDlMIF5mxXOE=
 github.com/DataDog/trivy v0.0.0-20260407220859-6cf8ddc1826c h1:oiwmRrkRVblZBI3SFVEnrwxkQ28W7nmwwI/VHgex0ZU=


### PR DESCRIPTION
<!-- dd-meta {"pullId":"119699a8-fc03-4522-a95f-7de9abef517a","source":"chat","resourceId":"b24038b3-8a45-429f-b001-da22407a1fa8","workflowId":"0ddbea72-16a0-42c5-ba1e-b7f2c92e216a","codeChangeId":"0ddbea72-16a0-42c5-ba1e-b7f2c92e216a","sourceType":"chat"} -->
### What does this PR do?

Bumps the `github.com/DataDog/rshell` dependency from `v0.0.10` to `v0.0.11`.

### Motivation

Keep the rshell restricted shell library up to date with the latest release.

### Describe how you validated your changes

Updated `go.mod` and `go.sum` with the correct module hash for `v0.0.11` retrieved from the module proxy.

### Additional Notes

Only `go.mod` and `go.sum` are changed.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b24038b3-8a45-429f-b001-da22407a1fa8)

Comment @datadog to request changes