### PR TITLE
[PROF-14281] Ensure API key redaction in flares

### DIFF
--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/converters"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/params"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type confMap = map[string]any
@@ -196,8 +195,6 @@ func buildConfig(agent configManager, p params.CollectorParams) confMap {
 		serviceExtensions = append(serviceExtensions, "ddprofiling/default")
 	}
 	_ = converters.Set(config, "service::extensions", serviceExtensions)
-
-	log.Debugf("Generated configuration: %+v", config)
 
 	return config
 }

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/extensions/hpflareextension"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/params"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type confMap = map[string]any
@@ -198,8 +197,6 @@ func buildConfig(agent configManager, p params.CollectorParams) confMap {
 		serviceExtensions = append(serviceExtensions, "ddprofiling/default")
 	}
 	_ = converters.Set(config, "service::extensions", serviceExtensions)
-
-	log.Debugf("Generated configuration: %+v", config)
 
 	return config
 }

--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -276,8 +276,8 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 
 	// Exact key matches for specific API keys and auth tokens
 	exactKeyReplacer := matchYAMLKey(
-		`(auth-tenantid|authority|cainzapp-api-key|cms-svc-api-key|lodauth|sec-websocket-key|statuskey|cookie|private-token|kong-admin-token|accesstoken|session_token)`,
-		[]string{"auth-tenantid", "authority", "cainzapp-api-key", "cms-svc-api-key", "lodauth", "sec-websocket-key", "statuskey", "cookie", "private-token", "kong-admin-token", "accesstoken", "session_token"},
+		`(auth-tenantid|authority|cainzapp-api-key|cms-svc-api-key|dd-api-key|lodauth|sec-websocket-key|statuskey|cookie|private-token|kong-admin-token|accesstoken|session_token)`,
+		[]string{"auth-tenantid", "authority", "cainzapp-api-key", "cms-svc-api-key", "dd-api-key", "lodauth", "sec-websocket-key", "statuskey", "cookie", "private-token", "kong-admin-token", "accesstoken", "session_token"},
 		[]byte(`$1 "********"`),
 	)
 	exactKeyReplacer.LastUpdated = parseVersion("7.70.2")

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -996,6 +996,9 @@ func TestNewHTTPHeaderAndExactKeys(t *testing.T) {
 		`cms-svc-api-key: cmskey789`,
 		`cms-svc-api-key: "********"`)
 	assertClean(t,
+		`dd-api-key: someapikey123`,
+		`dd-api-key: "********"`)
+	assertClean(t,
 		`lodauth: lodauth123`,
 		`lodauth: "********"`)
 	assertClean(t,


### PR DESCRIPTION
### What does this PR do?

- Adds `dd-api-key` to the flare scrubber's key-name-aware replacers
- Removes a debug log that printed the full generated OTel config, which included arbitrary `AdditionalHTTPHeaders` values the scrubber cannot pattern-match

### Motivation

The Host Profiler and OTel exporters write their effective config to flare bundles via `runtime.cfg`, which includes `dd-api-key` headers. While these values are always standard 32-char hex API keys caught by the value-pattern scrubber, `dd-api-key` should also be recognized as sensitive by key name; consistent with other known headers already in the list.

### Describe how you validated your changes
Added a `assertClean` case in `pkg/util/scrubber/default_test.go` covering a non-hex `dd-api-key` value.

### Additional Notes
