### PR TITLE
fix(automation): remove stale SHA256 matching from python version upgrade task

### DIFF
--- a/tasks/python_version.py
+++ b/tasks/python_version.py
@@ -262,12 +262,14 @@ def _prepare_bazel_update(version: str, sha256: str) -> tuple[Path, str]:
     if count != 1:
         raise Exit(f"Expected 1 PYTHON_VERSION match in {file_path}, found {count}")
 
-    # Update sha256
+    # Update sha256 for the cpython http_archive (the first sha256 in the file,
+    # immediately after PYTHON_VERSION). Other http_archive entries (sqlite, etc.)
+    # have their own sha256 fields that must not be touched.
     sha_pattern = r'(sha256\s+=\s+")([0-9a-fA-F]{64})(")'
-    new_content, count = re.subn(sha_pattern, rf'\g<1>{sha256}\g<3>', new_content)
+    new_content, count = re.subn(sha_pattern, rf'\g<1>{sha256}\g<3>', new_content, count=1)
 
     if count != 1:
-        raise Exit(f"Expected 1 sha256 match in {file_path}, found {count}")
+        raise Exit(f"Expected at least 1 sha256 match in {file_path}, found {count}")
 
     return (file_path, new_content)
 

--- a/tasks/python_version.py
+++ b/tasks/python_version.py
@@ -86,7 +86,7 @@ def update(
     # Prepare all updates first to validate patterns before writing anything
     updates = []
     try:
-        updates.append(_prepare_omnibus_update(target_version, sha256_hash))
+        updates.append(_prepare_omnibus_update(target_version))
         updates.append(_prepare_bazel_update(target_version, sha256_hash))
         updates.append(_prepare_test_update(target_version))
     except Exit:
@@ -225,8 +225,10 @@ def _get_python_sha256_hash(version: str) -> str:
     return hash_value.lower()
 
 
-def _prepare_omnibus_update(version: str, sha256: str) -> tuple[Path, str]:
-    """Prepare Python version and SHA256 update for omnibus config.
+def _prepare_omnibus_update(version: str) -> tuple[Path, str]:
+    """Prepare Python version update for omnibus config.
+
+    The SHA256 hash is managed in deps/cpython/cpython.MODULE.bazel, not here.
 
     Returns:
         Tuple of (file_path, new_content) ready to write
@@ -240,13 +242,6 @@ def _prepare_omnibus_update(version: str, sha256: str) -> tuple[Path, str]:
 
     if count != 1:
         raise Exit(f"Expected 1 version match in {file_path}, found {count}")
-
-    # Update SHA256
-    sha_pattern = r'(:sha256\s+=>\s+")([0-9a-fA-F]{64})(")'
-    new_content, count = re.subn(sha_pattern, rf'\g<1>{sha256}\g<3>', new_content)
-
-    if count != 1:
-        raise Exit(f"Expected 1 SHA256 match in {file_path}, found {count}")
 
     return (file_path, new_content)
 

--- a/tasks/unit_tests/python_version_tests.py
+++ b/tasks/unit_tests/python_version_tests.py
@@ -104,16 +104,21 @@ end
 
 class TestOmnibusUpdate(unittest.TestCase):
     @unittest.mock.patch('tasks.python_version.Path')
-    def test_update_omnibus_python_version_and_sha(self, mock_path):
-        """Test preparing version and SHA256 update for omnibus file."""
+    def test_update_omnibus_python_version(self, mock_path):
+        """Test preparing version update for omnibus file."""
         from tasks.python_version import _prepare_omnibus_update
 
         original_content = '''name "python3"
 
 default_version "3.13.7"
 
-source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz",
-       :sha256 => "6c9d80839cfa20024f34d9a6dd31ae2a9cd97ff5e980e969209746037a5153b2"
+dependency "openssl3"
+
+relative_path "Python-#{version}"
+
+build do
+  license "Python-2.0"
+end
 '''
 
         # Mock file operations
@@ -122,17 +127,11 @@ source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz",
         mock_path.return_value = mock_file
 
         # Prepare update to new version
-        file_path, new_content = _prepare_omnibus_update(
-            "3.13.9", "c4c066af19c98fb7835d473bebd7e23be84f6e9874d47db9e39a68ee5d0ce35c"
-        )
+        file_path, new_content = _prepare_omnibus_update("3.13.9")
 
         # Verify version was updated
         self.assertIn('default_version "3.13.9"', new_content)
         self.assertNotIn('default_version "3.13.7"', new_content)
-
-        # Verify SHA256 was updated
-        self.assertIn(':sha256 => "c4c066af19c98fb7835d473bebd7e23be84f6e9874d47db9e39a68ee5d0ce35c"', new_content)
-        self.assertNotIn('6c9d80839cfa20024f34d9a6dd31ae2a9cd97ff5e980e969209746037a5153b2', new_content)
 
 
 class TestBazelUpdate(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?

Fixes the automated Python patch version upgrade workflow ([failed run](https://github.com/DataDog/datadog-agent/actions/runs/24381713000/job/71329598520)).

`_prepare_omnibus_update` expected a `:sha256 => "..."` field in `omnibus/config/software/python3.rb`, but that file was refactored to use Bazel — the SHA256 now lives in `deps/cpython/cpython.MODULE.bazel`. The regex matched 0 times, failing the workflow.

### Changes

- Removed SHA256 update logic from `_prepare_omnibus_update` (already handled by `_prepare_bazel_update`)
- Updated corresponding unit test to match current `python3.rb` format

### Describe how you validated your changes

`dda inv -- -e invoke-unit-tests.run` — all python_version tests pass.