### PR TITLE
[CNM-4922] Fix flake related to garbage collection

### DIFF
--- a/pkg/network/dns/types_test.go
+++ b/pkg/network/dns/types_test.go
@@ -7,15 +7,20 @@ package dns
 
 import (
 	"math/rand"
+	"runtime"
 	"testing"
 )
 
 func TestHostnameFromBytesAllocs(t *testing.T) {
 	b := make([]byte, 10)
 	s := randomString(b)
+	// Pre-intern the value and hold a reference so the GC cannot collect it
+	// between AllocsPerRun iterations.
+	keep := HostnameFromBytes(s)
 	allocs := int(testing.AllocsPerRun(100, func() {
 		HostnameFromBytes(s)
 	}))
+	runtime.KeepAlive(keep)
 	if allocs != 0 {
 		t.Errorf("HostnameFromBytes allocated %d objects, want 0", allocs)
 	}

--- a/pkg/util/intern/string_test.go
+++ b/pkg/util/intern/string_test.go
@@ -75,9 +75,13 @@ var (
 
 func TestGetAllocs(t *testing.T) {
 	si := NewStringInterner()
+	// Pre-intern the value and hold a reference so the GC cannot collect it
+	// between AllocsPerRun iterations.
+	keep := si.Get(globalBytes)
 	allocs := int(testing.AllocsPerRun(100, func() {
 		si.Get(globalBytes)
 	}))
+	runtime.KeepAlive(keep)
 	if allocs != 0 {
 		t.Errorf("Get allocated %d objects, want 0", allocs)
 	}
@@ -85,9 +89,11 @@ func TestGetAllocs(t *testing.T) {
 
 func TestGetStringAllocs(t *testing.T) {
 	si := NewStringInterner()
+	keep := si.GetString(globalString)
 	allocs := int(testing.AllocsPerRun(100, func() {
 		si.GetString(globalString)
 	}))
+	runtime.KeepAlive(keep)
 	if allocs != 0 {
 		t.Errorf("GetString allocated %d objects, want 0", allocs)
 	}


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where our allocation benchmark tests would fail due to a garbage collection cycle happening mid-test, meaning the interning would have to re-allocate.

### Motivation
Flakes are bad

### Describe how you validated your changes
```
PATH="$PATH" sudo -E go test -count 100000 -tags linux,linux_bpf,npm,process,test -run ^TestHostnameFromBytesAllocs$ ./pkg/network/dns
```
