### PR TITLE
gazelle: collect tags from the test sources

### DIFF
--- a/bazel/rules/go_build_tags/BUILD.bazel
+++ b/bazel/rules/go_build_tags/BUILD.bazel
@@ -28,7 +28,9 @@ go_library(
         "@gazelle//rule",
         # buildtools is a transitive dep of @gazelle//rule; we need it directly
         # for bzl.Expr types used to generate select() expressions in gotags.
-        "@@gazelle++go_deps+com_github_bazelbuild_buildtools//build:build",
+        # Declared in deps/go.MODULE.bazel with an alias to avoid clashing with
+        # the http_archive buildifier repository.
+        "@com_github_bazelbuild_buildtools_go//build",
     ],
 )
 

--- a/bazel/rules/go_build_tags/BUILD.bazel
+++ b/bazel/rules/go_build_tags/BUILD.bazel
@@ -26,6 +26,9 @@ go_library(
     deps = [
         "@gazelle//language",
         "@gazelle//rule",
+        # buildtools is a transitive dep of @gazelle//rule; we need it directly
+        # for bzl.Expr types used to generate select() expressions in gotags.
+        "@@gazelle++go_deps+com_github_bazelbuild_buildtools//build:build",
     ],
 )
 

--- a/bazel/rules/go_build_tags/BUILD.bazel
+++ b/bazel/rules/go_build_tags/BUILD.bazel
@@ -1,11 +1,19 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 # strip the leading _ solely meant to prevent `go mod tidy` from adding @gazelle deps to the root go.mod
 copy_file(
     name = "gazelle_extension_src",
     src = "_gazelle_extension.go",
     out = "gazelle_extension.go",
+)
+
+# same trick: the test file imports testify but not gazelle, however keeping
+# the _ prefix is consistent and avoids any future tidy surprises
+copy_file(
+    name = "gazelle_extension_test_src",
+    src = "_gazelle_extension_test.go",
+    out = "gazelle_extension_test.go",
 )
 
 # prevent `bazel run //:gazelle` from removing @gazelle deps (reentrancy guard)
@@ -18,5 +26,15 @@ go_library(
     deps = [
         "@gazelle//language",
         "@gazelle//rule",
+    ],
+)
+
+go_test(
+    name = "gazelle_extension_test",
+    srcs = [":gazelle_extension_test_src"],
+    embed = [":gazelle_extension"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/bazel/rules/go_build_tags/_gazelle_extension.go
+++ b/bazel/rules/go_build_tags/_gazelle_extension.go
@@ -8,9 +8,20 @@
 // transition that propagates the "test" build tag to all transitive deps,
 // enabling //go:build test files in go_library targets to be compiled when
 // building tests but excluded from production builds.
+//
+// The extension also propagates any additional user-defined build tags found in
+// the test source files themselves. For example, if a test file is gated by
+// //go:build ec2, the extension adds "ec2" to gotags so rules_go does not
+// silently exclude the file, producing a test binary with no tests.
 package go_build_tags
 
 import (
+	"bufio"
+	"go/build/constraint"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/bazelbuild/bazel-gazelle/language"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
@@ -27,16 +38,189 @@ func NewLanguage() language.Language {
 
 func (*lang) Name() string { return extName }
 
+// Kinds declares that the gotags attribute of go_test rules is managed by this
+// extension. Marking it as mergeable ensures that Gazelle overwrites the
+// existing gotags value on each run rather than preserving the old value.
+func (*lang) Kinds() map[string]rule.KindInfo {
+	return map[string]rule.KindInfo{
+		"go_test": {
+			MergeableAttrs: map[string]bool{
+				"gotags": true,
+			},
+		},
+	}
+}
+
 // GenerateRules adds gotags = ["test"] to every go_test rule so that
 // rules_go's configuration transition propagates the "test" build tag to all
-// transitive library deps during test builds.
+// transitive library deps during test builds. It also adds any additional
+// user-defined build tags required by the test source files themselves.
+//
+// For AND expressions every tag is required, so all branches are collected.
+// For OR expressions the left branch is tried first; the right branch is only
+// consulted if the left produced no user-defined tags (e.g. the left side is
+// entirely system tags). NOT sub-expressions are skipped.
 func (*lang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
 	for _, r := range args.OtherGen {
-		if r.Kind() == "go_test" {
-			addStringToListIfMissing(r, "gotags", "test")
+		if r.Kind() != "go_test" {
+			continue
+		}
+		addStringToListIfMissing(r, "gotags", "test")
+		for _, tag := range requiredSourceTags(r.AttrStrings("srcs"), args.Dir) {
+			addStringToListIfMissing(r, "gotags", tag)
 		}
 	}
 	return language.GenerateResult{}
+}
+
+// requiredSourceTags collects user-defined build tags from the //go:build
+// directives of the given source files. Tags from all files are unioned;
+// duplicates are suppressed. Files that cannot be read are silently skipped.
+func requiredSourceTags(srcs []string, dir string) []string {
+	seen := make(map[string]struct{})
+	var result []string
+	for _, src := range srcs {
+		for _, tag := range tagsFromFile(filepath.Join(dir, src)) {
+			if _, ok := seen[tag]; !ok {
+				seen[tag] = struct{}{}
+				result = append(result, tag)
+			}
+		}
+	}
+	return result
+}
+
+// tagsFromFile returns user-defined build tags from the //go:build directive
+// in the given file. Tags are collected from all positive sub-expressions;
+// NOT sub-expressions are skipped.
+func tagsFromFile(path string) []string {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "//") {
+			break // past the leading comment block; no build constraint present
+		}
+		if !constraint.IsGoBuild(line) {
+			continue
+		}
+		expr, err := constraint.Parse(line)
+		if err != nil {
+			return nil
+		}
+		return positiveUserTags(expr)
+	}
+	return nil
+}
+
+// positiveUserTags walks a constraint expression tree and collects all
+// user-defined tags from positive sub-expressions. Both AND and OR branches
+// are traversed; NOT sub-expressions are skipped. Duplicates are removed
+// before returning.
+func positiveUserTags(expr constraint.Expr) []string {
+	var raw []string
+	walkPositive(expr, &raw)
+	seen := make(map[string]struct{}, len(raw))
+	result := raw[:0]
+	for _, t := range raw {
+		if _, ok := seen[t]; !ok {
+			seen[t] = struct{}{}
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func walkPositive(expr constraint.Expr, tags *[]string) {
+	switch e := expr.(type) {
+	case *constraint.TagExpr:
+		if !isSystemTag(e.Tag) && !isExcludedTag(e.Tag) {
+			*tags = append(*tags, e.Tag)
+		}
+	case *constraint.AndExpr:
+		walkPositive(e.X, tags)
+		walkPositive(e.Y, tags)
+	case *constraint.OrExpr:
+		// Satisfy the OR with as few tags as possible: recurse into the left
+		// branch first. Only fall through to the right if the left branch
+		// added no user-defined tags (e.g. the left side is entirely system
+		// tags such as "linux"). When the OR is already satisfied by a prior
+		// AND branch (e.g. ec2 && (ec2 || kubelet)), the left branch appends
+		// a duplicate which still advances len(*tags), so the right branch is
+		// naturally skipped; positiveUserTags removes the duplicate.
+		before := len(*tags)
+		walkPositive(e.X, tags)
+		if len(*tags) == before {
+			walkPositive(e.Y, tags)
+		}
+		// constraint.NotExpr: skip
+	}
+}
+
+// isExcludedTag reports whether tag should not be injected into gotags.
+// These are user-defined tags that require special infrastructure or build
+// contexts not available in the standard test environment.
+func isExcludedTag(tag string) bool {
+	_, ok := excludedTags[tag]
+	return ok
+}
+
+// excludedTags lists user-defined build tags that the extension must not
+// auto-inject into go_test gotags. Tags here require infrastructure or build
+// contexts (e.g. system-probe) that are not available in the standard test
+// environment. Add a tag here when including it in gotags would cause builds
+// to fail or tests to require unavailable hardware/drivers.
+var excludedTags = map[string]struct{}{
+	// npm requires the Windows npm kernel driver; only valid in system-probe builds.
+	"npm": {},
+}
+
+// isSystemTag reports whether tag is a Go toolchain-managed constraint that
+// rules_go handles via platform selection rather than gotags. This covers
+// GOOS values, GOARCH values, Go version tags (go1.N), and a handful of
+// special compiler/mode tags.
+func isSystemTag(tag string) bool {
+	if _, ok := knownGOOS[tag]; ok {
+		return true
+	}
+	if _, ok := knownGOARCH[tag]; ok {
+		return true
+	}
+	if strings.HasPrefix(tag, "go1.") {
+		return true
+	}
+	switch tag {
+	case "cgo", "gc", "gccgo", "ignore":
+		return true
+	}
+	return false
+}
+
+// knownGOOS is the set of valid GOOS values as of Go 1.24.
+var knownGOOS = map[string]struct{}{
+	"aix": {}, "android": {}, "darwin": {}, "dragonfly": {},
+	"freebsd": {}, "hurd": {}, "illumos": {}, "ios": {},
+	"js": {}, "linux": {}, "nacl": {}, "netbsd": {},
+	"openbsd": {}, "plan9": {}, "solaris": {}, "wasip1": {},
+	"windows": {}, "zos": {},
+}
+
+// knownGOARCH is the set of valid GOARCH values as of Go 1.24.
+var knownGOARCH = map[string]struct{}{
+	"386": {}, "amd64": {}, "amd64p32": {}, "arm": {},
+	"armbe": {}, "arm64": {}, "arm64be": {}, "loong64": {},
+	"mips": {}, "mipsle": {}, "mips64": {}, "mips64le": {},
+	"mips64p32": {}, "mips64p32le": {}, "ppc": {}, "ppc64": {},
+	"ppc64le": {}, "riscv": {}, "riscv64": {}, "s390": {},
+	"s390x": {}, "sparc": {}, "sparc64": {}, "wasm": {},
 }
 
 func addStringToListIfMissing(r *rule.Rule, attr, value string) {

--- a/bazel/rules/go_build_tags/_gazelle_extension.go
+++ b/bazel/rules/go_build_tags/_gazelle_extension.go
@@ -63,10 +63,11 @@ func (*lang) Kinds() map[string]rule.KindInfo {
 //   - Linux-only tags (knownLinuxOnlyTags) are wrapped in a select() so they
 //     are only active on Linux, matching the behaviour of dda inv test.
 //
-// For AND expressions every tag is required, so all branches are collected.
-// For OR expressions the left branch is tried first; the right branch is only
-// consulted if the left produced no user-defined tags (e.g. the left side is
-// entirely system tags). NOT sub-expressions are skipped.
+// Tags are collected from all positive sub-expressions of the constraint tree:
+// both AND and OR branches are fully traversed; NOT sub-expressions are skipped.
+// Collecting all OR branches is intentional: gotags drives a rules_go
+// configuration transition that propagates to all transitive library deps, so a
+// tag missing from gotags silently excludes library files that depend on it.
 func (*lang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
 	for _, r := range args.OtherGen {
 		if r.Kind() != "go_test" {
@@ -204,18 +205,14 @@ func walkPositive(expr constraint.Expr, tags *[]string) {
 		walkPositive(e.X, tags)
 		walkPositive(e.Y, tags)
 	case *constraint.OrExpr:
-		// Satisfy the OR with as few tags as possible: recurse into the left
-		// branch first. Only fall through to the right if the left branch
-		// added no user-defined tags (e.g. the left side is entirely system
-		// tags such as "linux"). When the OR is already satisfied by a prior
-		// AND branch (e.g. ec2 && (ec2 || kubelet)), the left branch appends
-		// a duplicate which still advances len(*tags), so the right branch is
-		// naturally skipped; positiveUserTags removes the duplicate.
-		before := len(*tags)
+		// Collect from both branches. Skipping the right branch when the left
+		// already contributes tags under-collects: gotags drives a rules_go
+		// configuration transition that propagates to all transitive library
+		// deps, so a tag missing from gotags silently excludes the library
+		// files that need it, regardless of which OR branch is "active".
+		// positiveUserTags deduplicates the result.
 		walkPositive(e.X, tags)
-		if len(*tags) == before {
-			walkPositive(e.Y, tags)
-		}
+		walkPositive(e.Y, tags)
 		// constraint.NotExpr: skip
 	}
 }

--- a/bazel/rules/go_build_tags/_gazelle_extension.go
+++ b/bazel/rules/go_build_tags/_gazelle_extension.go
@@ -276,7 +276,7 @@ func isSystemTag(tag string) bool {
 		return true
 	}
 	switch tag {
-	case "cgo", "gc", "gccgo", "ignore":
+	case "cgo", "gc", "gccgo", "ignore", "unix":
 		return true
 	}
 	return false

--- a/bazel/rules/go_build_tags/_gazelle_extension.go
+++ b/bazel/rules/go_build_tags/_gazelle_extension.go
@@ -13,6 +13,10 @@
 // the test source files themselves. For example, if a test file is gated by
 // //go:build ec2, the extension adds "ec2" to gotags so rules_go does not
 // silently exclude the file, producing a test binary with no tests.
+//
+// Tags listed in knownLinuxOnlyTags (mirroring tasks/build_tags.py LINUX_ONLY_TAGS)
+// are injected only on Linux via a select() expression, matching the behaviour of
+// dda inv test which never passes those tags on non-Linux platforms.
 package go_build_tags
 
 import (
@@ -24,6 +28,7 @@ import (
 
 	"github.com/bazelbuild/bazel-gazelle/language"
 	"github.com/bazelbuild/bazel-gazelle/rule"
+	bzl "github.com/bazelbuild/buildtools/build"
 )
 
 const extName = "go_build_tags"
@@ -51,10 +56,12 @@ func (*lang) Kinds() map[string]rule.KindInfo {
 	}
 }
 
-// GenerateRules adds gotags = ["test"] to every go_test rule so that
-// rules_go's configuration transition propagates the "test" build tag to all
-// transitive library deps during test builds. It also adds any additional
-// user-defined build tags required by the test source files themselves.
+// GenerateRules adds gotags to every go_test rule. "test" is always included.
+// Additional user-defined build tags found in the test source files are split
+// into two buckets:
+//   - cross-platform tags are added directly to the list.
+//   - Linux-only tags (knownLinuxOnlyTags) are wrapped in a select() so they
+//     are only active on Linux, matching the behaviour of dda inv test.
 //
 // For AND expressions every tag is required, so all branches are collected.
 // For OR expressions the left branch is tried first; the right branch is only
@@ -65,12 +72,60 @@ func (*lang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
 		if r.Kind() != "go_test" {
 			continue
 		}
-		addStringToListIfMissing(r, "gotags", "test")
+		alwaysTags := []string{"test"}
+		var linuxOnlyTags []string
 		for _, tag := range requiredSourceTags(r.AttrStrings("srcs"), args.Dir) {
-			addStringToListIfMissing(r, "gotags", tag)
+			if isLinuxOnlyTag(tag) {
+				linuxOnlyTags = appendIfMissing(linuxOnlyTags, tag)
+			} else {
+				alwaysTags = appendIfMissing(alwaysTags, tag)
+			}
 		}
+		setGoTags(r, alwaysTags, linuxOnlyTags)
 	}
 	return language.GenerateResult{}
+}
+
+// setGoTags sets the gotags attribute on r. When linuxOnlyTags is non-empty the
+// generated expression is:
+//
+//	alwaysTags + select({"@platforms//os:linux": linuxOnlyTags, "//conditions:default": []})
+//
+// so that only Linux Bazel builds compile the Linux-only gated source files.
+func setGoTags(r *rule.Rule, alwaysTags, linuxOnlyTags []string) {
+	if len(linuxOnlyTags) == 0 {
+		r.SetAttr("gotags", alwaysTags)
+		return
+	}
+	alwaysExprs := make([]bzl.Expr, len(alwaysTags))
+	for i, t := range alwaysTags {
+		alwaysExprs[i] = &bzl.StringExpr{Value: t}
+	}
+	linuxExprs := make([]bzl.Expr, len(linuxOnlyTags))
+	for i, t := range linuxOnlyTags {
+		linuxExprs[i] = &bzl.StringExpr{Value: t}
+	}
+	r.SetAttr("gotags", &bzl.BinaryExpr{
+		X:  &bzl.ListExpr{List: alwaysExprs},
+		Op: "+",
+		Y: &bzl.CallExpr{
+			X: &bzl.Ident{Name: "select"},
+			List: []bzl.Expr{
+				&bzl.DictExpr{
+					List: []*bzl.KeyValueExpr{
+						{
+							Key:   &bzl.StringExpr{Value: "@platforms//os:linux"},
+							Value: &bzl.ListExpr{List: linuxExprs},
+						},
+						{
+							Key:   &bzl.StringExpr{Value: "//conditions:default"},
+							Value: &bzl.ListExpr{},
+						},
+					},
+				},
+			},
+		},
+	})
 }
 
 // requiredSourceTags collects user-defined build tags from the //go:build
@@ -165,7 +220,30 @@ func walkPositive(expr constraint.Expr, tags *[]string) {
 	}
 }
 
-// isExcludedTag reports whether tag should not be injected into gotags.
+// isLinuxOnlyTag reports whether tag must only be injected into gotags on Linux.
+// This mirrors LINUX_ONLY_TAGS in tasks/build_tags.py: dda inv test never passes
+// these tags on non-Linux platforms, so including them unconditionally in gotags
+// would cause non-Linux Bazel builds to compile Linux-only test files.
+func isLinuxOnlyTag(tag string) bool {
+	_, ok := knownLinuxOnlyTags[tag]
+	return ok
+}
+
+// knownLinuxOnlyTags mirrors LINUX_ONLY_TAGS from tasks/build_tags.py (line 270).
+// Keep in sync when that set changes.
+var knownLinuxOnlyTags = map[string]struct{}{
+	"crio":      {},
+	"jetson":    {},
+	"linux_bpf": {},
+	"netcgo":    {},
+	"nvml":      {},
+	"pcap":      {},
+	"podman":    {},
+	"systemd":   {},
+	"trivy":     {},
+}
+
+// isExcludedTag reports whether tag should not be injected into gotags at all.
 // These are user-defined tags that require special infrastructure or build
 // contexts not available in the standard test environment.
 func isExcludedTag(tag string) bool {
@@ -223,12 +301,11 @@ var knownGOARCH = map[string]struct{}{
 	"s390x": {}, "sparc": {}, "sparc64": {}, "wasm": {},
 }
 
-func addStringToListIfMissing(r *rule.Rule, attr, value string) {
-	existing := r.AttrStrings(attr)
-	for _, s := range existing {
-		if s == value {
-			return
+func appendIfMissing(slice []string, s string) []string {
+	for _, existing := range slice {
+		if existing == s {
+			return slice
 		}
 	}
-	r.SetAttr(attr, append(existing, value))
+	return append(slice, s)
 }

--- a/bazel/rules/go_build_tags/_gazelle_extension_test.go
+++ b/bazel/rules/go_build_tags/_gazelle_extension_test.go
@@ -89,14 +89,12 @@ func TestPositiveUserTags(t *testing.T) {
 			[]string{"ec2"},
 		},
 		{
-			// Only the left branch is needed to satisfy the OR; docker is not added.
-			"OR: left branch wins",
+			"OR: both branches collected",
 			"kubelet || docker",
-			[]string{"kubelet"},
+			[]string{"kubelet", "docker"},
 		},
 		{
-			// Left branch is a system tag (filtered to nothing), so fall through to right.
-			"OR: left is system tag, right is user tag",
+			"OR: system tag on left, user tag on right",
 			"linux || ec2",
 			[]string{"ec2"},
 		},
@@ -111,15 +109,14 @@ func TestPositiveUserTags(t *testing.T) {
 			[]string{"test"},
 		},
 		{
-			"AND+OR: OR already satisfied by prior AND branch",
+			"AND+OR: both OR branches collected, duplicate removed",
 			"ec2 && (ec2 || kubelet)",
-			[]string{"ec2"},
+			[]string{"ec2", "kubelet"},
 		},
 		{
-			// Left branch of the OR (docker) is taken; containerd is not added.
-			"AND+OR: OR not yet satisfied, left branch taken",
+			"AND+OR: both OR branches collected",
 			"trivy && (docker || containerd)",
-			[]string{"trivy", "docker"},
+			[]string{"trivy", "docker", "containerd"},
 		},
 		{
 			// npm is excluded (requires Windows npm kernel driver); windows is a system tag.
@@ -128,8 +125,8 @@ func TestPositiveUserTags(t *testing.T) {
 			nil,
 		},
 		{
-			// Left branch adds linux_bpf (linux is system tag, filtered); right branch not explored.
-			"cross-platform OR: left branch has user tag",
+			// npm is excluded; linux_bpf is the only user tag from either branch.
+			"cross-platform OR: both branches collected, excluded tag filtered",
 			"(linux && linux_bpf) || (windows && npm)",
 			[]string{"linux_bpf"},
 		},
@@ -174,10 +171,9 @@ func TestTagsFromFile(t *testing.T) {
 			[]string{"test", "ec2"},
 		},
 		{
-			// Left branch of the OR is taken; docker is not added.
-			"OR expression",
+			"OR expression: both branches collected",
 			"//go:build kubelet || docker\n\npackage foo\n",
-			[]string{"kubelet"},
+			[]string{"kubelet", "docker"},
 		},
 		{
 			"no build constraint",
@@ -226,8 +222,8 @@ func TestRequiredSourceTags(t *testing.T) {
 
 	got := requiredSourceTags([]string{"a.go", "b.go", "c.go", "d.go", "e.go"}, dir)
 
-	// ec2 from a.go; kubelet from b.go (left branch of OR, docker not added);
+	// ec2 from a.go; kubelet+docker from b.go (both OR branches);
 	// ec2 already seen from c.go (deduped); linux filtered (system tag);
 	// !serverless from e.go skipped (NOT)
-	assert.Equal(t, []string{"ec2", "kubelet"}, got)
+	assert.Equal(t, []string{"ec2", "kubelet", "docker"}, got)
 }

--- a/bazel/rules/go_build_tags/_gazelle_extension_test.go
+++ b/bazel/rules/go_build_tags/_gazelle_extension_test.go
@@ -32,6 +32,8 @@ func TestIsSystemTag(t *testing.T) {
 		"go1.17", "go1.21", "go1.24",
 		// special compiler/mode tags
 		"cgo", "gc", "gccgo", "ignore",
+		// Go 1.19 pseudo-constraint covering all non-Windows GOOS values
+		"unix",
 	} {
 		assert.True(t, isSystemTag(tag), "expected system tag: %s", tag)
 	}

--- a/bazel/rules/go_build_tags/_gazelle_extension_test.go
+++ b/bazel/rules/go_build_tags/_gazelle_extension_test.go
@@ -45,6 +45,15 @@ func TestIsSystemTag(t *testing.T) {
 	}
 }
 
+func TestIsLinuxOnlyTag(t *testing.T) {
+	for _, tag := range []string{"crio", "jetson", "linux_bpf", "netcgo", "nvml", "pcap", "podman", "systemd", "trivy"} {
+		assert.True(t, isLinuxOnlyTag(tag), "expected linux-only tag: %s", tag)
+	}
+	for _, tag := range []string{"ec2", "kubelet", "docker", "test", "npm"} {
+		assert.False(t, isLinuxOnlyTag(tag), "expected non-linux-only tag: %s", tag)
+	}
+}
+
 func TestIsExcludedTag(t *testing.T) {
 	assert.True(t, isExcludedTag("npm"), "npm must be excluded: requires Windows npm kernel driver")
 	assert.False(t, isExcludedTag("ec2"), "ec2 must not be excluded")

--- a/bazel/rules/go_build_tags/_gazelle_extension_test.go
+++ b/bazel/rules/go_build_tags/_gazelle_extension_test.go
@@ -1,0 +1,222 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package go_build_tags
+
+import (
+	"go/build/constraint"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustParseConstraint(t *testing.T, expr string) constraint.Expr {
+	t.Helper()
+	e, err := constraint.Parse("//go:build " + expr)
+	require.NoError(t, err)
+	return e
+}
+
+func TestIsSystemTag(t *testing.T) {
+	for _, tag := range []string{
+		// GOOS
+		"linux", "darwin", "windows", "freebsd", "android", "ios",
+		// GOARCH
+		"amd64", "arm64", "386", "arm", "wasm",
+		// Go version
+		"go1.17", "go1.21", "go1.24",
+		// special compiler/mode tags
+		"cgo", "gc", "gccgo", "ignore",
+	} {
+		assert.True(t, isSystemTag(tag), "expected system tag: %s", tag)
+	}
+
+	for _, tag := range []string{
+		"ec2", "test", "kubelet", "docker", "linux_bpf", "serverless", "npm", "trivy",
+		// must not be confused with system tags
+		"go2", "go", "cgoish", "linuxbox",
+	} {
+		assert.False(t, isSystemTag(tag), "expected user tag: %s", tag)
+	}
+}
+
+func TestIsExcludedTag(t *testing.T) {
+	assert.True(t, isExcludedTag("npm"), "npm must be excluded: requires Windows npm kernel driver")
+	assert.False(t, isExcludedTag("ec2"), "ec2 must not be excluded")
+	assert.False(t, isExcludedTag("trivy"), "trivy must not be excluded")
+}
+
+func TestPositiveUserTags(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		want []string
+	}{
+		{
+			"single user tag",
+			"ec2",
+			[]string{"ec2"},
+		},
+		{
+			"single system tag is filtered",
+			"linux",
+			nil,
+		},
+		{
+			"AND: both user tags",
+			"test && ec2",
+			[]string{"test", "ec2"},
+		},
+		{
+			"AND: system + user",
+			"linux && ec2",
+			[]string{"ec2"},
+		},
+		{
+			// Only the left branch is needed to satisfy the OR; docker is not added.
+			"OR: left branch wins",
+			"kubelet || docker",
+			[]string{"kubelet"},
+		},
+		{
+			// Left branch is a system tag (filtered to nothing), so fall through to right.
+			"OR: left is system tag, right is user tag",
+			"linux || ec2",
+			[]string{"ec2"},
+		},
+		{
+			"NOT: skipped entirely",
+			"!ec2",
+			nil,
+		},
+		{
+			"AND with NOT: NOT branch skipped",
+			"test && !ec2",
+			[]string{"test"},
+		},
+		{
+			"AND+OR: OR already satisfied by prior AND branch",
+			"ec2 && (ec2 || kubelet)",
+			[]string{"ec2"},
+		},
+		{
+			// Left branch of the OR (docker) is taken; containerd is not added.
+			"AND+OR: OR not yet satisfied, left branch taken",
+			"trivy && (docker || containerd)",
+			[]string{"trivy", "docker"},
+		},
+		{
+			// npm is excluded (requires Windows npm kernel driver); windows is a system tag.
+			"excluded tag is filtered",
+			"windows && npm",
+			nil,
+		},
+		{
+			// Left branch adds linux_bpf (linux is system tag, filtered); right branch not explored.
+			"cross-platform OR: left branch has user tag",
+			"(linux && linux_bpf) || (windows && npm)",
+			[]string{"linux_bpf"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := positiveUserTags(mustParseConstraint(t, tt.expr))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestTagsFromFile(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			"simple user tag",
+			"//go:build ec2\n\npackage foo\n",
+			[]string{"ec2"},
+		},
+		{
+			"system tag only",
+			"//go:build linux\n\npackage foo\n",
+			nil,
+		},
+		{
+			"AND expression",
+			"//go:build test && ec2\n\npackage foo\n",
+			[]string{"test", "ec2"},
+		},
+		{
+			// Left branch of the OR is taken; docker is not added.
+			"OR expression",
+			"//go:build kubelet || docker\n\npackage foo\n",
+			[]string{"kubelet"},
+		},
+		{
+			"no build constraint",
+			"package foo\n",
+			nil,
+		},
+		{
+			"build constraint after package declaration",
+			"package foo\n//go:build ec2\n",
+			nil,
+		},
+		{
+			"blank line before constraint",
+			"\n//go:build ec2\n\npackage foo\n",
+			[]string{"ec2"},
+		},
+		{
+			"constraint preceded by another comment",
+			"// Copyright blah blah\n//go:build ec2\n\npackage foo\n",
+			[]string{"ec2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeFile(t, dir, tt.name+".go", tt.content)
+			got := tagsFromFile(path)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("missing file", func(t *testing.T) {
+		got := tagsFromFile(filepath.Join(dir, "does_not_exist.go"))
+		assert.Nil(t, got)
+	})
+}
+
+func TestRequiredSourceTags(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a.go", "//go:build ec2\n\npackage foo\n")
+	writeFile(t, dir, "b.go", "//go:build kubelet || docker\n\npackage foo\n")
+	writeFile(t, dir, "c.go", "//go:build ec2 && linux\n\npackage foo\n")
+	writeFile(t, dir, "d.go", "package foo\n")
+	writeFile(t, dir, "e.go", "//go:build !serverless\n\npackage foo\n")
+
+	got := requiredSourceTags([]string{"a.go", "b.go", "c.go", "d.go", "e.go"}, dir)
+
+	// ec2 from a.go; kubelet from b.go (left branch of OR, docker not added);
+	// ec2 already seen from c.go (deduped); linux filtered (system tag);
+	// !serverless from e.go skipped (NOT)
+	assert.Equal(t, []string{"ec2", "kubelet"}, got)
+}

--- a/comp/core/telemetry/impl/BUILD.bazel
+++ b/comp/core/telemetry/impl/BUILD.bazel
@@ -35,7 +35,11 @@ go_test(
         "telemetry_test.go",
     ],
     embed = [":impl"],
-    gotags = ["test"],
+    gotags = [
+        "test",
+        "functionaltests",
+        "stresstests",
+    ],
     deps = [
         "//comp/core/telemetry/def",
         "//pkg/util/fxutil",

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -9,6 +9,22 @@ go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 use_repo_rule("//bazel/repo:bazelify_go_work.bzl", "bazelify_go_work")(name = "bazelify_go_work")
 
 go_deps.from_file(go_work = "@bazelify_go_work//:go.work")
+
+# buildtools is a dep of the Gazelle extension at //bazel/rules/go_build_tags.
+# It is not in any module in the go.work so must be declared explicitly.
+# We alias it to avoid conflicting with the com_github_bazelbuild_buildtools
+# apparent name already claimed by the http_archive buildifier binary.
+go_deps.module(
+    path = "github.com/bazelbuild/buildtools",
+    sum = "h1:PmoVmwzAnGb0iCjulb7Mgsaqw2Wj36LQJ8VyYaFe/ak=",
+    version = "v0.0.0-20260211083412-859bfffeef82",
+)
+use_repo(
+    go_deps,
+    # buildtools Go packages, aliased to avoid clash with the http_archive buildifier repository.
+    com_github_bazelbuild_buildtools_go = "com_github_bazelbuild_buildtools",
+)
+
 go_deps.gazelle_override(
     directives = [
         "gazelle:proto disable",

--- a/pkg/fips/BUILD.bazel
+++ b/pkg/fips/BUILD.bazel
@@ -15,5 +15,8 @@ go_test(
     name = "fips_test",
     srcs = ["fips_test.go"],
     embed = [":fips"],
-    gotags = ["test"],
+    gotags = [
+        "test",
+        "goexperiment.systemcrypto",
+    ],
 )

--- a/pkg/fleet/installer/msi/BUILD.bazel
+++ b/pkg/fleet/installer/msi/BUILD.bazel
@@ -44,10 +44,7 @@ go_test(
         ],
         "//conditions:default": [],
     }),
-    gotags = [
-        "test",
-        "windows",
-    ],
+    gotags = ["test"],
     target_compatible_with = ["@platforms//os:windows"],
     deps = select({
         "@rules_go//go/platform:windows": [

--- a/pkg/util/aws/creds/BUILD.bazel
+++ b/pkg/util/aws/creds/BUILD.bazel
@@ -20,7 +20,10 @@ go_test(
         "detection_test.go",
     ],
     embed = [":creds"],
-    gotags = ["test"],
+    gotags = [
+        "test",
+        "ec2",
+    ],
     deps = [
         "//pkg/util/aws/creds/internal",
         "@com_github_stretchr_testify//assert",

--- a/pkg/util/aws/creds/BUILD.bazel
+++ b/pkg/util/aws/creds/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "credentials_test.go",
         "detection_test.go",
     ],
+    data = ["tags/payloads/security_cred.json"],
     embed = [":creds"],
     gotags = [
         "test",

--- a/pkg/util/gpu/BUILD.bazel
+++ b/pkg/util/gpu/BUILD.bazel
@@ -27,7 +27,12 @@ go_test(
         "nvml_test.go",
     ],
     embed = [":gpu"],
-    gotags = ["test"],
+    gotags = [
+        "test",
+    ] + select({
+        "@platforms//os:linux": ["nvml"],
+        "//conditions:default": [],
+    }),
     deps = [
         "@com_github_stretchr_testify//assert",
     ] + select({

--- a/pkg/util/trivy/walker/BUILD.bazel
+++ b/pkg/util/trivy/walker/BUILD.bazel
@@ -22,7 +22,12 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":walker"],
-    gotags = ["test"],
+    gotags = [
+        "test",
+    ] + select({
+        "@platforms//os:linux": ["trivy"],
+        "//conditions:default": [],
+    }),
     deps = [
         "@com_github_aquasecurity_trivy//pkg/fanal/analyzer",
         "@com_github_aquasecurity_trivy//pkg/fanal/walker",


### PR DESCRIPTION
### What does this PR do?

Extend our gazelle extension handling `test` build tags so that it also collects the individual tags used in the various test sources.

### Motivation

Our tests are lacking some build tags which causes them not to run.
This is needed for test coverage parity as we migrate to bazel.

https://datadoghq.atlassian.net/browse/ABLD-445

### Describe how you validated your changes

Local `bazel test //...` run

### Additional Notes

The trivy change is provided in isolation in https://github.com/DataDog/datadog-agent/pull/49435 to increase its visibility since that's the only non-bazel specific change

2 tests are seing some tags *removed* while that PR is meant to add additional test tags. This is expected:
* `pkg/fleet/installer/msi/BUILD.bazel`: `windows` is as system tag that we don't need to add ourselves
* `comp/core/telemetry/telemetryimpl/BUILD.bazel` we need the `//go:build test || functionaltests || stresstests` constraint to be safisfied for the mock to be compiled. The original tags were manually specified and weren't overridden by gazelle so far, but `test` is enough for the constraint to pass