### PR TITLE
[CWS] do not use the parent cgroup as a fallback (#49243)

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1691,7 +1691,7 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 
 		createdAt := event.GetTimestamp()
 
-		if cacheEntry := p.Resolvers.CGroupResolver.AddPID(pce.Pid, pce.PPid, createdAt, cgroupContext); cacheEntry == nil {
+		if cacheEntry := p.Resolvers.CGroupResolver.AddPID(pce.Pid, createdAt, cgroupContext); cacheEntry == nil {
 			seclog.Debugf("Failed to resolve cgroup for pid %d: %+v", pid, event.CgroupWrite.File.PathKey)
 		} else {
 			p.Resolvers.ProcessResolver.UpdateProcessContexts(pce, cacheEntry.GetCGroupContext(), cacheEntry.GetContainerContext())

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -42,7 +42,6 @@ const (
 	maxhostWorkloadEntries      = 1024
 	maxContainerWorkloadEntries = 1024
 	maxCacheEntries             = 2048
-	maxHistoryEntries           = 1024
 )
 
 // FSInterface defines the interface for CGroupFS operations
@@ -60,7 +59,6 @@ type Resolver struct {
 	cacheEntriesByPathKey *simplelru.LRU[uint64, *cgroupModel.CacheEntry]
 	hostCacheEntries      *simplelru.LRU[containerutils.CGroupID, *cgroupModel.CacheEntry]
 	containerCacheEntries *simplelru.LRU[containerutils.ContainerID, *cgroupModel.CacheEntry]
-	history               *simplelru.LRU[uint32, uint64]
 	dentryResolver        *dentry.Resolver
 
 	// metrics
@@ -107,11 +105,6 @@ func NewResolver(statsdClient statsd.ClientInterface, cgroupFS FSInterface, dent
 	}
 
 	cr.cacheEntriesByPathKey, err = simplelru.NewLRU(maxCacheEntries, func(_ uint64, _ *cgroupModel.CacheEntry) {})
-	if err != nil {
-		return nil, err
-	}
-
-	cr.history, err = simplelru.NewLRU(maxHistoryEntries, func(_ uint32, _ uint64) {})
 	if err != nil {
 		return nil, err
 	}
@@ -180,9 +173,6 @@ func (cr *Resolver) pushNewCacheEntry(pid uint32, containerContext model.Contain
 	// add the cgroup context to the cache
 	cr.cacheEntriesByPathKey.Add(cgroupContext.CGroupPathKey.Inode, cacheEntry)
 
-	// push pid:PathKey pair to an history cache for fallbacks for short lived processes
-	cr.history.Add(pid, cgroupContext.CGroupPathKey.Inode)
-
 	cr.addedCgroups.Inc()
 
 	return cacheEntry
@@ -214,7 +204,7 @@ func (cr *Resolver) resolveAndPushNewCacheEntry(pid uint32, cgroupContext model.
 	return cr.pushNewCacheEntry(pid, containerContext, cgroupContext)
 }
 
-func (cr *Resolver) resolveFromFallback(pid uint32, ppid uint32) *cgroupModel.CacheEntry {
+func (cr *Resolver) resolveFromFallback(pid uint32) *cgroupModel.CacheEntry {
 	cid, cgroup, _, err := cr.cgroupFS.FindCGroupContext(pid, pid)
 	if err == nil && cgroup.CGroupID != "" {
 		// check if the cgroup is already in the cache
@@ -242,41 +232,6 @@ func (cr *Resolver) resolveFromFallback(pid uint32, ppid uint32) *cgroupModel.Ca
 			CreatedAt:   uint64(cgroup.CreatedAt.UnixNano()),
 		}
 		seclog.Tracef("fallback to resolve cgroup for pid %d: %s", pid, cgroup.CGroupID)
-		cr.fallbackSucceed.Inc()
-
-		return cr.pushNewCacheEntry(pid, containerContext, cgroupContext)
-	}
-
-	// fallback can fail for short lived processes, in this case we try to assign the parent cgroup
-	if ppid == pid || ppid <= 0 {
-		seclog.Debugf("failed to fallback to resolve cgroup for %d, missing parend PPID: %d", pid, ppid)
-		return nil
-	}
-
-	if pathKey, found := cr.history.Get(ppid); found {
-		if cacheEntry, found := cr.cacheEntriesByPathKey.Get(pathKey); found {
-			seclog.Tracef("fallback to resolve cgroup for pid %d from parent: %d", pid, ppid)
-			cr.fallbackSucceed.Inc()
-
-			return cr.pushNewCacheEntry(pid, cacheEntry.GetContainerContext(), cacheEntry.GetCGroupContext())
-		}
-	}
-
-	// last try, fallback on proc for the parent
-	cid, cgroup, _, err = cr.cgroupFS.FindCGroupContext(ppid, ppid)
-	if err == nil && cgroup.CGroupID != "" {
-		cgroupContext := model.CGroupContext{
-			CGroupPathKey: model.PathKey{
-				MountID: cgroup.CGroupFileMountID,
-				Inode:   cgroup.CGroupFileInode,
-			},
-			CGroupID: cgroup.CGroupID,
-		}
-		containerContext := model.ContainerContext{
-			ContainerID: cid,
-			CreatedAt:   uint64(cgroup.CreatedAt.UnixNano()),
-		}
-		seclog.Tracef("fallback to resolve parent cgroup for ppid %d: %s", ppid, cgroup.CGroupID)
 		cr.fallbackSucceed.Inc()
 
 		return cr.pushNewCacheEntry(pid, containerContext, cgroupContext)
@@ -319,7 +274,7 @@ func (cr *Resolver) Delete(inode uint64) {
 		cr.remainingPids.Inc()
 
 		for _, pid := range pids {
-			cr.resolveFromFallback(pid, pid)
+			cr.resolveFromFallback(pid)
 		}
 	}
 
@@ -329,7 +284,7 @@ func (cr *Resolver) Delete(inode uint64) {
 // AddPID update the cgroup cache to associates a cgroup and a pid
 // Returns true if the kernel maps need to be synced (if we update somehow the process)
 // the cgroup context doesn't have to be resolved, it will be resolved when the cgroup is created.
-func (cr *Resolver) AddPID(pid uint32, ppid uint32, createdAt time.Time, cgroupContext model.CGroupContext) *cgroupModel.CacheEntry {
+func (cr *Resolver) AddPID(pid uint32, createdAt time.Time, cgroupContext model.CGroupContext) *cgroupModel.CacheEntry {
 	cr.Lock()
 	defer cr.Unlock()
 
@@ -370,7 +325,7 @@ func (cr *Resolver) AddPID(pid uint32, ppid uint32, createdAt time.Time, cgroupC
 		}
 	}
 
-	return cr.resolveFromFallback(pid, ppid)
+	return cr.resolveFromFallback(pid)
 }
 
 func (cr *Resolver) iterateCacheEntries(cb func(*cgroupModel.CacheEntry) bool) {

--- a/pkg/security/resolvers/cgroup/resolver_test.go
+++ b/pkg/security/resolvers/cgroup/resolver_test.go
@@ -63,109 +63,11 @@ func TestResolvePidCgroupFallback_SuccessDirectResolution(t *testing.T) {
 		nil,
 	)
 
-	cacheEntry := resolver.resolveFromFallback(1234, 5678)
+	cacheEntry := resolver.resolveFromFallback(1234)
 	assert.NotNil(t, cacheEntry)
 	assert.Equal(t, containerutils.CGroupID("test-cgroup-id"), cacheEntry.GetCGroupID())
 	assert.Equal(t, uint64(9876), cacheEntry.GetCGroupInode())
 	assert.Equal(t, containerutils.ContainerID("container-123"), cacheEntry.GetContainerID())
-
-	mockFS.AssertExpectations(t)
-}
-
-func TestResolvePidCgroupFallback_FailInvalidPPid(t *testing.T) {
-	resolver, mockFS := createTestResolver(t)
-
-	// Test case 1: PPid equals Pid
-	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
-		containerutils.ContainerID(""),
-		utils.CGroupContext{},
-		"",
-		errors.New("not found"),
-	)
-
-	cacheEntry := resolver.resolveFromFallback(1234, 1234)
-	assert.Nil(t, cacheEntry)
-
-	// Test case 2: PPid is 0
-	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
-		containerutils.ContainerID(""),
-		utils.CGroupContext{},
-		"",
-		errors.New("not found"),
-	)
-
-	cacheEntry = resolver.resolveFromFallback(1234, 0)
-	assert.Nil(t, cacheEntry)
-
-	mockFS.AssertExpectations(t)
-}
-
-func TestResolvePidCgroupFallback_SuccessFromHistory(t *testing.T) {
-	resolver, mockFS := createTestResolver(t)
-
-	ppid := uint32(5678)
-	parentPathKey := model.PathKey{Inode: 9999}
-
-	// Add parent cgroup to history
-	resolver.history.Add(ppid, parentPathKey.Inode)
-
-	// Add parent cgroup context to cache
-	parentCgroupContext := model.CGroupContext{
-		CGroupID:      "parent-cgroup-id",
-		CGroupPathKey: parentPathKey,
-	}
-	cacheEntry := resolver.AddPID(1234, 5678, time.Now(), parentCgroupContext)
-	assert.NotNil(t, cacheEntry)
-	assert.NotNil(t, cacheEntry.GetCGroupContext().Releasable)
-
-	// Mock failed direct resolution
-	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
-		containerutils.ContainerID(""),
-		utils.CGroupContext{},
-		"",
-		errors.New("not found"),
-	)
-
-	cacheEntry = resolver.resolveFromFallback(1234, 5678)
-	assert.NotNil(t, cacheEntry)
-	assert.Equal(t, containerutils.CGroupID("parent-cgroup-id"), cacheEntry.GetCGroupID())
-	assert.Equal(t, parentPathKey, cacheEntry.GetCGroupContext().CGroupPathKey)
-	// Note: containerutils.FindContainerID would be called here, but we can't easily mock it
-	// in this example as it's a package function
-
-	mockFS.AssertExpectations(t)
-}
-
-func TestResolvePidCgroupFallback_SuccessFromParentProc(t *testing.T) {
-	resolver, mockFS := createTestResolver(t)
-
-	expectedContext := utils.CGroupContext{
-		CGroupID:          "parent-cgroup-id",
-		CGroupFileMountID: 567,
-		CGroupFileInode:   8888,
-	}
-
-	// Mock failed direct resolution
-	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
-		containerutils.ContainerID(""),
-		utils.CGroupContext{},
-		"",
-		errors.New("not found"),
-	)
-
-	// Mock successful parent resolution
-	mockFS.On("FindCGroupContext", uint32(5678), uint32(5678)).Return(
-		containerutils.ContainerID("parent-container-456"),
-		expectedContext,
-		"/sys/fs/cgroup/parent",
-		nil,
-	)
-
-	cacheEntry := resolver.resolveFromFallback(1234, 5678)
-	assert.NotNil(t, cacheEntry)
-	assert.Equal(t, containerutils.CGroupID("parent-cgroup-id"), cacheEntry.GetCGroupID())
-	assert.Equal(t, expectedContext.CGroupFileInode, cacheEntry.GetCGroupInode())
-	assert.Equal(t, containerutils.ContainerID("parent-container-456"), cacheEntry.GetContainerID())
 
 	mockFS.AssertExpectations(t)
 }
@@ -181,81 +83,7 @@ func TestResolvePidCgroupFallback_CompleteFailure(t *testing.T) {
 		errors.New("not found"),
 	)
 
-	// Mock failed parent resolution
-	mockFS.On("FindCGroupContext", uint32(5678), uint32(5678)).Return(
-		containerutils.ContainerID(""),
-		utils.CGroupContext{},
-		"",
-		errors.New("parent not found"),
-	)
-
-	cacheEntry := resolver.resolveFromFallback(1234, 5678)
-	assert.Nil(t, cacheEntry)
-
-	mockFS.AssertExpectations(t)
-}
-
-func TestResolvePidCgroupFallback_HistoryFoundButCGroupMissing(t *testing.T) {
-	resolver, mockFS := createTestResolver(t)
-
-	// Add parent to history but not to cgroups cache
-	resolver.history.Add(uint32(5678), 9999)
-
-	expectedContext := utils.CGroupContext{
-		CGroupID:          "fallback-cgroup-id",
-		CGroupFileMountID: 789,
-		CGroupFileInode:   7777,
-	}
-
-	// Mock failed direct resolution
-	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
-		containerutils.ContainerID(""),
-		utils.CGroupContext{},
-		"",
-		errors.New("not found"),
-	)
-
-	// Mock successful parent proc resolution as fallback
-	mockFS.On("FindCGroupContext", uint32(5678), uint32(5678)).Return(
-		containerutils.ContainerID("fallback-container-789"),
-		expectedContext,
-		"/sys/fs/cgroup/fallback",
-		nil,
-	)
-
-	cacheEntry := resolver.resolveFromFallback(1234, 5678)
-	assert.NotNil(t, cacheEntry)
-	assert.Equal(t, containerutils.CGroupID("fallback-cgroup-id"), cacheEntry.GetCGroupID())
-	assert.Equal(t, expectedContext.CGroupFileInode, cacheEntry.GetCGroupInode())
-	assert.Equal(t, containerutils.ContainerID("fallback-container-789"), cacheEntry.GetContainerID())
-
-	mockFS.AssertExpectations(t)
-}
-
-func TestResolvePidCgroupFallback_EmptyCGroupIDIgnored(t *testing.T) {
-	resolver, mockFS := createTestResolver(t)
-
-	// Mock resolution that returns empty CGroupID (should be ignored)
-	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
-		containerutils.ContainerID("some-container"),
-		utils.CGroupContext{
-			CGroupID:          "", // Empty CGroupID
-			CGroupFileMountID: 42,
-			CGroupFileInode:   9876,
-		},
-		"/sys/fs/cgroup/test",
-		nil,
-	)
-
-	// Should fallback to parent resolution
-	mockFS.On("FindCGroupContext", uint32(5678), uint32(5678)).Return(
-		containerutils.ContainerID(""),
-		utils.CGroupContext{},
-		"",
-		errors.New("parent not found"),
-	)
-
-	cacheEntry := resolver.resolveFromFallback(1234, 5678)
+	cacheEntry := resolver.resolveFromFallback(1234)
 	assert.Nil(t, cacheEntry)
 
 	mockFS.AssertExpectations(t)
@@ -276,7 +104,7 @@ func TestResolvePidCgroupFallback_UpdateExistingCacheEntry(t *testing.T) {
 		nil,
 	)
 
-	cacheEntry := resolver.resolveFromFallback(1234, 9999)
+	cacheEntry := resolver.resolveFromFallback(1234)
 	assert.NotNil(t, cacheEntry)
 
 	// Mock resolution that returns empty CGroupID (should be ignored)
@@ -291,7 +119,7 @@ func TestResolvePidCgroupFallback_UpdateExistingCacheEntry(t *testing.T) {
 		nil,
 	)
 
-	cacheEntry = resolver.resolveFromFallback(5678, 9999)
+	cacheEntry = resolver.resolveFromFallback(5678)
 	assert.NotNil(t, cacheEntry)
 	assert.Equal(t, containerutils.CGroupID("fallback-cgroup-id-success"), cacheEntry.GetCGroupID())
 
@@ -322,7 +150,7 @@ func TestResolveForceFallbackIfCGroupIsNull(t *testing.T) {
 		nil,
 	)
 
-	cacheEntry = resolver.AddPID(1234, 5678, time.Now(), model.CGroupContext{})
+	cacheEntry = resolver.AddPID(1234, time.Now(), model.CGroupContext{})
 
 	assert.NotNil(t, cacheEntry)
 	assert.Equal(t, containerutils.CGroupID("fallback-cgroup-id"), cacheEntry.GetCGroupID())

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -597,7 +597,7 @@ func (p *EBPFResolver) insertEntry(entry *model.ProcessCacheEntry, cgroupContext
 		}
 
 		// add the new PID in the right cgroup_resolver bucket
-		if cacheEntry := p.cgroupResolver.AddPID(entry.Pid, entry.PPid, createdAt, cgroupContext); cacheEntry != nil {
+		if cacheEntry := p.cgroupResolver.AddPID(entry.Pid, createdAt, cgroupContext); cacheEntry != nil {
 			entry.CGroup = cacheEntry.GetCGroupContext()
 			entry.Process.ContainerContext = cacheEntry.GetContainerContext()
 		}


### PR DESCRIPTION
Using the parent cgroup as a fallback when cgroup resolution fails is dangerous: a process may legitimately belong to a different cgroup than its parent (e.g. when a new container is being spawned), so inheriting the parent cgroup produces an incorrect association.

This is especially risky for remediation: if a policy action (such as killing a container) is triggered on an event whose cgroup was resolved from the parent, the remediation targets the wrong container, causing unintended disruption.

Remove the two parent-cgroup fallback paths. When cgroup resolution fails the entry is now simply dropped instead of being mis-attributed.


(cherry picked from commit 171ea797a48d0db020545d9cd81f238ccd00b8ff)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
