### PR TITLE
[procmgr] Move processes.d from /etc/datadog-agent to /opt/datadog-agent

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -94,7 +94,7 @@ build do
             # Create empty directories so that they're owned by the package
             # (also requires `extra_package_file` directive in project def)
             mkdir "#{output_config_dir}/etc/datadog-agent/checks.d"
-            mkdir "#{output_config_dir}/etc/datadog-agent/processes.d"
+            mkdir "#{install_dir}/processes.d"
             mkdir "/var/log/datadog"
 
             # remove unused configs

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -94,8 +94,10 @@ build do
             # Create empty directories so that they're owned by the package
             # (also requires `extra_package_file` directive in project def)
             mkdir "#{output_config_dir}/etc/datadog-agent/checks.d"
-            mkdir "#{install_dir}/processes.d"
             mkdir "/var/log/datadog"
+
+            # Process manager config directory (read-only, under install dir)
+            mkdir "#{install_dir}/processes.d"
 
             # remove unused configs
             delete "#{output_config_dir}/etc/datadog-agent/conf.d/apm.yaml.default"

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
@@ -320,18 +320,23 @@ func modifyDDOTUnitFileForBackwardsCompatibility(ctx HookContext, unitName strin
 		return fmt.Errorf("failed to read unit file %s: %w", unitPath, err)
 	}
 
-	// Modify the content
-	modifiedContent := string(content)
-	// Remove "/ext/ddot" from all paths
-	modifiedContent = strings.ReplaceAll(modifiedContent, "/ext/ddot", "")
+	// Modify the content line-by-line so we can skip ConditionPathExists lines
+	// from the OCI path rewrite. The processes.d gate must always reference the
+	// Agent package tree, not the standalone DDOT package tree.
+	lines := strings.Split(string(content), "\n")
+	for i, line := range lines {
+		// Remove "/ext/ddot" from all paths
+		lines[i] = strings.ReplaceAll(line, "/ext/ddot", "")
 
-	// For OCI packages, replace "/opt/datadog-packages/datadog-agent" with "/opt/datadog-packages/datadog-agent-ddot"
-	// Do specific replacements first to avoid double-replacement issues
-	if isOCI {
-		// Replace paths with /stable or /experiment suffix first
-		modifiedContent = strings.ReplaceAll(modifiedContent, "/opt/datadog-packages/datadog-agent/stable", "/opt/datadog-packages/datadog-agent-ddot/stable")
-		modifiedContent = strings.ReplaceAll(modifiedContent, "/opt/datadog-packages/datadog-agent/experiment", "/opt/datadog-packages/datadog-agent-ddot/experiment")
+		// For OCI packages, rewrite Agent package paths to DDOT package paths,
+		// but skip ConditionPathExists lines so the processes.d gate keeps
+		// pointing at the Agent install directory.
+		if isOCI && !strings.HasPrefix(strings.TrimSpace(lines[i]), "ConditionPathExists=!") {
+			lines[i] = strings.ReplaceAll(lines[i], "/opt/datadog-packages/datadog-agent/stable", "/opt/datadog-packages/datadog-agent-ddot/stable")
+			lines[i] = strings.ReplaceAll(lines[i], "/opt/datadog-packages/datadog-agent/experiment", "/opt/datadog-packages/datadog-agent-ddot/experiment")
+		}
 	}
+	modifiedContent := strings.Join(lines, "\n")
 
 	// Write the modified content back
 	if err := os.WriteFile(unitPath, []byte(modifiedContent), 0644); err != nil {

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -72,7 +72,6 @@ var (
 	agentDirectories = file.Directories{
 		{Path: "/etc/datadog-agent", Mode: 0755, Owner: "dd-agent", Group: "dd-agent"},
 		{Path: "/etc/datadog-agent/managed", Mode: 0755, Owner: "dd-agent", Group: "dd-agent"},
-		{Path: "/etc/datadog-agent/processes.d", Mode: 0755, Owner: "dd-agent", Group: "dd-agent"},
 		{Path: "/var/log/datadog", Mode: 0750, Owner: "dd-agent", Group: "dd-agent"},
 		{Path: "/opt/datadog-packages/run", Mode: 0755, Owner: "dd-agent", Group: "dd-agent"},
 		{Path: "/opt/datadog-packages/tmp", Mode: 0755, Owner: "dd-agent", Group: "dd-agent"},
@@ -168,6 +167,10 @@ func installFilesystem(ctx HookContext) (err error) {
 	agentRunPath := file.Directory{Path: filepath.Join(ctx.PackagePath, "run"), Mode: 0755, Owner: "dd-agent", Group: "dd-agent"}
 	if err = agentRunPath.Ensure(ctx); err != nil {
 		return fmt.Errorf("failed to create run directory: %v", err)
+	}
+	processesDir := file.Directory{Path: filepath.Join(ctx.PackagePath, "processes.d"), Mode: 0755, Owner: "dd-agent", Group: "dd-agent"}
+	if err = processesDir.Ensure(ctx); err != nil {
+		return fmt.Errorf("failed to create processes.d directory: %v", err)
 	}
 
 	// 3. Create symlinks

--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-ddot.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-ddot.service.tmpl
@@ -11,7 +11,7 @@ BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-ddot.service
 {{- end}}
 ConditionPathExists={{.InstallDir}}/ext/ddot/embedded/bin/otel-agent
-ConditionPathExists=!{{.EtcDir}}/processes.d/datadog-agent-ddot.yaml
+ConditionPathExists=!{{.InstallDir}}/processes.d/datadog-agent-ddot.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-procmgrd.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-procmgrd.service.tmpl
@@ -17,7 +17,7 @@ Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-{{.EtcDir}}/environment
-Environment="DD_PM_CONFIG_DIR={{.EtcDir}}/processes.d"
+Environment="DD_PM_CONFIG_DIR={{.InstallDir}}/processes.d"
 RuntimeDirectory=datadog-procmgrd
 ExecStart={{.InstallDir}}/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-ddot-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-ddot-exp.service
@@ -4,7 +4,7 @@ After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-ddot.service
 ConditionPathExists=/opt/datadog-agent/ext/ddot/embedded/bin/otel-agent
-ConditionPathExists=!/etc/datadog-agent-exp/processes.d/datadog-agent-ddot.yaml
+ConditionPathExists=!/opt/datadog-agent/processes.d/datadog-agent-ddot.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-ddot.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-ddot.service
@@ -4,7 +4,7 @@ After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-ddot-exp.service
 ConditionPathExists=/opt/datadog-agent/ext/ddot/embedded/bin/otel-agent
-ConditionPathExists=!/etc/datadog-agent/processes.d/datadog-agent-ddot.yaml
+ConditionPathExists=!/opt/datadog-agent/processes.d/datadog-agent-ddot.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgrd-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgrd-exp.service
@@ -10,7 +10,7 @@ Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_PM_CONFIG_DIR=/etc/datadog-agent-exp/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgrd.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgrd.service
@@ -10,7 +10,7 @@ Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_PM_CONFIG_DIR=/etc/datadog-agent/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot-exp.service
@@ -4,7 +4,7 @@ After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-ddot.service
 ConditionPathExists=/opt/datadog-agent/ext/ddot/embedded/bin/otel-agent
-ConditionPathExists=!/etc/datadog-agent-exp/processes.d/datadog-agent-ddot.yaml
+ConditionPathExists=!/opt/datadog-agent/processes.d/datadog-agent-ddot.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot.service
@@ -4,7 +4,7 @@ After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-ddot-exp.service
 ConditionPathExists=/opt/datadog-agent/ext/ddot/embedded/bin/otel-agent
-ConditionPathExists=!/etc/datadog-agent/processes.d/datadog-agent-ddot.yaml
+ConditionPathExists=!/opt/datadog-agent/processes.d/datadog-agent-ddot.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgrd-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgrd-exp.service
@@ -10,7 +10,7 @@ Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_PM_CONFIG_DIR=/etc/datadog-agent-exp/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgrd.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgrd.service
@@ -10,7 +10,7 @@ Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_PM_CONFIG_DIR=/etc/datadog-agent/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-ddot-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-ddot-exp.service
@@ -4,7 +4,7 @@ After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-ddot.service
 ConditionPathExists=/opt/datadog-packages/datadog-agent/experiment/ext/ddot/embedded/bin/otel-agent
-ConditionPathExists=!/etc/datadog-agent-exp/processes.d/datadog-agent-ddot.yaml
+ConditionPathExists=!/opt/datadog-packages/datadog-agent/experiment/processes.d/datadog-agent-ddot.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-ddot.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-ddot.service
@@ -4,7 +4,7 @@ After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-ddot-exp.service
 ConditionPathExists=/opt/datadog-packages/datadog-agent/stable/ext/ddot/embedded/bin/otel-agent
-ConditionPathExists=!/etc/datadog-agent/processes.d/datadog-agent-ddot.yaml
+ConditionPathExists=!/opt/datadog-packages/datadog-agent/stable/processes.d/datadog-agent-ddot.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgrd-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgrd-exp.service
@@ -10,7 +10,7 @@ Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_PM_CONFIG_DIR=/etc/datadog-agent-exp/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/experiment/processes.d"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgrd.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgrd.service
@@ -10,7 +10,7 @@ Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_PM_CONFIG_DIR=/etc/datadog-agent/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/stable/processes.d"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-ddot-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-ddot-exp.service
@@ -4,7 +4,7 @@ After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-ddot.service
 ConditionPathExists=/opt/datadog-packages/datadog-agent/experiment/ext/ddot/embedded/bin/otel-agent
-ConditionPathExists=!/etc/datadog-agent-exp/processes.d/datadog-agent-ddot.yaml
+ConditionPathExists=!/opt/datadog-packages/datadog-agent/experiment/processes.d/datadog-agent-ddot.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-ddot.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-ddot.service
@@ -4,7 +4,7 @@ After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-ddot-exp.service
 ConditionPathExists=/opt/datadog-packages/datadog-agent/stable/ext/ddot/embedded/bin/otel-agent
-ConditionPathExists=!/etc/datadog-agent/processes.d/datadog-agent-ddot.yaml
+ConditionPathExists=!/opt/datadog-packages/datadog-agent/stable/processes.d/datadog-agent-ddot.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgrd-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgrd-exp.service
@@ -10,7 +10,7 @@ Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
-Environment="DD_PM_CONFIG_DIR=/etc/datadog-agent-exp/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/experiment/processes.d"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgrd.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgrd.service
@@ -10,7 +10,7 @@ Type=simple
 User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
-Environment="DD_PM_CONFIG_DIR=/etc/datadog-agent/processes.d"
+Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/stable/processes.d"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/procmgr/rust/src/platform/unix.rs
+++ b/pkg/procmgr/rust/src/platform/unix.rs
@@ -43,7 +43,7 @@ pub fn last_signal(status: &std::process::ExitStatus) -> Option<i32> {
 }
 
 pub fn default_config_dir() -> PathBuf {
-    PathBuf::from("/etc/datadog-agent/processes.d")
+    PathBuf::from("/opt/datadog-agent/processes.d")
 }
 
 /// Wait for a shutdown trigger (SIGTERM or SIGINT).

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
@@ -60,9 +60,9 @@ func TestProcmgrSmokeLinuxSuite(t *testing.T) {
 		awshost.ProvisionerNoFakeIntake(
 			awshost.WithRunOptions(
 				scenec2.WithAgentOptions(
-					agentparams.WithFile("/etc/datadog-agent/processes.d/test-sleep.yaml", testProcessConfig, true),
-					agentparams.WithFile("/etc/datadog-agent/processes.d/datadog-agent-ddot.yaml", embedded.DDOTProcessConfig, true),
-					agentparams.WithFile("/etc/datadog-agent/processes.d/missing-binary.yaml", missingBinaryConfig, true),
+					agentparams.WithFile("/opt/datadog-agent/processes.d/test-sleep.yaml", testProcessConfig, true),
+					agentparams.WithFile("/opt/datadog-agent/processes.d/datadog-agent-ddot.yaml", embedded.DDOTProcessConfig, true),
+					agentparams.WithFile("/opt/datadog-agent/processes.d/missing-binary.yaml", missingBinaryConfig, true),
 				),
 			),
 		),


### PR DESCRIPTION
### What does this PR do?
Moves the process manager config directory from the config path (`/etc/datadog-agent/processes.d`) to the install path (`/opt/datadog-agent/processes.d`).
- `default_config_dir()` in `platform/unix.rs` now returns `/opt/datadog-agent/processes.d`
- Omnibus finalize script creates `processes.d` under install dir instead of config dir
- Fleet installer creates the directory under `PackagePath` instead of as a global `/etc` directory
- Systemd templates reference `{{.InstallDir}}/processes.d` for both `DD_PM_CONFIG_DIR` and `ConditionPathExists`
- E2E test paths updated accordingly
### Motivation
Process configs are package-managed templates rendered at install time, not user-editable configuration. Placing them under the install path (`/opt/datadog-agent`) makes this distinction clear and enables the YAML file presence to serve as the on/off switch for procmgr vs systemd management of DDOT: the systemd unit uses `ConditionPathExists=!<InstallDir>/processes.d/datadog-agent-ddot.yaml` so both supervisors reference the same location.
### Describe how you validated your changes
- `cargo fmt --check`
- `cargo clippy --tests -- -D warnings`
- Systemd unit generation validated (pre-commit hook passed)
- E2E test paths updated to match new location
### Additional Notes
This is a prerequisite for fleet-driven rollback between procmgr and systemd DDOT management. With configs under the install path, the installer controls file presence without touching `/etc`.
