### PR TITLE
Enable dynamic netpath for EUDM mode

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1445,6 +1445,7 @@ func applyInfrastructureModeOverrides(config pkgconfigmodel.Config) {
 		config.Set("network_path.collector.filters", defaultNetworkPathCollectorFilters, pkgconfigmodel.SourceAgentRuntime) // Agent runtime source is required to override customer defined filters with default configuration
 
 		// Enable features for end_user_device mode
+		config.Set("network_path.connections_monitoring.enabled", true, pkgconfigmodel.SourceInfraMode)
 		config.Set("process_config.process_collection.enabled", true, pkgconfigmodel.SourceInfraMode)
 		config.Set("software_inventory.enabled", true, pkgconfigmodel.SourceInfraMode)
 		config.Set("notable_events.enabled", true, pkgconfigmodel.SourceInfraMode)

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -726,6 +726,8 @@ infrastructure_mode: end_user_device
 	assert.True(t, foundSlack, "*.slack.com should be in the default filters")
 	assert.True(t, foundGitHub, "*.github.com should be in the default filters")
 
+	// Check that connections monitoring is enabled
+	assert.True(t, config.GetBool("network_path.connections_monitoring.enabled"), "connections monitoring should be enabled in end_user_device mode")
 }
 
 func TestUsePodmanLogsAndDockerPathOverride(t *testing.T) {

--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -176,7 +176,7 @@ func load() (*types.Config, error) {
 	if cfg.GetBool(pngNS("enabled")) {
 		c.EnabledModules[PingModule] = struct{}{}
 	}
-	if cfg.GetBool(tracerouteNS("enabled")) {
+	if cfg.GetBool(tracerouteNS("enabled")) || eudmEnabled {
 		c.EnabledModules[TracerouteModule] = struct{}{}
 	}
 	if cfg.GetBool(discoveryNS("enabled")) {

--- a/pkg/system-probe/config/config_linux_bpf_test.go
+++ b/pkg/system-probe/config/config_linux_bpf_test.go
@@ -129,6 +129,37 @@ func TestNPMEnabled(t *testing.T) {
 	}
 }
 
+func TestTracerouteModuleEnabledForEUDM(t *testing.T) {
+	mock.New(t)
+	mock.NewSystemProbe(t)
+
+	tests := []struct {
+		name             string
+		eudm             bool
+		tracerouteConfig bool
+		expected         bool
+	}{
+		{"neither enabled", false, false, false},
+		{"traceroute config only", false, true, true},
+		{"eudm only", true, false, true},
+		{"both enabled", true, true, true},
+	}
+
+	for _, te := range tests {
+		t.Run(te.name, func(t *testing.T) {
+			if te.eudm {
+				t.Setenv("DD_INFRASTRUCTURE_MODE", "end_user_device")
+			} else {
+				t.Setenv("DD_INFRASTRUCTURE_MODE", "full")
+			}
+			t.Setenv("DD_TRACEROUTE_ENABLED", strconv.FormatBool(te.tracerouteConfig))
+			cfg, err := New("", "")
+			require.NoError(t, err)
+			assert.Equal(t, te.expected, cfg.ModuleIsEnabled(TracerouteModule), "unexpected traceroute module enablement: eudm: %v, traceroute config: %v", te.eudm, te.tracerouteConfig)
+		})
+	}
+}
+
 func TestRedisMonitoringEnabledForSupportedKernelsLinux(t *testing.T) {
 	t.Setenv("DD_SERVICE_MONITORING_CONFIG_REDIS_ENABLED", strconv.FormatBool(true))
 	cfg := mock.NewSystemProbe(t)


### PR DESCRIPTION
### What does this PR do?

Enables dynamic network path monitoring when `infrastructure_mode: end_user_device` is set. Two changes:

1. **Agent config** (`pkg/config/setup/config.go`): Sets `network_path.connections_monitoring.enabled = true` in the EUDM override so the network path collector actually starts and uses the domain filters that were already being configured.
2. **System-probe config** (`pkg/system-probe/config/config.go`): Enables `TracerouteModule` when EUDM is active so the agent can run traceroutes via system-probe RPC. Follows the same pattern as `NetworkTracerModule` enablement.

### Motivation

[WINA-2590](https://datadoghq.atlassian.net/browse/WINA-2590)

### Describe how you validated your changes

- Added assertion in `TestNetworkPathFiltersEndUserDeviceMode` that `connections_monitoring.enabled` is true
- Added `TestTracerouteModuleEnabledForEUDM` table-driven test covering all four combinations (neither, traceroute-only, eudm-only, both)

### Additional Notes

This does not change how CNM / the network tracer module is enabled for EUDM — that existing logic at `config.go:132` is untouched.

[WINA-2590]: https://datadoghq.atlassian.net/browse/WINA-2590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ