### PR TITLE
[EBPF-1081] gpu: improve speed of tests involving device events

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -835,6 +835,7 @@ func TestMetricsFollowSpec(t *testing.T) {
 	// - KubernetesDevicePlugins required for gpu.device.unhealthy metric
 	// - NVML required to ensure the NVML workloadmeta collector starts up
 	env.SetFeatures(t, env.KubernetesDevicePlugins, env.NVML)
+	nvidia.WithDeviceEventsSetWaitTimeoutForTest(t, time.Millisecond)
 
 	metricsSpec, err := gpuspec.LoadMetricsSpec()
 	require.NoError(t, err)

--- a/pkg/collector/corechecks/gpu/nvidia/device_events.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events.go
@@ -26,13 +26,15 @@ import (
 
 const (
 	eventSetMask                  = uint64(nvml.EventTypeXidCriticalError)
-	eventSetWaitTimeout           = 1000 * time.Millisecond
+	defaultEventSetWaitTimeout    = 1000 * time.Millisecond
 	devicePendingEventQueueSize   = 1000
 	deviceMaxRegistrationAttempts = 5
 	xidOriginDriver               = "driver"
 	xidOriginHardware             = "hardware"
 	xidOriginUnknown              = "unknown"
 )
+
+var eventSetWaitTimeout = defaultEventSetWaitTimeout
 
 // helps mocking an actual events gatherer in tests
 type deviceEventsCollectorCache interface {

--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -55,6 +55,8 @@ func TestDeviceEventsGatherer_GetWithUnregistered(t *testing.T) {
 }
 
 func TestDeviceEventsGatherer_RefreshGetSequence(t *testing.T) {
+	WithDeviceEventsSetWaitTimeoutForTest(t, time.Millisecond)
+
 	// by controlling this, we can influence the gathered device events
 	gatheredDeviceEvents := make(chan nvml.EventData, 10)
 	t.Cleanup(func() { close(gatheredDeviceEvents) })

--- a/pkg/collector/corechecks/gpu/nvidia/testutil.go
+++ b/pkg/collector/corechecks/gpu/nvidia/testutil.go
@@ -9,6 +9,8 @@ package nvidia
 
 import (
 	"fmt"
+	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/model"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
@@ -17,6 +19,17 @@ import (
 // SetStatsForTest replaces the cached stats. Intended for testing only.
 func (c *SystemProbeCache) SetStatsForTest(stats *model.GPUStats) {
 	c.stats = stats
+}
+
+// WithDeviceEventsSetWaitTimeoutForTest temporarily overrides the event wait
+// timeout used by the async gatherer worker, restoring the previous value on cleanup.
+func WithDeviceEventsSetWaitTimeoutForTest(t testing.TB, timeout time.Duration) {
+	t.Helper()
+	prev := eventSetWaitTimeout
+	eventSetWaitTimeout = timeout
+	t.Cleanup(func() {
+		eventSetWaitTimeout = prev
+	})
 }
 
 // InjectEventsForTest pushes events directly into the pending queue for a registered device.


### PR DESCRIPTION
### What does this PR do?
Reduces runtime of GPU tests that initialize device event collection by using a test-scoped override for the NVML device event wait timeout.

### Motivation
`TestMetricsFollowSpec` was spending most of its time waiting for device-events gatherer teardown across many subtests due to the default 1s wait. This caused the test to fail in some cases, see https://datadoghq.atlassian.net/browse/EBPF-1081

### Describe how you validated your changes
Unit tests updated.
- `dda inv test --targets=./pkg/collector/corechecks/gpu --extra-args=\"-run TestMetricsFollowSpec\"`
- `dda inv test --targets=./pkg/collector/corechecks/gpu/nvidia --extra-args=\"-run TestDeviceEventsGatherer_RefreshGetSequence\"`

### Additional Notes