### PR TITLE
[AGENTRUN-1229] Add env var overrides for Windows container infra check disabling

### DIFF
--- a/Dockerfiles/agent/entrypoint-ps1/60-disable-infra.ps1
+++ b/Dockerfiles/agent/entrypoint-ps1/60-disable-infra.ps1
@@ -1,18 +1,39 @@
 
 # Disable infra checks that would report metrics from the container (instead of the host),
-# if they're not already disabled
+# if they're not already disabled.
+#
+# Environment variable overrides:
+#   DD_WINDOWS_HOST_METRICS=true       - Keep ALL infra checks enabled
+#   DD_WINDOWS_ENABLE_DISK_CHECK=true  - Keep the disk check enabled
+#   DD_WINDOWS_ENABLE_NETWORK_CHECK=true - Keep the network check enabled
+#   DD_WINDOWS_ENABLE_WINPROC_CHECK=true - Keep the winproc check enabled
+#   DD_WINDOWS_ENABLE_FILE_HANDLE_CHECK=true - Keep the file_handle check enabled
+#   DD_WINDOWS_ENABLE_IO_CHECK=true    - Keep the IO check enabled
 
-$defaultChecks = @(
-    "disk",
-    "network",
-    "winproc",
-    "file_handle",
-    # TODO: Conditionally enable the IO check if the host drives are mounted in the container
-    "io"
-)
+if ($env:DD_WINDOWS_HOST_METRICS -eq "true") {
+    Write-Output "DD_WINDOWS_HOST_METRICS is set, keeping all infra checks enabled"
+    exit 0
+}
 
-ForEach ($defaultCheck in $defaultChecks) {
-    $confPath = "C:\ProgramData\Datadog\conf.d\$defaultCheck.d\conf.yaml.default"
+$defaultChecks = @{
+    "disk"        = "DD_WINDOWS_ENABLE_DISK_CHECK"
+    "network"     = "DD_WINDOWS_ENABLE_NETWORK_CHECK"
+    "winproc"     = "DD_WINDOWS_ENABLE_WINPROC_CHECK"
+    "file_handle" = "DD_WINDOWS_ENABLE_FILE_HANDLE_CHECK"
+    "io"          = "DD_WINDOWS_ENABLE_IO_CHECK"
+}
+
+ForEach ($entry in $defaultChecks.GetEnumerator()) {
+    $checkName = $entry.Key
+    $envVar = $entry.Value
+    $confPath = "C:\ProgramData\Datadog\conf.d\$checkName.d\conf.yaml.default"
+
+    $envValue = [System.Environment]::GetEnvironmentVariable($envVar)
+    if ($envValue -eq "true") {
+        Write-Output "$envVar is set, keeping $checkName check enabled"
+        continue
+    }
+
     if (Test-Path $confPath) {
         Remove-Item $confPath
     }

--- a/releasenotes/notes/windows-container-infra-check-overrides-ba38ff66ac8271cf.yaml
+++ b/releasenotes/notes/windows-container-infra-check-overrides-ba38ff66ac8271cf.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    Add environment variable overrides to selectively keep infrastructure checks
+    enabled in Windows containers. By default, the disk, network, winproc,
+    file_handle, and io checks are still removed at startup for backward
+    compatibility. Set ``DD_WINDOWS_HOST_METRICS=true`` to keep all infra checks,
+    or use per-check variables (e.g. ``DD_WINDOWS_ENABLE_DISK_CHECK=true``,
+    ``DD_WINDOWS_ENABLE_IO_CHECK=true``) to enable individual checks.


### PR DESCRIPTION
## What Does This Do?

The Windows container entrypoint script `60-disable-infra.ps1` unconditionally removes the default configs for disk, network, winproc, file_handle, and io checks at startup. This was introduced in #4885 (March 2020), before HostProcess containers existed, and means checks like the Go disk check (diskv2), which has full Windows support, never run in Windows containers.

This PR adds environment variable overrides so users can selectively keep infra checks enabled:

- `DD_WINDOWS_HOST_METRICS=true` keeps **all** infra checks enabled
- Per-check overrides:
  - `DD_WINDOWS_ENABLE_DISK_CHECK=true`
  - `DD_WINDOWS_ENABLE_NETWORK_CHECK=true`
  - `DD_WINDOWS_ENABLE_WINPROC_CHECK=true`
  - `DD_WINDOWS_ENABLE_FILE_HANDLE_CHECK=true`
  - `DD_WINDOWS_ENABLE_IO_CHECK=true`

Default behavior is **unchanged** so all checks are still removed unless the user explicitly opts in via env vars.

### Motivation

[AGENTRUN-1229](https://datadoghq.atlassian.net/browse/AGENTRUN-1229)

- On Linux containers, the disk check is never removed (only the network check is conditionally disabled when `/host/proc` is absent). Windows containers should have parity.
- With HostProcess containers (GA since Kubernetes 1.26), the host filesystem is accessible, so disk and IO metrics are meaningful.
- Users and the Helm chart can now opt in by setting the appropriate env vars.

## Possible Drawbacks / Trade-offs

None for existing users — the default behavior is preserved. Users must explicitly set env vars to change behavior.

## Describe how to test/QA your changes

1. Run a Windows Agent container **without** any new env vars → verify disk, network, winproc, file_handle, and io `conf.yaml.default` files are still removed (same as before).
2. Run with `DD_WINDOWS_ENABLE_DISK_CHECK=true` → verify only the disk check's `conf.yaml.default` is preserved; the other four are removed.
3. Run with `DD_WINDOWS_HOST_METRICS=true` → verify all five `conf.yaml.default` files are preserved.

[AGENTRUN-1229]: https://datadoghq.atlassian.net/browse/AGENTRUN-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ