### PR TITLE
[CONTP-1583] Collect cluster check status in DCA metadata

### DIFF
--- a/comp/metadata/clusterchecks/impl/clusterchecks.go
+++ b/comp/metadata/clusterchecks/impl/clusterchecks.go
@@ -11,7 +11,9 @@ package clusterchecksimpl
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -46,6 +48,9 @@ type Payload struct {
 
 	// Cluster check status information
 	ClusterCheckStatus map[string]interface{} `json:"clustercheck_status,omitempty"`
+
+	// Cluster check integration status (execution status from CLC runners)
+	ClusterCheckIntegrationStatus map[string][]metadata `json:"clustercheck_integration_status,omitempty"`
 
 	// Unique identifier for this payload
 	UUID string `json:"uuid"`
@@ -176,12 +181,13 @@ func (cc *clusterChecksImpl) getPayload() *Payload {
 	// to prevent sending to backend when both identifiers are missing. Flares report is using
 	// getAsJSON.
 	payload := &Payload{
-		Clustername:          cc.clustername,
-		ClusterID:            cc.clusterID,
-		Timestamp:            time.Now().UnixNano(),
-		ClusterCheckMetadata: make(map[string][]metadata),
-		ClusterCheckStatus:   make(map[string]interface{}),
-		UUID:                 uuid.GetUUID(),
+		Clustername:                   cc.clustername,
+		ClusterID:                     cc.clusterID,
+		Timestamp:                     time.Now().UnixNano(),
+		ClusterCheckMetadata:          make(map[string][]metadata),
+		ClusterCheckStatus:            make(map[string]interface{}),
+		ClusterCheckIntegrationStatus: make(map[string][]metadata),
+		UUID:                          uuid.GetUUID(),
 	}
 
 	// Collect cluster check metadata
@@ -269,26 +275,58 @@ func (cc *clusterChecksImpl) collectClusterCheckMetadata(payload *Payload) {
 				initConfig = string(config.InitConfig)
 			}
 
-			checkMetadata := metadata{
-				"config.hash":     checkid.BuildID(checkName, config.IntDigest(), config.Instances[0], config.InitConfig),
-				"config.provider": config.Provider,
-				"config.source":   config.Source,
-				"init_config":     initConfig,
-				"node_name":       node.Name,
-				"status":          "DISPATCHED",
-				"errors":          "", // Empty for now, ready for future error tracking
-			}
+			// Create one metadata entry per instance (multi-instance configs
+			// produce multiple entries, matching node agent behavior).
+			for i, inst := range config.Instances {
+				var configHash interface{}
+				if i < len(configResp.InstanceIDs) {
+					configHash = configResp.InstanceIDs[i]
+				} else {
+					configHash = checkid.BuildID(checkName, config.IntDigest(), inst, config.InitConfig)
+				}
 
-			if len(config.Instances) > 0 {
-				instanceConfig, err := scrubber.ScrubYamlString(string(config.Instances[0]))
+				instanceConfig, err := scrubber.ScrubYamlString(string(inst))
 				if err != nil {
 					cc.log.Errorf("Could not scrub instance_config for cluster check %s: %s", checkName, err)
-					instanceConfig = string(config.Instances[0])
+					instanceConfig = string(inst)
 				}
-				checkMetadata["instance_config"] = instanceConfig
-			}
 
-			payload.ClusterCheckMetadata[checkName] = append(payload.ClusterCheckMetadata[checkName], checkMetadata)
+				// Append instance index to source, matching the node agent's
+				// loader format (e.g. "file:/etc/.../http_check.yaml[0]")
+				configSource := fmt.Sprintf("%s[%d]", config.Source, i)
+
+				checkMetadata := metadata{
+					"config.hash":     configHash,
+					"config.provider": config.Provider,
+					"config.source":   configSource,
+					"init_config":     initConfig,
+					"instance_config": instanceConfig,
+					"node_name":       node.Name,
+					"dispatch_status": "DISPATCHED",
+				}
+
+				payload.ClusterCheckMetadata[checkName] = append(payload.ClusterCheckMetadata[checkName], checkMetadata)
+			}
+		}
+
+		// Build integration status from runner stats for this node.
+		// Only include cluster checks (IsClusterCheck is set by updateRunnersStats
+		// when the check ID exists in the DCA's idToDigest map).
+		for statsID, s := range node.Stats {
+			if !s.IsClusterCheck || s.TotalRuns == 0 {
+				continue
+			}
+			checkName := strings.SplitN(statsID, ":", 2)[0]
+			status := "OK"
+			if s.LastExecFailed {
+				status = "ERROR"
+			}
+			statusEntry := metadata{
+				"config.hash": statsID,
+				"status":      status,
+				"errors":      s.LastError,
+			}
+			payload.ClusterCheckIntegrationStatus[checkName] = append(payload.ClusterCheckIntegrationStatus[checkName], statusEntry)
 		}
 	}
 
@@ -305,24 +343,25 @@ func (cc *clusterChecksImpl) collectClusterCheckMetadata(payload *Payload) {
 			initConfig = string(config.InitConfig)
 		}
 
-		checkMetadata := metadata{
-			"config.hash":     checkid.BuildID(checkName, config.IntDigest(), config.Instances[0], config.InitConfig),
-			"config.provider": config.Provider,
-			"config.source":   config.Source,
-			"init_config":     initConfig,
-			"status":          "DANGLING",
-			"errors":          "Check not assigned to any node",
-		}
+		for i, inst := range config.Instances {
+			configSource := fmt.Sprintf("%s[%d]", config.Source, i)
 
-		if len(config.Instances) > 0 {
-			instanceConfig, err := scrubber.ScrubYamlString(string(config.Instances[0]))
+			checkMetadata := metadata{
+				"config.hash":     checkid.BuildID(checkName, config.IntDigest(), inst, config.InitConfig),
+				"config.provider": config.Provider,
+				"config.source":   configSource,
+				"init_config":     initConfig,
+				"dispatch_status": "DANGLING",
+			}
+
+			instanceConfig, err := scrubber.ScrubYamlString(string(inst))
 			if err != nil {
 				cc.log.Errorf("Could not scrub instance_config for dangling cluster check %s: %s", checkName, err)
-				instanceConfig = string(config.Instances[0])
+				instanceConfig = string(inst)
 			}
 			checkMetadata["instance_config"] = instanceConfig
-		}
 
-		payload.ClusterCheckMetadata[checkName] = append(payload.ClusterCheckMetadata[checkName], checkMetadata)
+			payload.ClusterCheckMetadata[checkName] = append(payload.ClusterCheckMetadata[checkName], checkMetadata)
+		}
 	}
 }

--- a/comp/metadata/clusterchecks/impl/clusterchecks_test.go
+++ b/comp/metadata/clusterchecks/impl/clusterchecks_test.go
@@ -1,0 +1,178 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build clusterchecks
+
+package clusterchecksimpl
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+)
+
+func TestPayloadIncludesIntegrationStatus(t *testing.T) {
+	payload := &Payload{
+		Clustername:                   "test-cluster",
+		ClusterID:                     "abc123",
+		ClusterCheckMetadata:          make(map[string][]metadata),
+		ClusterCheckStatus:            make(map[string]interface{}),
+		ClusterCheckIntegrationStatus: make(map[string][]metadata),
+		UUID:                          "test-uuid",
+	}
+
+	// Simulate what collectClusterCheckMetadata does for integration status
+	stats := types.CLCRunnersStats{
+		"kubernetes_state_core:db3f3028d40c564d": {
+			AverageExecutionTime: 3209,
+			MetricSamples:        197303,
+			TotalMetricSamples:   64518134,
+			Events:               0,
+			TotalEvents:          0,
+			ServiceChecks:        406,
+			TotalServiceChecks:   132762,
+			LastExecFailed:       false,
+			LastError:            "",
+			TotalRuns:            328,
+			TotalErrors:          0,
+			LastSuccessDate:      1775563775,
+			LastExecutionDate:    1775563775974,
+		},
+	}
+
+	for statsID, s := range stats {
+		if s.TotalRuns == 0 {
+			continue
+		}
+		checkName := "kubernetes_state_core"
+		status := "OK"
+		if s.LastExecFailed {
+			status = "ERROR"
+		}
+		statusEntry := metadata{
+			"config.hash": statsID,
+			"status":      status,
+			"errors":      s.LastError,
+		}
+		payload.ClusterCheckIntegrationStatus[checkName] = append(
+			payload.ClusterCheckIntegrationStatus[checkName], statusEntry)
+	}
+
+	// Verify the status was added
+	require.Len(t, payload.ClusterCheckIntegrationStatus, 1)
+	require.Len(t, payload.ClusterCheckIntegrationStatus["kubernetes_state_core"], 1)
+
+	entry := payload.ClusterCheckIntegrationStatus["kubernetes_state_core"][0]
+	assert.Equal(t, "kubernetes_state_core:db3f3028d40c564d", entry["config.hash"])
+	assert.Equal(t, "OK", entry["status"])
+	assert.Equal(t, "", entry["errors"])
+
+	// Verify JSON serialization includes the field
+	jsonBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &raw)
+	require.NoError(t, err)
+	assert.Contains(t, raw, "clustercheck_integration_status")
+}
+
+func TestPayloadEmptyIntegrationStatus(t *testing.T) {
+	payload := &Payload{
+		Clustername:                   "test-cluster",
+		ClusterID:                     "abc123",
+		ClusterCheckMetadata:          make(map[string][]metadata),
+		ClusterCheckStatus:            make(map[string]interface{}),
+		ClusterCheckIntegrationStatus: make(map[string][]metadata),
+		UUID:                          "test-uuid",
+	}
+
+	// No stats added — integration status should be empty
+	assert.Empty(t, payload.ClusterCheckIntegrationStatus)
+
+	// Verify JSON serialization omits empty field (omitempty)
+	jsonBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &raw)
+	require.NoError(t, err)
+	// omitempty on empty map — Go encodes empty maps, not nil maps
+	// So it will be present but empty
+	status, ok := raw["clustercheck_integration_status"]
+	if ok {
+		statusMap, _ := status.(map[string]interface{})
+		assert.Empty(t, statusMap)
+	}
+}
+
+func TestPayloadIntegrationStatusErrorCheck(t *testing.T) {
+	payload := &Payload{
+		Clustername:                   "test-cluster",
+		ClusterID:                     "abc123",
+		ClusterCheckMetadata:          make(map[string][]metadata),
+		ClusterCheckStatus:            make(map[string]interface{}),
+		ClusterCheckIntegrationStatus: make(map[string][]metadata),
+		UUID:                          "test-uuid",
+	}
+
+	statusEntry := metadata{
+		"config.hash": "my_check:abc123",
+		"status":      "ERROR",
+		"errors":      "connection refused",
+	}
+	payload.ClusterCheckIntegrationStatus["my_check"] = append(
+		payload.ClusterCheckIntegrationStatus["my_check"], statusEntry)
+
+	entry := payload.ClusterCheckIntegrationStatus["my_check"][0]
+	assert.Equal(t, "ERROR", entry["status"])
+	assert.Equal(t, "connection refused", entry["errors"])
+}
+
+func TestPayloadSkipsZeroRunStats(t *testing.T) {
+	payload := &Payload{
+		ClusterCheckIntegrationStatus: make(map[string][]metadata),
+	}
+
+	// Simulate stats with TotalRuns == 0 — should be skipped
+	stats := types.CLCRunnersStats{
+		"my_check:abc123": {
+			TotalRuns:   0,
+			TotalErrors: 0,
+		},
+		"my_check:def456": {
+			TotalRuns:      5,
+			TotalErrors:    1,
+			LastExecFailed: true,
+			LastError:      "timeout",
+		},
+	}
+
+	for statsID, s := range stats {
+		if s.TotalRuns == 0 {
+			continue
+		}
+		checkName := "my_check"
+		status := "OK"
+		if s.LastExecFailed {
+			status = "ERROR"
+		}
+		payload.ClusterCheckIntegrationStatus[checkName] = append(
+			payload.ClusterCheckIntegrationStatus[checkName], metadata{
+				"config.hash": statsID,
+				"status":      status,
+				"errors":      s.LastError,
+			})
+	}
+
+	// Only one entry (the one with TotalRuns > 0)
+	require.Len(t, payload.ClusterCheckIntegrationStatus["my_check"], 1)
+	assert.Equal(t, "ERROR", payload.ClusterCheckIntegrationStatus["my_check"][0]["status"])
+	assert.Equal(t, "timeout", payload.ClusterCheckIntegrationStatus["my_check"][0]["errors"])
+}

--- a/releasenotes-dca/notes/metadata-cluster-check-integration-status-253aacfdf99b6049.yaml
+++ b/releasenotes-dca/notes/metadata-cluster-check-integration-status-253aacfdf99b6049.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    The cluster agent metadata payload now includes a
+    ``clustercheck_integration_status`` field reporting check execution
+    status (OK/ERROR) for cluster checks running on CLC runners. This enables
+    the backend to populate ``datadog_agent_integration_status`` for cluster
+    checks. The ``clustercheck_metadata`` field now also reports all instances
+    for multi-instance checks and uses precomputed instance IDs for consistency.


### PR DESCRIPTION
Re-submit of #49350 (reverted due to unrelated E2E test failure in TestDDOTAutoInstalledWithEnvVar).

### Additional Notes
