### PR TITLE
Force Linux platform for editor/IDE build tag configuration

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -559,7 +559,9 @@ def _compute_build_size(ctx, build_exclude=None, flavor=AgentFlavor.base):
     return statinfo.st_size
 
 
-def compute_config_build_tags(targets="all", build_include=None, build_exclude=None, flavor=AgentFlavor.base.name, platform=None):
+def compute_config_build_tags(
+    targets="all", build_include=None, build_exclude=None, flavor=AgentFlavor.base.name, platform=None
+):
     flavor = AgentFlavor[flavor]
 
     if targets == "all":

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -559,7 +559,7 @@ def _compute_build_size(ctx, build_exclude=None, flavor=AgentFlavor.base):
     return statinfo.st_size
 
 
-def compute_config_build_tags(targets="all", build_include=None, build_exclude=None, flavor=AgentFlavor.base.name):
+def compute_config_build_tags(targets="all", build_include=None, build_exclude=None, flavor=AgentFlavor.base.name, platform=None):
     flavor = AgentFlavor[flavor]
 
     if targets == "all":
@@ -574,9 +574,9 @@ def compute_config_build_tags(targets="all", build_include=None, build_exclude=N
     if build_include is None:
         build_include = []
         for target in targets:
-            build_include.extend(get_default_build_tags(build=target, flavor=flavor))
+            build_include.extend(get_default_build_tags(build=target, flavor=flavor, platform=platform))
     else:
-        build_include = filter_incompatible_tags(build_include.split(","))
+        build_include = filter_incompatible_tags(build_include.split(","), platform=platform)
 
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     use_tags = get_build_tags(build_include, build_exclude)

--- a/tasks/claude.py
+++ b/tasks/claude.py
@@ -57,6 +57,7 @@ def set_buildtags(
         build_include=build_include,
         build_exclude=build_exclude,
         flavor=flavor,
+        platform="linux",
     )
 
     if not os.path.exists(PLUGIN_DIR):

--- a/tasks/emacs.py
+++ b/tasks/emacs.py
@@ -31,6 +31,7 @@ def set_buildtags(
         build_include=build_include,
         build_exclude=build_exclude,
         flavor=flavor,
+        platform="linux",
     )
 
     with open(".dir-locals.el", "w") as f:

--- a/tasks/vim.py
+++ b/tasks/vim.py
@@ -31,6 +31,7 @@ def set_buildtags(
         build_include=build_include,
         build_exclude=build_exclude,
         flavor=flavor,
+        platform="linux",
     )
 
     with open(".vimrc", "w") as f:

--- a/tasks/vscode.py
+++ b/tasks/vscode.py
@@ -72,6 +72,7 @@ def set_buildtags(
         build_include=build_include,
         build_exclude=build_exclude,
         flavor=flavor,
+        platform="linux",
     )
 
     if not os.path.exists(VSCODE_DIR):
@@ -203,7 +204,7 @@ def setup_settings(_, force=False):
         if not force:
             return
 
-    build_tags = sorted(compute_config_build_tags())
+    build_tags = sorted(compute_config_build_tags(platform="linux"))
     with open(template) as template_f, open(settings, "w") as settings_f:
         vscode_config_template = template_f.read()
         settings_f.write(


### PR DESCRIPTION
### What does this PR do?

Forces `platform="linux"` when computing build tags for editor/IDE configurations (Claude Code gopls plugin, VSCode, Emacs, Vim). This ensures all build tags — including Linux-specific ones like `docker`, `systemd`, `trivy`, `linux_bpf`, etc. — are always included in editor configs regardless of the developer's host OS.

### Motivation

The Claude Code gopls plugin has a `SessionStart` hook that auto-refreshes build tags via `dda inv claude.set-buildtags`. On macOS, `filter_incompatible_tags()` strips 12 Linux-specific tags (`docker`, `systemd`, `trivy`, `containerd`, `cri`, `crio`, `linux_bpf`, `netcgo`, `nvml`, `pcap`, `podman`, `jetson`), making gopls blind to files guarded by those tags.

Since most agent developers work on Linux features from their Mac, this was causing the gopls plugin to auto-update with an incomplete tag set (as demonstrated in PR #49453).

Editor/IDE tasks configure **code navigation**, not compilation — they need to see all files regardless of the developer's host OS.

### Describe how you validated your changes

- Ran `dda inv claude.set-buildtags` and verified the generated `plugin.json` contains the full set of 42+ tags including all previously-filtered Linux-specific tags.
- Verified the change is backward-compatible: `compute_config_build_tags()` defaults to `platform=None` (auto-detect), so non-editor callers are unaffected.

### Additional Notes

The same fix is applied to all editor config tasks (`vscode`, `emacs`, `vim`) since they share the same underlying issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)