### PR TITLE
[USM][Windows] Fix HTTP stats not attributed to client-side connections on loopback

### DIFF
--- a/pkg/network/encoding/marshal/usm_lookup_windows_test.go
+++ b/pkg/network/encoding/marshal/usm_lookup_windows_test.go
@@ -29,8 +29,9 @@ func TestUSMLookup(t *testing.T) {
 	data := make(map[types.ConnectionKey]*USMConnectionData[struct{}, any])
 	data[key] = val
 
-	// In windows the USMLookup operation is done only once and using the
-	// original tuple order, so in the case below only c1 should match the data
+	// USMLookup checks both (src->dst) and (dst->src), so both directions should match.
+	// This is required for server-side ETW stats (keyed as dst->src) to be found when
+	// the connection table reports the connection as src->dst.
 	c1 := network.ConnectionStats{ConnectionTuple: network.ConnectionTuple{
 		Source: util.AddressFromString("1.1.1.1"),
 		Dest:   util.AddressFromString("2.2.2.2"),
@@ -46,5 +47,5 @@ func TestUSMLookup(t *testing.T) {
 	}}
 
 	assert.Equal(t, val, USMLookup(c1, data))
-	assert.Equal(t, (*USMConnectionData[struct{}, any])(nil), USMLookup(c2, data))
+	assert.Equal(t, val, USMLookup(c2, data))
 }

--- a/pkg/network/event_common_windows.go
+++ b/pkg/network/event_common_windows.go
@@ -19,6 +19,7 @@ func ConnectionKeysFromConnectionStats(connectionStats ConnectionStats) []types.
 	// connection keys and check for both of them in the aggregations map.
 	connectionKeys := []types.ConnectionKey{
 		types.NewConnectionKey(connectionStats.Source, connectionStats.Dest, connectionStats.SPort, connectionStats.DPort),
+		types.NewConnectionKey(connectionStats.Dest, connectionStats.Source, connectionStats.DPort, connectionStats.SPort),
 	}
 
 	return connectionKeys


### PR DESCRIPTION
On loopback traffic, ETW stores HTTP stats under the server-side key (server:port, client:ephemeral). ConnectionKeysFromConnectionStats only generated the forward key, so the outbound (client-side) connection always missed the lookup and HTTP stats were orphaned - universal.http.client.hits was always 0 for same-host traffic.

Fix: add the reverse key to the slice, matching the Linux implementation in usm_connection_keys.go.

**Changes**
- event_common_windows.go: one-line addition of reverse key
- usm_lookup_windows_test.go: fix assertion that was locking in the broken behavior

**Validation**
Fakeintake: before fix client.hits=0, after fix client.hits=10, server.hits=10 for 10 loopback requests. Validated on the real Datadog dev backend (usm-test-yoav): both metrics appeared correctly, no spurious client.hits from external traffic.

**Risk:** additive only. Forward key unchanged; reverse key is new. Worst case: both client and server connections on the same host see the same HTTP stats, which is correct and matches Linux.