### PR TITLE
Changelog for nodetreemodel by default

### DIFF
--- a/releasenotes/notes/ntm-enabled-5fc066255b4b83e0.yaml
+++ b/releasenotes/notes/ntm-enabled-5fc066255b4b83e0.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Switch config implementation from viper to nodetreemodel by default. Can
+    be disabled with the env var DD_CONF_NODETREEMODEL=viper.

--- a/releasenotes/notes/ntm-enabled-5fc066255b4b83e0.yaml
+++ b/releasenotes/notes/ntm-enabled-5fc066255b4b83e0.yaml
@@ -8,5 +8,7 @@
 ---
 enhancements:
   - |
-    Switch config implementation from viper to nodetreemodel by default. Can
-    be disabled with the env var DD_CONF_NODETREEMODEL=viper.
+    Switch config implementation to an improved version by default. Can
+    be disabled with the env var DD_CONF_NODETREEMODEL=viper, or the config
+    setting ``conf_nodetreemodel: viper`` in ``datadog.yaml``.
+


### PR DESCRIPTION
### What does this PR do?

Adds a changelog for nodetreemodel. This was mistakingly left out of https://github.com/DataDog/datadog-agent/pull/48694.

### Motivation

Mention this change in default configuration in the changelog.

### Describe how you validated your changes

### Additional Notes
