### PR TITLE
Update the otel collector version

### DIFF
--- a/comp/otelcol/collector/impl/collector.go
+++ b/comp/otelcol/collector/impl/collector.go
@@ -216,7 +216,7 @@ func addFactories(reqs Requires, factories otelcol.Factories, gatewayUsage otel.
 }
 
 var buildInfo = component.BuildInfo{
-	Version:     "v0.147.0",
+	Version:     "v0.150.0",
 	Command:     filepath.Base(os.Args[0]),
 	Description: "Datadog Agent OpenTelemetry Collector",
 }


### PR DESCRIPTION
### What does this PR do?

The OpenTelemetry collector declared version slipped through #48796 unchanged, while it is usually updated by the collector update script.

### Motivation

Latest DDOT is declared as OTel collector `0.147.0` while it is in fact using upstream code version `0.150.0`