### PR TITLE
ci(ddot): Add apt mirror config to Dockerfile.agent-otel for CI reliability

### DIFF
--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -26,6 +26,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Set the working directory
 WORKDIR /workspace
 
+# NOTE about APT mirrorlists:
+# It seems that this feature could use some improvement. If you just get mirrorlist
+# from mirrors.ubuntu.com/mirrors.txt, it might contain faulty mirrors that either
+# cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
+# indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
+# should be reliable enough in combination and also well maintained.
+RUN if [ "$CI" = "true" ]; then \
+  echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
+  echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist.ports && \
+  sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
+         -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
+         -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' /etc/apt/sources.list; \
+  fi
+
 # Update and install necessary packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
### What does this PR do?
#incident-52989

Adds the CI apt mirrorlist configuration to `Dockerfiles/agent-ddot/Dockerfile.agent-otel`, matching the pattern already used in `Dockerfiles/base-image/Dockerfile`, `Dockerfiles/agent/Dockerfile`, and `Dockerfiles/cluster-agent/Dockerfile`.

When `CI=true`, apt sources are rewritten to prefer the EC2 regional mirror (`us-east-1.ec2.archive.ubuntu.com`) with `archive.ubuntu.com` as fallback, avoiding connection failures and timeouts against the default Ubuntu archive.

### Motivation

The `ddot_byoc_binary_build_test_ubuntu2004` CI job ([job 1601269008](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1601269008)) failed with exit code 100 because `apt-get` couldn't reach `archive.ubuntu.com`. The download phase took ~50 minutes at 29.3 kB/s before timing out on several packages. This is the same class of failure that the other Dockerfiles already mitigate with their mirrorlist setup — this Dockerfile was simply missing it.

### Describe how you validated your changes

Compared the added block character-by-character against the existing implementation in `Dockerfiles/base-image/Dockerfile` (lines 13-26). The `ARG CI` was already declared in the Dockerfile (line 19) and the CI job already passes `--build-arg CI`.

### Additional Notes

No user-facing changes — CI-only improvement.