### PR TITLE
Fix flaky `TestThrottled` (pkg/trace/log) with `testing/synctest`

### DIFF
--- a/pkg/trace/log/throttled_test.go
+++ b/pkg/trace/log/throttled_test.go
@@ -9,17 +9,14 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestThrottled(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
-	t.Run("basic", func(t *testing.T) {
+	basic := func(t *testing.T) {
 		l := NewThrottled(2, 10*time.Millisecond)
 		var out bytes.Buffer
 		logFunc := func(format string, params ...interface{}) {
@@ -33,9 +30,9 @@ func TestThrottled(t *testing.T) {
 			l.log(logFunc, "%d\n", i)
 		}
 		assert.Equal(t, "0\n1\nToo many similar messages, pausing up to 10ms...10\n11\nToo many similar messages, pausing up to 10ms...", out.String())
-	})
+	}
 
-	t.Run("resets", func(t *testing.T) {
+	resets := func(t *testing.T) {
 		l := NewThrottled(2, 10*time.Millisecond)
 		var out bytes.Buffer
 		logFunc := func(format string, params ...interface{}) {
@@ -50,9 +47,9 @@ func TestThrottled(t *testing.T) {
 		l.log(logFunc, "5\n")
 		l.log(logFunc, "6\n")
 		assert.Equal(t, "1\n2\n3\n4\n5\nToo many similar messages, pausing up to 10ms...", out.String())
-	})
+	}
 
-	t.Run("io.Writer", func(t *testing.T) {
+	ioWriter := func(t *testing.T) {
 		var out bytes.Buffer
 		SetLogger(NewBufferLogger(&out))
 		l := NewThrottled(2, 10*time.Millisecond)
@@ -69,5 +66,9 @@ func TestThrottled(t *testing.T) {
 		l.Write([]byte("9\n"))
 		logger.Flush()
 		assert.Equal(t, "[ERROR] 1\n[ERROR] 2\n[ERROR] 3\n[ERROR] 4\n[ERROR] 5\n[ERROR] Too many similar messages, pausing up to 10ms...", out.String())
-	})
+	}
+
+	t.Run("basic", func(t *testing.T) { synctest.Test(t, basic) })
+	t.Run("resets", func(t *testing.T) { synctest.Test(t, resets) })
+	t.Run("io.Writer", func(t *testing.T) { synctest.Test(t, ioWriter) })
 }


### PR DESCRIPTION
### What does this PR do?
Use `testing/synctest` to give each subtest a fake clock, making `time.AfterFunc` resets deterministic without any real sleeping.

This allows to **drop** the `t.Skip()` on `testing.Short()` now the 3 subtests complete in no time.

### Motivation
`TestThrottled/resets` was intermittently failing because `time.AfterFunc(10ms)` could fire after the `time.Sleep(20ms)` returned on a loaded runner, leaving the counter unreset and causing spurious throttle messages on my machine and in CI ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1593109688#L1067)):
```
==================== Test output for //pkg/trace/log:log_test:
--- FAIL: TestThrottled (0.12s)
    --- FAIL: TestThrottled/basic (0.04s)
        throttled_test.go:35:
            	Error Trace:	pkg/trace/log/throttled_test.go:35
            	Error:      	Not equal:
            	            	expected: "0\n1\nToo many similar messages, pausing up to 10ms...10\n11\nToo many similar messages, pausing up to 10ms..."
            	            	actual  : "0\n1\n2\nToo many similar messages, pausing up to 10ms...10\n11\nToo many similar messages, pausing up to 10ms..."

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -2,2 +2,3 @@
            	            	 1
            	            	+2
            	            	 Too many similar messages, pausing up to 10ms...10
            	Test:       	TestThrottled/basic
FAIL
================================================================================
```

The 2:1 sleep/timer ratio was too tight, and increasing it would have made the test slower.

### Describe how you validated your changes
`bazel test --nocache_test_results //pkg/trace/log:log_test` passes in 0.0s (was 0.1s).

### Additional Notes
Follows the pattern established in #43452 and refined in #45016 for `pkg/trace/containertags`: `synctest.Test(t, func)`.

Worth a read: [Testing concurrent code with testing/synctest](https://go.dev/blog/synctest).