### PR TITLE
dont send default via configsync

### DIFF
--- a/comp/api/api/apiimpl/internal/config/endpoint.go
+++ b/comp/api/api/apiimpl/internal/config/endpoint.go
@@ -93,6 +93,10 @@ func (c *configEndpoint) getAllConfigValuesHandler(w http.ResponseWriter, r *htt
 	log.Debugf("config endpoint received a request from '%s' for all authorized config values", r.RemoteAddr)
 	allValues := make(map[string]interface{}, len(c.authorizedConfigPaths))
 	for key := range c.authorizedConfigPaths {
+		// only send values that were explicitly configured above defaults as to not break IsConfigured for the sub-agent
+		if !c.cfg.IsConfigured(key) {
+			continue
+		}
 		if key == "logs_config.additional_endpoints" {
 			entries, err := encodeInterfaceSliceToStringMap(c.cfg, key)
 			if err != nil {

--- a/comp/api/api/apiimpl/internal/config/endpoint_test.go
+++ b/comp/api/api/apiimpl/internal/config/endpoint_test.go
@@ -181,6 +181,25 @@ func TestConfigListEndpoint(t *testing.T) {
 		},
 	}
 
+	// a key with only a default value must be excluded from the response so that IsConfigured() remains false on the receiving sub agent
+	t.Run("defaults_not_sent", func(t *testing.T) {
+		cfg, server, _ := getConfigServer(t, api.AuthorizedSet{"my.config.value": {}})
+
+		cfg.SetDefault("my.config.value", "default_value")
+
+		resp, err := server.Client().Get(server.URL + "/")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		data, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var configValues map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &configValues))
+		assert.NotContains(t, configValues, "my.config.value", "default-only values must not be sent via config sync")
+	})
+
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			cfg, server, _ := getConfigServer(t, test.authorizedConfigs)
@@ -205,7 +224,10 @@ func TestConfigListEndpoint(t *testing.T) {
 
 				expectedValues := make(map[string]interface{})
 				for key := range test.authorizedConfigs {
-					expectedValues[key] = cfg.Get(key)
+					// Only configured (non-default) values are included in the response
+					if cfg.IsConfigured(key) {
+						expectedValues[key] = cfg.Get(key)
+					}
 				}
 
 				assert.Equal(t, expectedValues, configValues)


### PR DESCRIPTION
### What does this PR do?
Don't send default values in the config sync endpoint response, Only values explicitly configured above SourceDefault are now sent to sub-agents

### Motivation
Config sync sends all values to sub-agents including defaults. The receiver writes them at SourceLocalConfigProcess, which is higher priority than SourceDefault, so `IsConfigured()` returns true for settings the user never set which can break things

Sub-agents share the same defaults as the core agent, so we just stop sending them.

### Describe how you validated your changes
CI, Unit Tests

### Additional Notes
