### PR TITLE
Fix AutoLogger uninstall cleanup to avoid reparse-point traversal

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/AutoLoggerCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/AutoLoggerCustomAction.cs
@@ -209,9 +209,23 @@ namespace Datadog.CustomActions
                 {
                     if (Directory.Exists(logonDurationDir))
                     {
+                        var logonDurationDirAttributes = File.GetAttributes(logonDurationDir);
+                        if ((logonDurationDirAttributes & FileAttributes.ReparsePoint) != 0)
+                        {
+                            session.Log($"Warning: skipping cleanup of reparse point directory: {logonDurationDir}");
+                            return ActionResult.Success;
+                        }
+
                         session.Log($"Cleaning logon duration directory: {logonDurationDir}");
                         foreach (var file in Directory.GetFiles(logonDurationDir))
                         {
+                            var fileAttributes = File.GetAttributes(file);
+                            if ((fileAttributes & FileAttributes.ReparsePoint) != 0)
+                            {
+                                session.Log($"Warning: skipping deletion of reparse point file: {file}");
+                                continue;
+                            }
+
                             File.Delete(file);
                         }
                         session.Log("Logon duration directory cleaned");


### PR DESCRIPTION
### Motivation
- The installer granted `ddagentuser` FullControl over the `logonduration` directory, and the deferred `RemoveAutoLogger` action runs as `SYSTEM`, so an attacker able to create a junction under that directory could cause SYSTEM to follow it and delete arbitrary files during uninstall/upgrade.

### Description
- Add a guard in `RemoveAutoLogger` (`tools/windows/DatadogAgentInstaller/CustomActions/AutoLoggerCustomAction.cs`) to skip cleaning the `logonduration` directory if it is a reparse point (junction/symlink) by checking `File.GetAttributes(...) & FileAttributes.ReparsePoint`.
- Skip deletion of any file entries that are themselves reparse points while continuing to delete regular files, and log warnings when skipping entries.
- Preserve existing behavior on normal files and return `ActionResult.Success` on guarded skips to avoid failing uninstalls.

### Testing
- Ran `dda inv --help` successfully as a lightweight validation step in this environment and committed the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df5aeda4a083329b0668353700f813)