### PR TITLE
[compliance] restrict oscap-exec to embedded oscap-io

### DIFF
--- a/cmd/security-agent/subcommands/compliance/oscapexec.go
+++ b/cmd/security-agent/subcommands/compliance/oscapexec.go
@@ -17,11 +17,10 @@ import (
 // oscapExecCommand returns the 'compliance oscap-exec' command
 func oscapExecCommand(_ *command.GlobalParams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "oscap-exec <binary-path> [args...]",
+		Use:    "oscap-exec [args...]",
 		Short:  "Execute oscap-io with dropped capabilities (internal use only)",
 		Long:   "Internal command that drops capabilities before executing oscap-io. This command should not be called directly by users.",
 		Hidden: true,
-		Args:   cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cli.RunOscapExec(args)
 		},

--- a/cmd/system-probe/subcommands/compliance/oscapexec.go
+++ b/cmd/system-probe/subcommands/compliance/oscapexec.go
@@ -17,11 +17,10 @@ import (
 // oscapExecCommand returns the 'compliance oscap-exec' command
 func oscapExecCommand(_ *command.GlobalParams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "oscap-exec <binary-path> [args...]",
+		Use:    "oscap-exec [args...]",
 		Short:  "Execute oscap-io with dropped capabilities (internal use only)",
 		Long:   "Internal command that drops capabilities before executing oscap-io. This command should not be called directly by users.",
 		Hidden: true,
-		Args:   cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cli.RunOscapExec(args)
 		},

--- a/pkg/compliance/cli/oscapexec.go
+++ b/pkg/compliance/cli/oscapexec.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"syscall"
 
 	"github.com/syndtr/gocapability/capability"
@@ -19,12 +20,10 @@ import (
 
 // RunOscapExec executes oscap-io with dropped capabilities
 func RunOscapExec(args []string) error {
-	if len(args) < 1 {
-		return errors.New("oscap-exec requires at least one argument (binary path)")
+	binaryPath, err := getOSCAPIODefaultBinPath()
+	if err != nil {
+		return err
 	}
-
-	binaryPath := args[0]
-	execArgs := args // args[0] will be the binary path (used as argv[0])
 
 	// Verify the binary exists
 	if _, err := os.Stat(binaryPath); err != nil {
@@ -43,12 +42,26 @@ func RunOscapExec(args []string) error {
 
 	// Execute oscap-io (replaces current process)
 	// Note: syscall.Exec never returns on success
+	execArgs := append([]string{binaryPath}, args...)
 	if err := syscall.Exec(binaryPath, execArgs, os.Environ()); err != nil {
 		return fmt.Errorf("failed to exec oscap-io at %s: %w", binaryPath, err)
 	}
 
 	// This line should never be reached
 	return nil
+}
+
+func getOSCAPIODefaultBinPath() (string, error) {
+	here, err := filepath.EvalSymlinks("/proc/self/exe")
+	if err != nil {
+		return "", errors.New("can't find own executable")
+	}
+
+	binPath := filepath.Join(here, "..", "..", "embedded", "bin", "oscap-io")
+	if _, err := os.Stat(binPath); err == nil {
+		return binPath, nil
+	}
+	return binPath, fmt.Errorf("can't access the default oscap-io binary at %s", binPath)
 }
 
 // dropCapabilities drops all capabilities except CAP_SYS_CHROOT and CAP_DAC_OVERRIDE

--- a/pkg/compliance/cli/oscapexec.go
+++ b/pkg/compliance/cli/oscapexec.go
@@ -8,12 +8,12 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
 
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	"github.com/syndtr/gocapability/capability"
 	"golang.org/x/sys/unix"
 )
@@ -52,9 +52,9 @@ func RunOscapExec(args []string) error {
 }
 
 func getOSCAPIODefaultBinPath() (string, error) {
-	here, err := filepath.EvalSymlinks("/proc/self/exe")
+	here, err := executable.Folder()
 	if err != nil {
-		return "", errors.New("can't find own executable")
+		return "", err
 	}
 
 	binPath := filepath.Join(here, "..", "..", "embedded", "bin", "oscap-io")

--- a/pkg/compliance/evaluator_xccdf.go
+++ b/pkg/compliance/evaluator_xccdf.go
@@ -24,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/metrics"
 	"github.com/DataDog/datadog-agent/pkg/compliance/scap"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
-	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -71,16 +70,6 @@ type oscapIO struct {
 	DoneCh   chan bool
 }
 
-// From pkg/collector/corechecks/embed/process_agent.go.
-func getOSCAPIODefaultBinPath() (string, error) {
-	here, _ := executable.Folder()
-	binPath := filepath.Join(here, "..", "..", "embedded", "bin", "oscap-io")
-	if _, err := os.Stat(binPath); err == nil {
-		return binPath, nil
-	}
-	return binPath, fmt.Errorf("Can't access the default oscap-io binary at %s", binPath)
-}
-
 func newOSCAPIO(file string) *oscapIO {
 	return &oscapIO{
 		File:     file,
@@ -111,13 +100,8 @@ func (p *oscapIO) Run(ctx context.Context) error {
 	}
 	args = append(args, p.File)
 
-	binPath, err := getOSCAPIODefaultBinPath()
-	if err != nil {
-		return err
-	}
-
-	// Build command: /proc/self/exe compliance oscap-exec <oscap-io-path> [args...]
-	execArgs := append([]string{"compliance", "oscap-exec", binPath}, args...)
+	// Build command: /proc/self/exe compliance oscap-exec [args...]
+	execArgs := append([]string{"compliance", "oscap-exec"}, args...)
 	cmd := exec.CommandContext(ctx, "/proc/self/exe", execArgs...)
 	cmd.Dir = filepath.Dir(p.File)
 	cmd.Env = os.Environ()


### PR DESCRIPTION
### Motivation
- Close a local privilege-escalation vector where the hidden `compliance oscap-exec` subcommand accepted a user-supplied binary path and would `exec` it with retained capabilities (`CAP_SYS_CHROOT`, `CAP_DAC_OVERRIDE`).
- Ensure only the intended embedded `oscap-io` binary is executed when running compliance benchmarks, preserving the original internal behavior while removing an attack surface.

### Description
- Remove the `binary-path` parameter from the hidden `compliance oscap-exec` commands in both `system-probe` and `security-agent` so the subcommand usage is now `oscap-exec [args...]` and no longer accepts an arbitrary executable path. 
- Change `RunOscapExec` in `pkg/compliance/cli/oscapexec.go` to resolve the embedded `oscap-io` path from the agent executable (`/proc/self/exe`) and always `exec` that trusted binary while forwarding remaining oscap arguments. 
- Update internal caller in `pkg/compliance/evaluator_xccdf.go` to stop passing a binary path and instead invoke `/proc/self/exe compliance oscap-exec [args...]` so behavior for internal consumers is preserved. 
- Remove redundant path-resolution code from the evaluator and add a local `getOSCAPIODefaultBinPath` helper in the cli package to centralize resolution logic.

### Testing
- Ran `gofmt -w` on the modified files to normalize formatting and it completed successfully. 
- Attempted `dda inv test --targets=./pkg/compliance/cli` but the test run could not complete in this environment due to a `git describe` tag resolution error in the test harness. 
- Ran `git diff --check` which passed with no whitespace or diff errors detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e082e06d248332a773b6c77f1204b7)