### PR TITLE
[ACIX-1310] fix(windows): Pass `GOPROXY` and `GONOSUMDB` to build containers

### DIFF
--- a/.gitlab/build/binary_build/schema_generation.yml
+++ b/.gitlab/build/binary_build/schema_generation.yml
@@ -80,6 +80,8 @@ generate_config_schema-windows:
       -e CI_PROJECT_NAME
       -e AWS_NETWORKING=true
       -e GOMODCACHE="c:\modcache"
+      -e GOPROXY
+      -e GONOSUMDB
       -e PIP_INDEX_URL
       -e DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS
       -e CI_IDENTITIES_GITLAB_ID_TOKEN

--- a/.gitlab/windows/build/binary_build/windows.yml
+++ b/.gitlab/windows/build/binary_build/windows.yml
@@ -23,6 +23,8 @@ build_windows_container_entrypoint:
       -e CI_PROJECT_NAME
       -e WINDOWS_BUILDER=true
       -e AWS_NETWORKING=true
+      -e GOPROXY
+      -e GONOSUMDB
       -e TARGET_ARCH="$ARCH"
       ${WINBUILDIMAGE}
       c:\mnt\Dockerfiles\agent\windows\entrypoint\build.bat

--- a/.gitlab/windows/build/lint/windows.yml
+++ b/.gitlab/windows/build/lint/windows.yml
@@ -23,6 +23,8 @@
       -e CI_PROJECT_NAME
       -e CI_IDENTITIES_GITLAB_ID_TOKEN
       -e GOMODCACHE="c:\modcache"
+      -e GOPROXY
+      -e GONOSUMDB
       -e RUST_LOG="uv=trace"
       ${WINBUILDIMAGE}
       powershell.exe -c "c:\mnt\tasks\winbuildscripts\Invoke-Linters.ps1 -BuildOutOfSource 1 -CheckGoVersion 1 -InstallDeps 1"

--- a/.gitlab/windows/build/package_build/windows.yml
+++ b/.gitlab/windows/build/package_build/windows.yml
@@ -29,6 +29,8 @@
       -e WINDOWS_DDPROCMON_VERSION
       -e WINDOWS_DDPROCMON_SHASUM
       -e GOMODCACHE="c:\modcache"
+      -e GOPROXY
+      -e GONOSUMDB
       -e AWS_NETWORKING=true
       -e SIGN_WINDOWS_DD_WCS=true
       -e TARGET_ARCH="$ARCH"
@@ -114,6 +116,8 @@ windows_msi_and_bosh_zip_x64-a7-fips:
       -e WINDOWS_DDPROCMON_VERSION
       -e WINDOWS_DDPROCMON_SHASUM
       -e GOMODCACHE="c:\modcache"
+      -e GOPROXY
+      -e GONOSUMDB
       -e AWS_NETWORKING=true
       -e SIGN_WINDOWS_DD_WCS=true
       -e BUCKET_BRANCH

--- a/.gitlab/windows/build/source_test/windows.yml
+++ b/.gitlab/windows/build/source_test/windows.yml
@@ -36,6 +36,8 @@
       -e AWS_NETWORKING=true
       -e SIGN_WINDOWS_DD_WCS=true
       -e GOMODCACHE="c:\modcache"
+      -e GOPROXY
+      -e GONOSUMDB
       -e JUNIT_TAR="c:\mnt\junit-${CI_JOB_NAME_SLUG}.tgz"
       -e PIP_INDEX_URL
       -e TEST_OUTPUT_FILE="${TEST_OUTPUT_FILE}.json"
@@ -85,6 +87,8 @@ tests_windows-x64:
       -e CI_PROJECT_NAME
       -e SIGN_WINDOWS_DD_WCS=true
       -e GOMODCACHE="c:\modcache"
+      -e GOPROXY
+      -e GONOSUMDB
       -e PIP_INDEX_URL
       ${WINBUILDIMAGE}
       c:\mnt\tasks\winbuildscripts\sysprobe.bat
@@ -109,6 +113,8 @@ tests_windows-x64:
       -e CI_PROJECT_NAME
       -e SIGN_WINDOWS_DD_WCS=true
       -e GOMODCACHE="c:\modcache"
+      -e GOPROXY
+      -e GONOSUMDB
       -e PIP_INDEX_URL
       ${WINBUILDIMAGE}
       c:\mnt\tasks\winbuildscripts\secagent.bat

--- a/.gitlab/windows/test/integration_test/windows.yml
+++ b/.gitlab/windows/test/integration_test/windows.yml
@@ -29,6 +29,8 @@
       -e CI_IDENTITIES_GITLAB_ID_TOKEN
       -e AWS_NETWORKING=true
       -e GOMODCACHE="c:\modcache"
+      -e GOPROXY
+      -e GONOSUMDB
       -e VCPKG_BINARY_SOURCES="clear;x-azblob,${vcpkgBlobSaSUrl}"
       -e PIP_INDEX_URL
       ${WINBUILDIMAGE}


### PR DESCRIPTION
### What does this PR do?
Adds `-e GOPROXY` and `-e GONOSUMDB` to several Windows build container invocations.

### Motivation
These are set at the global CI level to make sure go builds use ADMS, but these get stripped out when running in a Docker context.

### Describe how you validated your changes

### Additional Notes
