### PR TITLE
[ACIX-1310] fix(omnibus): Pass Go proxy env vars in local docker-build task

### DIFF
--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -686,6 +686,10 @@ def docker_build(
         "-e GIT_CONFIG_VALUE_0=/go/src/github.com/DataDog/datadog-agent",
         # Skip XZ compression - faster for local dev, use omnibus.build for CI
         "-e SKIP_PKG_COMPRESSION=true",
+        # Pass-through Go proxy env vars
+        "-e GOPROXY",
+        "-e GONOSUMDB",
+        "-e GOPRIVATE",
     ]
 
     # Build volume mounts (note: /opt/datadog-agent is a symlink created in build_cmd)


### PR DESCRIPTION
### What does this PR do?
Forward GOPROXY, GONOSUMDB, and GOPRIVATE into the Docker container spawned by `omnibus.docker-build`

### Motivation
 so that local builds respect the user's Go module proxy configuration (e.g. ADMS).

### Describe how you validated your changes

### Additional Notes
