### PR TITLE
Bump Python version to 3.13.13

### DIFF
--- a/deps/cpython/cpython.MODULE.bazel
+++ b/deps/cpython/cpython.MODULE.bazel
@@ -1,6 +1,6 @@
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-PYTHON_VERSION = "3.13.12"
+PYTHON_VERSION = "3.13.13"
 
 http_archive(
     name = "cpython",
@@ -15,7 +15,7 @@ http_archive(
         "//deps/cpython:0002-Set-the-install-name-to-use-rpath-instead-of-absolut.patch",
         "//deps/cpython:0003-propagate-pgo-test-exit-code.patch",
     ],
-    sha256 = "12e7cb170ad2d1a69aee96a1cc7fc8de5b1e97a2bdac51683a3db016ec9a2996",
+    sha256 = "f9cde7b0e2ec8165d7326e2a0f59ea2686ce9d0c617dbbb3d66a7e54d31b74b9",
     strip_prefix = "Python-{}".format(PYTHON_VERSION),
     url = "https://python.org/ftp/python/{0}/Python-{0}.tgz".format(PYTHON_VERSION),
 )

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -1,6 +1,6 @@
 name "python3"
 
-default_version "3.13.12"
+default_version "3.13.13"
 
 dependency "openssl3"
 

--- a/releasenotes/notes/Bump-embedded-Python-to-3.13.13-9a1e7fed60ed49f3.yaml
+++ b/releasenotes/notes/Bump-embedded-Python-to-3.13.13-9a1e7fed60ed49f3.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+- |
+    The Agent's embedded Python has been upgraded from 3.13.12 to 3.13.13

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -223,7 +223,7 @@ const (
 	ExpectedPythonVersion2 = "2.7.18"
 	// ExpectedPythonVersion3 is the expected python 3 version
 	// Bump this version when the version in omnibus/config/software/python3.rb changes
-	ExpectedPythonVersion3 = "3.13.12"
+	ExpectedPythonVersion3 = "3.13.13"
 	// ExpectedUnloadedPython is the status value for uninitialized lazy loaded python runtime
 	ExpectedUnloadedPython = "unused"
 )


### PR DESCRIPTION
### What does this PR do?

Upgrades the Agent's embedded Python from **3.13.12** to **3.13.13** (patch version update).

### Motivation

Keep embedded Python up-to-date with bug fixes and security patches. See the [official release page](https://www.python.org/downloads/release/python-31313/) for details.

### Changes

- `omnibus/config/software/python3.rb` — bumped `default_version`
- `deps/cpython/cpython.MODULE.bazel` — bumped `PYTHON_VERSION` and `sha256`
- `test/new-e2e/tests/agent-platform/common/agent_behaviour.go` — bumped `ExpectedPythonVersion3`
- Added release note

### Describe how you validated your changes

SHA256 hash fetched and verified against the official Python.org SBOM. CI is considered enough to validate changes.