### PR TITLE
[ACIX-1310] fix(ci): Fix rtloader test job + add missing cache extract to linux unit tests

### DIFF
--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -27,6 +27,7 @@
     TEST_OUTPUT_FILE: test_output
     EXTERNAL_LINKS_PATH: external_links_$CI_JOB_ID.json
   before_script:
+    - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
   script:
     - dda inv -- -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
@@ -119,6 +120,7 @@ tests_linux-arm64-py3:
     - .linux_tests
   needs: ["go_deps", "go_tools_deps_arm64"]
   before_script:
+    - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps_arm64]
   after_script:
     - !reference [.upload_junit_source]
@@ -210,6 +212,7 @@ tests_gpu:
   allow_failure: true
   before_script:
     - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
   after_script:
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]

--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -1,16 +1,20 @@
 ---
 .rtloader_tests:
   stage: source_test
-  needs: ["go_deps"]
-  before_script:
+  extends: .unit_test_base
+  rules:
+    - !reference [.except_disable_unit_tests]
+    - !reference [.fast_on_dev_branch_only]
+  script:
     - source /root/.bashrc && conda activate $CONDA_ENV
-    - !reference [.retrieve_linux_go_deps]
     - dda inv -- -e rtloader.make --install-prefix=$CI_PROJECT_DIR/dev
     - dda inv -- -e rtloader.install
     - dda inv -- -e rtloader.format --raise-if-changed
     - dda inv -- -e rtloader.test
-  # Placeholder script, overridden by .linux_tests when running all go tests
-  script: ["# Skipping go tests"]
+  after_script:
+    - !reference [.upload_junit_source]
+    - !reference [.upload_coverage]
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
 
 .linux_tests:
   stage: source_test
@@ -54,7 +58,6 @@
 
 tests_linux-x64-py3:
   extends:
-    - .rtloader_tests
     - .linux_tests
     - .linux_x64
   after_script:
@@ -65,7 +68,6 @@ tests_linux-x64-py3:
 
 tests_nodetreemodel:
   extends:
-    - .rtloader_tests
     - .linux_tests
     - .linux_x64
   after_script:
@@ -83,7 +85,6 @@ tests_nodetreemodel:
 
 tests_flavor_iot_linux-x64:
   extends:
-    - .rtloader_tests
     - .linux_tests
     - .linux_x64
   after_script:
@@ -94,7 +95,6 @@ tests_flavor_iot_linux-x64:
 
 tests_flavor_dogstatsd_linux-x64:
   extends:
-    - .rtloader_tests
     - .linux_tests
     - .linux_x64
   after_script:
@@ -105,7 +105,6 @@ tests_flavor_dogstatsd_linux-x64:
 
 tests_flavor_heroku_linux-x64:
   extends:
-    - .rtloader_tests
     - .linux_tests
     - .linux_x64
   after_script:
@@ -116,7 +115,6 @@ tests_flavor_heroku_linux-x64:
 
 tests_linux-arm64-py3:
   extends:
-    - .rtloader_tests
     - .linux_tests
   needs: ["go_deps", "go_tools_deps_arm64"]
   before_script:
@@ -129,6 +127,22 @@ tests_linux-arm64-py3:
   tags: ["arch:arm64", "specific:true"]
   variables:
     CONDA_ENV: ddpy3
+
+tests_rtloader-x64:
+  extends: .rtloader_tests
+  needs: ["go_deps", "go_tools_deps"]
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
+  tags: ["arch:amd64", "specific:true"]
+
+tests_rtloader-arm64:
+  extends: .rtloader_tests
+  needs: ["go_deps", "go_tools_deps_arm64"]
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps_arm64]
+  tags: ["arch:arm64", "specific:true"]
 
 
 tests_serverless-init:

--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -2,19 +2,15 @@
 .rtloader_tests:
   stage: source_test
   extends: .unit_test_base
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   rules:
     - !reference [.except_disable_unit_tests]
     - !reference [.fast_on_dev_branch_only]
   script:
-    - source /root/.bashrc && conda activate $CONDA_ENV
     - dda inv -- -e rtloader.make --install-prefix=$CI_PROJECT_DIR/dev
     - dda inv -- -e rtloader.install
     - dda inv -- -e rtloader.format --raise-if-changed
     - dda inv -- -e rtloader.test
-  after_script:
-    - !reference [.upload_junit_source]
-    - !reference [.upload_coverage]
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
 
 .linux_tests:
   stage: source_test

--- a/.gitlab/test/kernel_matrix_testing/common.yml
+++ b/.gitlab/test/kernel_matrix_testing/common.yml
@@ -173,6 +173,7 @@
   before_script:
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
     - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
     - !reference [.retrieve_linux_go_e2e_deps]
     - !reference [.retrieve_linux_pulumi_plugins]
     - !reference [.kmt_new_profile]


### PR DESCRIPTION
### What does this PR do?
Add missing cache extraction steps to some jobs (linux tests and KMT setup)

### Motivation
Otherwise these jobs do not benefit from the pre-caching of all go deps done in `go_deps` and end up redownloading go packages (from ADMS, but still).

### Describe how you validated your changes

### Additional Notes
