### PR TITLE
[observer/testbench] Default --skip-dropped to true

### DIFF
--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -60,7 +60,7 @@ func main() {
 	verbose := flag.Bool("verbose", false, "Include full detail in JSON output (headless mode only)")
 	memProfile := flag.String("memprofile", "", "Write heap profile to this file after headless run (headless mode only)")
 	sendAnomalyEvent := flag.String("send-anomaly-event", "", "Run scenario and send one Datadog event per correlation, then exit")
-	skipDropped := flag.Bool("skip-dropped", false, "Skip metrics marked as dropped by the live observer's channel during parquet load")
+	skipDropped := flag.Bool("skip-dropped", true, "Skip metrics marked as dropped by the live observer's channel during parquet load")
 	logsOnly := flag.Bool("logs-only", false, "Load only log rows from scenarios; skip parquet metrics and trace stats (interactive and headless)")
 	flag.Parse()
 

--- a/comp/observer/impl/advance_log.go
+++ b/comp/observer/impl/advance_log.go
@@ -21,9 +21,9 @@ const advanceLogFileName = "advances.jsonl"
 type advanceEntry struct {
 	DataTime           int64            `json:"data_time"`
 	Reason             string           `json:"reason"`
-	LatePoints         int64            `json:"late_points,omitempty"`            // points ingested after their timestamp was analyzed
+	LatePoints         int64            `json:"late_points,omitempty"`           // points ingested after their timestamp was analyzed
 	LatePointsBySource map[string]int64 `json:"late_points_by_source,omitempty"` // per-source breakdown
-	DroppedObs         int64            `json:"dropped_obs,omitempty"`            // observations dropped due to full channel
+	DroppedObs         int64            `json:"dropped_obs,omitempty"`           // observations dropped due to full channel
 	DroppedBySource    map[string]int64 `json:"dropped_by_source,omitempty"`     // per-source breakdown
 }
 
@@ -73,14 +73,14 @@ func (r *advanceLogRecorder) close() error {
 
 // advanceLogComparator compares advance sequences between live and replay.
 type advanceLogComparator struct {
-	liveAdvances           map[int64]advanceEntry // dataTime → full entry
-	replayOnly             []advanceEntry
-	liveOnly               []advanceEntry
-	matched                int
-	totalLatePoints        int64
-	totalDroppedObs        int64
-	totalLateBySource      map[string]int64
-	totalDroppedBySource   map[string]int64
+	liveAdvances         map[int64]advanceEntry // dataTime → full entry
+	replayOnly           []advanceEntry
+	liveOnly             []advanceEntry
+	matched              int
+	totalLatePoints      int64
+	totalDroppedObs      int64
+	totalLateBySource    map[string]int64
+	totalDroppedBySource map[string]int64
 }
 
 func newAdvanceLogComparator(path string) (*advanceLogComparator, error) {

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -129,7 +129,7 @@ type TestBench struct {
 	compCorrCache      []CompressedGroup
 	compCorrThreshold  float64
 	compCorrGeneration uint64
-	corrGeneration     uint64 // bumped after each rerunDetectorsLocked
+	corrGeneration     uint64  // bumped after each rerunDetectorsLocked
 	liveAdvanceTimes   []int64 // when set, replay uses live advance schedule
 
 	// SSE broadcast hub for pushing events to connected browsers.
@@ -564,7 +564,6 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 
 	return nil
 }
-
 
 // resetAllState resets all registered components that support Reset().
 func (tb *TestBench) resetAllState() {


### PR DESCRIPTION
## Summary

Changes the default of `--skip-dropped` from `false` to `true` in the observer testbench. Metrics flagged as `Dropped=true` in parquet (dropped by the live observer's channel backpressure) are now excluded from replay by default, improving parity with what the live observer actually processed.

Also fixes preexisting lint failures. 

## Evidence

### F1 comparison: default (with drops) vs skip-dropped (without drops)

| Scenario | BOCPD | BOCPD (skip) | ScanMW | ScanMW (skip) | ScanWelch | ScanWelch (skip) |
|----------|-------|-------------|--------|--------------|-----------|-----------------|
| 059_fortnite | 0.2723 | 0.2723 | 0.0267 | 0.0267 | 0.0203 | 0.0203 |
| 063_twilio | 0.9451 | 0.9451 | 0.1421 | 0.1421 | 0.1421 | 0.1421 |
| 093_cloudflare | 0.1111 | 0.1111 | 0.0525 | 0.0555 | 0.0353 | 0.0353 |
| 211_doordash | 0.0000 | 0.0000 | 0.2615 | 0.2615 | 0.0647 | 0.0584 |
| 213_pagerduty | 0.4793 | 0.4793 | 0.0172 | 0.0172 | 0.0138 | 0.0138 |
| 221_base | 0.0000 | 0.0000 | 0.0205 | 0.0183 | 0.0563 | 0.0519 |
| food_delivery_redis | 0.0000 | 0.0000 | 0.6187 | 0.6187 | 0.6187 | 0.6187 |

Max delta: 0.006 (noise-level). Skip-dropped has no meaningful effect on detection accuracy.

### Dropped metric volume per scenario

| Scenario | Dropped | Total | % | App-Level Dropped | % App |
|----------|---------|-------|---|-------------------|-------|
| 063_twilio | 384 | 599,539 | 0.1% | 0 | 0% |
| 093_cloudflare | 20,549 | 756,305 | 2.7% | 9,054 | 44% |
| 211_doordash | 10,074 | 572,854 | 1.8% | 2,365 | 24% |
| 221_base | 8,850 | 898,410 | 1.0% | 112 | 1.3% |
| food_delivery_redis | 4,419 | 543,183 | 0.8% | 323 | 7.3% |

### Dropped metric corpus analysis (from parquet `Dropped=true` column)

Drops are a mix of infrastructure and application metrics. Some scenarios have significant app-level drops (093_cloudflare: 44% of drops are `postgresql.*`/`coredns.*`), yet F1 is unaffected — the dropped samples occur at low frequency per metric (1-3 samples each) and don't affect changepoint detection windows.

**093_cloudflare** (20,549 dropped, 9,054 app-level):
- `dd.postgres.operation.time` (1,399), `postgresql.*` (~4.6K: activity, slru, wal, deadlocks, conflicts, connections)
- `coredns.*` (~1K: proxy_request_duration, response_size, health_request_duration, process/memstats)
- `system.fs.inodes.*` (~5K), `system.disk.*` (~5K)

**211_doordash** (10,074 dropped, 2,365 app-level):
- `coredns.*` (~1.5K: proxy_request_duration, process/memstats, gc_duration)
- `dd.postgres.operation.time` (50), `postgresql.*` (~100)
- `system.fs.inodes.*` (~3K), `system.disk.*` (~3K), `kubernetes.*` (~500)

**221_base** (8,850 dropped, 112 app-level):
- `redis.*` (112: cpu, replication, eventloop, acl — 1-3 samples each)
- `system.fs.inodes.*` (~3.5K), `system.disk.*` (~3.3K)

**food_delivery_redis** (4,419 dropped, 323 app-level):
- `redis.*` (323: mem, net, rdb, replication, slowlog — 2 samples each)
- `datadog.*` (~870), `system.*` (~1.2K), `kubernetes.*` (~190)

**063_twilio** (384 dropped, 0 app-level):
- All `kubernetes.*` (rest.client.latency, kubelet.runtime, probes)

### Why F1 is unaffected despite app-level drops

The dropped app-level metrics are sparse (1-3 samples per metric per scenario). Changepoint detectors need sustained shifts across multiple consecutive samples to trigger. Losing a handful of isolated samples from a metric's time series doesn't create or remove a detectable changepoint.

## Test plan

- [x] Ran eval-scenarios for all 3 detector combos with and without `--skip-dropped`
- [x] Verified max F1 delta is < 0.01 across all scenario × detector combinations
- [x] Analyzed dropped metric corpus from parquet `Dropped=true` column
- [ ] Can be reverted with `--skip-dropped=false` if needed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)