### PR TITLE
[PROF-14066] Bump ebpf-profiler fork and extend profiler deps check for pdata/pprofile

### DIFF
--- a/comp/host-profiler/symboluploader/symbol/elf.go
+++ b/comp/host-profiler/symboluploader/symbol/elf.go
@@ -44,7 +44,7 @@ type Elf struct {
 	elfDataDump string
 }
 
-func NewElfFromMapping(m *process.Mapping, gnuBuildID, goBuildID string, fileID libpf.FileID, pr process.Process) (*Elf, error) {
+func NewElfFromMapping(m *process.RawMapping, gnuBuildID, goBuildID string, fileID libpf.FileID, pr process.Process) (*Elf, error) {
 	wrapper, err := newElfWrapperFromMapping(m, pr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create elf wrapper from mapping: %w", err)

--- a/comp/host-profiler/symboluploader/symbol/elf_wrapper.go
+++ b/comp/host-profiler/symboluploader/symbol/elf_wrapper.go
@@ -79,7 +79,7 @@ func (e *elfWrapper) Close() error {
 	return e.elfFile.Close()
 }
 
-func newElfWrapperFromVDSO(m *process.Mapping, pr process.Process) (ef *elfWrapper, err error) {
+func newElfWrapperFromVDSO(m *process.RawMapping, pr process.Process) (ef *elfWrapper, err error) {
 	// vdso is not backed by a file
 	data := make([]byte, m.Length)
 	_, err = pr.GetRemoteMemory().ReadAt(data, int64(m.Vaddr))
@@ -94,14 +94,14 @@ func newElfWrapperFromVDSO(m *process.Mapping, pr process.Process) (ef *elfWrapp
 	return &elfWrapper{elfFile: elfFile, data: data, helper: &ProcessFileHelper{pid: pr.PID()}}, nil
 }
 
-func newElfWrapperFromMapping(m *process.Mapping, pr process.Process) (ef *elfWrapper, err error) {
+func newElfWrapperFromMapping(m *process.RawMapping, pr process.Process) (ef *elfWrapper, err error) {
 	if m.IsVDSO() {
 		return newElfWrapperFromVDSO(m, pr)
 	}
 
-	elfFile, err := pr.OpenELF(m.Path.String())
+	elfFile, err := pr.OpenELF(m.Path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open ELF file %s for PID %d: %w", m.Path.String(), pr.PID(), err)
+		return nil, fmt.Errorf("failed to open ELF file %s for PID %d: %w", m.Path, pr.PID(), err)
 	}
 	defer func() {
 		if err != nil {
@@ -111,7 +111,7 @@ func newElfWrapperFromMapping(m *process.Mapping, pr process.Process) (ef *elfWr
 
 	r, err := pr.OpenMappingFile(m)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open mapping file %s for PID %d: %w", m.Path.String(), pr.PID(), err)
+		return nil, fmt.Errorf("failed to open mapping file %s for PID %d: %w", m.Path, pr.PID(), err)
 	}
 	defer func() {
 		if err != nil {
@@ -121,10 +121,10 @@ func newElfWrapperFromMapping(m *process.Mapping, pr process.Process) (ef *elfWr
 
 	f, ok := r.(*os.File)
 	if !ok {
-		return nil, fmt.Errorf("failed to cast mapping file %s to *os.File for PID %d", m.Path.String(), pr.PID())
+		return nil, fmt.Errorf("failed to cast mapping file %s to *os.File for PID %d", m.Path, pr.PID())
 	}
 
-	return newElfWrapper(elfFile, m.Path.String(), f, &ProcessFileHelper{pid: pr.PID()}, nil)
+	return newElfWrapper(elfFile, m.Path, f, &ProcessFileHelper{pid: pr.PID()}, nil)
 }
 
 func newElfWrapperFromFile(filePath string, helper FileHelper) (ef *elfWrapper, err error) {

--- a/comp/host-profiler/symboluploader/symbol_uploader.go
+++ b/comp/host-profiler/symboluploader/symbol_uploader.go
@@ -230,7 +230,7 @@ func (d *DatadogSymbolUploader) UploadSymbols(execMeta *reporter.ExecutableMetad
 	if ok {
 		slog.Debug("Skipping symbol upload",
 			slog.String("reason", "already_uploaded"),
-			slog.String("path", execMeta.Mapping.Path.String()))
+			slog.String("path", execMeta.Mapping.Path))
 		return
 	}
 
@@ -254,7 +254,7 @@ func (d *DatadogSymbolUploader) UploadSymbols(execMeta *reporter.ExecutableMetad
 	default:
 		slog.Warn("Skipping symbol upload",
 			slog.String("reason", "upload_queue_full"),
-			slog.String("file", execMeta.Mapping.Path.String()),
+			slog.String("file", execMeta.Mapping.Path),
 			slog.String("file_id", mf.FileID.StringNoQuotes()))
 	}
 }
@@ -364,7 +364,7 @@ func (d *DatadogSymbolUploader) getSymbolsFromDisk(execMeta *reporter.Executable
 	elfSymbols, err := symbol.NewElfFromMapping(execMeta.Mapping, mf.GnuBuildID, mf.GoBuildID, mf.FileID, execMeta.Process)
 	if err != nil {
 		slog.Debug("Skipping symbol upload for executable",
-			slog.String("path", execMeta.Mapping.Path.String()),
+			slog.String("path", execMeta.Mapping.Path),
 			slog.String("error", err.Error()))
 		return nil
 	}

--- a/comp/host-profiler/symboluploader/symbol_uploader_test.go
+++ b/comp/host-profiler/symboluploader/symbol_uploader_test.go
@@ -55,8 +55,8 @@ func (d *dummyProcess) GetMachineData() process.MachineData {
 	return process.MachineData{}
 }
 
-func (d *dummyProcess) GetMappings() ([]process.Mapping, uint32, error) {
-	return nil, 0, errors.New("not implemented")
+func (d *dummyProcess) IterateMappings(_ func(m process.RawMapping) bool) (uint32, error) {
+	return 0, errors.New("not implemented")
 }
 
 func (d *dummyProcess) GetThreads() ([]process.ThreadInfo, error) {
@@ -67,16 +67,16 @@ func (d *dummyProcess) GetRemoteMemory() remotememory.RemoteMemory {
 	return remotememory.RemoteMemory{}
 }
 
-func (d *dummyProcess) GetMappingFileLastModified(_ *process.Mapping) int64 {
+func (d *dummyProcess) GetMappingFileLastModified(_ *process.RawMapping) int64 {
 	return 0
 }
 
-func (d *dummyProcess) CalculateMappingFileID(m *process.Mapping) (libpf.FileID, error) {
-	return libpf.FileIDFromExecutableFile(m.Path.String())
+func (d *dummyProcess) CalculateMappingFileID(m *process.RawMapping) (libpf.FileID, error) {
+	return libpf.FileIDFromExecutableFile(m.Path)
 }
 
-func (d *dummyProcess) OpenMappingFile(m *process.Mapping) (process.ReadAtCloser, error) {
-	return os.Open(m.Path.String())
+func (d *dummyProcess) OpenMappingFile(m *process.RawMapping) (process.ReadAtCloser, error) {
+	return os.Open(m.Path)
 }
 
 func (d *dummyProcess) OpenELF(name string) (*pfelf.File, error) {
@@ -109,8 +109,8 @@ func newExecutableMetadata(t *testing.T, filePath, goBuildID string) *reporter.E
 		GoBuildID:  goBuildID,
 	})
 	pr := &dummyProcess{pid: libpf.PID(os.Getpid())}
-	m := &process.Mapping{
-		Path: libpf.Intern(filePath),
+	m := &process.RawMapping{
+		Path: filePath,
 	}
 	return &reporter.ExecutableMetadata{
 		MappingFile:       mf,

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ replace (
 	// To update the Datadog/opentelemetry-ebpf-profiler dependency on latest commit on datadog branch, change the following line to:
 	// replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler datadog
 	// and run `go mod tidy` then `dda inv tidy`
-	go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260317195537-817b91eb7dd4
+	go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260416144717-96f8924d6e18
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2596,8 +2596,8 @@ github.com/DataDog/nikos v1.12.12 h1:72YrdzMeQT3wcXIDgiS1ClU53SzUdR7uAbp5FSSpo5k
 github.com/DataDog/nikos v1.12.12/go.mod h1:kZGOhfE76+nXS7V5PAlIw3MRxWKM70ynET4VeuZ4U4k=
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816 h1:8diKw2aLYE6LsjWfYxDEqx0ZmcyMMmqB+qapRJrGtys=
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816/go.mod h1:7cPuErOAt7k/oVWAVJnxqAC6mwArrAazkvk0RXiih2A=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260317195537-817b91eb7dd4 h1:9+K8vjF7sQSLjVJporNyv6nw46cMg/Q8ogxbBZmrf+A=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260317195537-817b91eb7dd4/go.mod h1:KEBv+q78RzBcDPNFm1WB0V0za14gY95E/Atp3dJZ/8M=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260416144717-96f8924d6e18 h1:VbUS1B3mpSjponiKDWHXtofoNBp99Nckf5uZaBeQyPo=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260416144717-96f8924d6e18/go.mod h1:34LtYk9Gh/SCItzi7v8ok9E5lk88AA5I+5aKoVKQClI=
 github.com/DataDog/rshell v0.0.10 h1:1jFuWzxxBNCv4tec1Rn1yZJrj9p3ZK7sRZEaHdxUk0Q=
 github.com/DataDog/rshell v0.0.10/go.mod h1:e6IP68xHScumYqM/9dT9y5H41EmStHDVEyCZKv5mEt4=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=
@@ -2790,8 +2790,8 @@ github.com/aws/aws-sdk-go-v2 v1.21.2/go.mod h1:ErQhvNuEMhJjweavOYhxVkn2RUx7kQXVA
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.14/go.mod h1:9NCTOURS8OpxvoAVHq79LK81/zC78hfRWFn+aL0SPcY=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 h1:3kGOqnh1pPeddVa/E37XNTaWJ8W6vrbYV9lJEkCnhuY=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.19.0/go.mod h1:ZwDUgFnQgsazQTnWfeLWk5GjeqTQTL8lMkoE1UXzxdE=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
 github.com/aws/aws-sdk-go-v2/config v1.32.14/go.mod h1:U4/V0uKxh0Tl5sxmCBZ3AecYny4UNlVmObYjKuuaiOo=
@@ -2850,8 +2850,8 @@ github.com/aws/aws-sdk-go-v2/service/pricing v1.40.11/go.mod h1:XFV2Em3Hn/2xirmm
 github.com/aws/aws-sdk-go-v2/service/rds v1.117.0 h1:T1Xe9sYxSUUQOvd1RsFeVk/IXFPdqSiN0atXu/Hy/8A=
 github.com/aws/aws-sdk-go-v2/service/rds v1.117.0/go.mod h1:QbXW4coAMakHQhf1qhE0eVVCen9gwB/Kvn+HHHKhpGY=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.40.2/go.mod h1:Zjfqt7KhQK+PO1bbOsFNzKgaq7TcxzmEoDWN8lM0qzQ=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1 h1:csi9NLpFZXb9fxY7rS1xVzgPRGMt7MSNWeQ6eo247kE=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1/go.mod h1:qXVal5H0ChqXP63t6jze5LmFalc7+ZE7wOdLtZ0LCP0=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2 h1:MRNiP6nqa20aEl8fQ6PJpEq11b2d40b16sm4WD7QgMU=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2/go.mod h1:FrNA56srbsr3WShiaelyWYEo70x80mXnVZ17ZZfbeqg=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0 h1:vL6rQXcGtFv9q/9eRPdI+lL+dvTm7xKGZYSHEvmrpDk=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0/go.mod h1:QwEDLD+7EukuEUnbWtiNE8LhgvvmhjZoi4XAppYPtyc=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.39.26 h1:iHwbjffXjdzQmk7p5GiCcG2q8b7I2w+u2rlw5G0PYiA=

--- a/tasks/host_profiler.py
+++ b/tasks/host_profiler.py
@@ -17,6 +17,8 @@ from tasks.libs.releasing.version import query_version
 
 EBPF_PROFILER_MODULE = "go.opentelemetry.io/ebpf-profiler"
 CILIUM_EBPF_MODULE = "github.com/cilium/ebpf"
+PPROFILE_MODULE = "go.opentelemetry.io/collector/pdata/pprofile"
+PPROFILE_MAX_VERSION = "v0.150.0"
 
 BIN_NAME = "host-profiler"
 BIN_DIR = os.path.join(".", "bin", "host-profiler")
@@ -118,62 +120,127 @@ def update_golden_tests(ctx):
     print("Golden test files updated successfully!")
 
 
+def _get_profiler_requires(ctx: Context) -> dict[str, str]:
+    """Download the ebpf-profiler fork and return its go.mod Require entries as {path: version}."""
+    res = ctx.run(f"go mod download -json {EBPF_PROFILER_MODULE}", hide=True, warn=True)
+    if not res or not res.ok:
+        raise Exit(f"Could not download {EBPF_PROFILER_MODULE}.", code=1)
+    go_mod_path = json.loads(res.stdout).get("GoMod")
+    if not go_mod_path:
+        raise Exit(f"Could not locate go.mod for {EBPF_PROFILER_MODULE}.", code=1)
+    res = ctx.run(f"go mod edit -json {go_mod_path}", hide=True, warn=True)
+    if not res or not res.ok:
+        raise Exit(f"Could not parse {EBPF_PROFILER_MODULE} go.mod.", code=1)
+    return {req["Path"]: req["Version"] for req in json.loads(res.stdout).get("Require", [])}
+
+
+def _get_agent_module_version(ctx: Context, module: str) -> str:
+    """Return the version of a module as resolved by the agent's go.mod."""
+    res = ctx.run(f"go list -m -json {module}", hide=True, warn=True)
+    if not res or not res.ok:
+        raise Exit(f"Could not resolve {module} in agent go.mod.", code=1)
+    version = json.loads(res.stdout).get("Version")
+    if not version:
+        raise Exit(f"No version found for {module} in agent go.mod.", code=1)
+    return version
+
+
+def _parse_semver(version: str) -> tuple[int, ...]:
+    """Parse a release semver string (e.g. 'v0.150.0') into a tuple of ints.
+
+    Only handles clean major.minor.patch tags — pseudo-versions or pre-release
+    suffixes will raise Exit with a clear message.
+    """
+    v = version.lstrip("v")
+    parts = v.split(".")
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError as e:
+        raise Exit(f"Cannot parse version {version!r} as semver (expected vX.Y.Z).", code=1) from e
+
+
 @task
 def validate_deps(ctx: Context):
-    """Check that the agent's cilium/ebpf version is compatible with the
-    opentelemetry-ebpf-profiler.
+    """Check that shared transitive dependencies between the agent and the
+    opentelemetry-ebpf-profiler remain compatible.
 
-    cilium/ebpf introduces breaking API changes across minor versions. Bumping
-    it in the agent without first updating the profiler fork can silently break
-    eBPF unwinding at runtime.
+    Currently validates:
+      - cilium/ebpf: major.minor must match between agent and profiler fork.
+      - pdata/pprofile: must be at most PPROFILE_MAX_VERSION or match the
+        profiler fork's version.
 
     TODO: This is a short-term guardrail. The long-term solution is to mirror
     the profiler's coredump test data to Datadog-owned blob storage and run
     the profiler's unwinding e2e tests directly from the agent CI whenever a
     common transitive dependency changes.
     """
-    # Download the profiler module (extracts it from the cache if needed) and
-    # get the path to its go.mod directly from the download output.
-    res = ctx.run(f"go mod download -json {EBPF_PROFILER_MODULE}", hide=True, warn=True)
-    if not res or not res.ok:
-        raise Exit(f"Could not download {EBPF_PROFILER_MODULE}.", code=1)
+    profiler_requires = _get_profiler_requires(ctx)
+    ok = True
 
-    go_mod_path = json.loads(res.stdout).get("GoMod")
-    if not go_mod_path:
-        raise Exit(f"Could not locate go.mod for {EBPF_PROFILER_MODULE}.", code=1)
+    # --- cilium/ebpf: major.minor must match ---
+    profiler_cilium = profiler_requires.get(CILIUM_EBPF_MODULE)
+    if profiler_cilium is None:
+        print(color_message(f"{CILIUM_EBPF_MODULE} not found in {EBPF_PROFILER_MODULE} go.mod.", "red"))
+        ok = False
+    else:
+        agent_cilium = _get_agent_module_version(ctx, CILIUM_EBPF_MODULE)
+        if agent_cilium.split(".")[:2] == profiler_cilium.split(".")[:2]:
+            print(
+                color_message(
+                    f"OK: {CILIUM_EBPF_MODULE} {agent_cilium} (agent) is compatible with {profiler_cilium} ({EBPF_PROFILER_MODULE})",
+                    "green",
+                )
+            )
+        else:
+            print(
+                color_message(
+                    f"MISMATCH: {CILIUM_EBPF_MODULE} version is incompatible with {EBPF_PROFILER_MODULE}!\n"
+                    f"  Agent uses:     {agent_cilium}\n"
+                    f"  Profiler needs: {profiler_cilium}\n"
+                    f"  Please reach out to #profiling-full-host-project to update the profiler fork and validate its e2e tests before bumping cilium/ebpf here.",
+                    "red",
+                )
+            )
+            ok = False
 
-    # Parse the profiler's go.mod to find its required cilium/ebpf version.
-    res = ctx.run(f"go mod edit -json {go_mod_path}", hide=True, warn=True)
-    if not res or not res.ok:
-        raise Exit(f"Could not parse {EBPF_PROFILER_MODULE} go.mod.", code=1)
-    profiler_requires = {req["Path"]: req["Version"] for req in json.loads(res.stdout).get("Require", [])}
+    # --- pdata/pprofile: at most PPROFILE_MAX_VERSION or matching profiler fork ---
+    # pprofile is experimental upstream and has constant breaking changes,
+    # so we cap the version to avoid silent incompatibilities with the profiler fork.
+    agent_pprofile = _get_agent_module_version(ctx, PPROFILE_MODULE)
+    profiler_pprofile = profiler_requires.get(PPROFILE_MODULE)
 
-    profiler_version = profiler_requires.get(CILIUM_EBPF_MODULE)
-    if profiler_version is None:
-        raise Exit(f"{CILIUM_EBPF_MODULE} not found in {EBPF_PROFILER_MODULE} go.mod.", code=1)
-
-    # Get the version the agent resolved.
-    res = ctx.run(f"go list -m -json {CILIUM_EBPF_MODULE}", hide=True, warn=True)
-    if not res or not res.ok:
-        raise Exit(f"Could not resolve {CILIUM_EBPF_MODULE} in agent go.mod.", code=1)
-    agent_version = json.loads(res.stdout).get("Version", "")
-
-    # Patch-level differences are fine; major.minor must match.
-    if agent_version.split(".")[:2] == profiler_version.split(".")[:2]:
+    if profiler_pprofile and agent_pprofile == profiler_pprofile:
         print(
             color_message(
-                f"OK: {CILIUM_EBPF_MODULE} {agent_version} (agent) is compatible with {profiler_version} ({EBPF_PROFILER_MODULE})",
+                f"OK: {PPROFILE_MODULE} {agent_pprofile} (agent) matches {profiler_pprofile} ({EBPF_PROFILER_MODULE})",
+                "green",
+            )
+        )
+    elif _parse_semver(agent_pprofile) <= _parse_semver(PPROFILE_MAX_VERSION):
+        print(
+            color_message(
+                f"OK: {PPROFILE_MODULE} {agent_pprofile} (agent) is within allowed ceiling {PPROFILE_MAX_VERSION}",
                 "green",
             )
         )
     else:
+        profiler_hint = (
+            f" or update the profiler fork to support it (currently requires {profiler_pprofile})"
+            if profiler_pprofile
+            else ""
+        )
         print(
             color_message(
-                f"MISMATCH: {CILIUM_EBPF_MODULE} version is incompatible with {EBPF_PROFILER_MODULE}!\n"
-                f"  Agent uses:     {agent_version}\n"
-                f"  Profiler needs: {profiler_version}\n"
-                f"  Please reach out to #profiling-full-host-project to update the profiler fork and validate its e2e tests before bumping cilium/ebpf here.",
+                f"MISMATCH: {PPROFILE_MODULE} version exceeds allowed bounds!\n"
+                f"  Agent uses:      {agent_pprofile}\n"
+                f"  Max allowed:     {PPROFILE_MAX_VERSION}\n"
+                f"  Profiler uses:   {profiler_pprofile or 'not found'}\n"
+                f"  Please either pin {PPROFILE_MODULE} to at most {PPROFILE_MAX_VERSION}{profiler_hint}.\n"
+                f"  Reach out to #profiling-full-host-project for guidance.",
                 "red",
             )
         )
+        ok = False
+
+    if not ok:
         raise Exit(code=1)

--- a/test/e2e-framework/go.mod
+++ b/test/e2e-framework/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.77.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.77.0
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8
 	github.com/aws/session-manager-plugin v0.0.0-20241119210807-82dc72922492
 	github.com/cenkalti/backoff/v5 v5.0.3
@@ -80,7 +80,7 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go v1.55.8 // indirect
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect

--- a/test/e2e-framework/go.sum
+++ b/test/e2e-framework/go.sum
@@ -41,8 +41,8 @@ github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 h1:3kGOqnh1pPeddVa/E37XNTaWJ8W6vrbYV9lJEkCnhuY=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
 github.com/aws/aws-sdk-go-v2/config v1.32.14/go.mod h1:U4/V0uKxh0Tl5sxmCBZ3AecYny4UNlVmObYjKuuaiOo=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8THYELoX6gVcUvgl6fI=
@@ -73,8 +73,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 h1:c31//R3x
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21/go.mod h1:r6+pf23ouCB718FUxaqzZdbpYFyDtehyZcmP5KL9FkA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.20 h1:siU1A6xjUZ2N8zjTHSXFhB9L/2OY8Dqs0xXiLjF30jA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.20/go.mod h1:4TLZCmVJDM3FOu5P5TJP0zOlu9zWgDWU7aUxWbr+rcw=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1 h1:csi9NLpFZXb9fxY7rS1xVzgPRGMt7MSNWeQ6eo247kE=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1/go.mod h1:qXVal5H0ChqXP63t6jze5LmFalc7+ZE7wOdLtZ0LCP0=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2 h1:MRNiP6nqa20aEl8fQ6PJpEq11b2d40b16sm4WD7QgMU=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2/go.mod h1:FrNA56srbsr3WShiaelyWYEo70x80mXnVZ17ZZfbeqg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8 h1:31Llf5VfrZ78YvYs7sWcS7L2m3waikzRc6q1nYenVS4=

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
@@ -214,7 +214,7 @@ require (
 	github.com/DataDog/dd-trace-go/v2 v2.7.0-rc.1
 	github.com/DataDog/orchestrion v1.4.0
 	github.com/avast/retry-go/v4 v4.7.0
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2
 	github.com/digitalocean/go-libvirt v0.0.0-20240812180835-9c6c0a310c6c
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -66,8 +66,8 @@ github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 h1:3kGOqnh1pPeddVa/E37XNTaWJ8W6vrbYV9lJEkCnhuY=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
 github.com/aws/aws-sdk-go-v2/config v1.32.14/go.mod h1:U4/V0uKxh0Tl5sxmCBZ3AecYny4UNlVmObYjKuuaiOo=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8THYELoX6gVcUvgl6fI=
@@ -98,8 +98,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 h1:c31//R3x
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21/go.mod h1:r6+pf23ouCB718FUxaqzZdbpYFyDtehyZcmP5KL9FkA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.20 h1:siU1A6xjUZ2N8zjTHSXFhB9L/2OY8Dqs0xXiLjF30jA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.20/go.mod h1:4TLZCmVJDM3FOu5P5TJP0zOlu9zWgDWU7aUxWbr+rcw=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1 h1:csi9NLpFZXb9fxY7rS1xVzgPRGMt7MSNWeQ6eo247kE=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1/go.mod h1:qXVal5H0ChqXP63t6jze5LmFalc7+ZE7wOdLtZ0LCP0=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2 h1:MRNiP6nqa20aEl8fQ6PJpEq11b2d40b16sm4WD7QgMU=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2/go.mod h1:FrNA56srbsr3WShiaelyWYEo70x80mXnVZ17ZZfbeqg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8 h1:31Llf5VfrZ78YvYs7sWcS7L2m3waikzRc6q1nYenVS4=


### PR DESCRIPTION
### What does this PR do?

- Extends `profiler_deps_check` to validate the`go.opentelemetry.io/collector/pdata/pprofile` version in addition to `cilium/ebpf`. The agent's `pprofile` version must either match the profiler fork's version or stay at or below `PPROFILE_MAX_VERSION` (`v0.150.0`).
- Bumps the `DataDog/opentelemetry-ebpf-profiler` fork to the latest commit on the `datadog` branch.

### Motivation

`pprofile` is experimental upstream and ships frequent breaking changes. Bumping it in the agent without a matching update in the profiler fork can silently break profile serialization at runtime, the same failure mode uncoordinated `cilium/ebpf` bumps cause for eBPF unwinding.

### Describe how you validated your changes

- `dda inv lint-licenses`, no drift.
- The `profiler_deps_check` CI job exercises the extended validation on this PR.

### Additional Notes

- Side-effect of `go mod tidy`: `aws-sdk-go-v2` submodules bumped from `v1.97.1` → `v1.97.2` (s3) and `v1.7.7` → `v1.7.8` (eventstream) in the e2e test modules.
- The `pprofile` ceiling is a short-term guardrail. Long-term plan is to run the profiler's e2e tests from the agent CI on shared-dep changes.