### PR TITLE
Add capacity-type:spot host tag on AWS Spot instances

### DIFF
--- a/pkg/util/ec2/tags/ec2_tags.go
+++ b/pkg/util/ec2/tags/ec2_tags.go
@@ -26,6 +26,7 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	pkgec2 "github.com/DataDog/datadog-agent/pkg/util/ec2"
 	ec2internal "github.com/DataDog/datadog-agent/pkg/util/ec2/internal"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -39,6 +40,7 @@ var (
 
 	// for testing purposes
 	fetchContainerInstanceARN = getContainerInstanceARN
+	isSpotInstance            = pkgec2.IsSpotInstance
 )
 
 func isTagExcluded(tag string) bool {
@@ -99,6 +101,16 @@ func GetInstanceInfo(ctx context.Context) ([]string, error) {
 			} else {
 				tags = append(tags, fmt.Sprintf("%s:%s", ciaTagName, arn))
 			}
+		}
+	}
+
+	// Add capacity-type:spot when running on a Spot instance
+	const capacityTypeTagName = "capacity-type"
+	if !isTagExcluded(capacityTypeTagName) {
+		if isSpot, err := isSpotInstance(ctx); err != nil {
+			log.Debugf("could not determine spot instance status: %v", err)
+		} else if isSpot {
+			tags = append(tags, fmt.Sprintf("%s:spot", capacityTypeTagName))
 		}
 	}
 

--- a/pkg/util/ec2/tags/ec2_tags.go
+++ b/pkg/util/ec2/tags/ec2_tags.go
@@ -110,7 +110,7 @@ func GetInstanceInfo(ctx context.Context) ([]string, error) {
 		if isSpot, err := isSpotInstance(ctx); err != nil {
 			log.Debugf("could not determine spot instance status: %v", err)
 		} else if isSpot {
-			tags = append(tags, fmt.Sprintf("%s:spot", capacityTypeTagName))
+			tags = append(tags, capacityTypeTagName+":spot")
 		}
 	}
 

--- a/pkg/util/ec2/tags/ec2_tags_test.go
+++ b/pkg/util/ec2/tags/ec2_tags_test.go
@@ -248,6 +248,10 @@ func TestCollectEC2InstanceInfo(t *testing.T) {
 	}
 	t.Cleanup(func() { fetchContainerInstanceARN = oldFetchARN })
 
+	oldIsSpot := isSpotInstance
+	isSpotInstance = func(_ context.Context) (bool, error) { return true, nil }
+	t.Cleanup(func() { isSpotInstance = oldIsSpot })
+
 	tags, err := GetInstanceInfo(context.Background())
 	require.NoError(t, err)
 
@@ -258,6 +262,7 @@ func TestCollectEC2InstanceInfo(t *testing.T) {
 		"image:ami-aaaaaaaaaaaaaaaaa",
 		"availability-zone:eu-west-3a",
 		"container_instance_arn:arn:aws:ecs:region:account:container-instance/ci-123",
+		"capacity-type:spot",
 	}
 	assert.Equal(t, expected, tags)
 

--- a/releasenotes/notes/add-capacity-type-spot-tag-130644d95d9f1021.yaml
+++ b/releasenotes/notes/add-capacity-type-spot-tag-130644d95d9f1021.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added a ``capacity-type:spot`` host tag on AWS EC2 Spot instances. The tag
+    is collected from IMDS and added alongside the other EC2 instance info
+    host tags when ``collect_ec2_instance_info`` is enabled.


### PR DESCRIPTION
### What does this PR do?

Adds a `capacity-type:spot` host tag on AWS when the EC2 instance is a
Spot instance. The tag is emitted as part of the EC2 instance info host
tags collected by `GetInstanceInfo` (gated by `collect_ec2_instance_info`).

### Motivation

Customers running Spot fleets want an easy way to distinguish Spot
capacity from on-demand capacity in Datadog without having to enable the
AWS crawler or configure a custom tag on every instance. The EC2 IMDS
`/instance-life-cycle` endpoint exposes this information, and an
`IsSpotInstance` helper was recently added to `pkg/util/ec2` (used by the
`cloud_hostinfo` check for Spot preemption events) — this PR reuses it
to surface the capacity type as a host tag.

The tag name `capacity-type` matches the convention used by Karpenter /
AWS EKS, so dashboards and monitors keyed on that tag work
interchangeably between cluster- and host-level data.

### Describe how you validated your changes

Deploy the Agent on a Spot instance on AWS with `collect_ec2_instance_info` enabled. The `capacity-type: spot` should be produced.

### Additional Notes