### PR TITLE
Quality Gates: Account for newly introduced outgoing connection

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -44,7 +44,7 @@ checks:
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."
     bounds:
       series: "connection.current"
-      upper_bound: 3
+      upper_bound: 4
 
 report_links:
   - text: "bounds checks dashboard"

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -70,7 +70,7 @@ checks:
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."
     bounds:
       series: "connection.current"
-      upper_bound: 3
+      upper_bound: 4
 
 report_links:
   - text: "bounds checks dashboard"


### PR DESCRIPTION
### What does this PR do?

Update the connection limit in both `quality_gate_idle` and `quality_gate_idle_all_features` to four connections.

### Motivation

New development (https://github.com/DataDog/datadog-agent/pull/49202) introduced a new outgoing connection.

### Describe how you validated your changes

Will be validated by the SMP run on this PR.
