### PR TITLE
ci(chainguard): Add dd-octo-sts policy for rshell version bump

### DIFF
--- a/.github/chainguard/self.rshell.bump-rshell-version.sts.yaml
+++ b/.github/chainguard/self.rshell.bump-rshell-version.sts.yaml
@@ -1,0 +1,15 @@
+---
+# Policy used by the `bump_datadog_agent` job in the DataDog/rshell GitLab CI.
+# Fires automatically on new rshell semver tags and can also be run manually
+# from main (e.g. to retry or bump to a specific version).
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: 'project_path:DataDog/rshell:(ref_type:tag:ref:v[0-9]+\.[0-9]+\.[0-9]+|ref_type:branch:ref:main)'
+
+claim_pattern:
+  project_path: DataDog/rshell
+  ref_protected: "true"
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/chainguard/self.rshell.bump-rshell-version.sts.yaml
+++ b/.github/chainguard/self.rshell.bump-rshell-version.sts.yaml
@@ -8,7 +8,6 @@ subject_pattern: 'project_path:DataDog/rshell:(ref_type:tag:ref:v[0-9]+\.[0-9]+\
 
 claim_pattern:
   project_path: DataDog/rshell
-  ref_protected: "true"
 
 permissions:
   contents: write


### PR DESCRIPTION
## What does this PR do?

Adds a `dd-octo-sts` policy allowing the `bump_datadog_agent` GitLab CI job in [`DataDog/rshell`](https://github.com/DataDog/rshell) to mint a short-lived GitHub token scoped to `DataDog/datadog-agent` and open a PR bumping the pinned rshell version.

## Motivation

Today every rshell release requires a hand-crafted PR in this repo to bump the `github.com/DataDog/rshell` line in `go.mod` + regenerate `go.sum` + add a reno note. Companion PR [`DataDog/rshell#188`](https://github.com/DataDog/rshell/pull/188) adds a GitLab pipeline that automates this on every new rshell tag. This policy is the auth anchor that pipeline needs.

## Policy scope

| Claim | Value | Why |
|---|---|---|
| `issuer` | `https://gitlab.ddbuild.io` | Accept only internal GitLab OIDC tokens |
| `subject_pattern` | rshell tag pipelines (`v*.*.*`) OR pipelines on `main` | Tags for the auto path; `main` for manual retries via `Run pipeline` + `BUMP_VERSION` |
| `claim_pattern.project_path` | `DataDog/rshell` | Belt-and-braces re-assertion |
| `permissions` | `contents: write`, `pull_requests: write` | Push the bump branch and open the draft PR — nothing more |

Mirrors the existing `self.buildimages-ci.push-to-datadog-agent.sts.yaml` pattern for another external GitLab project acting on this repo.

### Upstream defence

Tag creation on `DataDog/rshell` is already gated by two active GitHub rulesets — a DataDog org-wide `Global Tag Protection (public repos)` ruleset and a repo-specific `tag-protection` ruleset — both blocking creation/update/deletion of any tag for non-bypass users, with GPG/SSH signatures required. Only the `release.yml` workflow (approval-gated `release` environment) and explicit admins can create `v*` tags. By the time a tag reaches GitLab via the pull-mirror, it has already been vetted upstream, which is why the policy does not additionally require `ref_protected: "true"` on the GitLab side.

## Describe how you validated your changes

- Policy file parses as valid YAML.
- Subject pattern hand-traced against a mock GitLab OIDC JWT for a tag pipeline (`project_path:DataDog/rshell:ref_type:tag:ref:v0.0.12`) and for a main-branch pipeline (`project_path:DataDog/rshell:ref_type:branch:ref:main`) — both match.
- End-to-end validation will happen once this merges: the companion rshell PR is set up to exercise the token mint on the next tag pipeline.

## Possible Drawbacks / Trade-offs

Grants token-minting to rshell pipelines. Scope is intentionally minimal (two permissions) and restricted to the rshell project + either semver tags or `main`. Feature-branch pipelines fail the subject regex.

## Additional Notes

Keep as draft until the companion [`DataDog/rshell#188`](https://github.com/DataDog/rshell/pull/188) is ready to merge — these should land together.
