### PR TITLE
[ACTP] Wire real DogStatsD client into Private Action Runner metrics

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -73,6 +73,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/appsec"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/mcp"
 
+	statsd "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd/def"
+	statsdfx "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd/fx"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	metadatarunner "github.com/DataDog/datadog-agent/comp/metadata/runner"
 	metadatarunnerimpl "github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
@@ -252,6 +254,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				clusterchecksmetadatafx.Module(),
 				ipcfx.ModuleReadWrite(),
 				remotetraceroutefx.Module(),
+				statsdfx.Module(),
 			)
 		},
 	}
@@ -287,6 +290,7 @@ func start(log log.Component,
 	_ metadatarunner.Component,
 	tracerouteComp traceroute.Component,
 	eventPlatform eventplatform.Component,
+	statsdComp statsd.Component,
 ) error {
 	stopCh := make(chan struct{})
 	validatingStopCh := make(chan struct{})
@@ -614,7 +618,7 @@ func start(log log.Component,
 	}
 
 	if config.GetBool("private_action_runner.enabled") {
-		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, le, log, taggerComp, tracerouteComp, eventPlatform)
+		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, le, log, taggerComp, tracerouteComp, eventPlatform, statsdComp)
 		if err != nil {
 			log.Errorf("Cannot start private action runner: %v", err)
 		} else {
@@ -760,6 +764,7 @@ func startPrivateActionRunner(
 	tagger tagger.Component,
 	tracerouteComp traceroute.Component,
 	eventPlatform eventplatform.Component,
+	statsdComp statsd.Component,
 ) (func(), error) {
 	if rcClient == nil {
 		return nil, errors.New("Remote config is disabled or failed to initialize, remote config is a required dependency for private action runner")
@@ -768,7 +773,7 @@ func startPrivateActionRunner(
 		return nil, errors.New("leader election is not enabled on the Cluster Agent. The private action runner needs leader election for identity coordination across replicas")
 	}
 	le.StartLeaderElectionRun()
-	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp, eventPlatform)
+	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp, eventPlatform, statsdComp)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/privateactionrunner/subcommands/run/command.go
+++ b/cmd/privateactionrunner/subcommands/run/command.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
 	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
+	statsdfx "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd/fx"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	remotetraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
@@ -76,6 +77,7 @@ func runPrivateActionRunner(ctx context.Context, confPath string, extraConfFiles
 		logscompressionfx.Module(),
 		eventplatformreceiverimpl.Module(),
 		eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),
+		statsdfx.Module(),
 		privateactionrunnerfx.Module(),
 	}
 

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -20,6 +20,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
+	statsdcomp "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
@@ -61,6 +62,7 @@ type Requires struct {
 	Tagger        tagger.Component
 	Traceroute    traceroute.Component
 	EventPlatform eventplatform.Component
+	Statsd        statsdcomp.Component
 }
 
 // Provides defines the output of the privateactionrunner component
@@ -76,6 +78,7 @@ type PrivateActionRunner struct {
 	tagger         tagger.Component
 	traceroute     traceroute.Component
 	eventPlatform  eventplatform.Component
+	statsd         statsdcomp.Component
 
 	workflowRunner *runners.WorkflowRunner
 	commonRunner   *runners.CommonRunner
@@ -97,7 +100,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 		return Provides{}, privateactionrunner.ErrNotEnabled
 	}
 
-	runner, err := NewPrivateActionRunner(ctx, reqs.Config, reqs.Hostname, pkgrcclient.NewAdapter(reqs.RcClient), reqs.Log, reqs.Tagger, reqs.Traceroute, reqs.EventPlatform)
+	runner, err := NewPrivateActionRunner(ctx, reqs.Config, reqs.Hostname, pkgrcclient.NewAdapter(reqs.RcClient), reqs.Log, reqs.Tagger, reqs.Traceroute, reqs.EventPlatform, reqs.Statsd)
 	if err != nil {
 		return Provides{}, err
 	}
@@ -117,6 +120,7 @@ func NewPrivateActionRunner(
 	taggerComp tagger.Component,
 	tracerouteComp traceroute.Component,
 	eventPlatform eventplatform.Component,
+	statsdComp statsdcomp.Component,
 ) (*PrivateActionRunner, error) {
 	return &PrivateActionRunner{
 		coreConfig:     coreConfig,
@@ -126,6 +130,7 @@ func NewPrivateActionRunner(
 		tagger:         taggerComp,
 		traceroute:     tracerouteComp,
 		eventPlatform:  eventPlatform,
+		statsd:         statsdComp,
 		startChan:      make(chan struct{}),
 	}, nil
 }
@@ -140,7 +145,7 @@ func (p *PrivateActionRunner) getRunnerConfig(ctx context.Context) (*parconfig.C
 		p.coreConfig.Set(privateactionrunner.PARUrn, persistedIdentity.URN, model.SourceAgentRuntime)
 	}
 
-	cfg, err := parconfig.FromDDConfig(p.coreConfig)
+	cfg, err := parconfig.FromDDConfig(p.coreConfig, p.statsd)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -188,6 +189,7 @@ func GetBundleInheritedAllowedActions(actionsAllowlist map[string]sets.Set[strin
 func newMetricsClient(statsdComp statsdcomp.Component) statsd.ClientInterface {
 	client, err := statsdComp.Get()
 	if err != nil {
+		log.Warnf("Failed to get statsd client: %v", err)
 		return &statsd.NoOpClient{}
 	}
 	return client

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	statsdcomp "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd/def"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/actions"
@@ -23,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func FromDDConfig(config config.Component) (*Config, error) {
+func FromDDConfig(config config.Component, statsdComp statsdcomp.Component) (*Config, error) {
 	mainEndpoint := configutils.GetMainEndpoint(config, "https://api.", "dd_url")
 	ddHost := getDatadogHost(mainEndpoint)
 	ddSite := configutils.ExtractSiteFromURL(mainEndpoint)
@@ -81,7 +82,7 @@ func FromDDConfig(config config.Component) (*Config, error) {
 		HealthCheckEndpoint:       defaultHealthCheckEndpoint,
 		HeartbeatInterval:         heartbeatInterval,
 		Version:                   version.AgentVersion,
-		MetricsClient:             &statsd.NoOpClient{},
+		MetricsClient:             newMetricsClient(statsdComp),
 		ActionsAllowlist:          makeActionsAllowlist(config),
 		Allowlist:                 config.GetStringSlice(setup.PARHttpAllowlist),
 		AllowIMDSEndpoint:         config.GetBool(setup.PARHttpAllowImdsEndpoint),
@@ -182,4 +183,12 @@ func GetBundleInheritedAllowedActions(actionsAllowlist map[string]sets.Set[strin
 	}
 
 	return result
+}
+
+func newMetricsClient(statsdComp statsdcomp.Component) statsd.ClientInterface {
+	client, err := statsdComp.Get()
+	if err != nil {
+		return &statsd.NoOpClient{}
+	}
+	return client
 }

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	statsdimpl "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd/impl"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -213,7 +214,9 @@ func TestFromDDConfig(t *testing.T) {
 			mockConfig.SetWithoutSource(setup.PARUrn, "")
 
 			// Call FromDDConfig
-			cfg, err := FromDDConfig(mockConfig)
+			statsdProvides, err := statsdimpl.NewComponent()
+			require.NoError(t, err)
+			cfg, err := FromDDConfig(mockConfig, statsdProvides.Comp)
 			require.NoError(t, err)
 
 			// Verify both DDHost and DatadogSite are set correctly
@@ -320,7 +323,9 @@ func TestFromDDConfigPARRestrictedShellAllowedPathsSet(t *testing.T) {
 	mockConfig.SetWithoutSource(setup.PARUrn, "")
 	mockConfig.SetWithoutSource(setup.PARRestrictedShellAllowedPaths, []string{"/var/log", "/tmp"})
 
-	cfg, err := FromDDConfig(mockConfig)
+	statsdProvides, err := statsdimpl.NewComponent()
+	require.NoError(t, err)
+	cfg, err := FromDDConfig(mockConfig, statsdProvides.Comp)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/var/log", "/tmp"}, cfg.RShellAllowedPaths)
 }


### PR DESCRIPTION
### What does this PR do?

Replaces the hardcoded `NoOpClient` in the Private Action Runner's metrics config with a real DogStatsD client obtained from the agent's statsd Fx component. The `statsdfx.Module()` is added to both the cluster-agent and standalone PAR binary entry points, and the component is threaded through to `FromDDConfig` where the client is created.

### Motivation

The PAR already had observability code tracking execution metrics (`executions.started`, `executions.completed`, `executions.latency`, `health.check`, `keys_manager.startup_latency`) but all of them were silently discarded because `MetricsClient` was always a no-op stub. This activates that entire observability layer.

### Describe how you validated your changes

Updated `transform_test.go` to pass a real statsd component via `statsdimpl.NewComponent()` instead of relying on the no-op fallback.

### Additional Notes

`newMetricsClient` gracefully falls back to `NoOpClient` if `statsdComp.Get()` fails (e.g. missing `STATSD_URL` env var), so the PAR remains functional in environments without a statsd endpoint configured.