### PR TITLE
add local storage map size to ebpf check

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"math/rand"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 	"unsafe"
@@ -614,6 +615,16 @@ func (k *Probe) readSingleMap(mapid ebpf.MapID) (*model.EBPFMapStats, error) {
 		baseMapStats.MaxSize, baseMapStats.RSS = arrayMemoryUsage(mp, uint64(k.nrcpus))
 	case ebpf.LPMTrie:
 		baseMapStats.MaxSize, baseMapStats.RSS = trieMemoryUsage(mp, uint64(k.nrcpus))
+	case ebpf.TaskStorage, ebpf.SkStorage, ebpf.InodeStorage, ebpf.CgroupStorage:
+		if !preciseMapMemUsageSupported() {
+			return nil, fmt.Errorf("unsupported map %s(%d) type %s", name, mapid, mp.Type())
+		}
+		baseMapStats.RSS, err = localStorageMemoryUsage(mp)
+		if err != nil {
+			return nil, fmt.Errorf("read local storage usage %s(%d) type %s: %s", name, mapid, mp.Type(), err)
+		}
+		baseMapStats.MaxSize = baseMapStats.RSS
+
 	// TODO other map types
 	//case ebpf.Stack:
 	//case ebpf.ReusePortSockArray:
@@ -621,8 +632,6 @@ func (k *Probe) readSingleMap(mapid ebpf.MapID) (*model.EBPFMapStats, error) {
 	//case ebpf.DevMap, ebpf.DevMapHash:
 	//case ebpf.Queue:
 	//case ebpf.StructOpsMap:
-	//case ebpf.CGroupStorage:
-	//case ebpf.TaskStorage, ebpf.SkStorage, ebpf.InodeStorage:
 	default:
 		return nil, fmt.Errorf("unsupported map %s(%d) type %s", name, mapid, mp.Type())
 	}
@@ -828,6 +837,10 @@ func ringBufferMemoryUsage(mapStats *model.EBPFMapStats, mapid ebpf.MapID, mp *e
 	mapStats.MaxSize += ringInfo.Consumer.Len + ringInfo.Data.Len
 	mapStats.RSS = mapStats.MaxSize
 	return nil
+}
+
+func localStorageMemoryUsage(mp *ebpf.Map) (uint64, error) {
+	return mapMemlock(uint32(mp.FD()))
 }
 
 // entryCountBuffers is a struct that contains buffers used to get the number of entries
@@ -1207,11 +1220,10 @@ func hashMapNumberOfEntriesWithHelper(mp *ebpf.Map, mapid ebpf.MapID, mphCache *
 
 // https://lwn.net/ml/linux-mm/20230202014158.19616-6-laoar.shao@gmail.com/
 // https://github.com/torvalds/linux/commit/304849a27b341cf22d5c15096144cc8c1b69e0c0
-func preciseMapMemUsageSupported() bool {
+var preciseMapMemUsageSupported = sync.OnceValue(func() bool {
 	kv, err := kernel.HostVersion()
 	if err != nil {
 		return false
 	}
-
 	return kv >= kernel.VersionCode(6, 4, 0)
-}
+})

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -593,3 +593,55 @@ func TestHashMapNumberOfEntriesNoMemoryCorruption(t *testing.T) {
 		})
 	}
 }
+
+func TestLocalStorageMemoryUsage(t *testing.T) {
+	if !preciseMapMemUsageSupported() {
+		t.SkipNow()
+	}
+
+	ebpftest.TestBuildMode(t, ebpftest.CORE, "", func(t *testing.T) {
+		cfg := testConfig()
+
+		probe, err := NewProbe(cfg)
+		require.NoError(t, err)
+		t.Cleanup(probe.Close)
+
+		testMap, err := ebpf.NewMap(&ebpf.MapSpec{
+			Name:       "test_task_storage",
+			Type:       ebpf.TaskStorage,
+			KeySize:    4,
+			ValueSize:  8,
+			MaxEntries: 0,
+			Flags:      unix.BPF_F_NO_PREALLOC,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = testMap.Close() })
+
+		info, err := testMap.Info()
+		require.NoError(t, err)
+		id, _ := info.ID()
+
+		fd, err := unix.PidfdOpen(os.Getpid(), 0)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = unix.Close(fd) })
+
+		var val uint64 = 1
+		err = testMap.Update(&fd, &val, ebpf.UpdateAny)
+		require.NoError(t, err)
+
+		var result model.EBPFMapStats
+		require.Eventually(t, func() bool {
+			stats := probe.GetAndFlush()
+			for _, mapStats := range stats.Maps {
+				if mapStats.ID == uint32(id) {
+					result = mapStats
+					return true
+				}
+			}
+			return false
+		}, 5*time.Second, 500*time.Millisecond, "failed to find map")
+
+		assert.GreaterOrEqual(t, result.RSS, 8)
+		assert.Equal(t, result.RSS, result.MaxSize)
+	})
+}

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -610,7 +610,7 @@ func TestLocalStorageMemoryUsage(t *testing.T) {
 		kspec, err := btf.LoadKernelSpec()
 		require.NoError(t, err)
 
-		u32Type, err := kspec.TypeByID(1)
+		u32Type, err := kspec.AnyTypeByName("unsigned int")
 		require.NoError(t, err)
 
 		testMap, err := ebpf.NewMap(&ebpf.MapSpec{
@@ -635,7 +635,7 @@ func TestLocalStorageMemoryUsage(t *testing.T) {
 		t.Cleanup(func() { _ = unix.Close(fd) })
 
 		var val uint32 = 1
-		err = testMap.Update(&fd, &val, ebpf.UpdateAny)
+		err = testMap.Update(unsafe.Pointer(&fd), unsafe.Pointer(&val), ebpf.UpdateAny)
 		require.NoError(t, err)
 
 		var result model.EBPFMapStats
@@ -650,7 +650,7 @@ func TestLocalStorageMemoryUsage(t *testing.T) {
 			return false
 		}, 5*time.Second, 500*time.Millisecond, "failed to find map")
 
-		assert.GreaterOrEqual(t, result.RSS, 8)
+		assert.GreaterOrEqual(t, result.RSS, uint64(8))
 		assert.Equal(t, result.RSS, result.MaxSize)
 	})
 }

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -19,6 +19,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/perf"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/stretchr/testify/assert"
@@ -606,13 +607,21 @@ func TestLocalStorageMemoryUsage(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(probe.Close)
 
+		kspec, err := btf.LoadKernelSpec()
+		require.NoError(t, err)
+
+		u32Type, err := kspec.TypeByID(1)
+		require.NoError(t, err)
+
 		testMap, err := ebpf.NewMap(&ebpf.MapSpec{
 			Name:       "test_task_storage",
 			Type:       ebpf.TaskStorage,
 			KeySize:    4,
-			ValueSize:  8,
+			ValueSize:  4,
 			MaxEntries: 0,
 			Flags:      unix.BPF_F_NO_PREALLOC,
+			Key:        u32Type,
+			Value:      u32Type,
 		})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = testMap.Close() })
@@ -625,7 +634,7 @@ func TestLocalStorageMemoryUsage(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = unix.Close(fd) })
 
-		var val uint64 = 1
+		var val uint32 = 1
 		err = testMap.Update(&fd, &val, ebpf.UpdateAny)
 		require.NoError(t, err)
 


### PR DESCRIPTION
### What does this PR do?

Adds support to read memory usage of local storage map types in the ebpf check.

### Motivation

Understand memory usage of new usages of SK storage maps.

### Describe how you validated your changes

### Additional Notes
