### PR TITLE
pkg/trace: add method for otlp collector to add tags

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -67,6 +67,7 @@ type OTLPReceiver struct {
 	grpcMaxRecvMsgSize int
 	isStopped          atomic.Bool
 	mu                 sync.RWMutex
+	payloadTags        atomic.Pointer[map[string]string]
 }
 
 // NewOTLPReceiver returns a new OTLPReceiver which sends any incoming traces down the out channel.
@@ -258,6 +259,35 @@ func (o *OTLPReceiver) SetOTelAttributeTranslator(attrstrans *attributes.Transla
 	o.conf.OTLPReceiver.AttributesTranslator = attrstrans
 }
 
+const tagOTLPCollectorTags = "_dd.otlp_collector_tags"
+
+// SetPayloadTags replaces the tags flattened into TracerPayload.Tags
+// under the key _dd.otlp_collector_tags. Passing nil or an empty map
+// clears the entry. Safe for concurrent use; the input map is copied.
+func (o *OTLPReceiver) SetPayloadTags(tags map[string]string) {
+	if len(tags) == 0 {
+		o.payloadTags.Store(nil)
+		return
+	}
+	cp := make(map[string]string, len(tags))
+	for k, v := range tags {
+		cp[k] = v
+	}
+	o.payloadTags.Store(&cp)
+}
+
+func (o *OTLPReceiver) mergePayloadTags(dst map[string]string) map[string]string {
+	t := o.payloadTags.Load()
+	if t == nil || len(*t) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(map[string]string, 1)
+	}
+	dst[tagOTLPCollectorTags] = flatten(*t).String()
+	return dst
+}
+
 // ReceiveResourceSpans processes the given rspans and returns the source that it identified from processing them.
 func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.ResourceSpans, httpHeader http.Header, hostFromAttributesHandler attributes.HostFromAttributesHandler) (source.Source, error) {
 	o.mu.RLock()
@@ -385,6 +415,7 @@ func (o *OTLPReceiver) receiveResourceSpansV2(ctx context.Context, rspans ptrace
 			tagContainersTags: containerTags,
 		}
 	}
+	p.TracerPayload.Tags = o.mergePayloadTags(p.TracerPayload.Tags)
 
 	o.out <- &p
 	return src
@@ -518,6 +549,7 @@ func (o *OTLPReceiver) receiveResourceSpansV1(ctx context.Context, rspans ptrace
 			tagContainersTags: payloadTags.String(),
 		}
 	}
+	p.TracerPayload.Tags = o.mergePayloadTags(p.TracerPayload.Tags)
 
 	o.out <- &p
 	return src

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 	"unicode"
@@ -4495,4 +4496,160 @@ func TestConvertSpanDBNameMapping(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setPayloadTagsTestSpans() []testutil.OTLPResourceSpan {
+	return []testutil.OTLPResourceSpan{{
+		LibName:    "libname",
+		LibVersion: "1.2",
+		Attributes: map[string]interface{}{
+			string(semconv.ContainerIDKey):        "cid",
+			string(semconv.ContainerImageNameKey): "img",
+		},
+		Spans: []*testutil.OTLPSpan{{
+			TraceID: [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			Name:    "first",
+		}},
+	}}
+}
+
+func newPayloadTagsReceiver(t *testing.T, v2 bool) (*OTLPReceiver, <-chan *Payload) {
+	t.Helper()
+	cfg := NewTestConfig(t)
+	if !v2 {
+		cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
+	}
+	out := make(chan *Payload, 4)
+	rcv := NewOTLPReceiver(out, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})
+	return rcv, out
+}
+
+func sendAndCollect(t *testing.T, rcv *OTLPReceiver, out <-chan *Payload, spans []testutil.OTLPResourceSpan) *pb.TracerPayload {
+	t.Helper()
+	rspans := testutil.NewOTLPTracesRequest(spans).Traces().ResourceSpans().At(0)
+	rcv.ReceiveResourceSpans(context.Background(), rspans, http.Header{}, nil)
+	select {
+	case p := <-out:
+		return p.TracerPayload
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for payload")
+		return nil
+	}
+}
+
+func TestOTLPReceiverSetPayloadTags(t *testing.T) {
+	t.Run("appliesToV1Payload", func(t *testing.T) {
+		rcv, out := newPayloadTagsReceiver(t, false)
+		rcv.SetPayloadTags(map[string]string{
+			"_dd.pipeline_has_no_stats_connector": "true",
+			"custom.tag":                          "v",
+		})
+		tp := sendAndCollect(t, rcv, out, setPayloadTagsTestSpans())
+		require.Equal(t, map[string]string{
+			"_dd.pipeline_has_no_stats_connector": "true",
+			"custom.tag":                          "v",
+		}, unflatten(tp.Tags[tagOTLPCollectorTags]))
+		require.NotEmpty(t, tp.Tags[tagContainersTags], "container tags should still be set")
+	})
+
+	t.Run("appliesToV2Payload", func(t *testing.T) {
+		rcv, out := newPayloadTagsReceiver(t, true)
+		rcv.SetPayloadTags(map[string]string{
+			"_dd.pipeline_has_no_stats_connector": "true",
+			"custom.tag":                          "v",
+		})
+		tp := sendAndCollect(t, rcv, out, setPayloadTagsTestSpans())
+		require.Equal(t, map[string]string{
+			"_dd.pipeline_has_no_stats_connector": "true",
+			"custom.tag":                          "v",
+		}, unflatten(tp.Tags[tagOTLPCollectorTags]))
+		require.NotEmpty(t, tp.Tags[tagContainersTags], "container tags should still be set")
+	})
+
+	t.Run("nilAndEmptyClear", func(t *testing.T) {
+		for _, v2 := range []bool{false, true} {
+			rcv, out := newPayloadTagsReceiver(t, v2)
+			rcv.SetPayloadTags(map[string]string{"k": "v"})
+			tp := sendAndCollect(t, rcv, out, setPayloadTagsTestSpans())
+			require.Equal(t, "k:v", tp.Tags[tagOTLPCollectorTags])
+
+			rcv.SetPayloadTags(nil)
+			tp = sendAndCollect(t, rcv, out, setPayloadTagsTestSpans())
+			_, ok := tp.Tags[tagOTLPCollectorTags]
+			require.False(t, ok, "nil should clear prior tags (v2=%v)", v2)
+
+			rcv.SetPayloadTags(map[string]string{"k": "v"})
+			rcv.SetPayloadTags(map[string]string{})
+			tp = sendAndCollect(t, rcv, out, setPayloadTagsTestSpans())
+			_, ok = tp.Tags[tagOTLPCollectorTags]
+			require.False(t, ok, "empty map should clear prior tags (v2=%v)", v2)
+		}
+	})
+
+	t.Run("defensiveCopy", func(t *testing.T) {
+		for _, v2 := range []bool{false, true} {
+			rcv, out := newPayloadTagsReceiver(t, v2)
+			input := map[string]string{"k": "original"}
+			rcv.SetPayloadTags(input)
+			input["k"] = "mutated"
+			input["added"] = "late"
+			tp := sendAndCollect(t, rcv, out, setPayloadTagsTestSpans())
+			require.Equal(t, map[string]string{"k": "original"}, unflatten(tp.Tags[tagOTLPCollectorTags]), "v2=%v", v2)
+		}
+	})
+
+	t.Run("concurrent", func(t *testing.T) {
+		rcv, out := newPayloadTagsReceiver(t, true)
+		done := make(chan struct{})
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				case <-out:
+				}
+			}
+		}()
+
+		var wg sync.WaitGroup
+		stop := make(chan struct{})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			i := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if i%3 == 0 {
+					rcv.SetPayloadTags(nil)
+				} else {
+					rcv.SetPayloadTags(map[string]string{
+						"k":         strconv.Itoa(i),
+						"iteration": strconv.Itoa(i),
+					})
+				}
+				i++
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			spans := setPayloadTagsTestSpans()
+			for i := 0; i < 500; i++ {
+				rspans := testutil.NewOTLPTracesRequest(spans).Traces().ResourceSpans().At(0)
+				rcv.ReceiveResourceSpans(context.Background(), rspans, http.Header{}, nil)
+			}
+		}()
+
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			close(stop)
+		}()
+		wg.Wait()
+		close(done)
+	})
 }


### PR DESCRIPTION
This PR allows otlp collector to set tags to the exported trace-agent once https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47662

(generated with claude)
