### PR TITLE
[tagger] Fix ECS task completeness to account for missing v4 metadata on startup

### DIFF
--- a/comp/core/autodiscovery/listeners/container.go
+++ b/comp/core/autodiscovery/listeners/container.go
@@ -212,14 +212,6 @@ func computeContainerServiceIDs(entity string, image string, labels map[string]s
 	return ids
 }
 
-// areTagsComplete checks if the tags for a container are complete.
-// TODO: Completeness works by checking that all expected collectors have
-// reported tags for the container and its parent entity (Kubernetes pod, ECS
-// task). However, it does not account for collectors themselves reporting
-// partial data. This has been observed as with the ECS collector, where some
-// fields like "ecs_service" can be missing on the first pull. This happens
-// rarely. This is probably something that needs to be fixed in the collector
-// itself.
 func (l *ContainerListener) areTagsComplete(entity workloadmeta.Entity) bool {
 	container, ok := entity.(*workloadmeta.Container)
 	if !ok {

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -538,10 +538,14 @@ func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*types.Ta
 func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.TagInfo {
 	task := ev.Entity.(*workloadmeta.ECSTask)
 
-	// ECS tasks are reported by a single collector (ECS), so they're always
-	// expected to be complete. We track this because we need it to determine
-	// if tags for the task's containers are complete.
-	c.entityCompleteness[task.EntityID] = ev.IsComplete
+	// ECS tasks are reported by a single collector (ECS). So they are always
+	// marked as complete by workloadmeta. However, the ECS collector can report
+	// incomplete data. It seems that this happens when the v4 metadata endpoint
+	// is not yet available when a task is created. This is infrequent, but when
+	// it happens, the ECS collector doesn't set a cluster name, so tags are
+	// incomplete.
+	ecsTaskIsComplete := ev.IsComplete && task.ClusterName != ""
+	c.entityCompleteness[task.EntityID] = ecsTaskIsComplete
 
 	taskTags := taglist.NewTagList()
 
@@ -607,7 +611,7 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 			OrchestratorCardTags: orch,
 			LowCardTags:          append(low, clusterLow...),
 			StandardTags:         standard,
-			IsComplete:           ev.IsComplete && containerComplete,
+			IsComplete:           ecsTaskIsComplete && containerComplete,
 		})
 	}
 
@@ -624,7 +628,7 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 			OrchestratorCardTags: orch,
 			LowCardTags:          append(low, clusterLow...),
 			StandardTags:         standard,
-			IsComplete:           ev.IsComplete,
+			IsComplete:           ecsTaskIsComplete,
 		})
 	}
 
@@ -642,7 +646,7 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 				OrchestratorCardTags: clusterOrch,
 				LowCardTags:          clusterLow,
 				StandardTags:         clusterStandard,
-				IsComplete:           ev.IsComplete,
+				IsComplete:           ecsTaskIsComplete,
 			})
 		}
 	}

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -2608,12 +2608,27 @@ func TestHandleContainer_IsComplete(t *testing.T) {
 		EntityMeta: workloadmeta.EntityMeta{
 			Name: "test-task",
 		},
+		ClusterName: "test-cluster",
+	}
+
+	// ecsTaskWithoutClusterName simulates the v1 fallback case, where the ECS
+	// collector reports a task without ClusterName because the v4 metadata
+	// endpoint was not yet available.
+	ecsTaskWithoutClusterName := &workloadmeta.ECSTask{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindECSTask,
+			ID:   taskARN,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name: "test-task",
+		},
 	}
 
 	tests := []struct {
 		name                string
 		features            []env.Feature
 		container           workloadmeta.Container
+		ecsTask             *workloadmeta.ECSTask
 		parentInStore       bool // "parent" means pod or ECS task
 		parentIsComplete    bool
 		containerIsComplete bool
@@ -2672,17 +2687,19 @@ func TestHandleContainer_IsComplete(t *testing.T) {
 			name:                "ECS EC2: container incomplete",
 			features:            []env.Feature{env.ECSEC2},
 			container:           ecsContainer,
+			ecsTask:             ecsTask,
 			parentInStore:       true,
 			parentIsComplete:    true,
 			containerIsComplete: false,
 			expectedIsComplete:  false,
 		},
 		{
-			name:                "ECS EC2: container complete but task incomplete",
+			name:                "ECS EC2: task without cluster name is incomplete",
 			features:            []env.Feature{env.ECSEC2},
 			container:           ecsContainer,
+			ecsTask:             ecsTaskWithoutClusterName,
 			parentInStore:       true,
-			parentIsComplete:    false,
+			parentIsComplete:    true,
 			containerIsComplete: true,
 			expectedIsComplete:  false,
 		},
@@ -2690,6 +2707,7 @@ func TestHandleContainer_IsComplete(t *testing.T) {
 			name:                "ECS EC2: both container and task complete",
 			features:            []env.Feature{env.ECSEC2},
 			container:           ecsContainer,
+			ecsTask:             ecsTask,
 			parentInStore:       true,
 			parentIsComplete:    true,
 			containerIsComplete: true,
@@ -2733,10 +2751,10 @@ func TestHandleContainer_IsComplete(t *testing.T) {
 						IsComplete: test.parentIsComplete,
 					})
 				case workloadmeta.KindECSTask:
-					wmeta.Set(ecsTask)
+					wmeta.Set(test.ecsTask)
 					collector.handleECSTask(workloadmeta.Event{
 						Type:       workloadmeta.EventTypeSet,
-						Entity:     ecsTask,
+						Entity:     test.ecsTask,
 						IsComplete: test.parentIsComplete,
 					})
 				}


### PR DESCRIPTION
### What does this PR do?

This PR fixes an edge case in tag completeness when the agent is deployed on ECS.

It handles the case where the ECS workloadmeta collector has reported, but with incomplete data.

Based on some tests I ran, this happens rarely, only when a task is created and its containers don't yet have `ECS_CONTAINER_METADATA_URI_V4` set. This is expected (see this comment: https://github.com/DataDog/datadog-agent/blob/2bf4b8110ee87162995ee424a94970d91bbe5ea1/comp/core/workloadmeta/collectors/internal/ecs/v4parser.go#L83). When that happens, the code falls back to the v1 endpoint and doesn't report cluster or service information, so the related tags end up missing.


### Describe how you validated your changes

Checked this on an ECS cluster. I deployed an agent version without the fix and verified that when deploying a workload multiple times, some ECS-related tags were missing in some cases. Then I deployed the version with the fix and verified that the problem didn't happen anymore.