### PR TITLE
ci(ddot): Apply apt mirror rewrite to deb822 sources on Ubuntu 24.04

### DIFF
--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -35,9 +35,11 @@ WORKDIR /workspace
 RUN if [ "$CI" = "true" ]; then \
   echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
   echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist.ports && \
-  sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
-         -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
-         -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' /etc/apt/sources.list; \
+  for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+    [ -f "$f" ] && sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
+           -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
+           -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; \
+  done; \
   fi
 
 # Update and install necessary packages

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -36,9 +36,11 @@ RUN if [ "$CI" = "true" ]; then \
   echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
   echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist.ports && \
   for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
-    [ -f "$f" ] && sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
-           -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
-           -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; \
+    if [ -f "$f" ]; then \
+      sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
+             -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
+             -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; \
+    fi; \
   done; \
   fi
 


### PR DESCRIPTION
### What does this PR do?

Extends the CI apt-mirror rewrite in `Dockerfiles/agent-ddot/Dockerfile.agent-otel` so it also targets `/etc/apt/sources.list.d/ubuntu.sources` (deb822 format), not just `/etc/apt/sources.list`. The existing block is wrapped in a `for` loop that skips files that don't exist.

### Motivation

[#49464](https://github.com/DataDog/datadog-agent/pull/49464) added the apt mirrorlist to this Dockerfile, but the `sed` only rewrote `/etc/apt/sources.list`. The default `UBUNTU_VERSION` here is `24.04` (noble), whose base image uses the new deb822 format at `/etc/apt/sources.list.d/ubuntu.sources` — so the rewrite was a no-op and apt still hit `archive.ubuntu.com` directly.

This caused repeated `docker_image_build_otel` failures on `main`, e.g. [job 1604418443](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1604418443):

```
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/noble-updates/main/binary-amd64/Packages.gz
   File has unexpected size (2401883 != 2401874). Mirror sync in progress?
```

The job logs confirm the mirror `RUN` step executed successfully, but the following `apt-get update` step fetched directly from `archive.ubuntu.com` — proof the `sed` never touched the actual sources file.

### Describe how you validated your changes

- Inspected the `ubuntu:24.04` Docker image: sources live in `/etc/apt/sources.list.d/ubuntu.sources` (deb822), not `/etc/apt/sources.list`.
- The 20.04 path (`ddot_byoc_binary_build_test_ubuntu2004`) still works: `sources.list` exists there and the loop simply skips the missing deb822 file via `[ -f "$f" ]`.
- `mirror+file:` is a valid APT transport URI and works in both sources.list line format and deb822 `URIs:` field.

### Additional Notes

Same latent issue likely exists in `Dockerfiles/base-image/Dockerfile`, `Dockerfiles/agent/Dockerfile`, and `Dockerfiles/cluster-agent/Dockerfile` (all default to Ubuntu 24.04 with the same sed-only-on-sources.list block). Leaving those out of this PR to keep scope minimal; can follow up if they prove to be hitting the same failure mode.