### PR TITLE
[observer] Add anomaly_type tag to events / reports

### DIFF
--- a/cmd/observer-testbench/ui/src/constants.ts
+++ b/cmd/observer-testbench/ui/src/constants.ts
@@ -4,4 +4,4 @@
 // Copyright 2016-present Datadog, Inc.
 
 /** Tag keys surfaced in filter chips and anomaly list headers. */
-export const MAIN_TAG_FILTER_KEYS = new Set(['status', 'service', 'host', 'detector', 'pod_name', 'container_name']);
+export const MAIN_TAG_FILTER_KEYS = new Set(['anomaly_type', 'status', 'service', 'host', 'detector', 'pod_name', 'container_name']);

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -96,7 +96,7 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 				Title:          c.Title,
 				Message:        datadog.PtrString(msg),
 				Category:       datadogV2.EVENTCATEGORY_CHANGE,
-				Tags:           []string{"source:agent-q-branch-observer", "pattern:" + c.Pattern},
+				Tags:           buildEventTags(c),
 				Timestamp:      datadog.PtrString(ts),
 				AggregationKey: datadog.PtrString(aggKey),
 				Attributes:     attrs,
@@ -112,6 +112,58 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 		}
 	}
 	return err
+}
+
+// buildEventTags returns the Datadog event tags for a correlation.
+// It always includes "source:agent-q-branch-observer" and "pattern:{pattern}".
+// It adds "anomaly_type:metric" and/or "anomaly_type:log" depending on which
+// anomaly types are present (log-derived metric anomalies count as log).
+// It also propagates "service:", "env:", and "host:" dimensions collected from
+// each anomaly's source tags and from Context.SplitTags (set by the log pattern
+// extractor for sub-clustered log series).
+func buildEventTags(c observerdef.ActiveCorrelation) []string {
+	hasMetric := false
+	hasLog := false
+	dimensionSet := make(map[string]struct{})
+
+	for _, a := range c.Anomalies {
+		if a.Type == observerdef.AnomalyTypeLog || isLogDerivedAnomaly(a) {
+			hasLog = true
+		} else {
+			hasMetric = true
+		}
+		// Propagate dimensional tags from the source series.
+		for _, t := range a.Source.Tags {
+			for _, prefix := range []string{"service:", "env:", "host:"} {
+				if strings.HasPrefix(t, prefix) {
+					dimensionSet[t] = struct{}{}
+					break
+				}
+			}
+		}
+		// For log-derived anomalies, dimensional info lives in Context.SplitTags
+		// (set by the log tagged pattern clusterer).
+		if a.Context != nil {
+			for _, k := range []string{"service", "env", "host"} {
+				if v, ok := a.Context.SplitTags[k]; ok {
+					dimensionSet[k+":"+v] = struct{}{}
+				}
+			}
+		}
+	}
+
+	tags := []string{"source:agent-q-branch-observer", "pattern:" + c.Pattern}
+	if hasMetric {
+		tags = append(tags, "anomaly_type:metric")
+	}
+	if hasLog {
+		tags = append(tags, "anomaly_type:log")
+	}
+	for t := range dimensionSet {
+		tags = append(tags, t)
+	}
+	sort.Strings(tags[2:]) // keep source and pattern first; sort the rest for determinism
+	return tags
 }
 
 // buildChangeAttributes constructs the change event attributes for a correlation.

--- a/comp/observer/impl/notify_test.go
+++ b/comp/observer/impl/notify_test.go
@@ -1,0 +1,171 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+func TestBuildEventTags_BaseTagsAlwaysPresent(t *testing.T) {
+	c := observerdef.ActiveCorrelation{Pattern: "kernel_bottleneck"}
+	tags := buildEventTags(c)
+	assert.Contains(t, tags, "source:agent-q-branch-observer")
+	assert.Contains(t, tags, "pattern:kernel_bottleneck")
+}
+
+func TestBuildEventTags_MetricAnomalyType(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{Type: observerdef.AnomalyTypeMetric, Source: observerdef.SeriesDescriptor{Namespace: "dogstatsd"}},
+		},
+	}
+	tags := buildEventTags(c)
+	assert.Contains(t, tags, "anomaly_type:metric")
+	assert.NotContains(t, tags, "anomaly_type:log")
+}
+
+func TestBuildEventTags_LogAnomalyType(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{Type: observerdef.AnomalyTypeLog, Source: observerdef.SeriesDescriptor{Namespace: "log_detector"}},
+		},
+	}
+	tags := buildEventTags(c)
+	assert.Contains(t, tags, "anomaly_type:log")
+	assert.NotContains(t, tags, "anomaly_type:metric")
+}
+
+func TestBuildEventTags_LogDerivedMetricAnomaly(t *testing.T) {
+	// A metric anomaly originating from log_pattern_extractor with a pattern
+	// context is treated as a log anomaly.
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type: observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{
+					Namespace: LogPatternExtractorName,
+				},
+				Context: &observerdef.MetricContext{
+					Pattern: "some log pattern",
+				},
+			},
+		},
+	}
+	tags := buildEventTags(c)
+	assert.Contains(t, tags, "anomaly_type:log")
+	assert.NotContains(t, tags, "anomaly_type:metric")
+}
+
+func TestBuildEventTags_BothTypes(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{Type: observerdef.AnomalyTypeMetric, Source: observerdef.SeriesDescriptor{Namespace: "dogstatsd"}},
+			{Type: observerdef.AnomalyTypeLog, Source: observerdef.SeriesDescriptor{Namespace: "log_detector"}},
+		},
+	}
+	tags := buildEventTags(c)
+	assert.Contains(t, tags, "anomaly_type:metric")
+	assert.Contains(t, tags, "anomaly_type:log")
+}
+
+func TestBuildEventTags_DimensionalTagsFromSourceTags(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type: observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{
+					Namespace: "dogstatsd",
+					Tags:      []string{"service:web", "env:prod", "host:h1", "version:1.0"},
+				},
+			},
+		},
+	}
+	tags := buildEventTags(c)
+	assert.Contains(t, tags, "service:web")
+	assert.Contains(t, tags, "env:prod")
+	assert.Contains(t, tags, "host:h1")
+	assert.NotContains(t, tags, "version:1.0") // non-dimensional tags not propagated
+}
+
+func TestBuildEventTags_DimensionalTagsFromSplitTags(t *testing.T) {
+	// Log-derived anomalies carry dimensional info in Context.SplitTags.
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: LogPatternExtractorName},
+				Context: &observerdef.MetricContext{
+					Pattern: "some log pattern",
+					SplitTags: map[string]string{
+						"service": "api",
+						"env":     "staging",
+						"host":    "h2",
+					},
+				},
+			},
+		},
+	}
+	tags := buildEventTags(c)
+	assert.Contains(t, tags, "service:api")
+	assert.Contains(t, tags, "env:staging")
+	assert.Contains(t, tags, "host:h2")
+}
+
+func TestBuildEventTags_DeduplicatesDimensions(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: "ns", Tags: []string{"service:web"}},
+			},
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: "ns", Tags: []string{"service:web"}},
+			},
+		},
+	}
+	tags := buildEventTags(c)
+	count := 0
+	for _, t := range tags {
+		if t == "service:web" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "service:web should appear exactly once")
+}
+
+func TestBuildEventTags_SourceAndPatternAreFirstTwo(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "mypat",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: "ns", Tags: []string{"service:svc"}},
+			},
+		},
+	}
+	tags := buildEventTags(c)
+	assert.Equal(t, "source:agent-q-branch-observer", tags[0])
+	assert.Equal(t, "pattern:mypat", tags[1])
+	// Remaining tags are sorted
+	rest := tags[2:]
+	sorted := make([]string, len(rest))
+	copy(sorted, rest)
+	sort.Strings(sorted)
+	assert.Equal(t, sorted, rest)
+}

--- a/comp/observer/impl/reporter_testbench.go
+++ b/comp/observer/impl/reporter_testbench.go
@@ -54,7 +54,7 @@ func (r *replayReporter) Report(output observerdef.ReportOutput) {
 	for _, ac := range output.ActiveCorrelations {
 		if !r.seenPatterns[ac.Pattern] {
 			msg := buildChangeMessage(ac, r.storage)
-			tags := []string{"source:agent-q-branch-observer", "pattern:" + ac.Pattern}
+			tags := buildEventTags(ac)
 			r.events = append(r.events, ReportedEvent{
 				Pattern:       ac.Pattern,
 				Title:         ac.Title,


### PR DESCRIPTION
### What does this PR do?

Tag events sent to Datadog (and testbench reports) with `anomaly_type:metric`/`anomaly_type:log`.
Updated testbench UI as well.

### Motivation

### Describe how you validated your changes

### Additional Notes