### PR TITLE
[CNM-4859] Fix system-probe PID collision flake

### DIFF
--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"runtime"
 	"slices"
 	"sort"
@@ -93,7 +94,7 @@ func getExpectedConnections(encodedWithQueryType bool, httpOutBlob []byte) *mode
 				LastRetransmits:    201,
 				LastTcpEstablished: 1,
 				LastTcpClosed:      1,
-				Pid:                int32(6000),
+				Pid:                math.MaxInt32,
 				NetNS:              7,
 				IpTranslation: &model.IPTranslation{
 					ReplSrcIP:   "20.1.1.1",
@@ -206,7 +207,7 @@ func TestSerialization(t *testing.T) {
 				{ConnectionTuple: network.ConnectionTuple{
 					Source:    util.AddressFromString("10.1.1.1"),
 					Dest:      util.AddressFromString("10.2.2.2"),
-					Pid:       6000,
+					Pid:       math.MaxInt32,
 					NetNS:     7,
 					SPort:     1000,
 					DPort:     9000,


### PR DESCRIPTION
### What does this PR do?
This PR fixes a flake where the connection unexpectedly has `SystemProbeConn: true`.  This is because once in a while the test runner would coincidentally have the PID 6000 which is the PID used in the test. This fixes it by setting a PID beyond linux's range which will never collide.

### Motivation
Flakes are bad

### Describe how you validated your changes
The PID isn't going to be 6000, but you can test via:
```
PATH="$PATH" sudo -E go test -count 1 -timeout 120s -tags linux,linux_bpf,npm,process,test -run ^TestSerialization$ ./pkg/network/encoding/
```