### PR TITLE
[testbench] Add on-demand event send button to reports

### DIFF
--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -382,6 +382,14 @@ class ApiClient {
     return this.fetch('/reports');
   }
 
+  async sendReport(pattern: string, firstSeen: number): Promise<void> {
+    await this.fetch('/reports/send', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pattern, firstSeen }),
+    });
+  }
+
   async getComponentData(name: string): Promise<ComponentDataResponse> {
     return this.fetch(`/components/${encodeURIComponent(name)}/data`);
   }

--- a/cmd/observer-testbench/ui/src/components/ReportsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/ReportsView.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useRef, useEffect, useState } from 'react';
+import { useMemo, useRef, useEffect, useState, useCallback } from 'react';
 import * as d3 from 'd3';
 import type { ObserverState, ObserverActions } from '../hooks/useObserver';
+import { api } from '../api/client';
 import type { ScenarioInfo, ReportEvent } from '../api/client';
 import type { TimeRange, PhaseMarker } from './ChartWithAnomalyDetails';
 import { MAIN_TAG_FILTER_KEYS } from '../constants';
@@ -501,8 +502,26 @@ export function ReportsView({ state, actions, sidebarWidth, timeRange, onTimeRan
   const [timelineFocusedKey, setTimelineFocusedKey] = useState<string | null>(null);
   /** Which list rows show full message body (collapsed by default). */
   const [expandedRowKeys, setExpandedRowKeys] = useState<Set<string>>(() => new Set());
+  /** Send state per row key: 'idle' | 'sending' | 'sent' | 'error:<msg>' */
+  const [sendState, setSendState] = useState<Map<string, string>>(() => new Map());
   const reportRowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const initializedScenarioRef = useRef<string | null>(null);
+
+  const handleSendReport = useCallback(async (pattern: string, firstSeen: number, key: string) => {
+    setSendState((prev) => new Map(prev).set(key, 'sending'));
+    try {
+      await api.sendReport(pattern, firstSeen);
+      setSendState((prev) => new Map(prev).set(key, 'sent'));
+      setTimeout(() => setSendState((prev) => {
+        const next = new Map(prev);
+        if (next.get(key) === 'sent') next.set(key, 'idle');
+        return next;
+      }), 3000);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setSendState((prev) => new Map(prev).set(key, 'error:' + msg));
+    }
+  }, []);
 
   useEffect(() => {
     if (state.activeScenario && initializedScenarioRef.current !== state.activeScenario) {
@@ -699,6 +718,10 @@ export function ReportsView({ state, actions, sidebarWidth, timeRange, onTimeRan
                     const inView = !timeRange || (rep.lastUpdated >= timeRange.start && rep.firstSeen <= timeRange.end);
                     const isHi = activeReportIndex === idx;
                     const isExpanded = expandedRowKeys.has(rowKey);
+                    const rs = sendState.get(rowKey) ?? 'idle';
+                    const isSending = rs === 'sending';
+                    const isSent = rs === 'sent';
+                    const sendError = rs.startsWith('error:') ? rs.slice(6) : null;
                     return (
                       <div
                         key={rowKey}
@@ -712,29 +735,48 @@ export function ReportsView({ state, actions, sidebarWidth, timeRange, onTimeRan
                         onMouseEnter={() => setHoveredReportIndex(idx)}
                         onMouseLeave={() => setHoveredReportIndex(null)}
                       >
-                        <button
-                          type="button"
-                          onClick={() => toggleRowExpanded(rowKey)}
-                          className="w-full text-left px-4 py-2.5 flex items-start gap-2"
-                          aria-expanded={isExpanded}
-                        >
-                          <span className="mt-0.5 text-slate-500 tabular-nums w-4 flex-shrink-0 select-none" aria-hidden>
-                            {isExpanded ? '▼' : '▶'}
-                          </span>
-                          <span
-                            className="mt-1 w-2 h-2 rounded-full flex-shrink-0"
-                            style={{ backgroundColor: reportColor(rep.pattern) }}
-                          />
-                          <div className="min-w-0 flex-1">
-                            <div className="flex flex-wrap items-baseline gap-2">
-                              <span className="text-sm font-medium text-slate-100">{rep.title}</span>
-                              <span className="text-xs font-mono text-slate-500">{rep.formattedTime}</span>
+                        <div className="flex items-start">
+                          <button
+                            type="button"
+                            onClick={() => toggleRowExpanded(rowKey)}
+                            className="flex-1 min-w-0 text-left px-4 py-2.5 flex items-start gap-2"
+                            aria-expanded={isExpanded}
+                          >
+                            <span className="mt-0.5 text-slate-500 tabular-nums w-4 flex-shrink-0 select-none" aria-hidden>
+                              {isExpanded ? '▼' : '▶'}
+                            </span>
+                            <span
+                              className="mt-1 w-2 h-2 rounded-full flex-shrink-0"
+                              style={{ backgroundColor: reportColor(rep.pattern) }}
+                            />
+                            <div className="min-w-0 flex-1">
+                              <div className="flex flex-wrap items-baseline gap-2">
+                                <span className="text-sm font-medium text-slate-100">{rep.title}</span>
+                                <span className="text-xs font-mono text-slate-500">{rep.formattedTime}</span>
+                              </div>
+                              <div className="text-xs text-slate-500 font-mono mt-0.5 truncate" title={rep.pattern}>
+                                {rep.pattern}
+                              </div>
                             </div>
-                            <div className="text-xs text-slate-500 font-mono mt-0.5 truncate" title={rep.pattern}>
-                              {rep.pattern}
-                            </div>
-                          </div>
-                        </button>
+                          </button>
+                          <button
+                            type="button"
+                            disabled={isSending}
+                            onClick={(e) => { e.stopPropagation(); handleSendReport(rep.pattern, rep.firstSeen, rowKey); }}
+                            title="Send to Datadog backend"
+                            className={`flex-shrink-0 self-center mr-3 px-2 py-1 rounded text-[10px] font-mono transition-colors ${
+                              isSent
+                                ? 'bg-green-700/40 text-green-300 cursor-default'
+                                : sendError
+                                ? 'bg-red-700/40 text-red-300 hover:bg-red-700/60'
+                                : isSending
+                                ? 'bg-slate-700 text-slate-400 cursor-wait'
+                                : 'bg-slate-700 text-slate-300 hover:bg-purple-700/60 hover:text-purple-200'
+                            }`}
+                          >
+                            {isSending ? '…' : isSent ? '✓ sent' : sendError ? '✗ retry' : 'send'}
+                          </button>
+                        </div>
                         {isExpanded && (
                           <div className="px-4 pb-3 flex gap-2">
                             <span className="w-4 flex-shrink-0" aria-hidden />
@@ -749,6 +791,9 @@ export function ReportsView({ state, actions, sidebarWidth, timeRange, onTimeRan
                                     </span>
                                   ))}
                                 </div>
+                              )}
+                              {sendError && (
+                                <p className="text-[10px] text-red-400 mt-2 font-mono">Send error: {sendError}</p>
                               )}
                             </div>
                           </div>

--- a/cmd/observer-testbench/ui/src/components/ReportsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/ReportsView.tsx
@@ -530,10 +530,11 @@ export function ReportsView({ state, actions, sidebarWidth, timeRange, onTimeRan
       setHoveredReportIndex(null);
       setTimelineFocusedKey(null);
       setExpandedRowKeys(new Set());
+      setSendState(new Map());
     }
   }, [state.activeScenario]);
 
-  // Drop focus/expansion for reports that no longer exist (e.g. correlator rerun), not when only order/filter changes.
+  // Drop focus/expansion/send state for reports that no longer exist (e.g. correlator rerun), not when only order/filter changes.
   useEffect(() => {
     const validKeys = new Set(allReports.map(reportStableKey));
     setExpandedRowKeys((prev) => {
@@ -546,6 +547,15 @@ export function ReportsView({ state, actions, sidebarWidth, timeRange, onTimeRan
       return changed ? next : prev;
     });
     setTimelineFocusedKey((prev) => (prev && validKeys.has(prev) ? prev : null));
+    setSendState((prev) => {
+      let changed = false;
+      const next = new Map<string, string>();
+      for (const [k, v] of prev) {
+        if (validKeys.has(k)) next.set(k, v);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
   }, [allReports]);
 
   const tagGroups = useMemo(() => {
@@ -761,7 +771,7 @@ export function ReportsView({ state, actions, sidebarWidth, timeRange, onTimeRan
                           </button>
                           <button
                             type="button"
-                            disabled={isSending}
+                            disabled={isSending || isSent}
                             onClick={(e) => { e.stopPropagation(); handleSendReport(rep.pattern, rep.firstSeen, rowKey); }}
                             title="Send to Datadog backend"
                             className={`flex-shrink-0 self-center mr-3 px-2 py-1 rounded text-[10px] font-mono transition-colors ${

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -415,3 +415,93 @@ func (s *eventSender) sendCorrelationEvents(correlations []observerdef.ActiveCor
 		}
 	}
 }
+
+// newLiveEventSender creates an eventSender that always posts to the Datadog
+// API (ignoring observer.event_reporter.sending_enabled). Used for on-demand
+// sends from the testbench UI. Returns an error if api_key is not set.
+func newLiveEventSender(cfg config.Component, logger log.Component, storage observerdef.StorageReader) (*eventSender, error) {
+	apiKey := cfg.GetString("api_key")
+	if apiKey == "" {
+		return nil, errors.New("api_key is not set in configuration")
+	}
+	ctx := context.WithValue(
+		datadog.NewDefaultContext(context.Background()),
+		datadog.ContextAPIKeys,
+		map[string]datadog.APIKey{"apiKeyAuth": {Key: apiKey}},
+	)
+	return &eventSender{
+		api:     datadogV2.NewEventsApi(datadog.NewAPIClient(datadog.NewConfiguration())),
+		ctx:     ctx,
+		logger:  logger,
+		storage: storage,
+	}, nil
+}
+
+// sendReportedEvent posts a single ReportedEvent to the Datadog backend.
+// It replaces the original source tag with "source:observer-testbench" and
+// appends the provided extraTags (e.g. scenario and user).
+func (s *eventSender) sendReportedEvent(event ReportedEvent, extraTags []string) error {
+	// Rebuild tags: drop original source, replace with testbench source, add extras.
+	tags := []string{"source:observer-testbench"}
+	for _, t := range event.Tags {
+		if strings.HasPrefix(t, "source:") {
+			continue
+		}
+		tags = append(tags, t)
+	}
+	tags = append(tags, extraTags...)
+	sort.Strings(tags[1:]) // keep source:observer-testbench first
+
+	// Use current time: replay scenario timestamps are often hours/days old and
+	// the Datadog API rejects events with timestamps outside its acceptance window.
+	ts := time.Now().UTC().Format(time.RFC3339)
+	aggKey := "testbench:" + event.Pattern
+
+	s.logger.Infof("[observer] sending testbench event: pattern=%s title=%q", event.Pattern, event.Title)
+
+	if s.api == nil {
+		fmt.Printf("[dry-run] testbench event: pattern=%s title=%q tags=%v\n%s\n\n", event.Pattern, event.Title, tags, event.Message)
+		return nil
+	}
+
+	// EventPayload.Attributes is a required union field — omitting it causes a
+	// marshal error. Build a minimal ChangeEventCustomAttributes from the pattern.
+	name := event.Pattern
+	if len(name) > 128 {
+		name = name[:128]
+	}
+	changedResource := *datadogV2.NewChangeEventCustomAttributesChangedResource(
+		name,
+		datadogV2.CHANGEEVENTCUSTOMATTRIBUTESCHANGEDRESOURCETYPE_CONFIGURATION,
+	)
+	changeAttrs := *datadogV2.NewChangeEventCustomAttributes(changedResource)
+	changeAttrs.SetAuthor(*datadogV2.NewChangeEventCustomAttributesAuthor(
+		"datadog-agent-observer-testbench",
+		datadogV2.CHANGEEVENTCUSTOMATTRIBUTESAUTHORTYPE_AUTOMATION,
+	))
+	attrs := datadogV2.ChangeEventCustomAttributesAsEventPayloadAttributes(&changeAttrs)
+
+	payload := datadogV2.EventCreateRequestPayload{
+		Data: datadogV2.EventCreateRequest{
+			Type: datadogV2.EVENTCREATEREQUESTTYPE_EVENT,
+			Attributes: datadogV2.EventPayload{
+				Title:          event.Title,
+				Message:        datadog.PtrString(event.Message),
+				Category:       datadogV2.EVENTCATEGORY_CHANGE,
+				Tags:           tags,
+				Timestamp:      datadog.PtrString(ts),
+				AggregationKey: datadog.PtrString(aggKey),
+				Attributes:     attrs,
+			},
+		},
+	}
+	_, httpResp, err := s.api.CreateEvent(s.ctx, payload)
+	if err != nil && httpResp != nil {
+		body, readErr := io.ReadAll(httpResp.Body)
+		httpResp.Body.Close()
+		if readErr == nil {
+			return fmt.Errorf("API error (HTTP %d): %s", httpResp.StatusCode, string(body))
+		}
+	}
+	return err
+}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -1616,6 +1616,42 @@ func (tb *TestBench) GetReportedEvents() []ReportedEvent {
 	return tb.reportedEvents
 }
 
+// SendReportedEvent finds the ReportedEvent matching pattern+firstSeen and
+// posts it to the Datadog backend, tagging it with source:observer-testbench,
+// the active scenario name, and the OS user.
+func (tb *TestBench) SendReportedEvent(pattern string, firstSeen int64) error {
+	tb.mu.RLock()
+	var found *ReportedEvent
+	for i := range tb.reportedEvents {
+		e := &tb.reportedEvents[i]
+		if e.Pattern == pattern && e.FirstSeen == firstSeen {
+			found = e
+			break
+		}
+	}
+	scenario := tb.loadedScenario
+	tb.mu.RUnlock()
+	storage := tb.getStorage()
+
+	if found == nil {
+		return fmt.Errorf("report not found: pattern=%q firstSeen=%d", pattern, firstSeen)
+	}
+
+	sender, err := newLiveEventSender(tb.config.Cfg, tb.config.Logger, storage)
+	if err != nil {
+		return err
+	}
+
+	extraTags := []string{"scenario:" + scenario}
+	if u := os.Getenv("USER"); u != "" {
+		extraTags = append(extraTags, "user:"+u)
+	} else if h, err := os.Hostname(); err == nil {
+		extraTags = append(extraTags, "user:"+h)
+	}
+
+	return sender.sendReportedEvent(*found, extraTags)
+}
+
 // errorLogMessages contains realistic error messages for the demo scenario.
 var errorLogMessages = []string{
 	"request timeout: upstream service did not respond within 30s",

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -61,6 +61,7 @@ func (api *TestBenchAPI) Start(addr string) error {
 	mux.HandleFunc("/api/log-patterns", api.cors(api.handleLogPatterns))
 	mux.HandleFunc("/api/correlations", api.cors(api.handleCorrelations))
 	mux.HandleFunc("/api/reports", api.cors(api.handleReports))
+	mux.HandleFunc("/api/reports/send", api.cors(api.handleSendReport))
 	mux.HandleFunc("/api/stats", api.cors(api.handleStats))
 	mux.HandleFunc("/api/score", api.cors(api.handleScore))
 	mux.HandleFunc("/api/benchmark", api.cors(api.handleBenchmark))
@@ -1171,6 +1172,32 @@ func (api *TestBenchAPI) handleReports(w http.ResponseWriter, _ *http.Request) {
 		events = []ReportedEvent{}
 	}
 	api.writeJSON(w, events)
+}
+
+// handleSendReport posts a specific ReportedEvent to the Datadog backend.
+// Body: {"pattern":"...", "firstSeen": 123}
+func (api *TestBenchAPI) handleSendReport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		api.writeError(w, http.StatusMethodNotAllowed, "use POST")
+		return
+	}
+	var req struct {
+		Pattern   string `json:"pattern"`
+		FirstSeen int64  `json:"firstSeen"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		api.writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if req.Pattern == "" {
+		api.writeError(w, http.StatusBadRequest, "pattern is required")
+		return
+	}
+	if err := api.tb.SendReportedEvent(req.Pattern, req.FirstSeen); err != nil {
+		api.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	api.writeJSON(w, map[string]string{"status": "sent"})
 }
 
 // handleComponentAction handles /api/components/{name}/{action} (toggle, data).


### PR DESCRIPTION
### What does this PR do?

Allows sending individual ReportedEvents to the Datadog backend from the testbench UI with `source:observer-testbench` + scenario/user tags.

### Motivation

### Describe how you validated your changes

### Additional Notes