### PR TITLE
Set CGO_LDFLAGS for libpython in get_build_flags

### DIFF
--- a/pkg/collector/python/python_aix.go
+++ b/pkg/collector/python/python_aix.go
@@ -55,10 +55,11 @@ package python
 // With -bE:python.exp, the agent exports the symbols and extensions load cleanly.
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/../../../embedded/lib -lpython3
-
 // Forward declaration — we do not include Python.h to avoid pulling in
 // the entire CPython header tree; Py_IsInitialized has a stable ABI.
+// -lpython3 is supplied via CGO_LDFLAGS by get_build_flags() in
+// tasks/libs/common/utils.py, using the correct embedded_path regardless
+// of where the source tree is located.
 extern int Py_IsInitialized(void);
 */
 import "C"

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -276,6 +276,15 @@ def get_build_flags(
     if python_home_3:
         ldflags += f"-X {REPO_PATH}/pkg/collector/python.pythonHome3={python_home_3} "
 
+    # On AIX, libpython must be linked explicitly so that Python API symbols enter
+    # the XCOFF process-global symbol table at startup (required by C extension modules).
+    # Fall back to embedded_path when python_home_3 is not explicitly set, since on AIX
+    # Python is installed alongside rtloader under the same embedded prefix.
+    if sys.platform == 'aix':
+        aix_python_lib_path = python_home_3 or embedded_path
+        if aix_python_lib_path:
+            env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + f" -L{aix_python_lib_path}/lib -lpython3"
+
     # adding rtloader libs and headers to the env
     if rtloader_lib:
         if not headless_mode:
@@ -307,7 +316,7 @@ def get_build_flags(
         ldflags += "-s -w -linkmode=external "
         extldflags += "-static "
     elif rtloader_lib:
-        if sys.platform != "aix":  # AIX uses full-path linking in pkg/collector/python/init.go
+        if sys.platform != "aix":  # -r sets ELF RPATH; not valid for AIX XCOFF
             ldflags += f"-r {':'.join(rtloader_lib)} "
 
     if os.environ.get("DELVE"):

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -276,15 +276,6 @@ def get_build_flags(
     if python_home_3:
         ldflags += f"-X {REPO_PATH}/pkg/collector/python.pythonHome3={python_home_3} "
 
-    # On AIX, libpython must be linked explicitly so that Python API symbols enter
-    # the XCOFF process-global symbol table at startup (required by C extension modules).
-    # Fall back to embedded_path when python_home_3 is not explicitly set, since on AIX
-    # Python is installed alongside rtloader under the same embedded prefix.
-    if sys.platform == 'aix':
-        aix_python_lib_path = python_home_3 or embedded_path
-        if aix_python_lib_path:
-            env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + f" -L{aix_python_lib_path}/lib -lpython3"
-
     # adding rtloader libs and headers to the env
     if rtloader_lib:
         if not headless_mode:
@@ -296,6 +287,19 @@ def get_build_flags(
         if sys.platform == "aix":
             env['LIBPATH'] = os.environ.get('LIBPATH', '') + f":{':'.join(rtloader_lib)}"  # AIX
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + f" -L{' -L '.join(rtloader_lib)}"
+
+    # On AIX, libpython must be linked explicitly so that Python API symbols enter
+    # the XCOFF process-global symbol table at startup (required by C extension modules).
+    # Fall back to embedded_path when python_home_3 is not explicitly set, since on AIX
+    # Python is installed alongside rtloader under the same embedded prefix.
+    # Must follow the rtloader block: that block also writes env['CGO_LDFLAGS'] from
+    # os.environ, so placing this before it would cause the python flag to be dropped.
+    if sys.platform == 'aix':
+        aix_python_lib_path = python_home_3 or embedded_path
+        if aix_python_lib_path:
+            env['CGO_LDFLAGS'] = (
+                env.get('CGO_LDFLAGS', os.environ.get('CGO_LDFLAGS', '')) + f" -L{aix_python_lib_path}/lib -lpython3"
+            )
 
     if sys.platform == 'win32':
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + ' -Wl,--allow-multiple-definition'


### PR DESCRIPTION
### What does this PR do?
Moves AIX-specific linker flags for `libpython3` from a `#cgo LDFLAGS` directive in `pkg/collector/python/python_aix.go` into `get_build_flags()` in `tasks/libs/common/utils.py`.
Also adds `LIBPATH` alongside `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH` for AIX, and guards the `-r (ELF RPATH)` flag from being passed on AIX where it is not valid.

### Motivation
The `#cgo LDFLAGS` path (`-L${SRCDIR}/../../../embedded/lib`) hardcoded an assumption that the repo is checked out under `/opt/datadog-agent`. Building from any other path silently failed to link `libpython3`. Using `get_build_flags()` with the already-resolved embedded_path fixes this for both `dda inv agent.build` and the packaging pipeline.

### Describe how you validated your changes
Local testing.

### Additional Notes
