### PR TITLE
Add minimal credential helper for Buildbarn

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,14 +39,17 @@ common:lint --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect --output_gro
 common:lint --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=+rustfmt_checks
 
 # Linux config ---------------------------------------------------------------------------------------------------------
+common:linux --credential_helper=*.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper
 common:linux --strategy=sandboxed
 
 # macOS config ---------------------------------------------------------------------------------------------------------
+common:macos --credential_helper=*.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper
 common:macos --features=-macos_default_link_flags # https://github.com/bazelbuild/bazel/issues/23312
 common:macos --macos_minimum_os=12.0 # Keep in sync with https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
 common:macos --strategy=sandboxed
 
 # Windows config -------------------------------------------------------------------------------------------------------
+common:windows --credential_helper=*.us1.ddbuild.io=%workspace%/bazel/tools/credential-helper.bat
 common:windows --strategy=standalone # Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]
 # rules_python 1.9.0 transitions enable_runfiles to `true` for every py_ target on Windows. Pre-setting it here makes
 # that transition a no-op, so Bazel deduplicates python_win and avoids 2 concurrent MSBuild racing on shared resources.

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -1,5 +1,8 @@
 .bazel:defs:
   needs: [ ]
+  id_tokens:
+    BUILDBARN_ID_TOKEN:
+      aud: buildbarn.us1.ddbuild.io
   variables:
     BAZELISK_HOME: "$XDG_CACHE_HOME/bazelisk" # not all bazelisk versions may honor $XDG_CACHE_HOME
 

--- a/bazel/tools/credential-helper
+++ b/bazel/tools/credential-helper
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Credential Helpers Specification: https://github.com/EngFlow/credential-helper-spec/blob/main/spec.md
+IFS= read -d '' -r _ ||:
+if [ -n "${BUILDBARN_ID_TOKEN-}" ]; then
+    printf '{"headers":{"Authorization":["Bearer %s"]}}' "$BUILDBARN_ID_TOKEN"
+else
+    printf '{}'
+fi

--- a/bazel/tools/credential-helper.bat
+++ b/bazel/tools/credential-helper.bat
@@ -1,0 +1,9 @@
+@echo off
+
+:: Credential Helpers Specification: https://github.com/EngFlow/credential-helper-spec/blob/main/spec.md
+set /p _=
+if defined BUILDBARN_ID_TOKEN (
+    echo {"headers":{"Authorization":["Bearer %BUILDBARN_ID_TOKEN%"]}}
+) else (
+    echo {}
+)

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -16,6 +16,7 @@ CACHE_VERSION = 2
 
 ENV_PASSHTROUGH = {
     'BAZELISK_HOME': "Runner-dependent cache path used by `bazelisk` to manage `bazel` installations",
+    'BUILDBARN_ID_TOKEN': "OIDC token used by the Bazel credential helper to authenticate against the Buildbarn remote cache",
     'CI': "dda and `bazel` rely on this to be able to tell whether they're running on CI and adapt behavior",
     'DD_CC': 'Points at c compiler',
     'DD_CXX': 'Points at c++ compiler',
@@ -115,6 +116,7 @@ def _get_environment_for_cache(env: dict[str, str]) -> dict:
     """
     excluded_variables = {
         'APPDATA',
+        'BUILDBARN_ID_TOKEN',
         'DEB_GPG_KEY',
         'DEB_GPG_KEY_NAME',
         'DEB_SIGNING_PASSPHRASE',

--- a/tools/ci/docker-run-with-bazel-cache.ps1
+++ b/tools/ci/docker-run-with-bazel-cache.ps1
@@ -12,5 +12,11 @@ if (-not (($acl = Get-Acl $diskCache).Access | Where-Object { -not $_.IsInherite
     Set-Acl $diskCache $acl
     Get-ChildItem $diskCache -Recurse | ForEach-Object { Set-Acl $_.FullName $acl }
 }
-& docker run --rm --env=BAZELISK_HOME --env=CI --env=XDG_CACHE_HOME --volume="${env:XDG_CACHE_HOME}:${env:XDG_CACHE_HOME}" $args
+& docker run --rm `
+    --env=BAZELISK_HOME `
+    --env=BUILDBARN_ID_TOKEN `
+    --env=CI `
+    --env=XDG_CACHE_HOME `
+    --volume="${env:XDG_CACHE_HOME}:${env:XDG_CACHE_HOME}" `
+    $args
 exit $LASTEXITCODE


### PR DESCRIPTION
### What does this PR do?

Add two checked-in credential helper scripts - `bazel/tools/credential-helper` (bash, Linux/macOS) and `bazel/tools/credential-helper.bat` (Windows) - and wire them into the OS-specific `.bazelrc` sections and the GitLab OIDC token pipeline.

### Motivation
#48942 proposes adding the Tweag credential-helper binary to authenticate against the Buildbarn remote cache.
Bazelisk promise to bootstrap Bazel with minimal overhead is kind of defeated by pulling in a third-party binary for just populating a Bearer-token handshake.

Checked-in scripts cover the same need without prerequisites: they simply emit a `Bearer` token when `BUILDBARN_ID_TOKEN` is set, and fall back to an empty header map otherwise.

### Describe how you validated your changes
CI.

### Additional Notes
This covers only the GitLab integration so far, i.e. not GitHub actions yet.