### PR TITLE
Fix nil pointer panic in TestTryResolveMissingAncestor/ppid-zero-procfs-fails

### DIFF
--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -991,11 +991,11 @@ func TestTryResolveMissingAncestor(t *testing.T) {
 			t.Fatal()
 		}
 
-		// Use a fake PID that does not exist in procfs. With ppid=0 the
-		// resolver tries to read /proc/<pid>/status which will fail, so
-		// the Ancestor should remain nil and reparentFailed should be
-		// incremented.
-		child := newFakeForkEvent(0, 99998, 100, resolver)
+		// Use a PID above pid_max (4,194,304) so it can never exist in procfs
+		// regardless of host state. With ppid=0 the resolver tries to read
+		// /proc/<pid>/status which will fail, so the Ancestor should remain
+		// nil and reparentFailed should be incremented.
+		child := newFakeForkEvent(0, 5_000_099, 100, resolver)
 
 		resolver.Lock()
 		resolver.entryCache[child.ProcessCacheEntry.Pid] = child.ProcessCacheEntry


### PR DESCRIPTION
### What does this PR do?

Use a PID above `pid_max` (4,194,304) as the child pid in the `ppid-zero-procfs-fails` subtest of `TestTryResolveMissingAncestor`, matching the convention established in #49248.

### Motivation

The test was using pid `99998` to exercise the \"ppid=0, procfs lookup fails\" path. On a busy CI runner where that PID happens to exist, `TryReparentFromProcfs` reads `/proc/99998/status`, finds a real ppid, and recursively resolves the entire ancestor chain via `resolveFromProcfs`. That walk eventually reaches PID 1, where `statFile` panics on the nil `inodeFileMap` (not initialised in unit tests), causing a nondeterministic panic.

Using a PID above `pid_max` guarantees it can never exist in procfs regardless of host state.

Failing job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1597547214

### Describe how you validated your changes

CI

### Additional Notes

Same root cause as #49248, different test and more severe symptom (panic rather than assertion failure).