### PR TITLE
fix(selinux): target modular policy v19 for RHEL 7 compatibility

### DIFF
--- a/releasenotes/notes/fix-rhel7-selinux-policy-4a8acfc4bc283fd4.yaml
+++ b/releasenotes/notes/fix-rhel7-selinux-policy-4a8acfc4bc283fd4.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix the system-probe SELinux policy module failing to load on RHEL 7
+    with ``policydb module version 21 does not match my version range 4-19``.
+    The module is now compiled against modular policy version 19, which is
+    the highest version supported by RHEL 7 and is backward-compatible with
+    newer RHEL releases.

--- a/tasks/selinux.py
+++ b/tasks/selinux.py
@@ -31,8 +31,10 @@ def compile_system_probe_policy_file(
     # Compute the .pp packaged module name
     output_module_name = ".".join([os.path.join(output_directory, os.path.basename(policy_filename)), "pp"])
 
-    # Compile the module
-    command = f"checkmodule -M -m -o {temp_module_name} {te_file}"
+    # Compile the module targeting modular policy version 19, the highest version
+    # supported by libsepol on RHEL 7 (range 4-19). Newer distributions remain
+    # backward-compatible, so a v19 module loads on all supported RHEL releases.
+    command = f"checkmodule -M -m -c 19 -o {temp_module_name} {te_file}"
     ctx.run(command)
 
     # Package the module


### PR DESCRIPTION
### What does this PR do?

Pass `-c 19` to `checkmodule` when compiling the system-probe SELinux policy so the resulting `system_probe_policy.pp` targets modular policy version 19 instead of the toolchain default (21 on the current build image).

### Motivation

A customer running RHEL 7 reports that loading the system-probe SELinux module fails with:

```
policydb module version 21 does not match my version range 4-19
```

RHEL 7 ships `libsepol 2.5`, which only supports modular policy versions 4-19. The agent omnibus build runs in the `linux` build image (Ubuntu Noble, `libsepol 3.5`), which defaults to version 21. That default gets baked into the shipped `.pp`, so RHEL 7 can no longer load it.

`checkmodule` supports `-c VERSION` to target an older modular policy version. The current `.te` only uses features present in v19, and newer RHEL releases remain backward-compatible with v19 modules.

### Describe how you validated your changes

- Compiled the policy inside the build image and verified the module header reports version 19 (raw bytes `13 00 00 00`).
- Loaded the resulting `.pp` on a fresh `centos:7` container: `semodule -i` returns `Ok: transaction number 0.` and `semodule -l` lists `system_probe_policy 1.0`.
- Confirmed the previous build (module format 21) reproduces the customer error on the same container.

Tested on `CentOS Linux release 7.9.2009 (Core)` which has `libsepol.x86_64 v2.5-10.el7` installed, similar to RHEL 7.

**Without the fix (installing `datadog-agent-7.77.3-1.x86_64.rpm`)**
```
Loading SELinux policy module for datadog-agent.
Couldn't load system-probe policy (Attempting to install module '/etc/datadog-agent/selinux/system_probe_policy.pp':
Ok: return value of 0.
Committing changes:

libsemanage.semanage_pipe_data: Child process /usr/libexec/selinux/hll/pp failed with code: 255. (No such file or directory).
system_probe_policy: libsepol.policydb_read: policydb module version 21 does not match my version range 4-19
system_probe_policy: libsepol.sepol_module_package_read: invalid module in module package (at section 0)
system_probe_policy: Failed to read policy package
libsemanage.semanage_direct_commit: Failed to compile hll files into cil files.
 (No such file or directory).
semodule:  Failed!

exit status 1).
```

**With the fix (installing dev `*.rpm`)**

The error above is gone.

### Additional Notes

`checkmodule -c VERSION` requires `checkpolicy >= 3.3` (2021); the current `linux` build image uses `checkpolicy 3.5`.