### PR TITLE
[PAR] trace private action executions

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -24,6 +25,8 @@ import (
 	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	parconfig "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/parversion"
 	pkgrcclient "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/rcclient"
@@ -35,6 +38,7 @@ import (
 	taskverifier "github.com/DataDog/datadog-agent/pkg/privateactionrunner/task-verifier"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 )
 
@@ -75,6 +79,8 @@ type PrivateActionRunner struct {
 
 	workflowRunner *runners.WorkflowRunner
 	commonRunner   *runners.CommonRunner
+
+	telemetry *telemetry.Telemetry
 
 	started     bool
 	startOnce   sync.Once
@@ -193,6 +199,13 @@ func (p *PrivateActionRunner) start(ctx context.Context) error {
 	}
 	ctx = observability.AddCommonTagsToLogs(ctx, commonTags)
 
+	p.telemetry = telemetry.NewTelemetry(
+		&http.Client{Transport: httputils.CreateHTTPTransport(p.coreConfig)},
+		configutils.SanitizeAPIKey(p.coreConfig.GetString("api_key")),
+		cfg.DatadogSite,
+		observability.ParService,
+	)
+
 	p.logger.Info("Private action runner starting")
 	p.logger.Info("==> Version : " + parversion.RunnerVersion)
 	p.logger.Info("==> Site : " + cfg.DatadogSite)
@@ -240,6 +253,9 @@ func (p *PrivateActionRunner) Stop(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+	}
+	if p.telemetry != nil {
+		p.telemetry.Stop()
 	}
 	return nil
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -19,7 +19,9 @@ import (
 	"github.com/DataDog/rshell/interp"
 
 	"github.com/DataDog/datadog-agent/pkg/config/env"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/observability"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -98,7 +100,8 @@ func (h *RunCommandHandler) Run(
 	}
 	defer runner.Close()
 
-	runErr := runner.Run(ctx, prog)
+	// Spans emitted by rshell inherit the rshell service via context.
+	runErr := runner.Run(telemetry.WithService(ctx, observability.RshellService), prog)
 	exitCode := 0
 	if runErr != nil {
 		var es interp.ExitStatus

--- a/pkg/privateactionrunner/observability/traces.go
+++ b/pkg/privateactionrunner/observability/traces.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package observability
+
+const (
+	// Name of the service used for tracing the private action runner
+	ParService = "private-action-runner"
+
+	// Name of the sub-services that we want to trace
+	RshellService = "rshell"
+
+	// ActionRunOperation is the operation name for the span that covers a
+	// private action execution. Paired with the action FQN as the resource name.
+	ActionRunOperation = "action.run"
+)

--- a/pkg/privateactionrunner/runners/workflow_runner.go
+++ b/pkg/privateactionrunner/runners/workflow_runner.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/actions"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
@@ -85,7 +86,7 @@ func (n *WorkflowRunner) RunTask(
 	ctx context.Context,
 	task *types.Task,
 	credential *privateconnection.PrivateCredentials,
-) (interface{}, error) {
+) (output interface{}, err error) {
 	fqn := task.GetFQN()
 	bundleName, actionName := actions.SplitFQN(fqn)
 	bundle := n.registry.GetBundle(bundleName)
@@ -112,8 +113,14 @@ func (n *WorkflowRunner) RunTask(
 	defer heartbeatCancel()
 	go n.startHeartbeat(heartbeatCtx, task, logger)
 
+	ctx = telemetry.WithService(ctx, observability.ParService)
+	span, ctx := telemetry.StartSpanFromContext(ctx, observability.ActionRunOperation)
+	span.SetResourceName(fqn)
+	span.SetTag("task_id", task.Data.ID)
+	defer func() { span.Finish(err) }()
+
 	startTime := observability.ReportExecutionStart(n.config.MetricsClient, task.Data.Attributes.Client, fqn, task.Data.ID, logger)
-	output, err := action.Run(ctx, task, credential)
+	output, err = action.Run(ctx, task, credential)
 	observability.ReportExecutionCompleted(n.config.MetricsClient, task.Data.Attributes.Client, fqn, task.Data.ID, startTime, err, logger)
 
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

Adds tracing in the Private Action Runner so each task dispatch emits a span on `service: private-action-runner`. The rshell bundle swaps the context service to `rshell` before invoking the interpreter, so rshell-emitted child spans land on `service: rshell`.

### Span layout

```
action.run                          (service: private-action-runner)
  resource: <action FQN>
  tag:      task_id: <uuid>
  └── <rshell spans from DataDog/rshell#186>   (service: rshell)
```

### Changes

- `WorkflowRunner.RunTask` wraps every dispatch in an `action.run` span. Resource = action FQN, `task_id` as a tag.
- `rshell.runCommand` sets `service: rshell` on the context before invoking `interp.Runner.Run` so rshell's public callbacks (OnCommandDispatch, OnPipelineStart, …) attribute child spans correctly.
- PAR component bootstraps a `fleettelemetry.Telemetry` flusher at startup using `api_key` + configured `site` so spans ship to the instrumentation telemetry intake.
- New `pkg/privateactionrunner/observability/traces.go` holds the service and operation name constants.

## Motivation

Give PAR and rshell runtime visibility in APM. Enables debugging blocked commands, rshell script performance, and cross-service latency breakdown without log-mining.

## Depends on

- Tracer base changes: base of this PR (`jules.macret/Q/lightweight-tracer-improvements`)
- rshell callbacks: DataDog/rshell#186

## Describe how you validated your changes

- Unit tests pass (`dda inv test --targets=./pkg/privateactionrunner/...`)
- Deployed to a local Kind cluster; verified end-to-end in org2 (US1 prod) APM — `action.run` span with `service: private-action-runner` and rshell child spans with `service: rshell`

## Additional notes

Blocked by the two dependencies above. Merge base first, then this PR.