### PR TITLE
[observer] Prettify log metric extractor events

### DIFF
--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -38,6 +38,9 @@ func DefaultLogMetricsExtractorConfig() LogMetricsExtractorConfig {
 	}
 }
 
+// LogMetricsExtractorName is the canonical name for the log metrics extractor.
+const LogMetricsExtractorName = "log_metrics_extractor"
+
 // LogMetricsExtractor converts logs into timeseries metric outputs:
 // - JSON logs: numeric fields -> Avg aggregation
 // - Unstructured logs: pattern frequency -> Sum aggregation
@@ -61,7 +64,7 @@ func NewLogMetricsExtractor(config LogMetricsExtractorConfig) *LogMetricsExtract
 	return &LogMetricsExtractor{config: config}
 }
 
-func (a *LogMetricsExtractor) Name() string { return "log_metrics_extractor" }
+func (a *LogMetricsExtractor) Name() string { return LogMetricsExtractorName }
 
 // Reset clears cached per-series context so replay/reanalysis starts from the
 // currently observed data instead of reusing stale examples.

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -373,15 +373,24 @@ func anomalyDisplayKey(a observerdef.Anomaly) string {
 // log pattern extraction. These should be presented as log anomalies with
 // pattern/example/rate context rather than raw metric descriptions.
 func isLogDerivedAnomaly(a observerdef.Anomaly) bool {
-	return a.Type != observerdef.AnomalyTypeLog &&
-		a.Source.Namespace == LogPatternExtractorName &&
-		a.Context != nil &&
-		strings.TrimSpace(a.Context.Pattern) != ""
+	if a.Type == observerdef.AnomalyTypeLog || a.Context == nil {
+		return false
+	}
+	switch a.Source.Namespace {
+	case LogPatternExtractorName:
+		return strings.TrimSpace(a.Context.Pattern) != ""
+	case LogMetricsExtractorName:
+		return strings.TrimSpace(a.Context.Pattern) != "" || strings.TrimSpace(a.Context.Example) != ""
+	}
+	return false
 }
 
 // logDerivedDescription builds a human-readable description for a log-derived
 // metric anomaly, including pattern, example, and windowed average rate.
 func logDerivedDescription(a observerdef.Anomaly, storage observerdef.StorageReader) string {
+	if a.Source.Namespace == LogMetricsExtractorName {
+		return logFrequencyDerivedDescription(a, storage)
+	}
 	pattern := strings.TrimSpace(a.Context.Pattern)
 	var example string
 	// Don't display example if it's the same as the pattern
@@ -405,6 +414,22 @@ func logDerivedDescription(a observerdef.Anomaly, storage observerdef.StorageRea
 		}
 	}
 	return fmt.Sprintf("Log pattern change rate detected:\n\tpattern: %s%s%s%s", pattern, example, ratePart, tagsPart)
+}
+
+// logFrequencyDerivedDescription builds a human-readable description for
+// log.pattern.* anomalies from LogMetricsExtractor. The stored pattern is an
+// internal tokenized structural signature (not human-readable), so the example
+// log line is used as the primary identifier instead.
+func logFrequencyDerivedDescription(a observerdef.Anomaly, storage observerdef.StorageReader) string {
+	example := strings.TrimSpace(a.Context.Example)
+	if example == "" {
+		example = strings.TrimSpace(a.Context.Pattern)
+	}
+	var ratePart string
+	if rate, ok := logPatternRate(a, storage); ok {
+		ratePart = fmt.Sprintf("\n\trate: %.1flog/s", rate)
+	}
+	return fmt.Sprintf("Log frequency change detected:\n\texample: %s%s", example, ratePart)
 }
 
 // sendCorrelationEvents sends one event per correlation.

--- a/comp/observer/impl/notify_test.go
+++ b/comp/observer/impl/notify_test.go
@@ -14,6 +14,98 @@ import (
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
+func TestIsLogDerivedAnomaly_LogMetricsExtractorWithPattern(t *testing.T) {
+	a := observerdef.Anomaly{
+		Type:   observerdef.AnomalyTypeMetric,
+		Source: observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+		Context: &observerdef.MetricContext{
+			Pattern: "C3:C8_C1",
+			Example: "ERROR: connection refused to db.prod:5432",
+		},
+	}
+	assert.True(t, isLogDerivedAnomaly(a))
+}
+
+func TestIsLogDerivedAnomaly_LogMetricsExtractorExampleOnlyNoPattern(t *testing.T) {
+	// Even with an empty pattern, a non-empty example qualifies.
+	a := observerdef.Anomaly{
+		Type:   observerdef.AnomalyTypeMetric,
+		Source: observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+		Context: &observerdef.MetricContext{
+			Pattern: "",
+			Example: "some log line",
+		},
+	}
+	assert.True(t, isLogDerivedAnomaly(a))
+}
+
+func TestIsLogDerivedAnomaly_LogMetricsExtractorNoContext(t *testing.T) {
+	a := observerdef.Anomaly{
+		Type:    observerdef.AnomalyTypeMetric,
+		Source:  observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+		Context: nil,
+	}
+	assert.False(t, isLogDerivedAnomaly(a))
+}
+
+func TestBuildChangeMessage_LogMetricsExtractorUsesExample(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+				Context: &observerdef.MetricContext{
+					Pattern: "C3:C8_C1",
+					Example: "ERROR: connection refused to db.prod:5432",
+				},
+			},
+		},
+	}
+	msg := buildChangeMessage(c, nil)
+	assert.Contains(t, msg, "Log frequency change detected")
+	assert.Contains(t, msg, "ERROR: connection refused to db.prod:5432")
+	assert.NotContains(t, msg, "C3:C8_C1") // tokenized signature should not appear
+}
+
+func TestBuildChangeMessage_LogMetricsExtractorFallsBackToPatternWhenNoExample(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+				Context: &observerdef.MetricContext{
+					Pattern: "C3:C8_C1",
+					Example: "",
+				},
+			},
+		},
+	}
+	msg := buildChangeMessage(c, nil)
+	assert.Contains(t, msg, "Log frequency change detected")
+	assert.Contains(t, msg, "C3:C8_C1")
+}
+
+func TestBuildEventTags_LogMetricsExtractorTreatedAsLog(t *testing.T) {
+	c := observerdef.ActiveCorrelation{
+		Pattern: "p",
+		Anomalies: []observerdef.Anomaly{
+			{
+				Type:   observerdef.AnomalyTypeMetric,
+				Source: observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+				Context: &observerdef.MetricContext{
+					Pattern: "C3:C8_C1",
+					Example: "some log line",
+				},
+			},
+		},
+	}
+	tags := buildEventTags(c)
+	assert.Contains(t, tags, "anomaly_type:log")
+	assert.NotContains(t, tags, "anomaly_type:metric")
+}
+
 func TestBuildEventTags_BaseTagsAlwaysPresent(t *testing.T) {
 	c := observerdef.ActiveCorrelation{Pattern: "kernel_bottleneck"}
 	tags := buildEventTags(c)


### PR DESCRIPTION
### What does this PR do?

Now we have a proper description for anomalies detected from this detector, it replaces `log.pattern.<uggly-hash>...` events.

<img width="942" height="70" alt="Screenshot 2026-04-17 at 15 33 54" src="https://github.com/user-attachments/assets/c1d25384-ff0a-4577-9a2d-feddaa4cecbc" />


### Motivation

### Describe how you validated your changes

### Additional Notes
