### PR TITLE
bazel: revert back to upstream rules_go

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -78,12 +78,12 @@ bazel_dep(name = "rules_testing", version = "0.9.0", dev_dependency = True)
 # https://github.com/bazel-contrib/rules_go/pull/4586 gets merged
 git_override(
     module_name = "rules_go",
-    commit = "4cb2eab3d1aec456573f0cefd8e8800e9c68ae7d",
+    commit = "8808bb8c6604f1e7a2badbfcd9a9db4c32ba0a8c",  # main as of April 17, 2026
     patch_strip = 1,
     patches = [
         "//bazel/patches:rules_go-windows-symlink-workaround.patch",  # bazel-contrib/rules_go#3977
     ],
-    remote = "https://github.com/chouquette/rules_go.git",
+    remote = "https://github.com/bazel-contrib/rules_go.git",
 )
 
 # Temporary until rules_pkg > 1.2.0 is in BCR


### PR DESCRIPTION
### What does this PR do?

Stop using my personal rules_go fork

### Motivation

Now that our patch was merged, we can stop using a fork and revert back to the mainline

### Describe how you validated your changes

### Additional Notes
