### PR TITLE
[Backport 7.78.x]  fix(ssi): scope library volume mounts to targeted containers

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -2762,6 +2762,84 @@ func TestAutoinstrumentation(t *testing.T) {
 	}
 }
 
+func TestAutoinstrumentation_LocalLibInjectionPerContainerOnlyMountsLibraryOnTargetContainer(t *testing.T) {
+	mockConfig := common.FakeConfigWithValues(t, map[string]any{
+		"apm_config.instrumentation.enabled":     false,
+		"admission_controller.mutate_unlabelled": false,
+	})
+	mockMeta := common.FakeStoreWithDeployment(t, defaultDeployments)
+	mockDynamic := fake.NewSimpleDynamicClient(runtime.NewScheme())
+	mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.gradual_rollout.enabled", false)
+
+	for _, ns := range defaultNamespaces {
+		mockMeta.(workloadmetamock.Mock).Set(&ns)
+	}
+
+	webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil)
+	require.NoError(t, err)
+
+	pod := common.FakePodSpec{
+		Name:       "app",
+		NS:         "application",
+		ParentKind: "replicaset",
+		ParentName: "deployment-123",
+		Annotations: map[string]string{
+			"admission.datadoghq.com/app.java-lib.version": "v1",
+		},
+		Labels: map[string]string{
+			admissioncommon.EnabledLabelKey: "true",
+		},
+		Containers: []corev1.Container{
+			{Name: "app2"},
+		},
+	}.Create()
+
+	mutated, err := webhook.MutatePod(pod, pod.Namespace, mockDynamic)
+	require.NoError(t, err)
+	require.True(t, mutated)
+
+	validator := testutils.NewPodValidator(pod, testutils.InjectionModeAuto)
+	validator.RequireInjectorVersion(t, defaultInjectorVersion)
+	validator.RequireLibraryVersions(t, map[string]string{"java": "v1"})
+
+	var appCtr, app2Ctr *corev1.Container
+	for i := range pod.Spec.Containers {
+		switch pod.Spec.Containers[i].Name {
+		case "app":
+			appCtr = &pod.Spec.Containers[i]
+		case "app2":
+			app2Ctr = &pod.Spec.Containers[i]
+		}
+	}
+
+	require.NotNil(t, appCtr)
+	require.NotNil(t, app2Ctr)
+
+	appValidator := testutils.NewContainerValidator(appCtr, nil)
+	appValidator.RequireEnvs(t, map[string]string{
+		"LD_PRELOAD":            "/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so",
+		"DD_INJECT_SENDER_TYPE": "k8s",
+	})
+
+	app2Validator := testutils.NewContainerValidator(app2Ctr, nil)
+	app2Validator.RequireEnvs(t, map[string]string{
+		"LD_PRELOAD":            "/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so",
+		"DD_INJECT_SENDER_TYPE": "k8s",
+	})
+
+	hasLibraryMount := func(ctr *corev1.Container) bool {
+		for _, mount := range ctr.VolumeMounts {
+			if mount.MountPath == "/opt/datadog/apm/library" {
+				return true
+			}
+		}
+		return false
+	}
+
+	require.True(t, hasLibraryMount(appCtr), "target container should have the library mount")
+	require.False(t, hasLibraryMount(app2Ctr), "non-target container should not have the library mount")
+}
+
 func TestEnvVarsAlreadySet(t *testing.T) {
 	tests := map[string]struct {
 		config             map[string]any

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/csi.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/csi.go
@@ -121,11 +121,11 @@ func (p *CSIProvider) InjectLibrary(pod *corev1.Pod, cfg LibraryConfig) Mutation
 			},
 		},
 	})
-	patcher.AddVolumeMount(corev1.VolumeMount{
+	patcher.AddVolumeMountWithTarget(corev1.VolumeMount{
 		Name:      volumeName,
 		MountPath: asAbsPath(libraryPackagesDir) + "/" + cfg.Language,
 		ReadOnly:  true,
-	})
+	}, cfg.ContainerName)
 
 	return MutationResult{
 		Status: MutationStatusInjected,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/csi_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/csi_test.go
@@ -182,3 +182,27 @@ func TestCSIProvider_ContainerFilter(t *testing.T) {
 	assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 2) // app
 	assert.Len(t, pod.Spec.Containers[1].VolumeMounts, 0) // sidecar
 }
+
+func TestCSIProvider_InjectLibrary_TargetsSingleContainer(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "my-app:latest"},
+				{Name: "app2", Image: "my-app:latest"},
+			},
+		},
+	}
+
+	provider := libraryinjection.NewCSIProvider(libraryinjection.LibraryInjectionConfig{})
+	result := provider.InjectLibrary(pod, libraryinjection.LibraryConfig{
+		Language:      "java",
+		Package:       libraryinjection.NewLibraryImageFromFullRef("gcr.io/datadoghq/dd-lib-java-init:1.2.3", "1.2.3"),
+		ContainerName: "app",
+	})
+
+	assert.Equal(t, libraryinjection.MutationStatusInjected, result.Status)
+	require.Len(t, pod.Spec.Containers[0].VolumeMounts, 1)
+	assert.Equal(t, "/opt/datadog/apm/library/java", pod.Spec.Containers[0].VolumeMounts[0].MountPath)
+	assert.Empty(t, pod.Spec.Containers[1].VolumeMounts)
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/image_volume.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/image_volume.go
@@ -109,12 +109,12 @@ func (p *ImageVolumeProvider) InjectLibrary(pod *corev1.Pod, cfg LibraryConfig) 
 		},
 	})
 
-	patcher.AddVolumeMount(corev1.VolumeMount{
+	patcher.AddVolumeMountWithTarget(corev1.VolumeMount{
 		Name:      volumeName,
 		MountPath: asAbsPath(libraryPackagesDir) + "/" + cfg.Language,
 		SubPath:   librarySubPath,
 		ReadOnly:  true,
-	})
+	}, cfg.ContainerName)
 
 	return MutationResult{
 		Status: MutationStatusInjected,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/image_volume_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/image_volume_test.go
@@ -143,3 +143,27 @@ func TestImageVolumeProvider_InjectInjector_UsesConfiguredInitSecurityContext(t 
 	require.Len(t, pod.Spec.InitContainers, 1)
 	require.Same(t, sc, pod.Spec.InitContainers[0].SecurityContext)
 }
+
+func TestImageVolumeProvider_InjectLibrary_TargetsSingleContainer(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "my-app:latest"},
+				{Name: "app2", Image: "my-app:latest"},
+			},
+		},
+	}
+
+	provider := libraryinjection.NewImageVolumeProvider(libraryinjection.LibraryInjectionConfig{})
+	result := provider.InjectLibrary(pod, libraryinjection.LibraryConfig{
+		Language:      "java",
+		Package:       libraryinjection.NewLibraryImageFromFullRef("gcr.io/datadoghq/dd-lib-java-init:1.2.3", "1.2.3"),
+		ContainerName: "app",
+	})
+
+	assert.Equal(t, libraryinjection.MutationStatusInjected, result.Status)
+	require.Len(t, pod.Spec.Containers[0].VolumeMounts, 1)
+	assert.Equal(t, "/opt/datadog/apm/library/java", pod.Spec.Containers[0].VolumeMounts[0].MountPath)
+	assert.Empty(t, pod.Spec.Containers[1].VolumeMounts)
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/init_container.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/init_container.go
@@ -163,12 +163,12 @@ func (p *InitContainerProvider) InjectLibrary(pod *corev1.Pod, cfg LibraryConfig
 	patcher.AddInitContainer(initContainer)
 
 	// Volume mount for application containers
-	patcher.AddVolumeMount(corev1.VolumeMount{
+	patcher.AddVolumeMountWithTarget(corev1.VolumeMount{
 		Name:      InstrumentationVolumeName,
 		MountPath: asAbsPath(libraryPackagesDir),
 		SubPath:   libraryPackagesDir,
 		ReadOnly:  true,
-	})
+	}, cfg.ContainerName)
 
 	return MutationResult{
 		Status: MutationStatusInjected,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/init_container_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/init_container_test.go
@@ -75,6 +75,30 @@ func TestInjectLibrary(t *testing.T) {
 	assert.Equal(t, "gcr.io/datadoghq/dd-lib-java-init:latest", pod.Spec.InitContainers[0].Image)
 }
 
+func TestInjectLibrary_TargetsSingleContainer(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app"},
+				{Name: "app2"},
+			},
+		},
+	}
+
+	provider := libraryinjection.NewInitContainerProvider(libraryinjection.LibraryInjectionConfig{})
+	result := provider.InjectLibrary(pod, libraryinjection.LibraryConfig{
+		Language:      "java",
+		Package:       libraryinjection.NewLibraryImageFromFullRef("gcr.io/datadoghq/dd-lib-java-init:latest", ""),
+		ContainerName: "app",
+	})
+
+	require.Equal(t, libraryinjection.MutationStatusInjected, result.Status)
+	require.Len(t, pod.Spec.Containers[0].VolumeMounts, 1)
+	assert.Equal(t, "/opt/datadog/apm/library", pod.Spec.Containers[0].VolumeMounts[0].MountPath)
+	assert.Empty(t, pod.Spec.Containers[1].VolumeMounts)
+}
+
 func TestInjectInjector_SkipsWhenInsufficientResources(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/pod_patcher.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/pod_patcher.go
@@ -46,9 +46,18 @@ func (p *PodPatcher) AddVolume(vol corev1.Volume) {
 // AddVolumeMount adds a volume mount to all application containers (filtered by ContainerFilter).
 // If a mount with the same name and path exists, it replaces it.
 func (p *PodPatcher) AddVolumeMount(mount corev1.VolumeMount) {
+	p.AddVolumeMountWithTarget(mount, "")
+}
+
+// AddVolumeMountWithTarget adds a volume mount to filtered application containers.
+// If containerName is non-empty, only the matching container is mutated.
+func (p *PodPatcher) AddVolumeMountWithTarget(mount corev1.VolumeMount, containerName string) {
 	for i := range p.pod.Spec.Containers {
 		ctr := &p.pod.Spec.Containers[i]
 		if p.filter != nil && !p.filter(ctr) {
+			continue
+		}
+		if containerName != "" && ctr.Name != containerName {
 			continue
 		}
 		p.addVolumeMountToContainer(ctr, mount)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/pod_patcher_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/pod_patcher_test.go
@@ -122,6 +122,26 @@ func TestPodPatcher_AddVolumeMount_Replaces(t *testing.T) {
 	assert.True(t, pod.Spec.Containers[0].VolumeMounts[0].ReadOnly)
 }
 
+func TestPodPatcher_AddVolumeMountWithTarget(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app"},
+				{Name: "app2"},
+			},
+		},
+	}
+
+	patcher := libraryinjection.NewPodPatcher(pod, nil)
+	mount := corev1.VolumeMount{Name: "vol1", MountPath: "/path1", ReadOnly: true}
+	patcher.AddVolumeMountWithTarget(mount, "app")
+
+	assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 1)
+	assert.Equal(t, mount, pod.Spec.Containers[0].VolumeMounts[0])
+	assert.Empty(t, pod.Spec.Containers[1].VolumeMounts)
+}
+
 func TestPodPatcher_AddEnvVar_DoesNotOverwrite(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},

--- a/releasenotes-dca/notes/fix-ssi-targeted-library-mounts-e1cd2bb142ee87e0.yaml
+++ b/releasenotes-dca/notes/fix-ssi-targeted-library-mounts-e1cd2bb142ee87e0.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed a Cluster Agent issue where container-targeted APM library injection could mount a tracing library into all application containers in a pod instead of only the annotated container.


### PR DESCRIPTION
Backport 2a91625407a28f3453d911435ecdb4099c09a7f1 from #49440.

:warning: This PR was created manually because the [automated backport job failed to create the PR](https://github.com/DataDog/datadog-agent/actions/runs/24565921831/job/71831970406).

 ___

### What does this PR do?

Fixes a regression in APM library injection where container-targeted library annotations could mount the tracing library into all application containers in a pod instead of only the intended one.

The change restores per-container scoping for library volume mounts across all library injection providers (`init_container`, `csi`, and `image_volume`) and adds regression tests for the provider layer and webhook flow.

### Motivation

[A recent refactor](https://github.com/DataDog/datadog-agent/pull/44972) introduced `libraryinjection` providers and preserved the container-targeting information in `LibraryConfig.ContainerName`, but that information was no longer used when adding library volume mounts to application containers.

As a result, annotations such as `admission.datadoghq.com/app.java-lib.version` could unintentionally expose the library to sibling containers in the same pod, causing those containers to emit traces as well.

### Describe how you validated your changes

- Added unit tests for `init_container`, `csi`, and `image_volume` providers to verify that a library targeted at `app` is not mounted into `app2`.
- Added a `PodPatcher` unit test covering targeted volume mount behavior.
- Added an integration-style webhook test covering local library injection with a container-specific annotation on a multi-container pod.

Tested manually with this Deployment
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: java-app
  namespace: application
  labels:
    app: java-app
    tags.datadoghq.com/env: patjava
    tags.datadoghq.com/service: patjavalib
spec:
  replicas: 1
  selector:
    matchLabels:
      app: java-app
  template:
    metadata:
      labels:
        app: java-app
        admission.datadoghq.com/enabled: "true"
      annotations:
        admission.datadoghq.com/app.java-lib.version: "latest"
        ad.datadoghq.com/app.checks: |
          {
            "http_check": {
              "instances": [{
                "name": "java-lib-injection",
                "url": "http://%%host%%:%%port%%"
              }]
            }
          }
        ad.datadoghq.com/app2.checks: |
          {
            "http_check": {
              "instances": [{
                "name": "java-lib-injection",
                "url": "http://%%host%%:%%port%%"
              }]
            }
          }
    spec:
      containers:
        - name: app
          # image: solr:9.5.0
          image: tomcat:11.0
          ports:
            - name: main-http
              #containerPort: 8983 #solr
              containerPort: 8080 #tomcat
          env:
            - name: DD_TRACE_DEBUG
              value: "true"
        - name: app2
          # image: solr:9.5.0
          image: tomcat:11.0
          command: ["/bin/sh", "-c"]
          args:
            - |
              sed -i 's/port="8005"/port="-1"/' /usr/local/tomcat/conf/server.xml && \
              sed -i 's/port="8080"/port="8081"/' /usr/local/tomcat/conf/server.xml && \
              catalina.sh run
          ports:
            - name: main-http2
              # containerPort: 8983 #solr
              containerPort: 8081 #tomcat
          env:
            - name: CATALINA_OPTS
              value: "-Dserver.port=8081"
            - name: DD_TRACE_DEBUG
              value: "true"
```
Before: both containers are instrumented,
After: only the container `app`

### Additional Notes