### PR TITLE
fix(backport): Allow pushing backports containing `.github/workflows` changes w.r.t `main`

### DIFF
--- a/.github/chainguard/self.backport-pr.create-pr.sts.yaml
+++ b/.github/chainguard/self.backport-pr.create-pr.sts.yaml
@@ -11,3 +11,4 @@ claim_pattern:
 permissions:
   contents: write
   pull_requests: write
+  workflows: write


### PR DESCRIPTION
### What does this PR do?
Adds the `workflows: write` permission to the `.github/chainguard/self.backport-pr.create-pr.sts.yaml` policy.

### Motivation
The backport workflow sometimes fails because of this missing permission.
Explanation:
1. GitHub does not allow actions to push a new branch if it contains any changes w.r.t `main` (or whatever the default branch is) inside `.github/workflows` (`! [remote rejected] HEAD -> some-branch (refusing to allow a GitHub App to create or update workflow .github/workflows/the-other-action.yml without workflows permission)`)
2. The backport workflow works by cherry-picking the PR merge commit onto the target release branch (ex: `7.78.x`) and creating a new branch based on that, say `backport-X-to-7-78-x`
3. If the old release branch (`7.78.x`) is old enough, odds are `main` will have had changes to `.github/workflows` since then: `git diff main 7.78.x -- .github/workflows` is not empty
4. Therefore we will also have non empty `git diff main backport-X-to-7-78-x -- .github/workflows`
5. Thus GitHub refuses the push, failing the backport workflow

### Describe how you validated your changes

### Additional Notes
