### PR TITLE
[CWS] Replace glaslos/ssdeep with CGO implementation using precompute…

### DIFF
--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -21,8 +21,9 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/glaslos/ssdeep"
 	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/hash/ssdeep"
 	"golang.org/x/time/rate"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"

--- a/pkg/security/resolvers/hash/ssdeep/ssdeep.c
+++ b/pkg/security/resolvers/hash/ssdeep/ssdeep.c
@@ -1,0 +1,204 @@
+// ssdeep fuzzy hashing engine with precomputed sum_table.
+// Algorithm matches glaslos/ssdeep v0.4.0 (MIT) and the official ssdeep.
+// The lookup table replaces the per-byte ((h*0x93)^c)%64 with a single
+// array access, avoiding multiply+XOR+modulo on every byte.
+
+#include "ssdeep.h"
+#include <string.h>
+
+#define HASH_PRIME 0x93
+
+// Precomputed: sum_table[h][c] = ((h * 0x93) ^ c) % 64
+// for h in [0,63], c in [0,63]. Only bottom 6 bits of input byte matter.
+static const unsigned char sum_table[64][64] = {
+#define ROW(h) { \
+    ((h*HASH_PRIME)^0x00)%64,((h*HASH_PRIME)^0x01)%64,((h*HASH_PRIME)^0x02)%64,((h*HASH_PRIME)^0x03)%64, \
+    ((h*HASH_PRIME)^0x04)%64,((h*HASH_PRIME)^0x05)%64,((h*HASH_PRIME)^0x06)%64,((h*HASH_PRIME)^0x07)%64, \
+    ((h*HASH_PRIME)^0x08)%64,((h*HASH_PRIME)^0x09)%64,((h*HASH_PRIME)^0x0a)%64,((h*HASH_PRIME)^0x0b)%64, \
+    ((h*HASH_PRIME)^0x0c)%64,((h*HASH_PRIME)^0x0d)%64,((h*HASH_PRIME)^0x0e)%64,((h*HASH_PRIME)^0x0f)%64, \
+    ((h*HASH_PRIME)^0x10)%64,((h*HASH_PRIME)^0x11)%64,((h*HASH_PRIME)^0x12)%64,((h*HASH_PRIME)^0x13)%64, \
+    ((h*HASH_PRIME)^0x14)%64,((h*HASH_PRIME)^0x15)%64,((h*HASH_PRIME)^0x16)%64,((h*HASH_PRIME)^0x17)%64, \
+    ((h*HASH_PRIME)^0x18)%64,((h*HASH_PRIME)^0x19)%64,((h*HASH_PRIME)^0x1a)%64,((h*HASH_PRIME)^0x1b)%64, \
+    ((h*HASH_PRIME)^0x1c)%64,((h*HASH_PRIME)^0x1d)%64,((h*HASH_PRIME)^0x1e)%64,((h*HASH_PRIME)^0x1f)%64, \
+    ((h*HASH_PRIME)^0x20)%64,((h*HASH_PRIME)^0x21)%64,((h*HASH_PRIME)^0x22)%64,((h*HASH_PRIME)^0x23)%64, \
+    ((h*HASH_PRIME)^0x24)%64,((h*HASH_PRIME)^0x25)%64,((h*HASH_PRIME)^0x26)%64,((h*HASH_PRIME)^0x27)%64, \
+    ((h*HASH_PRIME)^0x28)%64,((h*HASH_PRIME)^0x29)%64,((h*HASH_PRIME)^0x2a)%64,((h*HASH_PRIME)^0x2b)%64, \
+    ((h*HASH_PRIME)^0x2c)%64,((h*HASH_PRIME)^0x2d)%64,((h*HASH_PRIME)^0x2e)%64,((h*HASH_PRIME)^0x2f)%64, \
+    ((h*HASH_PRIME)^0x30)%64,((h*HASH_PRIME)^0x31)%64,((h*HASH_PRIME)^0x32)%64,((h*HASH_PRIME)^0x33)%64, \
+    ((h*HASH_PRIME)^0x34)%64,((h*HASH_PRIME)^0x35)%64,((h*HASH_PRIME)^0x36)%64,((h*HASH_PRIME)^0x37)%64, \
+    ((h*HASH_PRIME)^0x38)%64,((h*HASH_PRIME)^0x39)%64,((h*HASH_PRIME)^0x3a)%64,((h*HASH_PRIME)^0x3b)%64, \
+    ((h*HASH_PRIME)^0x3c)%64,((h*HASH_PRIME)^0x3d)%64,((h*HASH_PRIME)^0x3e)%64,((h*HASH_PRIME)^0x3f)%64  \
+}
+    ROW(0),ROW(1),ROW(2),ROW(3),ROW(4),ROW(5),ROW(6),ROW(7),
+    ROW(8),ROW(9),ROW(10),ROW(11),ROW(12),ROW(13),ROW(14),ROW(15),
+    ROW(16),ROW(17),ROW(18),ROW(19),ROW(20),ROW(21),ROW(22),ROW(23),
+    ROW(24),ROW(25),ROW(26),ROW(27),ROW(28),ROW(29),ROW(30),ROW(31),
+    ROW(32),ROW(33),ROW(34),ROW(35),ROW(36),ROW(37),ROW(38),ROW(39),
+    ROW(40),ROW(41),ROW(42),ROW(43),ROW(44),ROW(45),ROW(46),ROW(47),
+    ROW(48),ROW(49),ROW(50),ROW(51),ROW(52),ROW(53),ROW(54),ROW(55),
+    ROW(56),ROW(57),ROW(58),ROW(59),ROW(60),ROW(61),ROW(62),ROW(63)
+#undef ROW
+};
+
+static inline unsigned char sum_hash(unsigned char c, unsigned char h) {
+    return sum_table[h][c & 0x3f];
+}
+
+int ssdeep_init(struct ssdeep_state *s) {
+    if (s == NULL)
+        return -1;
+    memset(s, 0, sizeof(*s));
+    s->iEnd = 1;
+    for (int i = 0; i < NUM_BLOCKHASHES; i++) {
+        s->blocks[i].blockSize = BLOCK_MIN << i;
+        s->blocks[i].h1 = HASH_INIT;
+        s->blocks[i].h2 = HASH_INIT;
+        s->blocks[i].hashLen = 0;
+    }
+    return 0;
+}
+
+static inline int is_start_block_full(const struct ssdeep_state *s) {
+    return s->totalSize > (uint64_t)s->blocks[s->iStart].blockSize * SPAMSUM_LENGTH
+        && s->blocks[s->iStart + 1].hashLen >= SPAMSUM_LENGTH / 2;
+}
+
+int ssdeep_update(struct ssdeep_state *s, const unsigned char *data, int len) {
+    if (s == NULL || data == NULL || len < 0)
+        return -1;
+
+    uint32_t rh1 = s->rh1, rh2 = s->rh2, rh3 = s->rh3, rn = s->rn;
+
+    s->totalSize += (uint64_t)len;
+
+    for (int di = 0; di < len; di++) {
+        unsigned char b = data[di];
+
+        for (int i = s->iStart; i < s->iEnd; i++) {
+            s->blocks[i].h1 = sum_hash(b, s->blocks[i].h1);
+            s->blocks[i].h2 = sum_hash(b, s->blocks[i].h2);
+        }
+
+        // Rolling hash (Adler-like)
+        rh2 -= rh1;
+        rh2 += ROLLING_WINDOW * (uint32_t)b;
+        rh1 += (uint32_t)b;
+        rh1 -= (uint32_t)s->window[rn];
+        s->window[rn] = b;
+        if (++rn == ROLLING_WINDOW)
+            rn = 0;
+        rh3 = (rh3 << 5) ^ (uint32_t)b;
+
+        uint32_t rh = rh1 + rh2 + rh3;
+        if (rh == 0xFFFFFFFFu)
+            continue;
+        if (((rh + 1) / BLOCK_MIN) & s->bsizeMask)
+            continue;
+        if ((rh + 1) % BLOCK_MIN)
+            continue;
+
+        for (int i = s->iStart; i < s->iEnd; i++) {
+            struct blockhash_state *block = &s->blocks[i];
+            if (rh % block->blockSize != (block->blockSize - 1))
+                continue;
+
+            if (block->hashLen == 0) {
+                if (s->iEnd <= NUM_BLOCKHASHES - 1) {
+                    struct blockhash_state *old = &s->blocks[s->iEnd - 1];
+                    struct blockhash_state *newb = &s->blocks[s->iEnd];
+                    newb->h1 = old->h1;
+                    newb->h2 = old->h2;
+                    s->iEnd++;
+                }
+            }
+            block->tail1 = block->h1;
+            block->tail2 = block->h2;
+            if (block->hashLen < SPAMSUM_LENGTH - 1) {
+                block->hashString[block->hashLen++] = block->tail1;
+                block->tail1 = 0;
+                block->h1 = HASH_INIT;
+                if (block->hashLen < SPAMSUM_LENGTH / 2) {
+                    block->h2 = HASH_INIT;
+                    block->tail2 = 0;
+                }
+            } else if (is_start_block_full(s)) {
+                s->iStart++;
+                s->bsizeMask = (s->bsizeMask << 1) + 1;
+            }
+        }
+    }
+
+    s->rh1 = rh1;
+    s->rh2 = rh2;
+    s->rh3 = rh3;
+    s->rn = rn;
+    return 0;
+}
+
+int ssdeep_digest(const struct ssdeep_state *s, char *result, int result_len) {
+    if (s == NULL || result == NULL || result_len < SSDEEP_MAX_RESULT)
+        return -1;
+
+    int i = s->iStart;
+    while (i < NUM_BLOCKHASHES - 1 &&
+           (uint64_t)((uint32_t)BLOCK_MIN << i) * SPAMSUM_LENGTH < s->totalSize)
+        i++;
+
+    if (i >= s->iEnd)
+        i = s->iEnd - 1;
+    while (i > s->iStart && s->blocks[i].hashLen < SPAMSUM_LENGTH / 2)
+        i--;
+
+    unsigned char buf1[SPAMSUM_LENGTH + 1];
+    unsigned char buf2[SPAMSUM_LENGTH + 1];
+    int len1, len2;
+
+    memcpy(buf1, s->blocks[i].hashString, s->blocks[i].hashLen);
+    len1 = s->blocks[i].hashLen;
+
+    if (i >= s->iEnd - 1) {
+        memcpy(buf2, s->blocks[i].hashString, s->blocks[i].hashLen);
+        len2 = s->blocks[i].hashLen;
+    } else {
+        memcpy(buf2, s->blocks[i + 1].hashString, s->blocks[i + 1].hashLen);
+        len2 = s->blocks[i + 1].hashLen;
+    }
+
+    if (len2 > SPAMSUM_LENGTH / 2 - 1)
+        len2 = SPAMSUM_LENGTH / 2 - 1;
+
+    uint32_t rh = s->rh1 + s->rh2 + s->rh3;
+    if (rh != 0) {
+        buf1[len1++] = s->blocks[i].h1;
+        if (i < s->iEnd - 1)
+            buf2[len2++] = s->blocks[i + 1].h2;
+        else
+            buf2[len2++] = s->blocks[i].h2;
+    } else {
+        if (len1 == SPAMSUM_LENGTH - 1 && s->blocks[i].tail1 != 0)
+            buf1[len1++] = s->blocks[i].tail1;
+        if (i < s->iEnd - 1) {
+            if (s->blocks[i + 1].tail2 != 0)
+                buf2[len2++] = s->blocks[i + 1].tail2;
+        } else {
+            if (s->blocks[i].tail2 != 0)
+                buf2[len2++] = s->blocks[i].tail2;
+        }
+    }
+
+    static const char b64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    for (int j = 0; j < len1; j++)
+        buf1[j] = b64[buf1[j]];
+    for (int j = 0; j < len2; j++)
+        buf2[j] = b64[buf2[j]];
+    buf1[len1] = '\0';
+    buf2[len2] = '\0';
+
+    int n = snprintf(result, result_len, "%u:%s:%s",
+                     s->blocks[i].blockSize, buf1, buf2);
+    if (n < 0)
+        return -1;
+    if (n >= result_len)
+        n = result_len - 1;
+    return n;
+}

--- a/pkg/security/resolvers/hash/ssdeep/ssdeep.go
+++ b/pkg/security/resolvers/hash/ssdeep/ssdeep.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package ssdeep implements the ssdeep fuzzy hashing algorithm via CGO, using a
+// precomputed lookup table for the FNV-based sum hash. The entire hot loop runs
+// in C with a single CGO call per Write, avoiding Go bounds-check overhead and
+// per-byte function call costs.
+//
+// Output is identical to glaslos/ssdeep v0.4.0 and the official ssdeep tool.
+package ssdeep
+
+/*
+#include "ssdeep.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"hash"
+	"math"
+	"unsafe"
+)
+
+// ErrFileTooSmall is returned when the input is smaller than 4096 bytes and
+// Force is false, matching glaslos/ssdeep behavior.
+var ErrFileTooSmall = errors.New("ssdeep: file too small")
+
+var (
+	// Force calculates the hash on invalid input (files < 4096 bytes)
+	Force = false
+)
+
+var _ hash.Hash = &State{}
+
+// State holds the CGO ssdeep computation state.
+type State struct {
+	cs       C.struct_ssdeep_state
+	written  int64
+	sumError error
+}
+
+// New returns a new ssdeep hash.Hash instance.
+func New() *State {
+	s := &State{}
+	C.ssdeep_init(&s.cs)
+	return s
+}
+
+// Write feeds data into the hash. Large buffers are split into chunks to
+// prevent integer overflow when casting len(p) to C.int.
+func (s *State) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	total := 0
+	for len(p) > 0 {
+		chunk := len(p)
+		if chunk > math.MaxInt32 {
+			chunk = math.MaxInt32
+		}
+		rc := C.ssdeep_update(&s.cs, (*C.uchar)(unsafe.Pointer(&p[0])), C.int(chunk))
+		if rc != 0 {
+			s.sumError = errors.New("ssdeep: update failed")
+			return total, s.sumError
+		}
+		s.written += int64(chunk)
+		total += chunk
+		p = p[chunk:]
+	}
+	return total, nil
+}
+
+// Sum appends the ssdeep digest to b. Returns b unchanged if the input was
+// smaller than 4096 bytes and Force is false.
+func (s *State) Sum(b []byte) []byte {
+	if !Force && s.written < 4096 {
+		s.sumError = ErrFileTooSmall
+		return b
+	}
+	var buf [C.SSDEEP_MAX_RESULT]C.char
+	n := int(C.ssdeep_digest(&s.cs, &buf[0], C.int(len(buf))))
+	if n <= 0 {
+		return b
+	}
+	if n >= int(C.SSDEEP_MAX_RESULT) {
+		n = int(C.SSDEEP_MAX_RESULT) - 1
+	}
+	return append(b, C.GoStringN(&buf[0], C.int(n))...)
+}
+
+// Err returns any error from the last Sum call (e.g. ErrFileTooSmall).
+func (s *State) Err() error {
+	return s.sumError
+}
+
+// Reset reinitializes the hash state.
+func (s *State) Reset() {
+	C.ssdeep_init(&s.cs)
+	s.written = 0
+	s.sumError = nil
+}
+
+// BlockSize returns the minimum block size.
+func (s *State) BlockSize() int {
+	return int(C.BLOCK_MIN)
+}
+
+// Size returns the hash output size.
+func (s *State) Size() int {
+	return int(C.SPAMSUM_LENGTH)
+}

--- a/pkg/security/resolvers/hash/ssdeep/ssdeep.h
+++ b/pkg/security/resolvers/hash/ssdeep/ssdeep.h
@@ -1,0 +1,35 @@
+#ifndef SSDEEP_H
+#define SSDEEP_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+#define ROLLING_WINDOW  7
+#define BLOCK_MIN       3u
+#define NUM_BLOCKHASHES 31
+#define SPAMSUM_LENGTH  64
+#define HASH_INIT       0x27
+#define SSDEEP_MAX_RESULT (SPAMSUM_LENGTH + SPAMSUM_LENGTH/2 + 20)
+
+struct blockhash_state {
+    unsigned char hashString[SPAMSUM_LENGTH];
+    uint32_t blockSize;
+    unsigned char h1, h2;
+    unsigned char tail1, tail2;
+    int hashLen;
+};
+
+struct ssdeep_state {
+    uint32_t rh1, rh2, rh3, rn;
+    unsigned char window[ROLLING_WINDOW];
+    int iStart, iEnd;
+    uint64_t totalSize;
+    uint32_t bsizeMask;
+    struct blockhash_state blocks[NUM_BLOCKHASHES];
+};
+
+int  ssdeep_init(struct ssdeep_state *s);
+int  ssdeep_update(struct ssdeep_state *s, const unsigned char *data, int len);
+int  ssdeep_digest(const struct ssdeep_state *s, char *result, int result_len);
+
+#endif

--- a/pkg/security/resolvers/hash/ssdeep/ssdeep_test.go
+++ b/pkg/security/resolvers/hash/ssdeep/ssdeep_test.go
@@ -1,0 +1,199 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package ssdeep
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	glaslos "github.com/glaslos/ssdeep"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func generateData(size int, pattern byte) []byte {
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = pattern + byte(i%251)
+	}
+	return data
+}
+
+func generateRandomData(size int) []byte {
+	data := make([]byte, size)
+	_, _ = rand.Read(data)
+	return data
+}
+
+// TestCompatibility verifies identical output vs glaslos/ssdeep for various inputs.
+func TestCompatibility(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"8KB_pattern_a", generateData(8*1024, 'a')},
+		{"8KB_pattern_z", generateData(8*1024, 'z')},
+		{"64KB_pattern", generateData(64*1024, 0x00)},
+		{"256KB_pattern", generateData(256*1024, 0x42)},
+		{"1MB_pattern", generateData(1024*1024, 0x7f)},
+		{"5MB_pattern", generateData(5*1024*1024, 0xAB)},
+	}
+	for _, size := range []int{8192, 65536, 262144, 1 << 20} {
+		data := generateRandomData(size)
+		tests = append(tests, struct {
+			name string
+			data []byte
+		}{fmt.Sprintf("%dB_random", size), data})
+	}
+
+	glaslos.Force = true
+	Force = true
+	defer func() {
+		glaslos.Force = false
+		Force = false
+	}()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected, err := glaslos.FuzzyBytes(tt.data)
+			require.NoError(t, err)
+
+			h := New()
+			h.Write(tt.data)
+			got := string(h.Sum(nil))
+
+			assert.Equal(t, expected, got,
+				"hash mismatch: glaslos=%q cgo=%q", expected, got)
+		})
+	}
+}
+
+// TestChunkedWrite verifies that writing in chunks produces the same result.
+func TestChunkedWrite(t *testing.T) {
+	glaslos.Force = true
+	Force = true
+	defer func() {
+		glaslos.Force = false
+		Force = false
+	}()
+
+	data := generateRandomData(256 * 1024)
+
+	expected, err := glaslos.FuzzyBytes(data)
+	require.NoError(t, err)
+
+	h := New()
+	for i := 0; i < len(data); i += 4096 {
+		end := i + 4096
+		if end > len(data) {
+			end = len(data)
+		}
+		h.Write(data[i:end])
+	}
+	got := string(h.Sum(nil))
+	assert.Equal(t, expected, got)
+}
+
+// TestFileTooSmall verifies the Force flag behavior for small inputs.
+func TestFileTooSmall(t *testing.T) {
+	data := generateData(2048, 'x')
+
+	h := New()
+	h.Write(data)
+
+	Force = false
+	result := h.Sum(nil)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, h.Err(), ErrFileTooSmall)
+
+	Force = true
+	defer func() { Force = false }()
+	h.Reset()
+	h.Write(data)
+	result = h.Sum(nil)
+	assert.NotEmpty(t, result)
+	assert.NoError(t, h.Err())
+}
+
+// TestEmptyWrite verifies that empty writes are handled correctly.
+func TestEmptyWrite(t *testing.T) {
+	h := New()
+	n, err := h.Write(nil)
+	assert.Equal(t, 0, n)
+	assert.NoError(t, err)
+
+	n, err = h.Write([]byte{})
+	assert.Equal(t, 0, n)
+	assert.NoError(t, err)
+}
+
+// TestReset verifies that Reset clears state for reuse.
+func TestReset(t *testing.T) {
+	Force = true
+	defer func() { Force = false }()
+
+	data := generateRandomData(8192)
+
+	h := New()
+	h.Write(data)
+	first := string(h.Sum(nil))
+
+	h.Reset()
+	h.Write(data)
+	second := string(h.Sum(nil))
+
+	assert.Equal(t, first, second)
+}
+
+var benchSizes = []struct {
+	name string
+	size int
+}{
+	{"8KB", 8 * 1024},
+	{"64KB", 64 * 1024},
+	{"256KB", 256 * 1024},
+	{"1MB", 1024 * 1024},
+	{"5MB", 5 * 1024 * 1024},
+}
+
+func BenchmarkGlaslos(b *testing.B) {
+	glaslos.Force = true
+	defer func() { glaslos.Force = false }()
+
+	for _, bs := range benchSizes {
+		data := generateRandomData(bs.size)
+		b.Run(bs.name, func(b *testing.B) {
+			b.SetBytes(int64(bs.size))
+			b.ReportAllocs()
+			for b.Loop() {
+				h := glaslos.New()
+				h.Write(data)
+				h.Sum(nil)
+			}
+		})
+	}
+}
+
+func BenchmarkCGO(b *testing.B) {
+	Force = true
+	defer func() { Force = false }()
+
+	for _, bs := range benchSizes {
+		data := generateRandomData(bs.size)
+		b.Run(bs.name, func(b *testing.B) {
+			b.SetBytes(int64(bs.size))
+			b.ReportAllocs()
+			for b.Loop() {
+				h := New()
+				h.Write(data)
+				h.Sum(nil)
+			}
+		})
+	}
+}


### PR DESCRIPTION

### What does this PR do?

Replace the pure Go glaslos/ssdeep fuzzy hashing library with a CGO implementation that uses a precomputed lookup table for the FNV-based sum hash. The per-byte operation ((h*0x93)^c)%64 is replaced with a single array access sum_table[h][c&0x3f], eliminating multiply+XOR+modulo on every byte at every active block level.

The C implementation processes the entire buffer in a single CGO call per Write, avoiding Go bounds-check overhead and per-byte function call costs. Output is verified identical to glaslos/ssdeep v0.4.0 across pattern and random inputs from 8KB to 5MB.

Security hardening applied:
- BLOCK_MIN defined as unsigned (3u) to prevent signed overflow in shifts
- NULL pointer checks on all public C functions
- ssdeep_update rejects negative length to prevent Go→C int overflow
- ssdeep_digest loop bounded by NUM_BLOCKHASHES-1 to prevent UB
- snprintf return value clamped to buffer size
- Go Write splits buffers > MaxInt32 to prevent C.int overflow
- Force flag / ErrFileTooSmall matches glaslos behavior for small files


### Motivation

ssdeep is one of the hottest functions in the system-probe profile and this reduces the CPU cost

### Describe how you validated your changes

### Additional Notes
