### PR TITLE
[CWS] Forward kworker events that lack a process context

### DIFF
--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -71,7 +71,7 @@ func NewEBPFFieldHandlers(config *config.Config, resolvers *resolvers.EBPFResolv
 // ResolveProcessCacheEntry queries the ProcessResolver to retrieve the ProcessContext of the event
 func (fh *EBPFFieldHandlers) ResolveProcessCacheEntry(ev *model.Event, newEntryCb func(*model.ProcessCacheEntry, error)) (*model.ProcessCacheEntry, bool) {
 	if ev.PIDContext.IsKworker {
-		return model.GetPlaceholderProcessCacheEntry(ev.PIDContext.Pid, ev.PIDContext.Tid, true), false
+		return model.GetPlaceholderProcessCacheEntry(ev.PIDContext), false
 	}
 
 	if ev.ProcessCacheEntry == nil && ev.PIDContext.Pid != 0 {
@@ -79,7 +79,7 @@ func (fh *EBPFFieldHandlers) ResolveProcessCacheEntry(ev *model.Event, newEntryC
 	}
 
 	if ev.ProcessCacheEntry == nil {
-		ev.ProcessCacheEntry = model.GetPlaceholderProcessCacheEntry(ev.PIDContext.Pid, ev.PIDContext.Tid, false)
+		ev.ProcessCacheEntry = model.GetPlaceholderProcessCacheEntry(ev.PIDContext)
 		return ev.ProcessCacheEntry, false
 	}
 

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -57,7 +57,7 @@ func (fh *EBPFLessFieldHandlers) ResolveProcessCacheEntry(ev *model.Event, _ fun
 	}
 
 	if ev.ProcessCacheEntry == nil {
-		ev.ProcessCacheEntry = model.GetPlaceholderProcessCacheEntry(ev.PIDContext.Pid, ev.PIDContext.Pid, false)
+		ev.ProcessCacheEntry = model.GetPlaceholderProcessCacheEntry(ev.PIDContext)
 		return ev.ProcessCacheEntry, false
 	}
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -63,7 +63,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/mount"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/netns"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/path"
-	"github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/bundled"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
@@ -1122,13 +1121,12 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 
 	event.ProcessContext = &event.ProcessCacheEntry.ProcessContext
 
-	if process.IsKworker(event.ProcessContext.PPid, event.ProcessContext.Pid) {
-		return false
-	}
-
 	if !eventWithNoProcessContext(eventType) {
 		if !isResolved {
-			event.Error = model.ErrNoProcessContext
+			// Is not process context is not a kworker it means that this a real resolution error
+			if !event.ProcessContext.IsKworker {
+				event.Error = model.ErrNoProcessContext
+			}
 		} else {
 			// If the kernel reports a different ppid than the one in our
 			// cache, the process was reparented (e.g. subreaper). Update

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -63,7 +63,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/mount"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/netns"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/path"
-	"github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/bundled"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
@@ -1122,13 +1121,14 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 
 	event.ProcessContext = &event.ProcessCacheEntry.ProcessContext
 
-	if process.IsKworker(event.ProcessContext.PPid, event.ProcessContext.Pid) {
-		return false
-	}
-
 	if !eventWithNoProcessContext(eventType) {
 		if !isResolved {
-			event.Error = model.ErrNoProcessContext
+			// Kworker/kthread processes run in kernel space and have no user-space
+			// process context by design; missing context is expected for them.
+			// For all other processes it is a genuine resolution error.
+			if !event.ProcessContext.IsKworker {
+				event.Error = model.ErrNoProcessContext
+			}
 		} else {
 			// If the kernel reports a different ppid than the one in our
 			// cache, the process was reparented (e.g. subreaper). Update

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -58,7 +58,7 @@ func (fh *FakeFieldHandlers) ResolveProcessCacheEntryFromPID(pid uint32) *Proces
 	if fh.PCEs[pid] != nil {
 		return fh.PCEs[pid]
 	}
-	return GetPlaceholderProcessCacheEntry(pid, pid, false)
+	return GetPlaceholderProcessCacheEntry(PIDContext{Pid: pid})
 }
 
 // Event represents an event sent from the kernel

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -242,10 +242,8 @@ func NewPlaceholderProcessCacheEntry(pid uint32, tid uint32, isKworker bool) *Pr
 var processContextZero = ProcessCacheEntry{ProcessContext: ProcessContext{Process: Process{Source: ProcessCacheEntryFromPlaceholder}}}
 
 // GetPlaceholderProcessCacheEntry returns an empty process cache entry for failed process resolutions
-func GetPlaceholderProcessCacheEntry(pid uint32, tid uint32, isKworker bool) *ProcessCacheEntry {
-	processContextZero.Pid = pid
-	processContextZero.Tid = tid
-	processContextZero.IsKworker = isKworker
+func GetPlaceholderProcessCacheEntry(pidContext PIDContext) *ProcessCacheEntry {
+	processContextZero.PIDContext = pidContext
 	processContextZero.markFileEventAsResolved()
 	return &processContextZero
 }


### PR DESCRIPTION
Previously, setProcessContext returned false for kworker events, causing them to be silently dropped before reaching consumers. Since kworkers run in kernel space and have no user-space process context by design, missing process context is not an error for them.

Remove the early kworker bail-out and only set ErrNoProcessContext for non-kworker events that fail resolution. As a clean-up, collapse the pid/tid/isKworker arguments of GetPlaceholderProcessCacheEntry into a single PIDContext parameter.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
