### PR TITLE
[q/eval] Lower parquet_count threshold from 100 to 50

### DIFF
--- a/tasks/libs/q/eval.py
+++ b/tasks/libs/q/eval.py
@@ -441,9 +441,10 @@ def _resolve_zip_from_runs_jsonl(ctx, name):
                     continue  # skip malformed records
 
         # Find the latest successful entry matching this episode.
-        # parquet_count < 100 indicates a failed or incomplete run (empirically: 0 or 2).
+        # parquet_count < 50 indicates a failed or truncated run. Known failures are 0 or 2.
+        # Post trace-removal, legitimate recordings on short scenarios produce ~60-90 parquets.
         matches = [
-            entry for entry in lines if entry.get("episode") == episode_name and entry.get("parquet_count", 0) >= 100
+            entry for entry in lines if entry.get("episode") == episode_name and entry.get("parquet_count", 0) >= 50
         ]
         if not matches:
             return None


### PR DESCRIPTION
## Summary

Lowers the `parquet_count` filter threshold in `_resolve_zip_from_runs_jsonl` at `tasks/libs/q/eval.py:446` from `>= 100` to `>= 50`.

## Why

Post trace-removal (#49276), legitimate recordings on short scenarios produce substantially fewer parquets than before. The old `>= 100` threshold was filtering out valid runs and causing `q.download-scenarios` to silently fall back to stale pre-trace-removal recordings.

Observed `parquet_count` values in `runs.jsonl` for `213_PagerDuty_June_2014_Outage` alone:
- `0`, `2` — known failed runs
- `36` — truncated recording (~18 min of 25)
- `60`, `86` — legitimate complete short-scenario recordings (post trace-removal)
- `194` — pre-trace-removal full recording

With threshold `100`, all recent April 2026 runs were skipped and the downloader kept returning the March 2026 zip.

## Choice of 50

- Failure modes are empirically `0` or `2` parquets
- Legitimate short-scenario recordings land around `60–90`
- `50` is safely above failures, below the lowest valid recording, and excludes truncated runs (the `36`-parquet April 16 run)

## Test plan
- [x] Verified `q.download-scenarios --scenario=213_pagerduty` now resolves the `20260417-e066c10048.zip` (60 parquets) instead of `20260319-af94cb8f2c.zip`
- [ ] Optional: re-run `q.download-scenarios` for other scenarios to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)