### PR TITLE
[OTAGENT-798] Fix incorrect warn log on `dd_url` in DDOT

### DIFF
--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -441,7 +441,7 @@ type defaultParseAddressFunc func(string) (host string, port int, err error)
 
 func parseAddressWithScheme(address string, defaultNoSSL bool, defaultParser defaultParseAddressFunc) (host string, port int, pathPrefix string, useSSL bool, err error) {
 	if strings.HasPrefix(address, "https://") || strings.HasPrefix(address, "http://") {
-		if strings.HasPrefix(address, "https://") && !defaultNoSSL {
+		if strings.HasPrefix(address, "https://") && defaultNoSSL {
 			log.Warn("dd_url set to a URL with an HTTPS prefix and logs_no_ssl set to true. These are conflicting options. In a future release logs_no_ssl will override the dd_url prefix.")
 		}
 		host, port, pathPrefix, useSSL, err = parseURL(address)

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -6,7 +6,9 @@
 package config
 
 import (
+	"bytes"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/types"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type ConfigTestSuite struct {
@@ -1128,6 +1131,48 @@ func Test_parseAddressWithScheme(t *testing.T) {
 			if gotUseSSL != tt.wantUseSSL {
 				t.Errorf("parseAddressWithScheme() gotUseSSL = %v, want %v", gotUseSSL, tt.wantUseSSL)
 			}
+		})
+	}
+}
+
+func TestLogsNoSSLWarnLog(t *testing.T) {
+	tests := []struct {
+		name         string
+		address      string
+		defaultNoSSL bool
+		wantWarn     bool
+	}{
+		{
+			name:         "https url with logs_no_ssl=true warns (genuine conflict)",
+			address:      "https://agent-http-intake.logs.datadoghq.com",
+			defaultNoSSL: true,
+			wantWarn:     true,
+		},
+		{
+			name:         "https url with logs_no_ssl=false does not warn (otel-agent default)",
+			address:      "https://agent-http-intake.logs.datadoghq.com",
+			defaultNoSSL: false,
+			wantWarn:     false,
+		},
+		{
+			name:         "http url with logs_no_ssl=true does not warn",
+			address:      "http://agent-http-intake.logs.datadoghq.com",
+			defaultNoSSL: true,
+			wantWarn:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger, err := pkglog.LoggerFromWriterWithMinLevelAndLvlMsgFormat(&buf, pkglog.WarnLvl)
+			assert.NoError(t, err)
+			pkglog.SetupLogger(logger, "warn")
+
+			_, _, _, _, _ = parseAddressWithScheme(tt.address, tt.defaultNoSSL, parseAddressAsHost)
+
+			got := strings.Contains(buf.String(), "logs_no_ssl set to true")
+			assert.Equal(t, tt.wantWarn, got, "unexpected warning log presence")
 		})
 	}
 }

--- a/releasenotes/notes/fix-otel-agent-spurious-dd-url-warn-69b5fa344589bfe3.yaml
+++ b/releasenotes/notes/fix-otel-agent-spurious-dd-url-warn-69b5fa344589bfe3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix spurious warn log on otel-agent startup about conflicting ``dd_url`` and ``logs_no_ssl`` settings.


### PR DESCRIPTION
### What does this PR do?
Fixes an incorrect warn log on otel-agent startup

### Motivation
This warn log appears with default values on otel-agent startup:
`dd_url: https://app.datadoghq.com/`
`logs_no_ssl: false`

### Describe how you validated your changes
Ran locally and verified warn log is gone

### Additional Notes
