### PR TITLE
Include integrations that don't have manifest.json

### DIFF
--- a/releasenotes/notes/include-manifestless-integrations-d2abd4431addfd74.yaml
+++ b/releasenotes/notes/include-manifestless-integrations-d2abd4431addfd74.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add logic to include integrations that do not have a manifest.json file in the Agent.

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -689,6 +689,24 @@ def check_supports_python_version(check_dir, python):
         return False
 
 
+def _load_manifest_platform_overrides(integrations_dir):
+    """
+    Read [overrides.manifest.platforms] from <integrations_dir>/.ddev/config.toml.
+
+    Returns a mapping of integration folder -> list of supported platform strings
+    (e.g. "linux", "windows", "mac_os"). Used as a fallback for integrations that
+    no longer ship a manifest.json.
+    """
+    import toml
+
+    config_path = os.path.join(integrations_dir, '.ddev', 'config.toml')
+    if not os.path.isfile(config_path):
+        return {}
+    with open(config_path) as f:
+        config = toml.load(f)
+    return config.get('overrides', {}).get('manifest', {}).get('platforms', {}) or {}
+
+
 @task
 def collect_integrations(_, integrations_dir, python_version, target_os, excluded):
     """
@@ -698,6 +716,7 @@ def collect_integrations(_, integrations_dir, python_version, target_os, exclude
     """
     import json
 
+    manifest_overrides = _load_manifest_platform_overrides(integrations_dir)
     integrations = []
 
     for entry in os.listdir(integrations_dir):
@@ -707,21 +726,24 @@ def collect_integrations(_, integrations_dir, python_version, target_os, exclude
 
         manifest_file_path = os.path.join(int_path, "manifest.json")
 
-        # If there is no manifest file, then we should assume the folder does not
-        # contain a working check and move onto the next
-        if not os.path.exists(manifest_file_path):
-            continue
+        if os.path.exists(manifest_file_path):
+            with open(manifest_file_path) as f:
+                manifest = json.load(f)
 
-        with open(manifest_file_path) as f:
-            manifest = json.load(f)
+            # Figure out whether the integration is supported on the target OS
+            if target_os == 'mac_os':
+                tag = 'Supported OS::macOS'
+            else:
+                tag = f'Supported OS::{target_os.capitalize()}'
 
-        # Figure out whether the integration is supported on the target OS
-        if target_os == 'mac_os':
-            tag = 'Supported OS::macOS'
+            if tag not in manifest['tile']['classifier_tags']:
+                continue
+        elif entry in manifest_overrides:
+            # No manifest.json; fall back to .ddev/config.toml [overrides.manifest.platforms]
+            if target_os not in manifest_overrides[entry]:
+                continue
         else:
-            tag = f'Supported OS::{target_os.capitalize()}'
-
-        if tag not in manifest['tile']['classifier_tags']:
+            # No manifest file and no override -> assume the folder is not a working check
             continue
 
         if not check_supports_python_version(int_path, python_version):

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -11,7 +11,7 @@ from tasks.libs.common.utils import get_metric_origin
 
 # Increase this value to force an update to the cache key, invalidating existing
 # caches and forcing a rebuild
-CACHE_VERSION = 2
+CACHE_VERSION = 3
 
 
 ENV_PASSHTROUGH = {


### PR DESCRIPTION
### What does this PR do?
We started to migrate away from manifest.json. New integrations are created without one. This change aims to change the logic to look at config.toml of the integrations-core repo to see ship some of these new integrations.

https://github.com/DataDog/integrations-core/blob/master/.ddev/config.toml#L244

Integrations that are missing:

- control_m
- krakend
- lustre
- n8n
- prefect

I checked the artifact for arm build in the CI triggered by the above and the check are there.
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1607210425
