### PR TITLE
fix(gohai): fall back to numeric UID when username lookup fails

### DIFF
--- a/pkg/gohai/processes/gops/process_info.go
+++ b/pkg/gohai/processes/gops/process_info.go
@@ -94,18 +94,28 @@ func newProcessInfo(p *process.Process, totalMem float64) (*ProcessInfo, error) 
 
 	pctMem := 100. * float64(memInfo.RSS) / totalMem
 
-	username, err := p.Username()
-	if err != nil {
-		// Fall back to the numeric UID string. This commonly happens for
-		// containerized processes whose UID does not exist in the host's
-		// /etc/passwd (e.g. a UID created inside a container image).
-		uids, uidErr := p.Uids()
-		if uidErr != nil || len(uids) == 0 {
-			username = ""
-		} else {
-			username = strconv.FormatUint(uint64(uids[0]), 10)
-		}
-	}
+	username := resolveUsername(p)
 
 	return &ProcessInfo{pid, ppid, name, memInfo.RSS, pctMem, memInfo.VMS, username}, nil
+}
+
+// usernameProvider abstracts the gopsutil methods needed to resolve a username.
+type usernameProvider interface {
+	Username() (string, error)
+	Uids() ([]uint32, error)
+}
+
+// resolveUsername returns the username for a process. If the username lookup
+// fails (common for containerized processes whose UID doesn't exist in the
+// host's /etc/passwd), it falls back to the numeric UID string.
+func resolveUsername(p usernameProvider) string {
+	username, err := p.Username()
+	if err == nil {
+		return username
+	}
+	uids, uidErr := p.Uids()
+	if uidErr != nil || len(uids) == 0 {
+		return ""
+	}
+	return strconv.FormatUint(uint64(uids[0]), 10)
 }

--- a/pkg/gohai/processes/gops/process_info.go
+++ b/pkg/gohai/processes/gops/process_info.go
@@ -10,6 +10,7 @@ package gops
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/shirou/gopsutil/v4/process"
@@ -95,7 +96,15 @@ func newProcessInfo(p *process.Process, totalMem float64) (*ProcessInfo, error) 
 
 	username, err := p.Username()
 	if err != nil {
-		return nil, err
+		// Fall back to the numeric UID string. This commonly happens for
+		// containerized processes whose UID does not exist in the host's
+		// /etc/passwd (e.g. a UID created inside a container image).
+		uids, uidErr := p.Uids()
+		if uidErr != nil || len(uids) == 0 {
+			username = ""
+		} else {
+			username = strconv.FormatUint(uint64(uids[0]), 10)
+		}
 	}
 
 	return &ProcessInfo{pid, ppid, name, memInfo.RSS, pctMem, memInfo.VMS, username}, nil

--- a/pkg/gohai/processes/gops/process_info_test.go
+++ b/pkg/gohai/processes/gops/process_info_test.go
@@ -8,8 +8,10 @@
 package gops
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,6 +32,74 @@ func TestGetProcesses_RecoversFromPanic(t *testing.T) {
 		// We don't assert on the error here since it depends on system state
 		_ = err
 	})
+}
+
+type mockUsernameProvider struct {
+	username    string
+	usernameErr error
+	uids        []uint32
+	uidsErr     error
+}
+
+func (m *mockUsernameProvider) Username() (string, error) {
+	return m.username, m.usernameErr
+}
+
+func (m *mockUsernameProvider) Uids() ([]uint32, error) {
+	return m.uids, m.uidsErr
+}
+
+func TestResolveUsername(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *mockUsernameProvider
+		expected string
+	}{
+		{
+			name:     "username lookup succeeds",
+			provider: &mockUsernameProvider{username: "root"},
+			expected: "root",
+		},
+		{
+			name: "username fails, falls back to UID",
+			provider: &mockUsernameProvider{
+				usernameErr: errors.New("user: unknown userid 501"),
+				uids:        []uint32{501},
+			},
+			expected: "501",
+		},
+		{
+			name: "username fails, UID is zero",
+			provider: &mockUsernameProvider{
+				usernameErr: errors.New("user: unknown userid 0"),
+				uids:        []uint32{0},
+			},
+			expected: "0",
+		},
+		{
+			name: "both username and UIDs fail",
+			provider: &mockUsernameProvider{
+				usernameErr: errors.New("user: unknown userid 501"),
+				uidsErr:     errors.New("no uids"),
+			},
+			expected: "",
+		},
+		{
+			name: "username fails, empty UIDs",
+			provider: &mockUsernameProvider{
+				usernameErr: errors.New("user: unknown userid 501"),
+				uids:        []uint32{},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveUsername(tt.provider)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 // TestPanicRecoveryMechanism tests that the recovery wrapper pattern correctly catches panics.

--- a/releasenotes/notes/gohai-username-fallback-be1ee74b98ae40db.yaml
+++ b/releasenotes/notes/gohai-username-fallback-be1ee74b98ae40db.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed the gohai resource check silently dropping processes whose UID
+    does not exist in the host's ``/etc/passwd``. This commonly affects
+    containerized processes running as UIDs created inside container images.
+    The "Processes memory usage" widget on the host infrastructure page now
+    correctly includes these processes by falling back to the numeric UID
+    string when username lookup fails.


### PR DESCRIPTION
### What does this PR do?

Falls back to the numeric UID string when `gopsutil.Process.Username()` fails in the gohai resource check, instead of silently dropping the process.

### Motivation

The "Processes memory usage" widget on the host infrastructure page was missing processes — including top memory consumers — because `newProcessInfo` in `pkg/gohai/processes/gops/process_info.go` treated a `Username()` failure as fatal and silently skipped the process.

Containerized processes commonly run as UIDs created inside their container image (e.g. `RUN useradd -u 501 app`). These UIDs don't exist in the host's `/etc/passwd`, which is mounted into the Datadog agent container. When `gopsutil` tries to resolve the UID to a username via `user.LookupId()`, it fails, and the entire process is dropped from the gohai payload before the top-20 sort even happens.

**Impact**: On a staging K8s node with 132 GB RAM, the #1 memory consumer (`adrian-cache`, ~128 GB RSS, UID 501) was completely invisible to the widget. The widget showed only ~2.78% memory usage (from processes running as `root`/`nobody`) while the host was at ~86% utilization. Live Processes (separate pipeline) showed correct data.

Fixes PRMS-3140.

### Describe how you validated your changes

- Confirmed on staging host `i-08b1214944310a57a` (stripe cluster) that `adrian-cache` runs as UID 501, which is absent from the host's `/etc/passwd`
- Verified `agent diagnose show-metadata gohai` output excludes adrian-cache (128 GB RSS) from the top-20 process list
- Existing unit tests pass (`go test ./pkg/gohai/processes/...`)
- `go vet` clean

### Additional Notes

The username field flows through to the widget's `color_by: "user"` in the treemap — tiles will be colored by the numeric UID string (e.g. `"501"`) instead of a resolved name. This is cosmetically imperfect but functionally correct; the critical fields (`rss`, `pct_mem`, `family`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)