### PR TITLE
[PRMS-3140] fall back to numeric UID when username lookup fails in Gohai

### DIFF
--- a/pkg/gohai/processes/gops/process_info.go
+++ b/pkg/gohai/processes/gops/process_info.go
@@ -94,18 +94,28 @@ func newProcessInfo(p *process.Process, totalMem float64) (*ProcessInfo, error) 
 
 	pctMem := 100. * float64(memInfo.RSS) / totalMem
 
-	username, err := p.Username()
-	if err != nil {
-		// Fall back to the numeric UID string. This commonly happens for
-		// containerized processes whose UID does not exist in the host's
-		// /etc/passwd (e.g. a UID created inside a container image).
-		uids, uidErr := p.Uids()
-		if uidErr != nil || len(uids) == 0 {
-			username = ""
-		} else {
-			username = strconv.FormatUint(uint64(uids[0]), 10)
-		}
-	}
+	username := resolveUsername(p)
 
 	return &ProcessInfo{pid, ppid, name, memInfo.RSS, pctMem, memInfo.VMS, username}, nil
+}
+
+// usernameProvider abstracts the gopsutil methods needed to resolve a username.
+type usernameProvider interface {
+	Username() (string, error)
+	Uids() ([]uint32, error)
+}
+
+// resolveUsername returns the username for a process. If the username lookup
+// fails (common for containerized processes whose UID doesn't exist in the
+// host's /etc/passwd), it falls back to the numeric UID string.
+func resolveUsername(p usernameProvider) string {
+	username, err := p.Username()
+	if err == nil {
+		return username
+	}
+	uids, uidErr := p.Uids()
+	if uidErr != nil || len(uids) == 0 {
+		return ""
+	}
+	return strconv.FormatUint(uint64(uids[0]), 10)
 }

--- a/pkg/gohai/processes/gops/process_info.go
+++ b/pkg/gohai/processes/gops/process_info.go
@@ -10,6 +10,7 @@ package gops
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/shirou/gopsutil/v4/process"
@@ -95,7 +96,15 @@ func newProcessInfo(p *process.Process, totalMem float64) (*ProcessInfo, error) 
 
 	username, err := p.Username()
 	if err != nil {
-		return nil, err
+		// Fall back to the numeric UID string. This commonly happens for
+		// containerized processes whose UID does not exist in the host's
+		// /etc/passwd (e.g. a UID created inside a container image).
+		uids, uidErr := p.Uids()
+		if uidErr != nil || len(uids) == 0 {
+			username = ""
+		} else {
+			username = strconv.FormatUint(uint64(uids[0]), 10)
+		}
 	}
 
 	return &ProcessInfo{pid, ppid, name, memInfo.RSS, pctMem, memInfo.VMS, username}, nil

--- a/pkg/gohai/processes/gops/process_info_test.go
+++ b/pkg/gohai/processes/gops/process_info_test.go
@@ -8,8 +8,10 @@
 package gops
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,6 +32,74 @@ func TestGetProcesses_RecoversFromPanic(t *testing.T) {
 		// We don't assert on the error here since it depends on system state
 		_ = err
 	})
+}
+
+type mockUsernameProvider struct {
+	username    string
+	usernameErr error
+	uids        []uint32
+	uidsErr     error
+}
+
+func (m *mockUsernameProvider) Username() (string, error) {
+	return m.username, m.usernameErr
+}
+
+func (m *mockUsernameProvider) Uids() ([]uint32, error) {
+	return m.uids, m.uidsErr
+}
+
+func TestResolveUsername(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *mockUsernameProvider
+		expected string
+	}{
+		{
+			name:     "username lookup succeeds",
+			provider: &mockUsernameProvider{username: "root"},
+			expected: "root",
+		},
+		{
+			name: "username fails, falls back to UID",
+			provider: &mockUsernameProvider{
+				usernameErr: errors.New("user: unknown userid 501"),
+				uids:        []uint32{501},
+			},
+			expected: "501",
+		},
+		{
+			name: "username fails, UID is zero",
+			provider: &mockUsernameProvider{
+				usernameErr: errors.New("user: unknown userid 0"),
+				uids:        []uint32{0},
+			},
+			expected: "0",
+		},
+		{
+			name: "both username and UIDs fail",
+			provider: &mockUsernameProvider{
+				usernameErr: errors.New("user: unknown userid 501"),
+				uidsErr:     errors.New("no uids"),
+			},
+			expected: "",
+		},
+		{
+			name: "username fails, empty UIDs",
+			provider: &mockUsernameProvider{
+				usernameErr: errors.New("user: unknown userid 501"),
+				uids:        []uint32{},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveUsername(tt.provider)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 // TestPanicRecoveryMechanism tests that the recovery wrapper pattern correctly catches panics.

--- a/releasenotes/notes/gohai-username-fallback-be1ee74b98ae40db.yaml
+++ b/releasenotes/notes/gohai-username-fallback-be1ee74b98ae40db.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed the gohai resource check silently dropping processes whose UID
+    does not exist in the host's ``/etc/passwd``. This commonly affects
+    containerized processes running as UIDs created inside container images.
+    The "Processes memory usage" widget on the host infrastructure page now
+    correctly includes these processes by falling back to the numeric UID
+    string when username lookup fails.


### PR DESCRIPTION
### What does this PR do?

Falls back to the numeric UID string when `gopsutil.Process.Username()` fails in the gohai resource check, instead of silently dropping the process.

### Motivation

The "Processes memory usage" widget on the host infrastructure page was missing processes — including top memory consumers — because `newProcessInfo` in `pkg/gohai/processes/gops/process_info.go` treated a `Username()` failure as fatal and silently skipped the process.

Containerized processes commonly run as UIDs created inside their container image (e.g. `RUN useradd -u 501 app`). These UIDs don't exist in the host's `/etc/passwd`, which is mounted into the Datadog agent container. When `gopsutil` tries to resolve the UID to a username via `user.LookupId()`, it fails, and the entire process is dropped from the gohai payload before the top-20 sort even happens.

**Example Impact**: On a staging K8s node with 132 GB RAM, the top 1 memory consumer (`adrian-cache`, ~128 GB RSS, UID 501) was completely invisible to the widget. The widget showed only ~2.78% memory usage (from processes running as `root`/`nobody`) while the host was at ~86% utilization. Live Processes (separate pipeline) showed correct data.

<img width="1626" height="707" alt="image" src="https://github.com/user-attachments/assets/4d148fe4-c5e1-4785-8ec0-af948acbfccc" />
<img width="1626" height="339" alt="image" src="https://github.com/user-attachments/assets/3f3e38b5-ac77-4a4b-b122-761e83621316" />


Fixes PRMS-3140.

### Describe how you validated your changes

#### Unit tests

New table-driven tests for `resolveUsername` covering: successful username lookup, UID fallback, and double-failure edge cases. Existing tests pass.

#### Local kind cluster (before/after comparison)

Deployed a test workload running as **UID 501** (not in the node's `/etc/passwd`) that allocates ~265 MB of heap RSS. Compared gohai output between an unpatched agent and the fixed agent on the same cluster.

**Before (unpatched agent — `7.78.0`):**

```
User       PctMem       RSS  Name
root        0.561%   357.0MB  kube-apiserver
root        0.512%   325.3MB  agent
root        0.217%   138.3MB  datadog-cluster-agent
root        0.211%   134.0MB  containerd-shim-runc-v2
root        0.172%   109.3MB  kube-controller-manager
root        0.155%    98.6MB  kubelet
root        0.142%    90.1MB  containerd
root        0.118%    75.1MB  etcd
root        0.094%    59.6MB  kube-scheduler
root        0.069%    44.1MB  kube-proxy
root        0.069%    43.8MB  kindnetd
root        0.064%    40.4MB  trace-agent
root        0.062%    39.4MB  local-path-provisioner
root        0.026%    16.5MB  systemd-journald
root        0.019%    11.9MB  systemd
root        0.001%     0.6MB  pause
```

- `python3` (UID 501, 265 MB RSS) — **missing** (silently dropped)
- `coredns` (UID 65532) — **missing** (silently dropped)
- Only 16 processes listed, all `root`. Every non-root UID process is invisible.

**After (this PR):**

```
User       PctMem       RSS  Name
root        0.543%   345.4MB  kube-apiserver
root        0.509%   323.7MB  agent
501         0.417%   264.9MB  python3          ← UID fallback
root        0.226%   143.7MB  datadog-cluster-agent
65532       0.212%   135.1MB  coredns          ← UID fallback
root        0.207%   131.6MB  containerd-shim-runc-v2
root        0.177%   112.8MB  kube-controller-manager
root        0.160%   101.5MB  kubelet
root        0.127%    80.8MB  containerd
root        0.112%    71.4MB  etcd
root        0.106%    67.2MB  systemd-journald
root        0.094%    59.9MB  kube-scheduler
root        0.076%    48.6MB  trace-agent
root        0.072%    45.7MB  kube-proxy
root        0.070%    44.3MB  kindnetd
root        0.062%    39.4MB  local-path-provisioner
root        0.019%    11.9MB  systemd
501,65535,root  0.012%     7.5MB  pause
```

- `python3` (UID 501, 265 MB) now appears with username `"501"`
- `coredns` (UID 65532, 135 MB) now appears with username `"65532"`
- 18 processes listed, correctly including non-root UID processes

#### Staging verification

As mentioned with impact, this failure is extremely common, even internally. I deployed a custom image with these changes to `morgrem.us1.staging.dog` and compared the memory widget before and after.

Before:
<img width="3252" height="664" alt="image" src="https://github.com/user-attachments/assets/3d25b40b-1553-4fb1-87a2-c48a866f37e8" />


After:
<img width="3252" height="664" alt="image" src="https://github.com/user-attachments/assets/74c19135-d15d-409e-b02b-5003d06e0b87" />

### Additional Notes

The username field flows through to the widget's `color_by: "user"` in the treemap — tiles will be colored by the numeric UID string (e.g. `"501"`) instead of a resolved name. This is cosmetically imperfect but functionally correct; the critical fields (`rss`, `pct_mem`, `family`) are unaffected.

This is consistent with how the process-agent handles the same situation in `pkg/process/checks/process_nix.go:formatUser` — it tries `user.LookupId()` but on failure still populates the numeric `Uid` field and leaves `Name` empty. Our fix applies the same pattern to gohai.

Free mem % is still likely to be inaccurate considering its calculated based on whatever memory the top 20 processes are not using.

🤖 Generated with [Claude Code](https://claude.com/claude-code)