### PR TITLE
omnibus: exclude INTEGRATIONS_CORE_VERSION from cache key

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -124,6 +124,7 @@ def _get_environment_for_cache(env: dict[str, str]) -> dict:
         'GOPRIVATE',
         'GOPROXY',
         'HOME',
+        'INTEGRATIONS_CORE_VERSION',
         'JARSIGN_JAR',
         'LD_PRELOAD',
         'LOCALAPPDATA',


### PR DESCRIPTION
### What does this PR do?
Adds `INTEGRATIONS_CORE_VERSION` to the excluded-variables set in `_get_environment_for_cache` (`tasks/libs/common/omnibus.py`), so it no longer contributes to the omnibus cache key.

### Motivation
Downstream pipelines triggered from `DataDog/integrations-core` override `INTEGRATIONS_CORE_VERSION` with a candidate SHA. Because that variable was part of the omnibus cache key, every such pipeline cache-missed on all ~9 omnibus build jobs, adding ~15 min to median pipeline duration compared to normal `main` pipelines.

Evidence collected from CI Visibility over the last 30 days:
- Normal `main` median duration: ~103 min (successful: ~99 min)
- Downstream-from-integrations-core median: ~118 min (successful: ~116 min)
- Cache miss counts: 0–2 per normal `main` pipeline vs **9–10 per downstream pipeline** (29/29 sampled).

The omnibus git cache is an incremental git mirror (all refs are stored as tags), so changing the integrations-core SHA should just trigger a single `git fetch` for the new ref rather than a full rebuild. Excluding the variable from the cache key preserves correctness while letting downstream pipelines reuse the `main` omnibus cache.

### Describe how you validated your changes
- [ ] Confirm no regression in existing omnibus unit tests (`tasks/unit_tests/omnibus_tests.py`).
- [ ] Trigger a downstream pipeline from `integrations-core` against this branch and confirm cache misses drop from ~9 to ≤1 and pipeline duration shortens accordingly.

### Additional Notes
A follow-up could also exclude `OMNIBUS_RUBY_VERSION` for the same reason, but this PR keeps scope minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)