### PR TITLE
[observer] Improve log anomaly reports

### DIFF
--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -522,7 +522,7 @@ func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
 	}
 	a.Context = &observerdef.MetricContext{
 		Pattern:   ctx.Pattern,
-		Example:   truncate(ctx.Example, 120),
+		Example:   truncate(ctx.Example, 160),
 		Source:    ctx.Source,
 		SplitTags: ctx.SplitTags,
 	}

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -23,9 +23,18 @@ import (
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
-// logPatternRateWindowSec is the window (seconds) for averaging log pattern
-// rates shown in reports and event messages.
-const logPatternRateWindowSec = 60
+const (
+	// logPatternRateWindowSec is the current-rate averaging window (seconds).
+	logPatternRateWindowSec = 60
+	// logPatternPrevRateWindowSec is the baseline window length: [-6min, -1min].
+	logPatternPrevRateWindowSec = 5 * logPatternRateWindowSec
+
+	// Thresholds for surfacing a rate-change annotation.
+	// Both must be exceeded: relative change guards against noise at low rates,
+	// absolute change guards against large relative swings near zero.
+	logRateChangeRelThreshold = 0.3
+	logRateChangeAbsThreshold = 2
+)
 
 // eventSender formats and dispatches one Datadog event per correlation.
 // When api is nil, send prints to stdout (dry-run mode) instead of calling the API.
@@ -60,9 +69,8 @@ func newEventSender(cfg config.Component, logger log.Component, storage observer
 	}, nil
 }
 
-// logPatternRate returns the average log/s over the last logPatternRateWindowSec seconds
-// for the given anomaly. It uses SumRange on storage when a series ref is available,
-// otherwise falls back to DebugInfo.CurrentValue.
+// logPatternRate returns the avg log/s over [T-60s, T]. Falls back to
+// DebugInfo.CurrentValue when no storage ref is available.
 func logPatternRate(a observerdef.Anomaly, storage observerdef.StorageReader) (rate float64, ok bool) {
 	if a.SourceRef != nil && storage != nil {
 		total := storage.SumRange(a.SourceRef.Ref, a.Timestamp-logPatternRateWindowSec, a.Timestamp, observerdef.AggregateCount)
@@ -72,6 +80,40 @@ func logPatternRate(a observerdef.Anomaly, storage observerdef.StorageReader) (r
 		return a.DebugInfo.CurrentValue, true
 	}
 	return 0, false
+}
+
+// logPatternPrevRate returns the avg log/s over the baseline window [-6min, -1min].
+// No DebugInfo fallback: CurrentValue is always present-tense.
+func logPatternPrevRate(a observerdef.Anomaly, storage observerdef.StorageReader) (rate float64, ok bool) {
+	if a.SourceRef != nil && storage != nil {
+		start := a.Timestamp - logPatternPrevRateWindowSec - logPatternRateWindowSec
+		total := storage.SumRange(a.SourceRef.Ref, start, a.Timestamp-logPatternRateWindowSec, observerdef.AggregateCount)
+		return total / logPatternPrevRateWindowSec, true
+	}
+	return 0, false
+}
+
+// isSignificantRateChange reports whether the rate shift from prev to curr
+// exceeds both the absolute and relative thresholds.
+func isSignificantRateChange(prev, curr float64) bool {
+	diff := curr - prev
+	if diff < 0 {
+		diff = -diff
+	}
+	denom := max(prev, curr)
+	return diff >= logRateChangeAbsThreshold && denom > 0 && diff/denom >= logRateChangeRelThreshold
+}
+
+// logRatePart formats the rate annotation for a log-derived anomaly description.
+func logRatePart(a observerdef.Anomaly, storage observerdef.StorageReader) string {
+	curr, ok := logPatternRate(a, storage)
+	if !ok {
+		return ""
+	}
+	if prev, ok := logPatternPrevRate(a, storage); ok && isSignificantRateChange(prev, curr) {
+		return fmt.Sprintf("\n\trate: %.1flog/s (was %.1flog/s last minutes)", curr, prev)
+	}
+	return fmt.Sprintf("\n\trate: %.1flog/s", curr)
 }
 
 // send formats a correlation into a change event and either prints or posts it.
@@ -397,10 +439,7 @@ func logDerivedDescription(a observerdef.Anomaly, storage observerdef.StorageRea
 	if a.Context.Example != "" && strings.TrimSpace(a.Context.Example) != pattern {
 		example = "\n\texample: " + strings.TrimSpace(a.Context.Example)
 	}
-	var ratePart string
-	if rate, ok := logPatternRate(a, storage); ok {
-		ratePart = fmt.Sprintf("\n\trate: %.1flog/s", rate)
-	}
+	ratePart := logRatePart(a, storage)
 	var tagsPart string
 	if len(a.Context.SplitTags) > 0 {
 		var parts []string
@@ -425,11 +464,7 @@ func logFrequencyDerivedDescription(a observerdef.Anomaly, storage observerdef.S
 	if example == "" {
 		example = strings.TrimSpace(a.Context.Pattern)
 	}
-	var ratePart string
-	if rate, ok := logPatternRate(a, storage); ok {
-		ratePart = fmt.Sprintf("\n\trate: %.1flog/s", rate)
-	}
-	return fmt.Sprintf("Log frequency change detected:\n\texample: %s%s", example, ratePart)
+	return fmt.Sprintf("Log frequency change detected:\n\texample: %s%s", example, logRatePart(a, storage))
 }
 
 // sendCorrelationEvents sends one event per correlation.

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -88,6 +88,9 @@ func logPatternPrevRate(a observerdef.Anomaly, storage observerdef.StorageReader
 	if a.SourceRef != nil && storage != nil {
 		start := a.Timestamp - logPatternPrevRateWindowSec - logPatternRateWindowSec
 		total := storage.SumRange(a.SourceRef.Ref, start, a.Timestamp-logPatternRateWindowSec, observerdef.AggregateCount)
+		if total == 0 {
+			return 0, false
+		}
 		return total / logPatternPrevRateWindowSec, true
 	}
 	return 0, false

--- a/comp/observer/impl/notify_test.go
+++ b/comp/observer/impl/notify_test.go
@@ -6,6 +6,7 @@
 package observerimpl
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -13,6 +14,32 @@ import (
 
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
+
+// sumRangeStorage is a minimal StorageReader that answers SumRange calls via a
+// user-supplied function and panics on all other methods (they are unused in
+// notify_test.go).
+type sumRangeStorage struct {
+	fn func(handle observerdef.SeriesRef, start, end int64, agg observerdef.Aggregate) float64
+}
+
+func (s *sumRangeStorage) SumRange(handle observerdef.SeriesRef, start, end int64, agg observerdef.Aggregate) float64 {
+	return s.fn(handle, start, end, agg)
+}
+func (s *sumRangeStorage) ListSeries(_ observerdef.SeriesFilter) []observerdef.SeriesMeta {
+	panic("not implemented")
+}
+func (s *sumRangeStorage) GetSeriesRange(_ observerdef.SeriesRef, _, _ int64, _ observerdef.Aggregate) *observerdef.Series {
+	panic("not implemented")
+}
+func (s *sumRangeStorage) ForEachPoint(_ observerdef.SeriesRef, _, _ int64, _ observerdef.Aggregate, _ func(*observerdef.Series, observerdef.Point)) bool {
+	panic("not implemented")
+}
+func (s *sumRangeStorage) PointCount(_ observerdef.SeriesRef) int { panic("not implemented") }
+func (s *sumRangeStorage) PointCountUpTo(_ observerdef.SeriesRef, _ int64) int {
+	panic("not implemented")
+}
+func (s *sumRangeStorage) WriteGeneration(_ observerdef.SeriesRef) int64 { panic("not implemented") }
+func (s *sumRangeStorage) SeriesGeneration() uint64                      { panic("not implemented") }
 
 func TestIsLogDerivedAnomaly_LogMetricsExtractorWithPattern(t *testing.T) {
 	a := observerdef.Anomaly{
@@ -260,4 +287,104 @@ func TestBuildEventTags_SourceAndPatternAreFirstTwo(t *testing.T) {
 	copy(sorted, rest)
 	sort.Strings(sorted)
 	assert.Equal(t, sorted, rest)
+}
+
+// --- isSignificantRateChange ---
+
+func TestIsSignificantRateChange_BothAboveThresholds(t *testing.T) {
+	// curr is 3× prev → relative change = 2/3 > 0.5, absolute > 0.1
+	assert.True(t, isSignificantRateChange(1.0, 3.0))
+}
+
+func TestIsSignificantRateChange_RelativeBelowThreshold(t *testing.T) {
+	// 10 → 13: relative change = 3/13 ≈ 0.23 < 0.5
+	assert.False(t, isSignificantRateChange(10.0, 13.0))
+}
+
+func TestIsSignificantRateChange_AbsoluteBelowThreshold(t *testing.T) {
+	// 0.01 → 0.05: absolute change = 0.04 < 0.1, even though relative is large
+	assert.False(t, isSignificantRateChange(0.01, 0.05))
+}
+
+func TestIsSignificantRateChange_BothZero(t *testing.T) {
+	assert.False(t, isSignificantRateChange(0.0, 0.0))
+}
+
+func TestIsSignificantRateChange_RateDrops(t *testing.T) {
+	// 5 → 1: large drop, should be significant
+	assert.True(t, isSignificantRateChange(5.0, 1.0))
+}
+
+// --- rate display in buildChangeMessage ---
+
+// makeStorageWithRates returns a sumRangeStorage whose SumRange returns
+// prevTotal for the earlier window and currTotal for the current window,
+// identified by the end timestamp.
+func makeStorageWithRates(ts int64, prevTotal, currTotal float64) *sumRangeStorage {
+	return &sumRangeStorage{
+		fn: func(_ observerdef.SeriesRef, start, end int64, _ observerdef.Aggregate) float64 {
+			if end == ts-logPatternRateWindowSec {
+				return prevTotal
+			}
+			return currTotal
+		},
+	}
+}
+
+func makeLogPatternAnomaly(ts int64) observerdef.Anomaly {
+	return observerdef.Anomaly{
+		Type:      observerdef.AnomalyTypeMetric,
+		Timestamp: ts,
+		Source:    observerdef.SeriesDescriptor{Namespace: LogPatternExtractorName},
+		SourceRef: &observerdef.QueryHandle{Ref: observerdef.SeriesRef(42)},
+		Context: &observerdef.MetricContext{
+			Pattern: "connection refused",
+			Example: "ERROR: connection refused to db:5432",
+		},
+	}
+}
+
+func TestBuildChangeMessage_RateChangedDisplay(t *testing.T) {
+	const ts = int64(10000)
+	// prev window: 6 logs/s, curr window: 0.5 log/s — large drop, should show "changed from"
+	storage := makeStorageWithRates(ts, 6.0*logPatternPrevRateWindowSec, 0.5*logPatternRateWindowSec)
+	c := observerdef.ActiveCorrelation{
+		Pattern:   "p",
+		Anomalies: []observerdef.Anomaly{makeLogPatternAnomaly(ts)},
+	}
+	msg := buildChangeMessage(c, storage)
+	assert.Contains(t, msg, fmt.Sprintf("rate: %.1flog/s (was %.1flog/s last minutes)", 0.5, 6.0))
+}
+
+func TestBuildChangeMessage_RateUnchanged_ShowsPlainRate(t *testing.T) {
+	const ts = int64(10000)
+	// Both windows return the same rate → not significant, plain display
+	storage := makeStorageWithRates(ts, 3.0*logPatternPrevRateWindowSec, 3.0*logPatternRateWindowSec)
+	c := observerdef.ActiveCorrelation{
+		Pattern:   "p",
+		Anomalies: []observerdef.Anomaly{makeLogPatternAnomaly(ts)},
+	}
+	msg := buildChangeMessage(c, storage)
+	assert.Contains(t, msg, fmt.Sprintf("\n\trate: %.1flog/s", 3.0))
+	// No previous rate display
+	assert.NotContains(t, msg, "was")
+	assert.NotContains(t, msg, "last minutes")
+}
+
+func TestBuildChangeMessage_LogFrequency_RateChangedDisplay(t *testing.T) {
+	const ts = int64(10000)
+	// prev window: 0.2 log/s, curr window: 5.0 log/s — large jump
+	storage := makeStorageWithRates(ts, 0.2*logPatternPrevRateWindowSec, 5.0*logPatternRateWindowSec)
+	a := observerdef.Anomaly{
+		Type:      observerdef.AnomalyTypeMetric,
+		Timestamp: ts,
+		Source:    observerdef.SeriesDescriptor{Namespace: LogMetricsExtractorName},
+		SourceRef: &observerdef.QueryHandle{Ref: observerdef.SeriesRef(7)},
+		Context: &observerdef.MetricContext{
+			Example: "panic: runtime error",
+		},
+	}
+	c := observerdef.ActiveCorrelation{Pattern: "p", Anomalies: []observerdef.Anomaly{a}}
+	msg := buildChangeMessage(c, storage)
+	assert.Contains(t, msg, fmt.Sprintf("rate: %.1flog/s (was %.1flog/s last minutes)", 5.0, 0.2))
 }


### PR DESCRIPTION
### What does this PR do?

- Compares previous log rate and displays it if there is a noticeable change
- Truncate 120 -> 160 chars for the log example

<img width="1313" height="253" alt="Screenshot 2026-04-20 at 10 32 37" src="https://github.com/user-attachments/assets/cda37f93-502c-4b4d-9609-2d3c571e2f4b" />

### Motivation

### Describe how you validated your changes

### Additional Notes
