### PR TITLE
[observer] Added option to disable logs agent for eks gensim

### DIFF
--- a/tasks/e2e_framework/aws/gensim_eks.py
+++ b/tasks/e2e_framework/aws/gensim_eks.py
@@ -99,6 +99,7 @@ _VALID_MODES = ("record-parquet", "live-anomaly-detection", "live-and-record")
         "debug": "Enable Pulumi debug logging",
         "skip_build": "Skip episode image building (use cached ECR images from a previous run)",
         "send_dd_event": "Send a Datadog event when the run is submitted (default: true)",
+        "disable_logs_agent": "Disable log collection in the Helm values for the gensim Datadog Agent (default: false)",
     }
 )
 def submit_gensim_eks(
@@ -115,6 +116,7 @@ def submit_gensim_eks(
     config_path: str | None = None,
     skip_build: bool = False,
     send_dd_event: bool = True,
+    disable_logs_agent: bool = False,
 ) -> None:
     """
     Submit a gensim evaluation run to an EKS cluster.
@@ -131,6 +133,7 @@ def submit_gensim_eks(
         inv aws.eks.gensim.submit --image=docker.io/datadog/agent-dev:my-tag --episodes=authcore-pgbouncer:pool-saturation
         inv aws.eks.gensim.submit --image=... --episode-manifest=./gensim-eval-scenarios.json
         inv aws.eks.gensim.submit --image=... --episodes=... --mode=live-anomaly-detection
+        inv aws.eks.gensim.submit --image=... --episodes=... --disable-logs-agent
     """
     from pydantic_core._pydantic_core import ValidationError
 
@@ -332,6 +335,7 @@ def submit_gensim_eks(
         "gensim:imageRegistry": ecr_registry,
         "gensim:episodeDataDir": str(gensim_repo_path),
         "gensim:mode": mode,
+        "gensim:disableLogsAgent": disable_logs_agent,
         # Datadog keys -- must be explicit since install_agent=False
         "ddagent:apiKey": _get_api_key(local_config),
         "ddagent:appKey": _get_app_key(local_config),

--- a/test/e2e-framework/scenarios/aws/gensim-eks/agent-values.yaml.tmpl
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/agent-values.yaml.tmpl
@@ -8,8 +8,10 @@ datadog:
     instrumentation:
       enabled: true
   logs:
-    enabled: true
+    enabled: {{.LogsEnabled}}
+{{- if .LogsEnabled}}
     containerCollectAll: true
+{{- end}}
   processAgent:
     enabled: true
     processCollection: true

--- a/test/e2e-framework/scenarios/aws/gensim-eks/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/run.go
@@ -32,6 +32,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -112,6 +113,14 @@ func Run(ctx *pulumi.Context) error {
 	if mode == "" {
 		mode = "record-parquet"
 	}
+
+	disableLogsAgent := false
+	if v := strings.TrimSpace(cfg.Get("disableLogsAgent")); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			disableLogsAgent = b
+		}
+	}
+	logsEnabled := !disableLogsAgent
 
 	// If no episodes are specified, stop here — cluster-only mode.
 	if episodes == "" {
@@ -195,6 +204,7 @@ func Run(ctx *pulumi.Context) error {
 	if err := deployOrchestratorJob(
 		ctx, &awsEnv, kubeProvider, sa, ddSecret,
 		episodes, agentImage, gensimSha, namespace, s3Bucket, imageRegistry, episodeDataDir, mode,
+		logsEnabled,
 	); err != nil {
 		return err
 	}
@@ -285,6 +295,7 @@ func deployOrchestratorJob(
 	imageRegistry string,
 	episodeDataDir string,
 	mode string,
+	logsEnabled bool,
 ) error {
 	kubeOpts := []pulumi.ResourceOption{pulumi.Provider(kubeProvider)}
 
@@ -411,7 +422,7 @@ func deployOrchestratorJob(
 	}
 
 	// ── Agent values ConfigMap ───────────────────────────────────────────────
-	renderedValues, err := renderAgentValues(agentImage, mode)
+	renderedValues, err := renderAgentValues(agentImage, mode, logsEnabled)
 	if err != nil {
 		return err
 	}
@@ -529,7 +540,7 @@ var agentValuesTmpl string
 
 // renderAgentValues renders the agent Helm values template with the given image and mode.
 // mode is one of "record-parquet" or "live-anomaly-detection".
-func renderAgentValues(agentImage, mode string) (string, error) {
+func renderAgentValues(agentImage, mode string, logsEnabled bool) (string, error) {
 	idx := strings.LastIndex(agentImage, ":")
 	if idx < 0 {
 		return "", fmt.Errorf("invalid image reference %q: expected format repo:tag (e.g. docker.io/datadog/agent-dev:latest)", agentImage)
@@ -543,7 +554,10 @@ func renderAgentValues(agentImage, mode string) (string, error) {
 	}
 
 	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, struct{ ImageRepo, ImageTag, Mode string }{repo, tag, mode})
+	err = tmpl.Execute(&buf, struct {
+		ImageRepo, ImageTag, Mode string
+		LogsEnabled               bool
+	}{repo, tag, mode, logsEnabled})
 	if err != nil {
 		return "", fmt.Errorf("rendering agent-values template: %w", err)
 	}

--- a/test/e2e-framework/scenarios/aws/gensim-eks/run_test.go
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/run_test.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package gensimeks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderAgentValues_LogsEnabled(t *testing.T) {
+	image := "docker.io/datadog/agent-dev:my-tag"
+	mode := "record-parquet"
+
+	out, err := renderAgentValues(image, mode, true)
+	require.NoError(t, err)
+	require.Contains(t, out, "logs:")
+	require.Contains(t, out, "enabled: true")
+	require.Contains(t, out, "containerCollectAll: true")
+
+	out, err = renderAgentValues(image, mode, false)
+	require.NoError(t, err)
+	require.Contains(t, out, "enabled: false")
+	require.NotContains(t, out, "containerCollectAll")
+}
+
+func TestRenderAgentValues_InvalidImage(t *testing.T) {
+	_, err := renderAgentValues("notag", "record-parquet", true)
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "invalid image reference"))
+}


### PR DESCRIPTION
### What does this PR do?

Added option to disable logs agent for eks gensim task, this will be used for edge only log AD.

### Motivation

### Describe how you validated your changes

### Additional Notes
