### PR TITLE
[procmgr] Build dd-procmgrd unconditionally on Linux

### DIFF
--- a/.gitlab/build/package_build/installer.yml
+++ b/.gitlab/build/package_build/installer.yml
@@ -3,7 +3,9 @@
 # Datadog installer payloads
 #
 .common_build_oci:
-  extends: .bazel:defs:cache:omnibus-transition
+  extends:
+    - .bazel:defs:cache:omnibus-transition
+    - .rust_internal_registry
   script:
     - AGENT_VERSION="$(dda inv agent.version -u)-1" || exit $?
     - export INSTALL_DIR=/opt/datadog-packages/datadog-agent/"$AGENT_VERSION"

--- a/.gitlab/build/package_build/linux.yml
+++ b/.gitlab/build/package_build/linux.yml
@@ -11,7 +11,7 @@
   - ${S3_CP_CMD} "${S3_PERMANENT_ARTIFACTS_URI}/llc-${CLANG_LLVM_VER}.${PACKAGE_ARCH}.${CLANG_BUILD_VERSION}" /tmp/system-probe/llc-bpf
   - cp $CI_PROJECT_DIR/minimized-btfs.tar.xz /tmp/system-probe/minimized-btfs.tar.xz
   - chmod 0744 /tmp/system-probe/clang-bpf /tmp/system-probe/llc-bpf
-  - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --with-dd-procmgrd --flavor "$FLAVOR" --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR"
+  - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --flavor "$FLAVOR" --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR"
   - ls -la $OMNIBUS_PACKAGE_DIR
   - !reference [.upload_sbom_artifacts]
 

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -241,7 +241,7 @@ build do
   end
 
   # dd-procmgrd (process manager daemon)
-  if ENV['WITH_DD_PROCMGRD'] == 'true'
+  if linux_target? and !heroku_target?
     command_on_repo_root "bazelisk run #{bazel_flags} //pkg/procmgr/rust:install -- --destdir=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
   end
 

--- a/packages/agent/product/BUILD.bazel
+++ b/packages/agent/product/BUILD.bazel
@@ -48,7 +48,6 @@ pkg_filegroup(
         # TODO: system-probe - eBPF
 
         # TODO: //pkg/discovery/module/rust
-        # TODO: //pkg/procmgr/rust
         # TODO: security-agent
         # TODO: cws-instrumentation
         # TODO: secret-generic-connector
@@ -57,9 +56,11 @@ pkg_filegroup(
     ] + select({
         "//packages/agent:linux_default": [
             "//pkg/discovery/module/rust:all_files",
+            "//pkg/procmgr/rust:all_files",
         ],
         "//packages/agent:linux_fips": [
             "//pkg/discovery/module/rust:all_files",
+            "//pkg/procmgr/rust:all_files",
         ],
         "//packages/agent:linux_heroku": [],
         "//conditions:default": [

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -143,6 +143,7 @@ pkg_files(
         mode = "0755",
     ),
     prefix = "embedded/bin",
+    visibility = ["//packages:__subpackages__"],
 )
 
 pkg_install(

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -100,6 +100,7 @@ def get_omnibus_env(
     hardened_runtime=False,
     system_probe_bin=None,
     with_sd_agent=False,  # No-op; kept for backward compatibility
+    with_dd_procmgrd=False,  # No-op; kept for backward compatibility
     go_mod_cache=None,
     flavor=AgentFlavor.base,
     pip_config_file="pip.conf",
@@ -217,6 +218,7 @@ def build(
     hardened_runtime=False,
     system_probe_bin=None,
     with_sd_agent=False,  # No-op; kept for backward compatibility
+    with_dd_procmgrd=False,  # No-op; kept for backward compatibility
     go_mod_cache=None,
     python_mirror=None,
     pip_config_file="pip.conf",
@@ -246,6 +248,7 @@ def build(
         hardened_runtime=hardened_runtime,
         system_probe_bin=system_probe_bin,
         with_sd_agent=with_sd_agent,
+        with_dd_procmgrd=with_dd_procmgrd,
         go_mod_cache=go_mod_cache,
         flavor=flavor,
         pip_config_file=pip_config_file,
@@ -392,6 +395,7 @@ def manifest(
     hardened_runtime=False,
     system_probe_bin=None,
     with_sd_agent=False,
+    with_dd_procmgrd=False,
     go_mod_cache=None,
 ):
     flavor = AgentFlavor[flavor]
@@ -405,6 +409,7 @@ def manifest(
         hardened_runtime=hardened_runtime,
         system_probe_bin=system_probe_bin,
         with_sd_agent=with_sd_agent,
+        with_dd_procmgrd=with_dd_procmgrd,
         go_mod_cache=go_mod_cache,
         flavor=flavor,
     )

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -100,7 +100,6 @@ def get_omnibus_env(
     hardened_runtime=False,
     system_probe_bin=None,
     with_sd_agent=False,  # No-op; kept for backward compatibility
-    with_dd_procmgrd=False,
     go_mod_cache=None,
     flavor=AgentFlavor.base,
     pip_config_file="pip.conf",
@@ -151,8 +150,6 @@ def get_omnibus_env(
 
     if system_probe_bin:
         env['SYSTEM_PROBE_BIN'] = system_probe_bin
-    if with_dd_procmgrd:
-        env['WITH_DD_PROCMGRD'] = 'true'
     env['AGENT_FLAVOR'] = flavor.name
 
     if custom_config_dir:
@@ -220,7 +217,6 @@ def build(
     hardened_runtime=False,
     system_probe_bin=None,
     with_sd_agent=False,  # No-op; kept for backward compatibility
-    with_dd_procmgrd=False,
     go_mod_cache=None,
     python_mirror=None,
     pip_config_file="pip.conf",
@@ -250,7 +246,6 @@ def build(
         hardened_runtime=hardened_runtime,
         system_probe_bin=system_probe_bin,
         with_sd_agent=with_sd_agent,
-        with_dd_procmgrd=with_dd_procmgrd,
         go_mod_cache=go_mod_cache,
         flavor=flavor,
         pip_config_file=pip_config_file,
@@ -397,7 +392,6 @@ def manifest(
     hardened_runtime=False,
     system_probe_bin=None,
     with_sd_agent=False,
-    with_dd_procmgrd=False,
     go_mod_cache=None,
 ):
     flavor = AgentFlavor[flavor]
@@ -411,7 +405,6 @@ def manifest(
         hardened_runtime=hardened_runtime,
         system_probe_bin=system_probe_bin,
         with_sd_agent=with_sd_agent,
-        with_dd_procmgrd=with_dd_procmgrd,
         go_mod_cache=go_mod_cache,
         flavor=flavor,
     )


### PR DESCRIPTION
### What does this PR do?

Makes `dd-procmgrd` (the process manager daemon) always included in Linux agent packages, removing the opt-in `--with-dd-procmgrd` flag.

### Motivation

This is the first step toward making `dd-procmgrd` the default process manager for DDOT on Linux bare metal hosts. Currently, procmgrd is only built when the CI pipeline explicitly passes `--with-dd-procmgrd`. Since all Linux CI builds already pass this flag, this PR simply makes it unconditional and removes the indirection.

### Describe how you validated your changes

- Verified that the only CI consumer of `--with-dd-procmgrd` was `.gitlab/build/package_build/linux.yml` (already passing it).
- Confirmed no remaining references to `WITH_DD_PROCMGRD` env var in the codebase after the change.
- All pre-commit hooks pass.

### Additional Notes