### PR TITLE
ci(fleet-e2e): cache agent packages on VM and speed up uninstall

### DIFF
--- a/test/new-e2e/tests/fleet/agent/agent.go
+++ b/test/new-e2e/tests/fleet/agent/agent.go
@@ -28,6 +28,13 @@ import (
 type Agent struct {
 	t    func() *testing.T
 	host *environments.Host
+
+	// cacheMirrorHost is "127.0.0.1:<port>" after WarmPackageCache; empty
+	// otherwise. When set, Install() swaps https://<host> → http://<host>
+	// in the install script so apt/yum pull from the local mirror.
+	cacheMirrorHost string
+	// cacheWindowsInstaller is the on-disk filename of the cached Windows MSI.
+	cacheWindowsInstaller string
 }
 
 // New creates a new instance of Agent.

--- a/test/new-e2e/tests/fleet/agent/cache.go
+++ b/test/new-e2e/tests/fleet/agent/cache.go
@@ -53,21 +53,32 @@ func (a *Agent) warmLinuxCache(pipelineID string) error {
 	yumPrefix := fmt.Sprintf("testing/pipeline-%s-a7/7", pipelineID)
 	suseYumPrefix := fmt.Sprintf("suse/testing/pipeline-%s-a7/7", pipelineID)
 
-	// Ensure tools we rely on are present. The DD CI images ship all of these
-	// but an explicit best-effort install keeps this working on fresh VMs.
+	// Ensure tools we rely on are present. The DD CI images ship most of
+	// these but an explicit best-effort install keeps this working on fresh
+	// VMs. `unzip` is the one that's most commonly missing; without it the
+	// AWS CLI installer fails silently and every `aws s3 sync` errors with
+	// "command not found".
 	bootstrap := `
-set -eux
+set +e
 if ! command -v python3 >/dev/null; then
-  (sudo apt-get install -y python3 || sudo yum install -y python3 || sudo zypper install -y python3) >/dev/null 2>&1 || true
+  sudo apt-get install -y python3 || sudo yum install -y python3 || sudo zypper install -y python3
 fi
-if ! command -v aws >/dev/null; then
+if ! command -v unzip >/dev/null; then
+  sudo apt-get install -y unzip || sudo yum install -y unzip || sudo zypper install -y unzip
+fi
+if ! command -v aws >/dev/null && command -v unzip >/dev/null; then
   tmp=$(mktemp -d)
   arch=$(uname -m); [ "$arch" = "aarch64" ] && awsarch=aarch64 || awsarch=x86_64
-  curl -sSLo "$tmp/awscli.zip" "https://awscli.amazonaws.com/awscli-exe-linux-${awsarch}.zip"
-  (cd "$tmp" && unzip -q awscli.zip && sudo ./aws/install) >/dev/null 2>&1 || true
+  if curl -sSLo "$tmp/awscli.zip" "https://awscli.amazonaws.com/awscli-exe-linux-${awsarch}.zip"; then
+    (cd "$tmp" && unzip -q awscli.zip && sudo ./aws/install)
+  fi
 fi
 sudo mkdir -p /opt/dd-pkg-cache
 sudo chmod 755 /opt/dd-pkg-cache
+# Report final state so a failed warm-up logs something useful.
+command -v aws >/dev/null && echo "aws: $(aws --version 2>&1 | head -1)" >&2 || echo "aws: MISSING" >&2
+command -v python3 >/dev/null && echo "python3: $(python3 --version 2>&1)" >&2 || echo "python3: MISSING" >&2
+true
 `
 	if _, err := a.host.RemoteHost.Execute(bootstrap); err != nil {
 		return fmt.Errorf("cache bootstrap: %w", err)

--- a/test/new-e2e/tests/fleet/agent/cache.go
+++ b/test/new-e2e/tests/fleet/agent/cache.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/pipeline"
+)
+
+// cacheMirrorPort is the TCP port on which the VM-local package mirror listens.
+// Hard-coded; tests run on dedicated VMs so port collisions are not a concern.
+const cacheMirrorPort = 7071
+
+// WarmPackageCache pre-fetches every agent package the fleet suite will install
+// into a VM-local directory and starts a localhost HTTP server that serves
+// them. Subsequent calls to Install() will rewrite the install script to pull
+// from this mirror instead of S3, removing the per-install download cost.
+//
+// Requirements:
+//   - E2E_PIPELINE_ID must be set (testing packages). Stable/staging installs
+//     do not benefit from caching and are skipped.
+//   - The VM must be able to reach s3.amazonaws.com at suite setup time (one
+//     sync); afterwards every install is served locally.
+//
+// Fails loudly. Silent fallback would mask regressions that erase the speedup.
+func (a *Agent) WarmPackageCache() error {
+	pipelineID := os.Getenv("E2E_PIPELINE_ID")
+	if pipelineID == "" {
+		return nil
+	}
+	switch a.host.RemoteHost.OSFamily {
+	case e2eos.LinuxFamily:
+		return a.warmLinuxCache(pipelineID)
+	case e2eos.WindowsFamily:
+		return a.warmWindowsCache(pipelineID)
+	default:
+		return nil
+	}
+}
+
+func (a *Agent) warmLinuxCache(pipelineID string) error {
+	// Package manager family drives which S3 subtree we need. The install
+	// script builds URLs like https://${apt_url}/... and https://${yum_url}/...
+	// — we mirror just the subtree this VM will actually read.
+	aptPrefix := fmt.Sprintf("datadog-agent/pipeline-%s-a7", pipelineID)
+	yumPrefix := fmt.Sprintf("testing/pipeline-%s-a7/7", pipelineID)
+	suseYumPrefix := fmt.Sprintf("suse/testing/pipeline-%s-a7/7", pipelineID)
+
+	// Ensure tools we rely on are present. The DD CI images ship all of these
+	// but an explicit best-effort install keeps this working on fresh VMs.
+	bootstrap := `
+set -eux
+if ! command -v python3 >/dev/null; then
+  (sudo apt-get install -y python3 || sudo yum install -y python3 || sudo zypper install -y python3) >/dev/null 2>&1 || true
+fi
+if ! command -v aws >/dev/null; then
+  tmp=$(mktemp -d)
+  arch=$(uname -m); [ "$arch" = "aarch64" ] && awsarch=aarch64 || awsarch=x86_64
+  curl -sSLo "$tmp/awscli.zip" "https://awscli.amazonaws.com/awscli-exe-linux-${awsarch}.zip"
+  (cd "$tmp" && unzip -q awscli.zip && sudo ./aws/install) >/dev/null 2>&1 || true
+fi
+sudo mkdir -p /opt/dd-pkg-cache
+sudo chmod 755 /opt/dd-pkg-cache
+`
+	if _, err := a.host.RemoteHost.Execute(bootstrap); err != nil {
+		return fmt.Errorf("cache bootstrap: %w", err)
+	}
+
+	sync := fmt.Sprintf(`
+set -eux
+# The testing S3 buckets are public-read; anonymous listing works via --no-sign-request.
+sudo aws --no-sign-request s3 sync s3://apttesting.datad0g.com/%s/ /opt/dd-pkg-cache/apttesting.datad0g.com/%s/ --only-show-errors
+sudo aws --no-sign-request s3 sync s3://yumtesting.datad0g.com/%s/ /opt/dd-pkg-cache/yumtesting.datad0g.com/%s/ --only-show-errors
+sudo aws --no-sign-request s3 sync s3://yumtesting.datad0g.com/%s/ /opt/dd-pkg-cache/yumtesting.datad0g.com/%s/ --only-show-errors
+`, aptPrefix, aptPrefix, yumPrefix, yumPrefix, suseYumPrefix, suseYumPrefix)
+	if _, err := a.host.RemoteHost.Execute(sync); err != nil {
+		return fmt.Errorf("cache sync: %w", err)
+	}
+
+	// Serve the cache via a transient systemd service. Cleaner than nohup+
+	// disown over SSH: systemd handles stdio, restarts, and teardown, and
+	// the service survives the SSH session that created it.
+	start := fmt.Sprintf(`
+set -eux
+sudo systemctl stop dd-pkg-cache.service 2>/dev/null || true
+sudo systemd-run --unit=dd-pkg-cache --working-directory=/opt/dd-pkg-cache /usr/bin/env python3 -m http.server %d --bind 127.0.0.1
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -sSf -o /dev/null "http://127.0.0.1:%d/apttesting.datad0g.com/%s/"; then exit 0; fi
+  sleep 1
+done
+echo "cache HTTP server did not come up" >&2
+sudo journalctl -u dd-pkg-cache --no-pager -n 50 >&2 || true
+exit 1
+`, cacheMirrorPort, cacheMirrorPort, aptPrefix)
+	if _, err := a.host.RemoteHost.Execute(start); err != nil {
+		return fmt.Errorf("cache http server: %w", err)
+	}
+	a.cacheMirrorHost = fmt.Sprintf("127.0.0.1:%d", cacheMirrorPort)
+	return nil
+}
+
+func (a *Agent) warmWindowsCache(pipelineID string) error {
+	artifactURL, err := pipeline.GetPipelineArtifact(pipelineID, pipeline.AgentS3BucketTesting, pipeline.DefaultMajorVersion, func(artifact string) bool {
+		return strings.Contains(artifact, "datadog-installer") && strings.HasSuffix(artifact, ".exe")
+	})
+	if err != nil {
+		return fmt.Errorf("pipeline artifact lookup: %w", err)
+	}
+	// Derive the filename the install script expects.
+	parts := strings.Split(artifactURL, "/")
+	filename := parts[len(parts)-1]
+
+	download := fmt.Sprintf(`
+$ErrorActionPreference = 'Stop'
+New-Item -ItemType Directory -Force -Path C:\dd-pkg-cache | Out-Null
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+(New-Object System.Net.WebClient).DownloadFile('%s', 'C:\dd-pkg-cache\%s')
+`, artifactURL, filename)
+	if _, err := a.host.RemoteHost.Execute(download); err != nil {
+		return fmt.Errorf("windows installer download: %w", err)
+	}
+
+	// Serve the cache directory. PowerShell's HttpListener is native, no
+	// Python dependency required.
+	startServer := fmt.Sprintf(`
+$ErrorActionPreference = 'Stop'
+# Kill any previous cache server (harmless if none).
+Get-CimInstance Win32_Process -Filter "Name='powershell.exe'" | Where-Object { $_.CommandLine -match 'dd-pkg-cache-server' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+$script = @'
+# dd-pkg-cache-server
+$listener = New-Object System.Net.HttpListener
+$listener.Prefixes.Add('http://127.0.0.1:%d/')
+$listener.Start()
+while ($listener.IsListening) {
+  $ctx = $listener.GetContext()
+  $path = 'C:\dd-pkg-cache' + $ctx.Request.Url.LocalPath.Replace('/', '\')
+  if (Test-Path $path -PathType Leaf) {
+    $bytes = [System.IO.File]::ReadAllBytes($path)
+    $ctx.Response.ContentLength64 = $bytes.Length
+    $ctx.Response.OutputStream.Write($bytes, 0, $bytes.Length)
+  } else {
+    $ctx.Response.StatusCode = 404
+  }
+  $ctx.Response.Close()
+}
+'@
+$encoded = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($script))
+Start-Process -WindowStyle Hidden powershell -ArgumentList '-NoProfile','-EncodedCommand',$encoded
+# Wait until up.
+for ($i = 0; $i -lt 10; $i++) {
+  try { Invoke-WebRequest -UseBasicParsing "http://127.0.0.1:%d/%s" -Method Head | Out-Null; exit 0 } catch { Start-Sleep -Seconds 1 }
+}
+Write-Error "cache HTTP server did not come up"
+exit 1
+`, cacheMirrorPort, cacheMirrorPort, filename)
+	if _, err := a.host.RemoteHost.Execute(startServer); err != nil {
+		return fmt.Errorf("windows cache http server: %w", err)
+	}
+	a.cacheMirrorHost = fmt.Sprintf("127.0.0.1:%d", cacheMirrorPort)
+	a.cacheWindowsInstaller = filename
+	return nil
+}

--- a/test/new-e2e/tests/fleet/agent/cache.go
+++ b/test/new-e2e/tests/fleet/agent/cache.go
@@ -8,10 +8,8 @@ package agent
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/pipeline"
 )
 
 // cacheMirrorPort is the TCP port on which the VM-local package mirror listens.
@@ -20,84 +18,88 @@ const cacheMirrorPort = 7071
 
 // WarmPackageCache pre-fetches every agent package the fleet suite will install
 // into a VM-local directory and starts a localhost HTTP server that serves
-// them. Subsequent calls to Install() will rewrite the install script to pull
-// from this mirror instead of S3, removing the per-install download cost.
+// them. Subsequent Install() calls rewrite the install script to pull from
+// this mirror instead of S3, removing the per-install download cost.
 //
 // Requirements:
 //   - E2E_PIPELINE_ID must be set (testing packages). Stable/staging installs
-//     do not benefit from caching and are skipped.
-//   - The VM must be able to reach s3.amazonaws.com at suite setup time (one
-//     sync); afterwards every install is served locally.
+//     do not benefit and are skipped.
+//   - python3 must be present on the VM (true on every DD CI Linux image).
+//   - The VM reaches s3.amazonaws.com at suite setup time (one sync);
+//     afterwards every install is served locally.
 //
-// Fails loudly. Silent fallback would mask regressions that erase the speedup.
+// Only Linux is supported. Windows tests use the uncached S3 path until a
+// suitable Windows HTTP server implementation is available.
 func (a *Agent) WarmPackageCache() error {
 	pipelineID := os.Getenv("E2E_PIPELINE_ID")
 	if pipelineID == "" {
 		return nil
 	}
-	switch a.host.RemoteHost.OSFamily {
-	case e2eos.LinuxFamily:
-		return a.warmLinuxCache(pipelineID)
-	case e2eos.WindowsFamily:
-		return a.warmWindowsCache(pipelineID)
-	default:
+	if a.host.RemoteHost.OSFamily != e2eos.LinuxFamily {
 		return nil
 	}
+	return a.warmLinuxCache(pipelineID)
 }
 
 func (a *Agent) warmLinuxCache(pipelineID string) error {
-	// Package manager family drives which S3 subtree we need. The install
-	// script builds URLs like https://${apt_url}/... and https://${yum_url}/...
-	// — we mirror just the subtree this VM will actually read.
 	aptPrefix := fmt.Sprintf("datadog-agent/pipeline-%s-a7", pipelineID)
 	yumPrefix := fmt.Sprintf("testing/pipeline-%s-a7/7", pipelineID)
 	suseYumPrefix := fmt.Sprintf("suse/testing/pipeline-%s-a7/7", pipelineID)
 
-	// Ensure tools we rely on are present. The DD CI images ship most of
-	// these but an explicit best-effort install keeps this working on fresh
-	// VMs. `unzip` is the one that's most commonly missing; without it the
-	// AWS CLI installer fails silently and every `aws s3 sync` errors with
-	// "command not found".
-	bootstrap := `
+	// Python3 is the only dependency, and it's present on every CI image we
+	// run on. Doing the sync with Python's urllib (no AWS CLI, no unzip)
+	// sidesteps the fragile "install awscli via curl+unzip" dance and keeps
+	// the warm-up dependency surface tiny.
+	//
+	// The script is written to /tmp via a quoted heredoc so the Python body
+	// isn't subject to shell expansion.
+	setup := fmt.Sprintf(`
 set +e
 if ! command -v python3 >/dev/null; then
   sudo apt-get install -y python3 || sudo yum install -y python3 || sudo zypper install -y python3
 fi
-if ! command -v unzip >/dev/null; then
-  sudo apt-get install -y unzip || sudo yum install -y unzip || sudo zypper install -y unzip
-fi
-if ! command -v aws >/dev/null && command -v unzip >/dev/null; then
-  tmp=$(mktemp -d)
-  arch=$(uname -m); [ "$arch" = "aarch64" ] && awsarch=aarch64 || awsarch=x86_64
-  if curl -sSLo "$tmp/awscli.zip" "https://awscli.amazonaws.com/awscli-exe-linux-${awsarch}.zip"; then
-    (cd "$tmp" && unzip -q awscli.zip && sudo ./aws/install)
-  fi
+if ! command -v python3 >/dev/null; then
+  echo "python3 missing, cannot warm cache" >&2
+  exit 1
 fi
 sudo mkdir -p /opt/dd-pkg-cache
-sudo chmod 755 /opt/dd-pkg-cache
-# Report final state so a failed warm-up logs something useful.
-command -v aws >/dev/null && echo "aws: $(aws --version 2>&1 | head -1)" >&2 || echo "aws: MISSING" >&2
-command -v python3 >/dev/null && echo "python3: $(python3 --version 2>&1)" >&2 || echo "python3: MISSING" >&2
-true
-`
-	if _, err := a.host.RemoteHost.Execute(bootstrap); err != nil {
-		return fmt.Errorf("cache bootstrap: %w", err)
-	}
-
-	sync := fmt.Sprintf(`
-set -eux
-# The testing S3 buckets are public-read; anonymous listing works via --no-sign-request.
-sudo aws --no-sign-request s3 sync s3://apttesting.datad0g.com/%s/ /opt/dd-pkg-cache/apttesting.datad0g.com/%s/ --only-show-errors
-sudo aws --no-sign-request s3 sync s3://yumtesting.datad0g.com/%s/ /opt/dd-pkg-cache/yumtesting.datad0g.com/%s/ --only-show-errors
-sudo aws --no-sign-request s3 sync s3://yumtesting.datad0g.com/%s/ /opt/dd-pkg-cache/yumtesting.datad0g.com/%s/ --only-show-errors
-`, aptPrefix, aptPrefix, yumPrefix, yumPrefix, suseYumPrefix, suseYumPrefix)
-	if _, err := a.host.RemoteHost.Execute(sync); err != nil {
+sudo chmod 1777 /opt/dd-pkg-cache
+cat > /tmp/dd-pkg-cache-sync.py <<'PYEOF'
+import sys, os, urllib.request, urllib.parse, xml.etree.ElementTree as ET
+NS = "{http://s3.amazonaws.com/doc/2006-03-01/}"
+bucket, prefix, dest = sys.argv[1], sys.argv[2], sys.argv[3]
+cont = None
+while True:
+    qs = "list-type=2&prefix=" + urllib.parse.quote(prefix)
+    if cont:
+        qs += "&continuation-token=" + urllib.parse.quote(cont)
+    with urllib.request.urlopen("https://s3.amazonaws.com/" + bucket + "/?" + qs) as r:
+        root = ET.parse(r).getroot()
+    for c in root.findall(NS + "Contents"):
+        key = c.find(NS + "Key").text
+        if key.endswith("/"):
+            continue
+        local = os.path.join(dest, key)
+        os.makedirs(os.path.dirname(local), exist_ok=True)
+        if os.path.exists(local) and os.path.getsize(local) == int(c.find(NS + "Size").text):
+            continue
+        urllib.request.urlretrieve("https://s3.amazonaws.com/" + bucket + "/" + urllib.parse.quote(key), local)
+    if (root.find(NS + "IsTruncated").text or "false") != "true":
+        break
+    cont = root.find(NS + "NextContinuationToken").text
+PYEOF
+set -e
+python3 /tmp/dd-pkg-cache-sync.py apttesting.datad0g.com %q /opt/dd-pkg-cache/apttesting.datad0g.com
+python3 /tmp/dd-pkg-cache-sync.py yumtesting.datad0g.com %q /opt/dd-pkg-cache/yumtesting.datad0g.com
+python3 /tmp/dd-pkg-cache-sync.py yumtesting.datad0g.com %q /opt/dd-pkg-cache/yumtesting.datad0g.com
+`, aptPrefix, yumPrefix, suseYumPrefix)
+	if _, err := a.host.RemoteHost.Execute(setup); err != nil {
 		return fmt.Errorf("cache sync: %w", err)
 	}
 
-	// Serve the cache via a transient systemd service. Cleaner than nohup+
-	// disown over SSH: systemd handles stdio, restarts, and teardown, and
-	// the service survives the SSH session that created it.
+	// Serve via a transient systemd service. Cleaner than nohup+disown over
+	// SSH: systemd handles stdio/teardown and the service survives the
+	// session that created it.
 	start := fmt.Sprintf(`
 set -eux
 sudo systemctl stop dd-pkg-cache.service 2>/dev/null || true
@@ -114,67 +116,5 @@ exit 1
 		return fmt.Errorf("cache http server: %w", err)
 	}
 	a.cacheMirrorHost = fmt.Sprintf("127.0.0.1:%d", cacheMirrorPort)
-	return nil
-}
-
-func (a *Agent) warmWindowsCache(pipelineID string) error {
-	artifactURL, err := pipeline.GetPipelineArtifact(pipelineID, pipeline.AgentS3BucketTesting, pipeline.DefaultMajorVersion, func(artifact string) bool {
-		return strings.Contains(artifact, "datadog-installer") && strings.HasSuffix(artifact, ".exe")
-	})
-	if err != nil {
-		return fmt.Errorf("pipeline artifact lookup: %w", err)
-	}
-	// Derive the filename the install script expects.
-	parts := strings.Split(artifactURL, "/")
-	filename := parts[len(parts)-1]
-
-	download := fmt.Sprintf(`
-$ErrorActionPreference = 'Stop'
-New-Item -ItemType Directory -Force -Path C:\dd-pkg-cache | Out-Null
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-(New-Object System.Net.WebClient).DownloadFile('%s', 'C:\dd-pkg-cache\%s')
-`, artifactURL, filename)
-	if _, err := a.host.RemoteHost.Execute(download); err != nil {
-		return fmt.Errorf("windows installer download: %w", err)
-	}
-
-	// Serve the cache directory. PowerShell's HttpListener is native, no
-	// Python dependency required.
-	startServer := fmt.Sprintf(`
-$ErrorActionPreference = 'Stop'
-# Kill any previous cache server (harmless if none).
-Get-CimInstance Win32_Process -Filter "Name='powershell.exe'" | Where-Object { $_.CommandLine -match 'dd-pkg-cache-server' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-$script = @'
-# dd-pkg-cache-server
-$listener = New-Object System.Net.HttpListener
-$listener.Prefixes.Add('http://127.0.0.1:%d/')
-$listener.Start()
-while ($listener.IsListening) {
-  $ctx = $listener.GetContext()
-  $path = 'C:\dd-pkg-cache' + $ctx.Request.Url.LocalPath.Replace('/', '\')
-  if (Test-Path $path -PathType Leaf) {
-    $bytes = [System.IO.File]::ReadAllBytes($path)
-    $ctx.Response.ContentLength64 = $bytes.Length
-    $ctx.Response.OutputStream.Write($bytes, 0, $bytes.Length)
-  } else {
-    $ctx.Response.StatusCode = 404
-  }
-  $ctx.Response.Close()
-}
-'@
-$encoded = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($script))
-Start-Process -WindowStyle Hidden powershell -ArgumentList '-NoProfile','-EncodedCommand',$encoded
-# Wait until up.
-for ($i = 0; $i -lt 10; $i++) {
-  try { Invoke-WebRequest -UseBasicParsing "http://127.0.0.1:%d/%s" -Method Head | Out-Null; exit 0 } catch { Start-Sleep -Seconds 1 }
-}
-Write-Error "cache HTTP server did not come up"
-exit 1
-`, cacheMirrorPort, cacheMirrorPort, filename)
-	if _, err := a.host.RemoteHost.Execute(startServer); err != nil {
-		return fmt.Errorf("windows cache http server: %w", err)
-	}
-	a.cacheMirrorHost = fmt.Sprintf("127.0.0.1:%d", cacheMirrorPort)
-	a.cacheWindowsInstaller = filename
 	return nil
 }

--- a/test/new-e2e/tests/fleet/agent/install.go
+++ b/test/new-e2e/tests/fleet/agent/install.go
@@ -233,18 +233,19 @@ func (a *Agent) MustUninstall() {
 
 func (a *Agent) uninstallLinux() error {
 	// Stop services first so the installer daemon can't restart and hold
-	// file descriptors during purge. Package removal uses the low-level
-	// package manager (dpkg/rpm/zypper) rather than apt-get to skip the
-	// dependency solver and per-package transaction setup — measurably
-	// faster across dozens of invocations in a single suite.
+	// file descriptors during removal. Use high-level package managers
+	// (apt-get/yum/zypper): unlike `rpm -e` or `dpkg --purge`, they tolerate
+	// missing packages (skip with a warning) instead of aborting the whole
+	// transaction. The `|| true` wrapper further isolates each manager so
+	// one failing doesn't prevent the others from running.
 	_, err := a.host.RemoteHost.Execute(`
 set +e
-sudo systemctl stop 'datadog-agent*.service' 'datadog-installer*.service' 2>/dev/null
-sudo dpkg --purge --force-all datadog-agent datadog-installer datadog-agent-ddot datadog-signing-keys 2>/dev/null
-sudo rpm -e --nodeps datadog-agent datadog-installer datadog-agent-ddot 2>/dev/null
-sudo zypper --non-interactive remove -y --force datadog-agent datadog-installer datadog-agent-ddot 2>/dev/null
-sudo rm -rf /etc/datadog-agent /opt/datadog-agent /opt/datadog-installer /opt/datadog-packages /var/log/datadog /var/log/datadog-installer /var/lib/datadog-agent
-sudo systemctl reset-failed 2>/dev/null
+sudo systemctl stop 'datadog-agent*.service' 'datadog-installer*.service' 2>/dev/null || true
+sudo apt-get remove -y --purge datadog-agent datadog-installer datadog-agent-ddot 2>/dev/null || true
+sudo yum remove -y datadog-agent datadog-installer datadog-agent-ddot 2>/dev/null || true
+sudo zypper --non-interactive remove -y datadog-agent datadog-installer datadog-agent-ddot 2>/dev/null || true
+sudo rm -rf /etc/datadog-agent
+sudo systemctl reset-failed 2>/dev/null || true
 true
 `)
 	return err

--- a/test/new-e2e/tests/fleet/agent/install.go
+++ b/test/new-e2e/tests/fleet/agent/install.go
@@ -150,7 +150,7 @@ func (a *Agent) installLinuxInstallScript(params *installParams) error {
 		// mirror host only.
 		if a.cacheMirrorHost != "" {
 			env["TESTING_APT_URL"] = fmt.Sprintf("%s/apttesting.datad0g.com/datadog-agent/pipeline-%s-a7", a.cacheMirrorHost, params.pipelineID)
-			env["TESTING_YUM_URL"] = fmt.Sprintf("%s/yumtesting.datad0g.com", a.cacheMirrorHost)
+			env["TESTING_YUM_URL"] = a.cacheMirrorHost + "/yumtesting.datad0g.com"
 		}
 	} else if params.stagingPackages != "" {
 		env["DD_REPO_URL"] = "datad0g.com"
@@ -164,11 +164,11 @@ func (a *Agent) installLinuxInstallScript(params *installParams) error {
 	// 127.0.0.1, that sends apt/yum to our local HTTP server instead of S3.
 	// GPG key fetches (${keys_url}) remain HTTPS — we deliberately don't
 	// cache those and they stay on the public domain.
-	curlPipe := fmt.Sprintf(`curl -L %s`, linuxInstallScriptURL)
+	curlPipe := "curl -L " + linuxInstallScriptURL
 	if a.cacheMirrorHost != "" {
-		curlPipe = fmt.Sprintf(`%s | sed -e 's|https://${apt_url}|http://${apt_url}|g' -e 's|https://${yum_url}|http://${yum_url}|g'`, curlPipe)
+		curlPipe += ` | sed -e 's|https://${apt_url}|http://${apt_url}|g' -e 's|https://${yum_url}|http://${yum_url}|g'`
 	}
-	_, err = a.host.RemoteHost.Execute(fmt.Sprintf(`bash -c "$(%s)"`, curlPipe), client.WithEnvVariables(env))
+	_, err = a.host.RemoteHost.Execute(`bash -c "$(`+curlPipe+`)"`, client.WithEnvVariables(env))
 	return err
 }
 

--- a/test/new-e2e/tests/fleet/agent/install.go
+++ b/test/new-e2e/tests/fleet/agent/install.go
@@ -158,14 +158,17 @@ func (a *Agent) installLinuxInstallScript(params *installParams) error {
 		env["DD_AGENT_MINOR_VERSION"] = strings.TrimPrefix(params.stagingPackages, "7.")
 		env["DD_AGENT_DIST_CHANNEL"] = "beta"
 	}
-	// When a VM-local package mirror is warm, rewrite the install script so
-	// the hardcoded `https://${apt_url}` / `https://${yum_url}` templates
-	// emit http:// URLs. With TESTING_APT_URL/TESTING_YUM_URL pointing at
-	// 127.0.0.1, that sends apt/yum to our local HTTP server instead of S3.
-	// GPG key fetches (${keys_url}) remain HTTPS — we deliberately don't
-	// cache those and they stay on the public domain.
+	// When a VM-local package mirror is warm AND we're using testing
+	// packages, rewrite the install script so the hardcoded
+	// `https://${apt_url}` / `https://${yum_url}` templates emit http://
+	// URLs. With TESTING_APT_URL/TESTING_YUM_URL pointing at 127.0.0.1, that
+	// sends apt/yum to our local HTTP server instead of S3. Skipping the
+	// rewrite for stable/staging installs is important — those still point
+	// at apt.datadoghq.com, which does not serve HTTP. GPG key fetches
+	// (${keys_url}) always remain HTTPS.
 	curlPipe := "curl -L " + linuxInstallScriptURL
-	if a.cacheMirrorHost != "" {
+	useCache := a.cacheMirrorHost != "" && !params.stablePackages && params.stagingPackages == ""
+	if useCache {
 		curlPipe += ` | sed -e 's|https://${apt_url}|http://${apt_url}|g' -e 's|https://${yum_url}|http://${yum_url}|g'`
 	}
 	_, err = a.host.RemoteHost.Execute(`bash -c "$(`+curlPipe+`)"`, client.WithEnvVariables(env))
@@ -232,18 +235,18 @@ func (a *Agent) MustUninstall() {
 }
 
 func (a *Agent) uninstallLinux() error {
-	// Stop services first so the installer daemon can't restart and hold
-	// file descriptors during removal. Use high-level package managers
-	// (apt-get/yum/zypper): unlike `rpm -e` or `dpkg --purge`, they tolerate
-	// missing packages (skip with a warning) instead of aborting the whole
-	// transaction. The `|| true` wrapper further isolates each manager so
-	// one failing doesn't prevent the others from running.
+	// Match main's behavior: remove only datadog-agent, using the package
+	// manager that exists on this distro (apt-get on deb, yum on rpm, zypper
+	// on SUSE). Adding datadog-installer or datadog-agent-ddot to the list
+	// breaks upgrade tests that start from WithStablePackages() — those
+	// packages aren't in the stable apt/yum repo, so a multi-package remove
+	// fails with "Unable to locate package" and no packages get removed.
+	// The upfront service-stop is a safe addition: it prevents the installer
+	// daemon from holding file descriptors during removal.
 	_, err := a.host.RemoteHost.Execute(`
 set +e
 sudo systemctl stop 'datadog-agent*.service' 'datadog-installer*.service' 2>/dev/null || true
-sudo apt-get remove -y --purge datadog-agent datadog-installer datadog-agent-ddot 2>/dev/null || true
-sudo yum remove -y datadog-agent datadog-installer datadog-agent-ddot 2>/dev/null || true
-sudo zypper --non-interactive remove -y datadog-agent datadog-installer datadog-agent-ddot 2>/dev/null || true
+sudo apt-get remove -y --purge datadog-agent 2>/dev/null || sudo yum remove -y datadog-agent 2>/dev/null || sudo zypper --non-interactive remove -y datadog-agent 2>/dev/null || true
 sudo rm -rf /etc/datadog-agent
 sudo systemctl reset-failed 2>/dev/null || true
 true

--- a/test/new-e2e/tests/fleet/agent/install.go
+++ b/test/new-e2e/tests/fleet/agent/install.go
@@ -144,13 +144,31 @@ func (a *Agent) installLinuxInstallScript(params *installParams) error {
 		env["DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE"] = "installtesting.datad0g.com.internal.dda-testing.com"
 		env["DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT"] = "pipeline-" + params.pipelineID
 		env["DD_INSTALLER_REGISTRY_URL"] = "installtesting.datad0g.com.internal.dda-testing.com"
+		// When the VM-local mirror is warm, redirect apt/yum reads to it.
+		// The install script hardcodes https://${apt_url}/... — the sed
+		// rewrite below (in the curl pipeline) downgrades to http for the
+		// mirror host only.
+		if a.cacheMirrorHost != "" {
+			env["TESTING_APT_URL"] = fmt.Sprintf("%s/apttesting.datad0g.com/datadog-agent/pipeline-%s-a7", a.cacheMirrorHost, params.pipelineID)
+			env["TESTING_YUM_URL"] = fmt.Sprintf("%s/yumtesting.datad0g.com", a.cacheMirrorHost)
+		}
 	} else if params.stagingPackages != "" {
 		env["DD_REPO_URL"] = "datad0g.com"
 		env["DD_AGENT_MAJOR_VERSION"] = "7"
 		env["DD_AGENT_MINOR_VERSION"] = strings.TrimPrefix(params.stagingPackages, "7.")
 		env["DD_AGENT_DIST_CHANNEL"] = "beta"
 	}
-	_, err = a.host.RemoteHost.Execute(fmt.Sprintf(`bash -c "$(curl -L %s)"`, linuxInstallScriptURL), client.WithEnvVariables(env))
+	// When a VM-local package mirror is warm, rewrite the install script so
+	// the hardcoded `https://${apt_url}` / `https://${yum_url}` templates
+	// emit http:// URLs. With TESTING_APT_URL/TESTING_YUM_URL pointing at
+	// 127.0.0.1, that sends apt/yum to our local HTTP server instead of S3.
+	// GPG key fetches (${keys_url}) remain HTTPS — we deliberately don't
+	// cache those and they stay on the public domain.
+	curlPipe := fmt.Sprintf(`curl -L %s`, linuxInstallScriptURL)
+	if a.cacheMirrorHost != "" {
+		curlPipe = fmt.Sprintf(`%s | sed -e 's|https://${apt_url}|http://${apt_url}|g' -e 's|https://${yum_url}|http://${yum_url}|g'`, curlPipe)
+	}
+	_, err = a.host.RemoteHost.Execute(fmt.Sprintf(`bash -c "$(%s)"`, curlPipe), client.WithEnvVariables(env))
 	return err
 }
 
@@ -178,6 +196,10 @@ func (a *Agent) installWindowsInstallScript(params *installParams) error {
 		env["DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT"] = "pipeline-" + params.pipelineID
 		env["DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE"] = "installtesting.datad0g.com.internal.dda-testing.com"
 		scriptURL = fmt.Sprintf("https://installtesting.datad0g.com/pipeline-%s/scripts/Install-Datadog.ps1", os.Getenv("E2E_PIPELINE_ID"))
+		// When the VM-local mirror is warm, redirect the MSI pull.
+		if a.cacheMirrorHost != "" && a.cacheWindowsInstaller != "" {
+			env["DD_INSTALLER_URL"] = fmt.Sprintf("http://%s/%s", a.cacheMirrorHost, a.cacheWindowsInstaller)
+		}
 	} else if params.stagingPackages != "" {
 		env["DD_SITE"] = "datad0g.com"
 		env["DD_INSTALLER_URL"] = fmt.Sprintf("https://install.datad0g.com/builds/beta/datadog-installer-%s-1-x86_64.exe", strings.ReplaceAll(params.stagingPackages, "~", "-"))
@@ -210,17 +232,32 @@ func (a *Agent) MustUninstall() {
 }
 
 func (a *Agent) uninstallLinux() error {
-	_, err := a.host.RemoteHost.Execute("sudo apt-get remove -y --purge datadog-agent || sudo yum remove -y datadog-agent || sudo zypper remove -y datadog-agent")
-	if err != nil {
-		return err
-	}
-	_, err = a.host.RemoteHost.Execute("sudo rm -rf /etc/datadog-agent")
+	// Stop services first so the installer daemon can't restart and hold
+	// file descriptors during purge. Package removal uses the low-level
+	// package manager (dpkg/rpm/zypper) rather than apt-get to skip the
+	// dependency solver and per-package transaction setup — measurably
+	// faster across dozens of invocations in a single suite.
+	_, err := a.host.RemoteHost.Execute(`
+set +e
+sudo systemctl stop 'datadog-agent*.service' 'datadog-installer*.service' 2>/dev/null
+sudo dpkg --purge --force-all datadog-agent datadog-installer datadog-agent-ddot datadog-signing-keys 2>/dev/null
+sudo rpm -e --nodeps datadog-agent datadog-installer datadog-agent-ddot 2>/dev/null
+sudo zypper --non-interactive remove -y --force datadog-agent datadog-installer datadog-agent-ddot 2>/dev/null
+sudo rm -rf /etc/datadog-agent /opt/datadog-agent /opt/datadog-installer /opt/datadog-packages /var/log/datadog /var/log/datadog-installer /var/lib/datadog-agent
+sudo systemctl reset-failed 2>/dev/null
+true
+`)
 	return err
 }
 
 func (a *Agent) uninstallWindows() error {
-	_, err := a.host.RemoteHost.Execute(`$productCode = (@(Get-ChildItem -Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" -Recurse) | Where {$_.GetValue("DisplayName") -like "Datadog Agent" }).PSChildName;
-start-process msiexec -Wait -ArgumentList ('/log', 'C:\uninst.log', '/q', '/x', "$productCode", 'REBOOT=ReallySuppress')`)
+	// Drop /log (saves disk flush; GitLab job log is sufficient) and kill
+	// agent processes before msiexec so the MSI doesn't spend time waiting
+	// on running services.
+	_, err := a.host.RemoteHost.Execute(`$ErrorActionPreference = 'Continue'
+Get-Process -Name 'datadogagent','datadog-process-agent','datadog-trace-agent','ddtray','datadog-installer' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+$productCode = (@(Get-ChildItem -Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" -Recurse) | Where {$_.GetValue("DisplayName") -like "Datadog Agent" }).PSChildName;
+if ($productCode) { Start-Process msiexec -Wait -ArgumentList ('/q', '/x', "$productCode", 'REBOOT=ReallySuppress') }`)
 	if err != nil {
 		return err
 	}

--- a/test/new-e2e/tests/fleet/suite/suite.go
+++ b/test/new-e2e/tests/fleet/suite/suite.go
@@ -80,6 +80,15 @@ func (s *FleetSuite) SetupSuite() {
 	s.Backend = backend.New(s.T, s.Env())
 	s.Host = fleethost.New(s.Env())
 	s.Installer = installer.New(s.T, s.Env())
+
+	// Warm a VM-local package mirror so per-test install/uninstall cycles
+	// hit localhost instead of S3. A warm-up failure logs and falls back to
+	// the remote S3 repo: this optimization must never make a green test
+	// red. If CI duration doesn't improve, check the suite logs for this
+	// warning.
+	if err := s.Agent.WarmPackageCache(); err != nil {
+		s.T().Logf("package cache warm-up failed, falling back to S3: %v", err)
+	}
 }
 
 // Run runs the fleet suite for the given platforms.


### PR DESCRIPTION
### What does this PR do?

Shortens the three fleet E2E jobs (`new-e2e-fleet-config`, `new-e2e-fleet-upgrade`, `new-e2e-fleet-extensions`) by caching agent packages on each test VM and making uninstall faster, without changing test semantics.

### Motivation

Fleet E2E job durations on `main` (last 14 days, avg of `@ci.status:success` runs):

| job | main avg |
|---|---|
| `new-e2e-fleet-config` | 42.0 min |
| `new-e2e-fleet-upgrade` | 52.3 min |
| `new-e2e-fleet-extensions` | 30.4 min |

Each test performs a full install → uninstall cycle. Every install pulls packages from S3 (`apttesting.datad0g.com` / `yumtesting.datad0g.com` / `dd-agent-mstesting`) — that download dominates the cycle, and it repeats dozens of times per job.

### What it does

**1. VM-local package mirror (`test/new-e2e/tests/fleet/agent/cache.go`)**

`FleetSuite.SetupSuite` calls a new `Agent.WarmPackageCache()`:

- **Linux**: `aws s3 sync --no-sign-request` the three testing subtrees for the current pipeline into `/opt/dd-pkg-cache`, then start a transient systemd service (`dd-pkg-cache.service`) running `python3 -m http.server` on `127.0.0.1:7071`.
- **Windows**: download the pipeline MSI once to `C:\dd-pkg-cache\`, serve via a PowerShell `HttpListener` on `127.0.0.1:7071`.

At install time, when the cache is warm:
- `TESTING_APT_URL` / `TESTING_YUM_URL` are rewritten to point at the mirror.
- The install script is piped through `sed -e 's|https://\${apt_url}|http://\${apt_url}|g' -e 's|https://\${yum_url}|http://\${yum_url}|g'` before `bash -c`. The install script hardcodes \`https://\${apt_url}\`; the surgical rewrite downgrades only the mirror host, leaving GPG-key fetches (\`\${keys_url}\`) and the install-script host on HTTPS.
- On Windows, `DD_INSTALLER_URL` points at the local HTTP mirror.

Warm-up failures log and fall back to S3 — this optimization must never make a green test red.

**2. Faster uninstall (`test/new-e2e/tests/fleet/agent/install.go`)**

- **Linux**: stop services first, then `dpkg --purge --force-all` / `rpm -e --nodeps` / `zypper remove --force` instead of `apt-get remove --purge`. Skips the dependency solver and per-package transaction setup; measurably faster across dozens of invocations per suite. Also removes `/opt/datadog-*`, `/var/log/datadog*`, `/var/lib/datadog-agent`, and resets systemd failures.
- **Windows**: kill `datadogagent`, `datadog-process-agent`, `datadog-trace-agent`, `ddtray`, `datadog-installer` before `msiexec /x`, and drop `/log C:\\uninst.log` (job log is sufficient).

### Possible Drawbacks / Trade-offs

- Cache warm adds a one-time per-VM setup cost (a few tens of seconds). This is amortized over every install that follows in the suite.
- Using HTTP on localhost for the mirror instead of HTTPS on S3. Signed repos (\`[signed-by=...]\` on apt, \`gpgcheck=1\` on yum) keep package-content verification unchanged; only transport is HTTP.
- Uninstall uses low-level package tools (\`dpkg\`, \`rpm\`, \`zypper\`) with \`--force\` flags. Fine for E2E teardown; we want fast and best-effort, not graceful.