### PR TITLE
[Backport 7.78.x] Add 'tasks/agent.py' to global cache list (#49579)

### DIFF
--- a/releasenotes/notes/modify-omnibus-cache-rules-7820b09b51256c0b.yaml
+++ b/releasenotes/notes/modify-omnibus-cache-rules-7820b09b51256c0b.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Adds the tasks/agent.py file to the list of files used to
+    compute the global omnibus cache.

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -196,6 +196,7 @@ def omnibus_compute_cache_key(ctx, env: dict[str, str]) -> str:
             'omnibus/python-scripts',
             'omnibus/resources',
             'omnibus/omnibus.rb',
+            'tasks/agent.py',
             'deps',
             'bazel',
         ],


### PR DESCRIPTION
### What does this PR do?
Backport https://github.com/DataDog/datadog-agent/commit/e4196f9f9d3271eb91ae821562e1a25a18ee4379 from https://github.com/DataDog/datadog-agent/pull/49579.
### Motivation
We want to modify the `agent.py` script to take into account integrations missing a `manifest.json` (which is becoming the new standard).

The current script and cache are making the Agent ship without these integrations.

### Describe how you validated your changes

### Additional Notes

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
