### PR TITLE
[q/eval] Coerce --seed to int in all 4 eval tasks

### DIFF
--- a/tasks/q.py
+++ b/tasks/q.py
@@ -406,7 +406,7 @@ def eval_combinations(
 
     if seed is not None:
         seed = int(seed)
-    if seed is None:
+    else:
         seed = random.randint(0, 2**32 - 1)
 
     force_enable_list = [c.strip() for c in force_enable.split(",") if c.strip()]
@@ -659,7 +659,7 @@ def eval_bayesian(
 
     if seed is not None:
         seed = int(seed)
-    if seed is None:
+    else:
         seed = random.randint(0, 2**32 - 1)
 
     if not _prepare_eval_output_dir(output_dir, overwrite=overwrite):
@@ -979,7 +979,7 @@ def eval_pipeline(
 
     if seed is not None:
         seed = int(seed)
-    if seed is None:
+    else:
         seed = random.randint(0, 2**32 - 1)
 
     rng = random.Random(seed)
@@ -1313,7 +1313,7 @@ def eval_component(
 
     if seed is not None:
         seed = int(seed)
-    if seed is None:
+    else:
         seed = random.randint(0, 2**32 - 1)
 
     # --- deterministic seed derivation ---

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -404,6 +404,8 @@ def eval_combinations(
         build_testbench(ctx)
         build_scorer(ctx)
 
+    if seed is not None:
+        seed = int(seed)
     if seed is None:
         seed = random.randint(0, 2**32 - 1)
 
@@ -655,6 +657,8 @@ def eval_bayesian(
         print(color_message(f"Error: locked components not in active set: {', '.join(sorted(not_active))}", Color.RED))
         return
 
+    if seed is not None:
+        seed = int(seed)
     if seed is None:
         seed = random.randint(0, 2**32 - 1)
 
@@ -752,7 +756,7 @@ def eval_bayesian(
         return score
 
     optuna.logging.set_verbosity(optuna.logging.WARNING)
-    sampler = optuna.samplers.TPESampler(seed=int(seed) if seed is not None else None)
+    sampler = optuna.samplers.TPESampler(seed=seed)
     study = optuna.create_study(direction="maximize", sampler=sampler)
     study.optimize(objective, n_trials=n_trials)
 
@@ -973,6 +977,8 @@ def eval_pipeline(
     if not _prepare_eval_output_dir(output_dir, overwrite=overwrite):
         return
 
+    if seed is not None:
+        seed = int(seed)
     if seed is None:
         seed = random.randint(0, 2**32 - 1)
 
@@ -1305,6 +1311,8 @@ def eval_component(
         print(color_message(f"Error: cannot force-disable the evaluated component '{component}'", Color.RED))
         return
 
+    if seed is not None:
+        seed = int(seed)
     if seed is None:
         seed = random.randint(0, 2**32 - 1)
 

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -752,7 +752,7 @@ def eval_bayesian(
         return score
 
     optuna.logging.set_verbosity(optuna.logging.WARNING)
-    sampler = optuna.samplers.TPESampler(seed=seed)
+    sampler = optuna.samplers.TPESampler(seed=int(seed) if seed is not None else None)
     study = optuna.create_study(direction="maximize", sampler=sampler)
     study.optimize(objective, n_trials=n_trials)
 


### PR DESCRIPTION
## Summary

Fixes `--seed` CLI flag in all four eval invoke tasks: `q.eval-bayesian`, `q.eval-combinations`, `q.eval-pipeline`, `q.eval-component`.

## Why

Invoke passes CLI args as strings when the default is `None`, regardless of the `int` annotation. So `--seed 42` becomes the string `"42"` inside the function.

Downstream behavior differs by library:

| Task | Downstream | Symptom |
|---|---|---|
| `eval_bayesian` | `optuna.TPESampler()` → numpy `RandomState.seed()` | **Crashes** — `TypeError: Cannot cast scalar from dtype('<U2') to dtype('int64')` |
| `eval_combinations`, `eval_pipeline`, `eval_component` | Python stdlib `random.Random(seed)` | **Silent** — stdlib hashes the string, producing a different RNG sequence than programmatic `seed=42` |

The silent cases are arguably worse: someone reproduces a run with `--seed 42`, gets different results than before, and doesn't know why.

The docs at [Evals & fine tuning](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/6528369095/) advertise `--seed 42` as a supported flag, so this is fixing documented behavior that was never reliable from CLI.

## Change

Coerce `seed` to `int` at function entry in all 4 tasks:

```python
if seed is not None:
    seed = int(seed)
```

## Test plan
- [x] Verified `dda inv --dep=optuna q.eval-bayesian --only bocpd --n-trials 50 --seed 42 --scenarios ...` succeeds (manual reproduction)
- [x] Passing no `--seed` still works (the `None` path is unchanged)
- [ ] `q.eval-combinations`, `q.eval-pipeline`, `q.eval-component` not individually re-run, but the fix is a pure coercion added before existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)