### PR TITLE
Temporary fix for spammy log

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -129,6 +129,10 @@ type ntmConfig struct {
 	// only hold an RLock, so a plain map would cause concurrent map writes.
 	unknownKeys sync.Map
 
+	// All the keys for which we emitted a warnings upon calling `Set`. We don't want to flood the logs with the same
+	// message. This map is used to keep track of already emitted errors
+	setWarnings map[string]bool
+
 	// extraConfigFilePaths represents additional configuration file paths that will be merged into the main configuration when ReadInConfig() is called.
 	extraConfigFilePaths []string
 
@@ -226,8 +230,11 @@ func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 	// convert the value to the type of the default
 	if declaredNode.IsLeafNode() {
 		if converted, err := convertToDefaultType(newValue, declaredNode.Get()); err == nil {
-			if reflect.TypeOf(converted) != reflect.TypeOf(newValue) {
-				log.Warnf("Set('%s'): converting value from %T to %T to match default type", key, newValue, converted)
+			if ok := c.setWarnings[key]; !ok {
+				if reflect.TypeOf(converted) != reflect.TypeOf(newValue) {
+					log.Warnf("Set('%s'): converting value from %T to %T to match default type", key, newValue, converted)
+					c.setWarnings[key] = true
+				}
 			}
 			newValue = converted
 		}
@@ -1169,6 +1176,7 @@ func NewNodeTreeConfig(name string, envPrefix string, envKeyReplacer *strings.Re
 		sequenceID:         0,
 		configEnvVars:      map[string][]string{},
 		knownKeys:          map[string]bool{},
+		setWarnings:        map[string]bool{},
 		defaults:           newInnerNode(nil),
 		file:               newInnerNode(nil),
 		unknown:            newInnerNode(nil),


### PR DESCRIPTION
### What does this PR do?

The configsync API currently rely on JSON which produce float64 for all number. This create a warning every time we sync the config. As a temporary fix we only print each warning once. A proper fix, of the configsync api will be made later

### Describe how you validated your changes

Running the CI.