### PR TITLE
Reduce SNMP debug logging

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -403,8 +403,8 @@ func (d *DeviceCheck) getValuesAndTags(sess session.Session, deviceReachable boo
 
 	valuesStore, err := fetch.Fetch(sess, d.profileCache.scalarOIDs, d.profileCache.columnOIDs,
 		d.oidBatchSizeOptimizers, d.config.BulkMaxRepetitions)
-	if log.ShouldLog(log.DebugLvl) {
-		log.Debugf("fetched values: %v", valuestore.ResultValueStoreAsString(valuesStore))
+	if log.ShouldLog(log.TraceLvl) {
+		log.Tracef("fetched values: %v", valuestore.ResultValueStoreAsString(valuesStore))
 	}
 
 	if err != nil {

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
@@ -118,8 +118,8 @@ func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions u
 			return nil, fetchErr
 		}
 		results = getNextResults
-		if log.ShouldLog(log.DebugLvl) {
-			log.Debugf("fetch column: GetNext results: %v", gosnmplib.PacketAsString(results))
+		if log.ShouldLog(log.TraceLvl) {
+			log.Tracef("fetch column: GetNext results: %v", gosnmplib.PacketAsString(results))
 		}
 	} else {
 		getBulkResults, err := sess.GetBulk(requestOids, bulkMaxRepetitions)
@@ -129,8 +129,8 @@ func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions u
 			return nil, fetchErr
 		}
 		results = getBulkResults
-		if log.ShouldLog(log.DebugLvl) {
-			log.Debugf("fetch column: GetBulk results: %v", gosnmplib.PacketAsString(results))
+		if log.ShouldLog(log.TraceLvl) {
+			log.Tracef("fetch column: GetBulk results: %v", gosnmplib.PacketAsString(results))
 		}
 	}
 	return results, nil

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_scalar.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_scalar.go
@@ -141,8 +141,8 @@ func doDoFetchScalarOids(session session.Session, oids []string) (*gosnmp.SnmpPa
 		log.Debug(fetchErr.Error())
 		return nil, fetchErr
 	}
-	if log.ShouldLog(log.DebugLvl) {
-		log.Debugf("fetch scalar: results: %s", gosnmplib.PacketAsString(results))
+	if log.ShouldLog(log.TraceLvl) {
+		log.Tracef("fetch scalar: results: %s", gosnmplib.PacketAsString(results))
 	}
 	return results, nil
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -6,6 +6,7 @@
 package report
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -128,6 +129,7 @@ func (ms *MetricSender) reportScalarMetrics(metric profiledefinition.MetricsConf
 func (ms *MetricSender) reportColumnMetrics(metricConfig profiledefinition.MetricsConfig, values *valuestore.ResultValueStore, tags []string, deviceID string) map[string]map[string]MetricSample {
 	rowTagsCache := make(map[string][]string)
 	skippedInterfaceIndexes := make(map[string]bool)
+	var missingOIDs []*valuestore.OIDNotFoundError
 
 	samples := map[string]map[string]MetricSample{}
 
@@ -140,7 +142,12 @@ func (ms *MetricSender) reportColumnMetrics(metricConfig profiledefinition.Metri
 			var err error
 			metricValues, err = getColumnValueFromSymbol(values, symbol)
 			if err != nil {
-				log.Debugf("report column: error getting column value: %v", err)
+				var oidErr *valuestore.OIDNotFoundError
+				if errors.As(err, &oidErr) {
+					missingOIDs = append(missingOIDs, oidErr)
+				} else {
+					log.Debugf("report column: error getting column value: %v", err)
+				}
 				continue
 			}
 		}
@@ -185,6 +192,9 @@ func (ms *MetricSender) reportColumnMetrics(metricConfig profiledefinition.Metri
 			samples[sample.symbol.Name][fullIndex] = sample
 			ms.sendInterfaceVolumeMetrics(symbol, fullIndex, values, rowTags)
 		}
+	}
+	if len(missingOIDs) > 0 {
+		log.Debugf("report column: missing OIDs: %v", valuestore.ListOIDs(missingOIDs))
 	}
 	return samples
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
@@ -376,7 +376,7 @@ func Test_metricSender_reportMetrics(t *testing.T) {
 			},
 			values: &valuestore.ResultValueStore{},
 			expectedLogs: []logCount{
-				{"[DEBUG] reportScalarMetrics: report scalar: error getting scalar value: value for Scalar OID `1.2.3.4.5` not found in results", 1},
+				{"[DEBUG] reportScalarMetrics: report scalar: error getting scalar value: OID 1.2.3.4.5 not found", 1},
 			},
 		},
 		{

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils.go
@@ -6,6 +6,7 @@
 package report
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -92,6 +93,7 @@ func processValueUsingSymbolConfig(value valuestore.ResultValue, symbol profiled
 // getTagsFromMetricTagConfigList retrieve tags using the metric config and values
 func getTagsFromMetricTagConfigList(mtcl profiledefinition.MetricTagConfigList, fullIndex string, values *valuestore.ResultValueStore) []string {
 	var rowTags []string
+	var missingOIDs []*valuestore.OIDNotFoundError
 	indexes := strings.Split(fullIndex, ".")
 	for _, metricTag := range mtcl {
 		// get tag using `index` field
@@ -113,7 +115,12 @@ func getTagsFromMetricTagConfigList(mtcl profiledefinition.MetricTagConfigList, 
 			// TODO: Support extract value see II-635
 			columnValues, err := getColumnValueFromSymbol(values, profiledefinition.SymbolConfig(metricTag.Symbol))
 			if err != nil {
-				log.Debugf("error getting column value: %v", err)
+				var oidErr *valuestore.OIDNotFoundError
+				if errors.As(err, &oidErr) {
+					missingOIDs = append(missingOIDs, oidErr)
+				} else {
+					log.Debugf("error getting column value: %v", err)
+				}
 				continue
 			}
 
@@ -137,6 +144,9 @@ func getTagsFromMetricTagConfigList(mtcl profiledefinition.MetricTagConfigList, 
 			}
 			rowTags = append(rowTags, checkconfig.BuildMetricTagsFromValue(&metricTag, strValue)...)
 		}
+	}
+	if len(missingOIDs) > 0 {
+		log.Debugf("missing OIDs: %v", valuestore.ListOIDs(missingOIDs))
 	}
 	return rowTags
 }
@@ -185,6 +195,7 @@ func getInterfaceConfig(interfaceConfigs []snmpintegration.InterfaceConfig, inde
 // getConstantMetricValues retrieve all metric tags indexes and set their value as 1
 func getConstantMetricValues(mtcl profiledefinition.MetricTagConfigList, values *valuestore.ResultValueStore) map[string]valuestore.ResultValue {
 	constantValues := make(map[string]valuestore.ResultValue)
+	var missingOIDs []*valuestore.OIDNotFoundError
 	for _, metricTag := range mtcl {
 		if len(metricTag.IndexTransform) > 0 {
 			// If index transform is set, indexes are from another table, we don't want to collect them
@@ -193,7 +204,12 @@ func getConstantMetricValues(mtcl profiledefinition.MetricTagConfigList, values 
 		if metricTag.Symbol.OID != "" {
 			columnValues, err := getColumnValueFromSymbol(values, profiledefinition.SymbolConfig(metricTag.Symbol))
 			if err != nil {
-				log.Debugf("error getting column value: %v", err)
+				var oidErr *valuestore.OIDNotFoundError
+				if errors.As(err, &oidErr) {
+					missingOIDs = append(missingOIDs, oidErr)
+				} else {
+					log.Debugf("error getting column value: %v", err)
+				}
 				continue
 			}
 			for index := range columnValues {
@@ -205,6 +221,9 @@ func getConstantMetricValues(mtcl profiledefinition.MetricTagConfigList, values 
 				}
 			}
 		}
+	}
+	if len(missingOIDs) > 0 {
+		log.Debugf("missing OIDs: %v", valuestore.ListOIDs(missingOIDs))
 	}
 	return constantValues
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
@@ -51,7 +51,7 @@ func Test_getScalarValueFromSymbol(t *testing.T) {
 			values:        mockValues,
 			symbol:        profiledefinition.SymbolConfig{OID: "1.2.3.99", Name: "mySymbol"},
 			expectedValue: valuestore.ResultValue{},
-			expectedError: "value for Scalar OID `1.2.3.99` not found in results",
+			expectedError: "OID 1.2.3.99 not found",
 		},
 		{
 			name:   "extract value pattern error",
@@ -235,7 +235,7 @@ func Test_getColumnValueFromSymbol(t *testing.T) {
 			values:         mockValues,
 			symbol:         profiledefinition.SymbolConfig{OID: "1.2.3.99", Name: "mySymbol"},
 			expectedValues: nil,
-			expectedError:  "value for Column OID `1.2.3.99` not found in results",
+			expectedError:  "OID 1.2.3.99 not found",
 		},
 		{
 			name:   "invalid extract value pattern",
@@ -609,7 +609,7 @@ metric_tags:
 			},
 			expectedTags: []string(nil),
 			expectedLogs: []logCount{
-				{"[DEBUG] getTagsFromMetricTagConfigList: error getting column value: value for Column OID `1.2.3.4.8.1.2`", 1},
+				{"[DEBUG] getTagsFromMetricTagConfigList: missing OIDs: [1.2.3.4.8.1.2]", 1},
 			},
 		},
 		{
@@ -799,7 +799,7 @@ metric_tags:
 			logs := b.String()
 
 			for _, aLogCount := range tt.expectedLogs {
-				assert.Equal(t, aLogCount.count, strings.Count(logs, aLogCount.log), logs)
+				assert.Equal(t, aLogCount.count, strings.Count(logs, aLogCount.log), "%q\n%q", aLogCount.log, logs)
 			}
 		})
 	}
@@ -1087,7 +1087,7 @@ func Test_getContantMetricValues(t *testing.T) {
 			values:         &valuestore.ResultValueStore{},
 			expectedValues: map[string]valuestore.ResultValue{},
 			expectedLogs: []logCount{
-				{"error getting column value", 1},
+				{"missing OIDs: [1.2.3]", 1},
 			},
 		},
 		{

--- a/pkg/collector/corechecks/snmp/internal/valuestore/values.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/values.go
@@ -125,7 +125,7 @@ func (v *ResultValueStore) GetColumnValueAsFloat(oid string, index string) float
 	}
 	floatValue, err := value.ToFloat64()
 	if err != nil {
-		log.Tracef("failed to convert to string for OID %s with value %v: %s", oid, value, err)
+		log.Tracef("failed to convert to float for OID %s with value %v: %s", oid, value, err)
 		return 0
 	}
 	return floatValue
@@ -161,8 +161,8 @@ func ResultValueStoreAsString(values *ResultValueStore) string {
 	}
 	jsonPayload, err := json.Marshal(values)
 	if err != nil {
-		log.Debugf("error marshaling debugVar: %s", err)
-		return ""
+		log.Debugf("error marshaling result store: %s", err)
+		return "(marshaling error)"
 	}
 	return string(jsonPayload)
 }

--- a/pkg/collector/corechecks/snmp/internal/valuestore/values.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/values.go
@@ -7,12 +7,46 @@ package valuestore
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"sort"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+// OIDNotFoundError is returned when an OID cannot be found in the value store
+type OIDNotFoundError struct {
+	OID   string
+	Index string // optional, empty if not applicable
+}
+
+func (e *OIDNotFoundError) Error() string {
+	if e.Index == "" {
+		return fmt.Sprintf("OID %s not found", e.OID)
+	}
+	return fmt.Sprintf("OID %s index %s not found", e.OID, e.Index)
+}
+
+// ListOIDs formats a list of *OIDNotFoundErrors concisely for debug logging.
+// The output will simply be a space-separated list of OIDs, with '#<index>'
+// appended to any that were missing an index, e.g. [1.2.3 1.2.4#22 1.4.5]
+func ListOIDs(errs []*OIDNotFoundError) string {
+	var b strings.Builder
+	b.WriteString("[")
+	for i, err := range errs {
+		b.WriteString(err.OID)
+		if err.Index != "" {
+			b.WriteString("#" + err.Index)
+		}
+		if i < len(errs)-1 {
+			b.WriteString(" ")
+		}
+	}
+	b.WriteString("]")
+	return b.String()
+}
 
 // ColumnResultValuesType is used to store results fetched for column oids
 // Structure: map[<COLUMN OIDS AS STRING>]map[<ROW INDEX>]ResultValue
@@ -43,7 +77,7 @@ func (v *ResultValueStore) ContainsScalarValue(oid string) bool {
 func (v *ResultValueStore) GetScalarValue(oid string) (ResultValue, error) {
 	value, ok := v.ScalarValues[oid]
 	if !ok {
-		return ResultValue{}, fmt.Errorf("value for Scalar OID `%s` not found in results", oid)
+		return ResultValue{}, &OIDNotFoundError{OID: oid}
 	}
 	return value, nil
 }
@@ -61,7 +95,7 @@ func (v *ResultValueStore) ContainsColumnValues(oid string) bool {
 func (v *ResultValueStore) GetColumnValues(oid string) (map[string]ResultValue, error) {
 	values, ok := v.ColumnValues[oid]
 	if !ok {
-		return nil, fmt.Errorf("value for Column OID `%s` not found in results", oid)
+		return nil, &OIDNotFoundError{OID: oid}
 	}
 	retValues := make(map[string]ResultValue, len(values))
 	maps.Copy(retValues, values)
@@ -73,11 +107,11 @@ func (v *ResultValueStore) GetColumnValues(oid string) (map[string]ResultValue, 
 func (v *ResultValueStore) getColumnValue(oid string, index string) (ResultValue, error) {
 	values, ok := v.ColumnValues[oid]
 	if !ok {
-		return ResultValue{}, fmt.Errorf("value for Column OID `%s` not found in results", oid)
+		return ResultValue{}, &OIDNotFoundError{OID: oid}
 	}
 	value, ok := values[index]
 	if !ok {
-		return ResultValue{}, fmt.Errorf("value for Column OID `%s` and index `%s` not found in results", oid, index)
+		return ResultValue{}, &OIDNotFoundError{OID: oid, Index: index}
 	}
 	return value, nil
 }
@@ -102,6 +136,9 @@ func (v *ResultValueStore) GetColumnIndexes(columnOid string) ([]string, error) 
 	indexesMap := make(map[string]struct{})
 	metricValues, err := v.GetColumnValues(columnOid)
 	if err != nil {
+		if errors.Is(err, &OIDNotFoundError{}) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("error getting column value oid=%s: %s", columnOid, err)
 	}
 	for fullIndex := range metricValues {

--- a/pkg/collector/corechecks/snmp/internal/valuestore/values_test.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/values_test.go
@@ -58,7 +58,7 @@ func Test_resultValueStore_getColumnValueAsFloat(t *testing.T) {
 
 func Test_resultValueStore_GetColumnIndexes(t *testing.T) {
 	indexes, err := storeMock.GetColumnIndexes("0.0")
-	assert.EqualError(t, err, "error getting column value oid=0.0: value for Column OID `0.0` not found in results")
+	assert.EqualError(t, err, "error getting column value oid=0.0: OID 0.0 not found")
 	assert.Nil(t, indexes)
 
 	indexes, err = storeMock.GetColumnIndexes("1.1.1")

--- a/pkg/snmp/gosnmplib/gosnmp_utils.go
+++ b/pkg/snmp/gosnmplib/gosnmp_utils.go
@@ -17,13 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-type debugVariable struct {
-	Oid      string      `json:"oid"`
-	Type     string      `json:"type"`
-	Value    interface{} `json:"value"`
-	ParseErr string      `json:"parse_err,omitempty"`
-}
-
 var strippableSpecialChars = map[byte]bool{'\r': true, '\n': true, '\t': true, 00: true}
 
 // IsStringPrintable returns true if the provided byte array is only composed of printable characeters
@@ -122,34 +115,34 @@ func hexify(bytesValue []byte) string {
 	return fmt.Sprintf("%#x", bytesValue)
 }
 
+func formatValue(pdu gosnmp.SnmpPDU) string {
+	resValue, err := GetValueFromPDU(pdu)
+	if err == nil {
+		resValueStr, err := StandardTypeToString(resValue)
+		if err == nil {
+			return fmt.Sprintf("%v(%v)", pdu.Type, resValueStr)
+		}
+	}
+	return fmt.Sprintf("(Unparseable %v: %v)", pdu.Type, err)
+}
+
 // PacketAsString used to format gosnmp.SnmpPacket for debug/trace logging
 func PacketAsString(packet *gosnmp.SnmpPacket) string {
 	if packet == nil {
 		return ""
 	}
-	var debugVariables []debugVariable
-	for _, pduVariable := range packet.Variables {
-		var parseError string
-		name := pduVariable.Name
-		value := fmt.Sprintf("%v", pduVariable.Value)
-		resValue, err := GetValueFromPDU(pduVariable)
-		if err == nil {
-			resValueStr, err := StandardTypeToString(resValue)
-			if err == nil {
-				value = resValueStr
-			}
-		}
-		if err != nil {
-			parseError = fmt.Sprintf("`%s`", err)
-		}
-		debugVar := debugVariable{Oid: name, Type: fmt.Sprintf("%v", pduVariable.Type), Value: value, ParseErr: parseError}
-		debugVariables = append(debugVariables, debugVar)
+	variables := map[string]string{}
+	for _, pdu := range packet.Variables {
+		variables[pdu.Name] = formatValue(pdu)
 	}
 
-	jsonPayload, err := json.Marshal(debugVariables)
+	jsonPayload, err := json.Marshal(variables)
 	if err != nil {
 		log.Debugf("error marshaling debugVar: %s", err)
-		jsonPayload = []byte(``)
+		jsonPayload = []byte(`<marshal error>`)
 	}
-	return fmt.Sprintf("error=%s(code:%d, idx:%d), values=%s", packet.Error, packet.Error, packet.ErrorIndex, jsonPayload)
+	if packet.Error != 0 {
+		return fmt.Sprintf("error=%s(code:%d, idx:%d), values=%s", packet.Error, packet.Error, packet.ErrorIndex, jsonPayload)
+	}
+	return string(jsonPayload)
 }

--- a/pkg/snmp/gosnmplib/gosnmp_utils.go
+++ b/pkg/snmp/gosnmplib/gosnmp_utils.go
@@ -138,7 +138,7 @@ func PacketAsString(packet *gosnmp.SnmpPacket) string {
 
 	jsonPayload, err := json.Marshal(variables)
 	if err != nil {
-		log.Debugf("error marshaling debugVar: %s", err)
+		log.Debugf("error marshaling pdu data: %s", err)
 		jsonPayload = []byte(`<marshal error>`)
 	}
 	if packet.Error != 0 {

--- a/pkg/snmp/gosnmplib/gosnmp_utils_test.go
+++ b/pkg/snmp/gosnmplib/gosnmp_utils_test.go
@@ -34,7 +34,7 @@ func TestPacketToString(t *testing.T) {
 					},
 				},
 			},
-			expectedStr: "error=NoError(code:0, idx:0), values=[{\"oid\":\"1.3.6.1.2.1.1.2.0\",\"type\":\"ObjectIdentifier\",\"value\":\"1.3.6.1.4.1.3375.2.1.3.4.1\"},{\"oid\":\"1.3.6.1.2.1.1.3.0\",\"type\":\"Counter32\",\"value\":\"10\"}]",
+			expectedStr: `{"1.3.6.1.2.1.1.2.0":"ObjectIdentifier(1.3.6.1.4.1.3375.2.1.3.4.1)","1.3.6.1.2.1.1.3.0":"Counter32(10)"}`,
 		},
 		{
 			name: "invalid ipaddr",
@@ -47,7 +47,7 @@ func TestPacketToString(t *testing.T) {
 					},
 				},
 			},
-			expectedStr: "error=NoError(code:0, idx:0), values=[{\"oid\":\"1.3.6.1.2.1.1.2.0\",\"type\":\"IPAddress\",\"value\":\"10\",\"parse_err\":\"`oid 1.3.6.1.2.1.1.2.0: IPAddress should be string type but got type `int` and value `10``\"}]",
+			expectedStr: "{\"1.3.6.1.2.1.1.2.0\":\"(Unparseable IPAddress: oid 1.3.6.1.2.1.1.2.0: IPAddress should be string type but got type `int` and value `10`)\"}",
 		},
 		{
 			name:        "nil packet loglevel",


### PR DESCRIPTION
### What does this PR do?

This PR makes three changes aimed at reducing the volume of logs generated in debug mode.
1. We log SNMP values in a more compact fashion, e.g. `"1.2.3.4":"Counter(5)"` instead of `{"oid":"1.2.3.4", "type":"Counter", "value":"5"}`
2. We only log actual values when TRACE-level debugging is enabled.
3. In various places where we loop over all OIDs provided by a profile, we now log any missing OIDs once at the end of the loop instead of emitting one log line per missing OID.

### Motivation
For an agent monitoring a few dozen devices, running in debug mode can currently generate more than 1MB of logs per second; since the amount of disk storage allocated for logs is finite, this frequently means that a debug flare for an SNMP-heavy agent may contain 80MB of logs yet only have about one minute of log data.

In one flare, the `GetBulk results` and `fetched values` log lines alone accounted for more than 75% of all log data; simply moving those to trace will greatly extend the amount of useful logging data.

Roughly half of the remaining volume of logs came from the logging of missing OIDs, which is generally not indicative of an actual problem (it most commonly comes from profiles that include OIDs that the target device *might* expose, but which can safely be skipped if the device isn't configured to expose them). Consolidating these somewhat reduces the total volume just by collapsing long stretches like
```
2026-01-10 13:24:15 EDT | CORE | DEBUG | (pkg/collector/corechecks/snmp/internal/report/report_metrics.go:143 in reportColumnMetrics) | report column: error getting column value: value for Column OID `1.3.6.1.4.1.20.1` not found in results
2026-01-10 13:24:15 EDT | CORE | DEBUG | (pkg/collector/corechecks/snmp/internal/report/report_metrics.go:143 in reportColumnMetrics) | report column: error getting column value: value for Column OID `1.3.6.1.4.1.20.2` not found in results
2026-01-10 13:24:15 EDT | CORE | DEBUG | (pkg/collector/corechecks/snmp/internal/report/report_metrics.go:143 in reportColumnMetrics) | report column: error getting column value: value for Column OID `1.3.6.1.4.1.20.3` not found in results
2026-01-10 13:24:15 EDT | CORE | DEBUG | (pkg/collector/corechecks/snmp/internal/report/report_metrics.go:143 in reportColumnMetrics) | report column: error getting column value: value for Column OID `1.3.6.1.4.1.20.4` not found in results
2026-01-10 13:24:15 EDT | CORE | DEBUG | (pkg/collector/corechecks/snmp/internal/report/report_metrics.go:143 in reportColumnMetrics) | report column: error getting column value: value for Column OID `1.3.6.1.4.1.20.5` not found in results
...
```
into a single log statement.

### Describe how you validated your changes

Unit and local testing; I did not test this against an agent monitoring dozens of devices to precisely measure the reduction in log size.
