### PR TITLE
[ABLD-387] Normalize `//go:generate` directives: `stringer`

### DIFF
--- a/pkg/gpu/cuda/cubin.go
+++ b/pkg/gpu/cuda/cubin.go
@@ -4,7 +4,7 @@
 // Copyright 2024-present Datadog, Inc.
 
 // Generate String() methods for nvInfoAttr,nvInfoFormat enums so they can be printed in logs/error messages
-//go:generate go run golang.org/x/tools/cmd/stringer@latest -output cubin_string.go -type=nvInfoAttr,nvInfoFormat -linecomment
+//go:generate go run golang.org/x/tools/cmd/stringer -output cubin_string.go -type=nvInfoAttr,nvInfoFormat -linecomment
 
 package cuda
 

--- a/pkg/gpu/cuda/cubin_string.go
+++ b/pkg/gpu/cuda/cubin_string.go
@@ -80,10 +80,11 @@ const _nvInfoAttr_name = "nviAttrErrornviAttrPadnviAttrImageSlotnviAttrJumptable
 var _nvInfoAttr_index = [...]uint16{0, 12, 22, 38, 60, 77, 94, 112, 128, 152, 170, 187, 210, 234, 250, 271, 285, 299, 315, 334, 365, 392, 418, 444, 461, 481, 502, 523, 541, 564, 591, 610, 631, 650, 672, 690, 709, 723, 752, 775, 801, 829, 854, 873, 888, 910, 940, 968, 983, 1002, 1032, 1052, 1069, 1097, 1116, 1128, 1149, 1168, 1195, 1226, 1251, 1279, 1299, 1321, 1342, 1360}
 
 func (i nvInfoAttr) String() string {
-	if i >= nvInfoAttr(len(_nvInfoAttr_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_nvInfoAttr_index)-1 {
 		return "nvInfoAttr(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _nvInfoAttr_name[_nvInfoAttr_index[i]:_nvInfoAttr_index[i+1]]
+	return _nvInfoAttr_name[_nvInfoAttr_index[idx]:_nvInfoAttr_index[idx+1]]
 }
 func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
@@ -100,9 +101,9 @@ const _nvInfoFormat_name = "nviFmtNonenviFmtBvalnviFmtHvalnviFmtSval"
 var _nvInfoFormat_index = [...]uint8{0, 10, 20, 30, 40}
 
 func (i nvInfoFormat) String() string {
-	i -= 1
-	if i >= nvInfoFormat(len(_nvInfoFormat_index)-1) {
-		return "nvInfoFormat(" + strconv.FormatInt(int64(i+1), 10) + ")"
+	idx := int(i) - 1
+	if i < 1 || idx >= len(_nvInfoFormat_index)-1 {
+		return "nvInfoFormat(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _nvInfoFormat_name[_nvInfoFormat_index[i]:_nvInfoFormat_index[i+1]]
+	return _nvInfoFormat_name[_nvInfoFormat_index[idx]:_nvInfoFormat_index[idx+1]]
 }

--- a/pkg/gpu/cuda/fatbin.go
+++ b/pkg/gpu/cuda/fatbin.go
@@ -11,7 +11,7 @@
 // - https://datadoghq.atlassian.net/wiki/spaces/EBPFTEAM/pages/4084204125/Fatbin+Cubin+binary+format
 
 // Generate String() methods for fatbinDataKind enums so they can be printed in logs/error messages
-//go:generate go run golang.org/x/tools/cmd/stringer@latest -output fatbin_string.go -type=fatbinDataKind -linecomment
+//go:generate go run golang.org/x/tools/cmd/stringer -output fatbin_string.go -type=fatbinDataKind -linecomment
 
 // Package cuda provides helpers for CUDA binary parsing
 package cuda

--- a/pkg/gpu/cuda/fatbin_string.go
+++ b/pkg/gpu/cuda/fatbin_string.go
@@ -17,9 +17,9 @@ const _fatbinDataKind_name = "fatbinDataKindPtxfatbinDataKindSm"
 var _fatbinDataKind_index = [...]uint8{0, 17, 33}
 
 func (i fatbinDataKind) String() string {
-	i -= 1
-	if i >= fatbinDataKind(len(_fatbinDataKind_index)-1) {
-		return "fatbinDataKind(" + strconv.FormatInt(int64(i+1), 10) + ")"
+	idx := int(i) - 1
+	if i < 1 || idx >= len(_fatbinDataKind_index)-1 {
+		return "fatbinDataKind(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _fatbinDataKind_name[_fatbinDataKind_index[i]:_fatbinDataKind_index[i+1]]
+	return _fatbinDataKind_name[_fatbinDataKind_index[idx]:_fatbinDataKind_index[idx+1]]
 }

--- a/pkg/gpu/ebpf/kprobe_types.go
+++ b/pkg/gpu/ebpf/kprobe_types.go
@@ -5,7 +5,7 @@
 
 //go:build ignore || generate
 
-//go:generate go run golang.org/x/tools/cmd/stringer@latest -output kprobe_types_string_linux.go -type=CudaEventType -linecomment
+//go:generate go run golang.org/x/tools/cmd/stringer -output kprobe_types_string_linux.go -type=CudaEventType -linecomment
 
 package ebpf
 

--- a/pkg/gpu/ebpf/kprobe_types_string_linux.go
+++ b/pkg/gpu/ebpf/kprobe_types_string_linux.go
@@ -22,8 +22,9 @@ const _CudaEventType_name = "CudaEventTypeKernelLaunchCudaEventTypeMemoryCudaEve
 var _CudaEventType_index = [...]uint8{0, 25, 44, 61, 83, 113, 136, 154}
 
 func (i CudaEventType) String() string {
-	if i >= CudaEventType(len(_CudaEventType_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_CudaEventType_index)-1 {
 		return "CudaEventType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _CudaEventType_name[_CudaEventType_index[i]:_CudaEventType_index[i+1]]
+	return _CudaEventType_name[_CudaEventType_index[idx]:_CudaEventType_index[idx+1]]
 }

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:generate go run golang.org/x/tools/cmd/stringer@latest -output event_common_string.go -type=ConnectionType,ConnectionFamily,ConnectionDirection,EphemeralPortType -linecomment
+//go:generate go run golang.org/x/tools/cmd/stringer -output event_common_string.go -type=ConnectionType,ConnectionFamily,ConnectionDirection,EphemeralPortType -linecomment
 
 package network
 

--- a/pkg/network/event_common_string.go
+++ b/pkg/network/event_common_string.go
@@ -17,10 +17,11 @@ const _ConnectionType_name = "TCPUDP"
 var _ConnectionType_index = [...]uint8{0, 3, 6}
 
 func (i ConnectionType) String() string {
-	if i >= ConnectionType(len(_ConnectionType_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_ConnectionType_index)-1 {
 		return "ConnectionType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _ConnectionType_name[_ConnectionType_index[i]:_ConnectionType_index[i+1]]
+	return _ConnectionType_name[_ConnectionType_index[idx]:_ConnectionType_index[idx+1]]
 }
 func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
@@ -35,31 +36,33 @@ const _ConnectionFamily_name = "v4v6"
 var _ConnectionFamily_index = [...]uint8{0, 2, 4}
 
 func (i ConnectionFamily) String() string {
-	if i >= ConnectionFamily(len(_ConnectionFamily_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_ConnectionFamily_index)-1 {
 		return "ConnectionFamily(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _ConnectionFamily_name[_ConnectionFamily_index[i]:_ConnectionFamily_index[i+1]]
+	return _ConnectionFamily_name[_ConnectionFamily_index[idx]:_ConnectionFamily_index[idx+1]]
 }
 func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
+	_ = x[UNKNOWN-0]
 	_ = x[INCOMING-1]
 	_ = x[OUTGOING-2]
 	_ = x[LOCAL-3]
 	_ = x[NONE-4]
 }
 
-const _ConnectionDirection_name = "incomingoutgoinglocalnone"
+const _ConnectionDirection_name = "UNKNOWNincomingoutgoinglocalnone"
 
-var _ConnectionDirection_index = [...]uint8{0, 8, 16, 21, 25}
+var _ConnectionDirection_index = [...]uint8{0, 7, 15, 23, 28, 32}
 
 func (i ConnectionDirection) String() string {
-	i -= 1
-	if i >= ConnectionDirection(len(_ConnectionDirection_index)-1) {
-		return "ConnectionDirection(" + strconv.FormatInt(int64(i+1), 10) + ")"
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_ConnectionDirection_index)-1 {
+		return "ConnectionDirection(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _ConnectionDirection_name[_ConnectionDirection_index[i]:_ConnectionDirection_index[i+1]]
+	return _ConnectionDirection_name[_ConnectionDirection_index[idx]:_ConnectionDirection_index[idx+1]]
 }
 func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
@@ -75,8 +78,9 @@ const _EphemeralPortType_name = "unspecifiedephemeralnot ephemeral"
 var _EphemeralPortType_index = [...]uint8{0, 11, 20, 33}
 
 func (i EphemeralPortType) String() string {
-	if i >= EphemeralPortType(len(_EphemeralPortType_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_EphemeralPortType_index)-1 {
 		return "EphemeralPortType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _EphemeralPortType_name[_EphemeralPortType_index[i]:_EphemeralPortType_index[i+1]]
+	return _EphemeralPortType_name[_EphemeralPortType_index[idx]:_EphemeralPortType_index[idx+1]]
 }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:generate stringer -type=HashState -linecomment -output model_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=HashState -linecomment -output model_string.go
 
 // Package model holds model related files
 package model

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:generate stringer -type=HashState -linecomment -output model_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type=HashState -linecomment -output model_string.go
 
 // Package model holds model related files
 package model

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -522,17 +522,15 @@ def generate_cws_documentation(ctx):
 @task
 def cws_go_generate(ctx, verbose=False):
     # run different `go generate` for pkg/security/secl and pkg/security
-    ctx.run("go install golang.org/x/tools/cmd/stringer")
     ctx.run("go install github.com/mailru/easyjson/easyjson")
     ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/generators/accessors")
     ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/generators/event_deep_copy")
     ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/generators/operators")
     with ctx.cd("./pkg/security/secl"):
         if sys.platform == "linux":
-            ctx.run("GOOS=windows go generate ./...")
-        # Disable cross generation from windows for now. Need to fix the stringer issue.
-        # elif sys.platform == "win32":
-        #     ctx.run("set GOOS=linux && go generate ./...")
+            ctx.run("GOOS=windows go generate -run=-tag.+windows ./...")
+        elif is_windows:
+            ctx.run('set "GOOS=linux" && go generate -run=-tag.+unix ./...')
         cmd = "go generate"
         if verbose:
             cmd += " -v"


### PR DESCRIPTION
### What does this PR do?
1. replace bare `stringer` and `go run .../stringer@latest` with `go run golang.org/x/tools/cmd/stringer` (no version suffix) in all `//go:generate` directives across the repo except `pkg/template/` (see notes)
    - => apply `go generate` changes resulting from the version alignment (see golang/tools#597 for diffs),
2. drop `go install golang.org/x/tools/cmd/stringer` from `cws_go_generate`
    - => scope the `GOOS` cross-gen pass with `-run=-tag.+<os>`, matching only directives that carry a platform-specific `-tags` argument (i.e. not `stringer`),
    - => enable the previously disabled Windows -> Linux cross-gen pass with the same scope,

### Motivation
Three styles coexisted:
1. bare `stringer`: depends on whatever binary is in `$PATH`, not tied to the version in `go.mod`,
2. `go run .../stringer@latest`: non-reproducible, may silently upgrade `stringer` on every invocation,
3. `go run golang.org/x/tools/cmd/stringer`: resolved from `go.mod` via the `go.work` workspace (currently v0.44.0).

The third form is strictly preferable: it is **reproducible** and follows the version already **pinned** in `go.mod`.

The cross-gen scoping is its direct consequence: `go run stringer` under a foreign `GOOS` may cross-compile the tool for that OS, potentially producing an incompatible binary.
The Windows -> Linux pass was disabled exactly because bare `stringer` in `model.go` triggered this failure, whereas `accessors` and `event_deep_copy` are pre-installed binaries that tolerate a foreign `GOOS`.
The `-tag.+<os>` filter is more future-proof than a tool-name whitelist: it matches any directive that targets a specific platform and excludes platform-agnostic generators (`operators`, `stringer`) regardless of how many are added later.

### Describe how you validated your changes
Ran `dda inv security-agent.cws-go-generate` on Linux and Windows.

### Additional Notes
`pkg/template/` is a **vendored** + patched copy of the Go stdlib `html/template` and `text/template` packages; its directives are kept verbatim.