### PR TITLE
[PROF-14303] fix: add compilation tag to remove unneeded imports

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -77,6 +77,7 @@ ALL_TAGS = {
     "zstd",
     "cel",
     "cws_instrumentation_injector_only",  # used for building cws-instrumentation with only the injector code
+    "remove_all_sd",  # remove all discovery provider from prometheusreceiver components 
 }.union(COMMON_TAGS)
 
 ### Tag inclusion lists
@@ -254,7 +255,9 @@ OTEL_AGENT_TAGS = {"otlp", "zlib", "zstd", "kubelet"}
 
 LOADER_TAGS = set()
 
-HOST_PROFILER_TAGS = set()
+# We need to remove all discovery provider from prometheusreceiver components to avoid loading too many dependencies in the host-profiler binary.
+# imported by https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/f963ab53ee55aeb56d58617ed12c840e8b07cc53/receiver/prometheusreceiver/factory.go#L10
+HOST_PROFILER_TAGS = {"remove_all_sd"}
 
 PRIVATEACTIONRUNNER_TAGS = set()
 

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -77,7 +77,7 @@ ALL_TAGS = {
     "zstd",
     "cel",
     "cws_instrumentation_injector_only",  # used for building cws-instrumentation with only the injector code
-    "remove_all_sd",  # remove all discovery provider from prometheusreceiver components 
+    "remove_all_sd",  # remove all discovery provider from prometheusreceiver components
 }.union(COMMON_TAGS)
 
 ### Tag inclusion lists

--- a/tools/host-profiler/build_and_launch.sh
+++ b/tools/host-profiler/build_and_launch.sh
@@ -7,7 +7,7 @@ if [ "${DO_NOT_START_PROFILER}" = "1" ]; then
     sleep infinity
 else
     mkdir -p bin/host-profiler
-    go build -ldflags="-X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=docker-dev" \
+    go build -tags "remove_all_sd" -ldflags="-X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=docker-dev" \
       -o bin/host-profiler/host-profiler ./cmd/host-profiler
 
     # Launch the profiler


### PR DESCRIPTION
### What does this PR do?

Add a compilation tag to remove unneeded imports by `prometheusreceiver`

### Motivation
We observed an increase in the host-profiler binary size.

Documented here:
https://ddstaging.datadoghq.com/notebook/14306483/increased-memory-usage-by-the-profiler?cell_id=a5ud1gfy&refresh_mode=sliding&utc_override=false&from_ts=1776068860423&to_ts=1776673660423#packages

### Describe how you validated your changes

On amd64.
Before : 268.4MiB
After: 204.5MiB

### Additional Notes
