### PR TITLE
[ABLD-387] Normalize `//go:generate` directives: `mockgen`

### DIFF
--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -44,7 +44,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
-//go:generate mockgen -source=$GOFILE -package=$GOPACKAGE -destination=epforwarder_mockgen.go
+//go:generate go run github.com/golang/mock/mockgen -source=$GOFILE -package=$GOPACKAGE -destination=epforwarder_mockgen.go
 
 // Module defines the fx options for this component.
 func Module(params Params) fxutil.Module {

--- a/pkg/databasemonitoring/aws/client.go
+++ b/pkg/databasemonitoring/aws/client.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 )
 
-//go:generate mockgen -source=$GOFILE -package=$GOPACKAGE -destination=rdsclient_mockgen.go
+//go:generate go run github.com/golang/mock/mockgen -source=$GOFILE -package=$GOPACKAGE -destination=rdsclient_mockgen.go
 
 // RdsClient is the interface for describing cluster and instance endpoints
 type RdsClient interface {

--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -25,14 +25,8 @@ TOOL_LIST = [
     'github.com/aarzilli/whydeadcode',
 ]
 
-# TODO(agent-build): replace `//go:generate mockgen` by `//go:generate go run github.com/golang/mock/mockgen` to remove:
-TOOL_LIST_PROTO = [
-    'github.com/golang/mock/mockgen',
-]
-
 TOOLS = {
     'internal/tools': TOOL_LIST,
-    'internal/tools/proto': TOOL_LIST_PROTO,
 }
 
 


### PR DESCRIPTION
### What does this PR do?
Replace bare `mockgen` with `go run github.com/golang/mock/mockgen` in all `//go:generate` directives across the repo.

### Motivation
Two forms are possible:
1. bare `mockgen`: depends on whatever binary is in PATH, not tied to the version in `go.mod`,
2. `go run github.com/golang/mock/mockgen`: resolved from `go.mod` via the `go.work` workspace (currently v1.7.0-rc.1).

The second form is strictly preferable: it is reproducible and follows the version already pinned in `go.mod`.

### Additional Notes
Removes `TOOL_LIST_PROTO` and the associated TODO from `tasks/install_tasks.py`, as `mockgen` no longer needs to be pre-installed.
Further cleanups will follow.