### PR TITLE
Restore DMG signing to release tag pipelines

### DIFF
--- a/.gitlab/build/package_build/dmg.yml
+++ b/.gitlab/build/package_build/dmg.yml
@@ -29,6 +29,9 @@
      - if: $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
        variables:
          SIGN: true  # for `main` and release branches
+     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
+       variables:
+         SIGN: true  # for release and RC tags (CI_COMMIT_BRANCH is unset on tag pipelines)
      - if: $CI_COMMIT_BRANCH =~ /notarization/
        variables:
          SIGN: true  # for branches with "notarization" in their name - should we need to tune it

--- a/releasenotes/notes/fix-macos-signing-tag-pipelines-6cea28668537403a.yaml
+++ b/releasenotes/notes/fix-macos-signing-tag-pipelines-6cea28668537403a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix missing signature on macOS Agent packages


### PR DESCRIPTION
### What does this PR do?

Fixes a regression in signing, where release-tagged Gitlab pipelines were not applying signing on macos.

### Motivation

Issue with signing detected during 7.79.0 release cycle.

### Describe how you validated your changes

### Additional Notes
