### PR TITLE
e2e: retry stack on Azure AKS route table not found

### DIFF
--- a/test/e2e-framework/testing/utils/infra/retriable_errors.go
+++ b/test/e2e-framework/testing/utils/infra/retriable_errors.go
@@ -86,5 +86,10 @@ func getKnownErrors() []knownError {
 			retryType:    ReCreate,
 			maxRetry:     stackUpMaxRetry,
 		},
+		{
+			errorMessage: `Failed to get route table object .+ from resource group`,
+			retryType:    ReCreate,
+			maxRetry:     stackUpMaxRetry,
+		},
 	}
 }

--- a/test/e2e-framework/testing/utils/infra/stack_manager_test.go
+++ b/test/e2e-framework/testing/utils/infra/stack_manager_test.go
@@ -334,6 +334,11 @@ func TestStackManager(t *testing.T) {
 				errMessage:        "waiting for ECS Service (arn:aws:ecs:us-east-1:669783387624:service/fakeintake-ecs/ci-633219896-4670-e2e-dockersuite-80f62edf7bcc6194-aws-fakeintake-dockervm-srv) create: timeout while waiting for state to become 'tfSTABLE' (last state: 'tfPENDING', timeout: 20m0s)",
 				expectedRetryType: ReCreate,
 			},
+			{
+				name:              "azure-aks-route-table-not-found",
+				errMessage:        "Failed to get route table object aks-agentpool-11552782-routetable from resource group MC_dd-agent-qa_ci-1610150873-4670-e2e-ssisuite-3ee33dbd6447d70c-aks-aks_westus2.",
+				expectedRetryType: ReCreate,
+			},
 		}
 
 		for _, te := range testErrors {


### PR DESCRIPTION
## Summary
- Add the Azure AKS "Failed to get route table object ... from resource group ..." error to the list of retriable errors that trigger a full destroy + recreate of the Pulumi stack.
- Add a matching unit test case in `stack_manager_test.go`.

Azure occasionally fails AKS cluster creation with this error while the route table object for the managed cluster's agentpool is not yet visible. Recreating the stack recovers. Confirmed in Datadog CI logs across multiple recent `new-e2e-ssi-aks` failures (e.g. job `1610150873` on 2026-04-20).

This is the smallest change that should let the AKS E2E job stabilize. If Azure keeps producing new failure modes here and this job stays flaky, we should revisit whether it can be made blocking.

## Test plan
- [x] `dda inv -- -e new-e2e-tests.run --module-name test/e2e-framework --targets ./testing/utils/infra --tags e2eunit` — all `TestStackManager` subtests pass locally, including `should-return-retry-strategy-on-retriable-errors` with the new `azure-aks-route-table-not-found` case.