### PR TITLE
[PROF-14304] Hook up host-profiler in datadog-agent repo binary size gates

### DIFF
--- a/.gitlab/build/binary_build/host_profiler.yml
+++ b/.gitlab/build/binary_build/host_profiler.yml
@@ -20,8 +20,12 @@
 
 build_host_profiler_binary_x64:
   extends: [.build_host_profiler_binary_common]
+  rules:
+    - when: on_success
   tags: ["arch:amd64", "specific:true"]
 
 build_host_profiler_binary_arm64:
   extends: [.build_host_profiler_binary_common]
+  rules:
+    - when: on_success
   tags: ["arch:arm64", "specific:true"]

--- a/.gitlab/build/binary_build/host_profiler.yml
+++ b/.gitlab/build/binary_build/host_profiler.yml
@@ -4,7 +4,6 @@
   stage: binary_build
   timeout: 25m
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   script:
     - !reference [.retrieve_linux_go_deps]
@@ -20,12 +19,8 @@
 
 build_host_profiler_binary_x64:
   extends: [.build_host_profiler_binary_common]
-  rules:
-    - when: on_success
   tags: ["arch:amd64", "specific:true"]
 
 build_host_profiler_binary_arm64:
   extends: [.build_host_profiler_binary_common]
-  rules:
-    - when: on_success
   tags: ["arch:arm64", "specific:true"]

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -279,9 +279,13 @@ docker_build_fips_agent7_arm64_jmx:
 
 docker_build_base_image_amd64:
   extends: [.docker_build_base_image, .docker_build_amd64]
+  rules:
+    - when: on_success
 
 docker_build_base_image_arm64:
   extends: [.docker_build_base_image, .docker_build_arm64]
+  rules:
+    - when: on_success
 
 .docker_build_host_profiler_standalone:
   extends: .docker_build_job_definition
@@ -302,6 +306,8 @@ docker_build_base_image_arm64:
 docker_build_host_profiler_standalone_amd64:
   extends:
     [.docker_build_host_profiler_standalone, .docker_build_amd64]
+  rules:
+    - when: on_success
   needs:
     - job: docker_build_base_image_amd64
     - job: build_host_profiler_binary_x64
@@ -311,6 +317,8 @@ docker_build_host_profiler_standalone_amd64:
 docker_build_host_profiler_standalone_arm64:
   extends:
     [.docker_build_host_profiler_standalone, .docker_build_arm64]
+  rules:
+    - when: on_success
   needs:
     - job: docker_build_base_image_arm64
     - job: build_host_profiler_binary_arm64

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -305,6 +305,8 @@ docker_build_host_profiler_standalone_amd64:
   needs:
     - job: docker_build_base_image_amd64
     - job: build_host_profiler_binary_x64
+  variables:
+    STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_host_profiler_amd64"
 
 docker_build_host_profiler_standalone_arm64:
   extends:
@@ -312,6 +314,8 @@ docker_build_host_profiler_standalone_arm64:
   needs:
     - job: docker_build_base_image_arm64
     - job: build_host_profiler_binary_arm64
+  variables:
+    STATIC_QUALITY_GATE_NAME: "static_quality_gate_docker_host_profiler_arm64"
 
 .docker_build_ot_agent_standalone:
   extends: .docker_build_job_definition

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -268,7 +268,6 @@ docker_build_fips_agent7_arm64_jmx:
 .docker_build_base_image:
   extends: .docker_build_job_definition
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   needs: []
   variables:
@@ -279,13 +278,9 @@ docker_build_fips_agent7_arm64_jmx:
 
 docker_build_base_image_amd64:
   extends: [.docker_build_base_image, .docker_build_amd64]
-  rules:
-    - when: on_success
 
 docker_build_base_image_arm64:
   extends: [.docker_build_base_image, .docker_build_arm64]
-  rules:
-    - when: on_success
 
 .docker_build_host_profiler_standalone:
   extends: .docker_build_job_definition
@@ -294,7 +289,6 @@ docker_build_base_image_arm64:
     - cp cmd/host-profiler/dist/host-profiler-config.yaml $BUILD_CONTEXT/
     - ls -l $BUILD_CONTEXT/
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/ddot-ebpf
@@ -306,8 +300,6 @@ docker_build_base_image_arm64:
 docker_build_host_profiler_standalone_amd64:
   extends:
     [.docker_build_host_profiler_standalone, .docker_build_amd64]
-  rules:
-    - when: on_success
   needs:
     - job: docker_build_base_image_amd64
     - job: build_host_profiler_binary_x64
@@ -317,8 +309,6 @@ docker_build_host_profiler_standalone_amd64:
 docker_build_host_profiler_standalone_arm64:
   extends:
     [.docker_build_host_profiler_standalone, .docker_build_arm64]
-  rules:
-    - when: on_success
   needs:
     - job: docker_build_base_image_arm64
     - job: build_host_profiler_binary_arm64

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -38,6 +38,8 @@ static_quality_gates:
     - docker_build_cws_instrumentation_arm64
     - docker_build_dogstatsd_amd64
     - docker_build_dogstatsd_arm64
+    - docker_build_host_profiler_standalone_amd64
+    - docker_build_host_profiler_standalone_arm64
     - dogstatsd_deb-x64
     - dogstatsd_deb-arm64
     - dogstatsd_rpm-x64

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -38,10 +38,8 @@ static_quality_gates:
     - docker_build_cws_instrumentation_arm64
     - docker_build_dogstatsd_amd64
     - docker_build_dogstatsd_arm64
-    - job: docker_build_host_profiler_standalone_amd64
-      optional: true
-    - job: docker_build_host_profiler_standalone_arm64
-      optional: true
+    - docker_build_host_profiler_standalone_amd64
+    - docker_build_host_profiler_standalone_arm64
     - dogstatsd_deb-x64
     - dogstatsd_deb-arm64
     - dogstatsd_rpm-x64

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -38,8 +38,10 @@ static_quality_gates:
     - docker_build_cws_instrumentation_arm64
     - docker_build_dogstatsd_amd64
     - docker_build_dogstatsd_arm64
-    - docker_build_host_profiler_standalone_amd64
-    - docker_build_host_profiler_standalone_arm64
+    - job: docker_build_host_profiler_standalone_amd64
+      optional: true
+    - job: docker_build_host_profiler_standalone_arm64
+      optional: true
     - dogstatsd_deb-x64
     - dogstatsd_deb-arm64
     - dogstatsd_rpm-x64

--- a/tasks/static_quality_gates/gates.py
+++ b/tasks/static_quality_gates/gates.py
@@ -361,7 +361,9 @@ class DockerArtifactMeasurer:
         Generate Docker image URL based on gate configuration.
         """
         # Extract flavor from gate name
-        if "cluster" in config.gate_name:
+        if "host_profiler" in config.gate_name:
+            flavor = "ddot-ebpf"
+        elif "cluster" in config.gate_name:
             flavor = "cluster-agent"
         elif "dogstatsd" in config.gate_name:
             flavor = "dogstatsd"
@@ -376,7 +378,8 @@ class DockerArtifactMeasurer:
         jmx = "-jmx" if "jmx" in config.gate_name else ""
 
         # Handle image suffix
-        image_suffix = ("-7" if flavor == "agent" else "") + jmx
+        # ddot-ebpf uses TAG_SUFFIX: -7 in its CI build job, same as agent
+        image_suffix = ("-7" if flavor in ("agent", "ddot-ebpf") else "") + jmx
 
         # Handle nightly builds
         if os.environ.get("BUCKET_BRANCH") == "nightly" and flavor != "dogstatsd":

--- a/tasks/unit_tests/static_quality_gates/gates_tests.py
+++ b/tasks/unit_tests/static_quality_gates/gates_tests.py
@@ -343,6 +343,14 @@ class TestDockerArtifactMeasurer(unittest.TestCase):
                 "static_quality_gate_docker_agent_jmx_amd64",
                 "registry.ddbuild.io/ci/datadog-agent/agent:v71580015-668844-7-jmx-amd64",
             ),
+            (
+                "static_quality_gate_docker_host_profiler_amd64",
+                "registry.ddbuild.io/ci/datadog-agent/ddot-ebpf:v71580015-668844-7-amd64",
+            ),
+            (
+                "static_quality_gate_docker_host_profiler_arm64",
+                "registry.ddbuild.io/ci/datadog-agent/ddot-ebpf:v71580015-668844-7-arm64",
+            ),
         ]
 
         for gate_name, expected_url in test_cases:
@@ -365,6 +373,10 @@ class TestDockerArtifactMeasurer(unittest.TestCase):
             (
                 "static_quality_gate_docker_cluster_amd64",
                 "registry.ddbuild.io/ci/datadog-agent/cluster-agent-nightly:v71580015-668844-amd64",
+            ),
+            (
+                "static_quality_gate_docker_host_profiler_amd64",
+                "registry.ddbuild.io/ci/datadog-agent/ddot-ebpf-nightly:v71580015-668844-7-amd64",
             ),
         ]
 

--- a/tasks/unit_tests/static_quality_gates_tests.py
+++ b/tasks/unit_tests/static_quality_gates_tests.py
@@ -397,6 +397,14 @@ class TestDockerArtifactMeasurer(unittest.TestCase):
                 "static_quality_gate_docker_agent_jmx_amd64",
                 "registry.ddbuild.io/ci/datadog-agent/agent:v71580015-668844-7-jmx-amd64",
             ),
+            (
+                "static_quality_gate_docker_host_profiler_amd64",
+                "registry.ddbuild.io/ci/datadog-agent/ddot-ebpf:v71580015-668844-7-amd64",
+            ),
+            (
+                "static_quality_gate_docker_host_profiler_arm64",
+                "registry.ddbuild.io/ci/datadog-agent/ddot-ebpf:v71580015-668844-7-arm64",
+            ),
         ]
 
         for gate_name, expected_url in test_cases:
@@ -419,6 +427,10 @@ class TestDockerArtifactMeasurer(unittest.TestCase):
             (
                 "static_quality_gate_docker_cluster_amd64",
                 "registry.ddbuild.io/ci/datadog-agent/cluster-agent-nightly:v71580015-668844-amd64",
+            ),
+            (
+                "static_quality_gate_docker_host_profiler_amd64",
+                "registry.ddbuild.io/ci/datadog-agent/ddot-ebpf-nightly:v71580015-668844-7-amd64",
             ),
         ]
 

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -58,6 +58,12 @@ static_quality_gate_docker_cws_instrumentation_amd64:
 static_quality_gate_docker_cws_instrumentation_arm64:
   max_on_disk_size: 6.92 MiB
   max_on_wire_size: 3.09 MiB
+static_quality_gate_docker_host_profiler_amd64:
+  max_on_disk_size: 500 MiB
+  max_on_wire_size: 200 MiB
+static_quality_gate_docker_host_profiler_arm64:
+  max_on_disk_size: 500 MiB
+  max_on_wire_size: 200 MiB
 static_quality_gate_docker_dogstatsd_amd64:
   max_on_disk_size: 39.54 MiB
   max_on_wire_size: 15.87 MiB

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -59,11 +59,11 @@ static_quality_gate_docker_cws_instrumentation_arm64:
   max_on_disk_size: 6.92 MiB
   max_on_wire_size: 3.09 MiB
 static_quality_gate_docker_host_profiler_amd64:
-  max_on_disk_size: 500 MiB
-  max_on_wire_size: 200 MiB
+  max_on_disk_size: 301.8 MiB
+  max_on_wire_size: 111.6 MiB
 static_quality_gate_docker_host_profiler_arm64:
-  max_on_disk_size: 500 MiB
-  max_on_wire_size: 200 MiB
+  max_on_disk_size: 313.4 MiB
+  max_on_wire_size: 106.0 MiB
 static_quality_gate_docker_dogstatsd_amd64:
   max_on_disk_size: 39.54 MiB
   max_on_wire_size: 15.87 MiB

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -59,11 +59,11 @@ static_quality_gate_docker_cws_instrumentation_arm64:
   max_on_disk_size: 6.92 MiB
   max_on_wire_size: 3.09 MiB
 static_quality_gate_docker_host_profiler_amd64:
-  max_on_disk_size: 301.8 MiB
-  max_on_wire_size: 111.6 MiB
+  max_on_disk_size: 315.8 MiB
+  max_on_wire_size: 125.6 MiB
 static_quality_gate_docker_host_profiler_arm64:
-  max_on_disk_size: 313.4 MiB
-  max_on_wire_size: 106.0 MiB
+  max_on_disk_size: 327.4 MiB
+  max_on_wire_size: 120.0 MiB
 static_quality_gate_docker_dogstatsd_amd64:
   max_on_disk_size: 39.54 MiB
   max_on_wire_size: 15.87 MiB


### PR DESCRIPTION
### What does this PR do?

This PR adds the `host-profiler` to the static gate check to monitor binary size changes.
Following a discussion between @Gandem and @dd-ddamien, we agreed to set the limit to +15MiB.

### Motivation

We observed some recent regressions in binary size, which we have tracked and documented here: https://ddstaging.datadoghq.com/notebook/14306483/increased-memory-usage-by-the-profiler?cell_id=a5ud1gfy&refresh_mode=sliding&utc_override=false&view=view-mode&from_ts=1776068860423&to_ts=1776673660423

### Describe how you validated your changes

### Additional Notes
