### PR TITLE
Allow running event gRPC server in system-probe

### DIFF
--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -264,12 +264,12 @@ func (rsa *RuntimeSecurityAgent) DispatchEvent(evt *api.SecurityEventMessage) {
 		if rsa.secInfoReporter == nil {
 			return
 		}
-		rsa.secInfoReporter.ReportRaw(evt.GetData(), evt.Service, evt.Timestamp.AsTime(), evt.GetTags()...)
+		rsa.secInfoReporter.ReportRaw(evt.GetData(), evt.Service, evt.GetHostname(), evt.Timestamp.AsTime(), evt.GetTags()...)
 	} else {
 		if rsa.reporter == nil {
 			return
 		}
-		rsa.reporter.ReportRaw(evt.GetData(), evt.Service, evt.Timestamp.AsTime(), evt.GetTags()...)
+		rsa.reporter.ReportRaw(evt.GetData(), evt.Service, evt.GetHostname(), evt.Timestamp.AsTime(), evt.GetTags()...)
 
 		log.Tracef("runtime message report : %s", string(evt.GetData()))
 	}

--- a/pkg/security/common/raw_reporter.go
+++ b/pkg/security/common/raw_reporter.go
@@ -9,5 +9,5 @@ import "time"
 
 // RawReporter defines an interface for reporting raw rule events
 type RawReporter interface {
-	ReportRaw(content []byte, service string, timestamp time.Time, tags ...string)
+	ReportRaw(content []byte, service string, hostname string, timestamp time.Time, tags ...string)
 }

--- a/pkg/security/module/client.go
+++ b/pkg/security/module/client.go
@@ -65,7 +65,7 @@ func (c *SecurityAgentAPIClient) logConnectError(err error) {
 // SendEvents sends events to the security agent
 func (c *SecurityAgentAPIClient) SendEvents(ctx context.Context, msgs chan *api.SecurityEventMessage, onConnectCb func()) {
 	for {
-		seclog.Trace("connecting to security agent event grpc server")
+		seclog.Debugf("connecting to security agent event grpc server")
 
 		stream, err := c.SecurityAgentAPIClient.SendEvent(context.Background())
 		if err != nil {

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -204,8 +204,20 @@ func NewCWSConsumer(cmdServer *CommandServer, evm *eventmonitor.EventMonitor, cf
 	seclog.Debugf("Registering API server")
 	api.RegisterSecurityModuleCmdServer(c.cmdServer.grpcCmdServer.ServiceRegistrar(), c.apiServer)
 
-	if cfg.EventGRPCServer != "security-agent" {
-		seclog.Infof("start security module event grpc server with %s", cfg.SocketPath)
+	switch cfg.EventGRPCServer {
+	case "security-agent":
+		// system-probe connects to security-agent's event server; no local server needed here
+	case "system-probe":
+		// system-probe acts as the event server for remote system-probes (e.g., in micro VMs via vsock)
+		seclog.Infof("starting system-probe remote event server on %s", cfg.SocketPath)
+
+		family, addr := socket.GetSocketAddress(cfg.SocketPath)
+		c.grpcEventServer = grpcutils.NewServer(family, addr)
+
+		api.RegisterSecurityAgentAPIServer(c.grpcEventServer.ServiceRegistrar(), NewRemoteEventServer(c.apiServer))
+	default:
+		// legacy mode: system-probe hosts SecurityModuleEvent server, security-agent connects
+		seclog.Infof("starting security module event grpc server on %s", cfg.SocketPath)
 
 		family := common.GetFamilyAddress(cfg.SocketPath)
 		c.grpcEventServer = grpcutils.NewServer(family, cfg.SocketPath)

--- a/pkg/security/module/msg_sender.go
+++ b/pkg/security/module/msg_sender.go
@@ -96,9 +96,9 @@ var _ EndpointsStatusFetcher = &DirectEventMsgSender{}
 // Send the message
 func (ds *DirectEventMsgSender) Send(msg *api.SecurityEventMessage, _ func(*api.SecurityEventMessage)) {
 	if msg.Track == string(common.SecInfo) {
-		ds.secInfoReporter.ReportRaw(msg.Data, msg.Service, msg.Timestamp.AsTime(), msg.Tags...)
+		ds.secInfoReporter.ReportRaw(msg.Data, msg.Service, msg.Hostname, msg.Timestamp.AsTime(), msg.Tags...)
 	} else {
-		ds.reporter.ReportRaw(msg.Data, msg.Service, msg.Timestamp.AsTime(), msg.Tags...)
+		ds.reporter.ReportRaw(msg.Data, msg.Service, msg.Hostname, msg.Timestamp.AsTime(), msg.Tags...)
 	}
 }
 

--- a/pkg/security/module/remote_event_server.go
+++ b/pkg/security/module/remote_event_server.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package module holds module related files
+package module
+
+import (
+	"io"
+
+	"google.golang.org/grpc"
+
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	empty "google.golang.org/protobuf/types/known/emptypb"
+)
+
+// RemoteEventServer implements the SecurityAgentAPI gRPC service in system-probe,
+// allowing remote system-probes (e.g., running in micro VMs) to connect via vsock
+// and forward their security events to the host system-probe for backend delivery.
+type RemoteEventServer struct {
+	api.UnimplementedSecurityAgentAPIServer
+
+	msgSender          EventMsgSender
+	activityDumpSender ActivityDumpMsgSender
+	expireEvent        func(*api.SecurityEventMessage)
+	expireDump         func(*api.ActivityDumpStreamMessage)
+}
+
+// NewRemoteEventServer returns a RemoteEventServer wired to the given APIServer's senders.
+func NewRemoteEventServer(apiServer *APIServer) *RemoteEventServer {
+	return &RemoteEventServer{
+		msgSender:          apiServer.msgSender,
+		activityDumpSender: apiServer.activityDumpSender,
+		expireEvent:        apiServer.expireEvent,
+		expireDump:         apiServer.expireDump,
+	}
+}
+
+// SendEvent receives security events from a remote system-probe and forwards them through the local pipeline.
+func (s *RemoteEventServer) SendEvent(stream grpc.ClientStreamingServer[api.SecurityEventMessage, empty.Empty]) error {
+	for {
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		seclog.Tracef("received remote event from rule `%s`", msg.RuleID)
+		s.msgSender.Send(msg, s.expireEvent)
+	}
+	return nil
+}
+
+// SendActivityDumpStream receives activity dumps from a remote system-probe and forwards them through the local pipeline.
+func (s *RemoteEventServer) SendActivityDumpStream(stream grpc.ClientStreamingServer[api.ActivityDumpStreamMessage, empty.Empty]) error {
+	for {
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		seclog.Tracef("received remote activity dump [%s]", msg.GetSelector())
+		s.activityDumpSender.Send(msg, s.expireDump)
+	}
+	return nil
+}

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -245,6 +245,7 @@ type APIServer struct {
 	stopper  startstop.Stopper
 	wg       sync.WaitGroup
 
+	hostname               string
 	securityAgentAPIClient *SecurityAgentAPIClient
 }
 
@@ -446,6 +447,7 @@ func (a *APIServer) start(ctx context.Context) {
 					Service:   msg.service,
 					Tags:      msg.tags,
 					Timestamp: timestamppb.New(msg.timestamp),
+					Hostname:  a.hostname,
 				}
 				a.updateMsgService(m)
 
@@ -933,10 +935,11 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 		connEstablished: atomic.NewBool(false),
 		envAsTags:       getEnvAsTags(cfg),
 		containerFilter: containerFilter,
+		hostname:        hostname,
 	}
 
-	if !cfg.SendPayloadsFromSystemProbe && cfg.EventGRPCServer == "security-agent" {
-		seclog.Infof("setting up security agent api client")
+	if !cfg.SendPayloadsFromSystemProbe && (cfg.EventGRPCServer == "security-agent" || cfg.EventGRPCServer == "system-probe") {
+		seclog.Infof("setting up runtime security agent api client")
 
 		securityAgentAPIClient, err := NewSecurityAgentAPIClient(cfg)
 		if err != nil {

--- a/pkg/security/proto/api/api.pb.go
+++ b/pkg/security/proto/api/api.pb.go
@@ -32,6 +32,7 @@ type SecurityEventMessage struct {
 	Timestamp      *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=Timestamp,proto3" json:"Timestamp,omitempty"`
 	OriginalRuleID string                 `protobuf:"bytes,6,opt,name=OriginalRuleID,proto3" json:"OriginalRuleID,omitempty"`
 	Track          string                 `protobuf:"bytes,7,opt,name=Track,proto3" json:"Track,omitempty"`
+	Hostname       string                 `protobuf:"bytes,8,opt,name=Hostname,proto3" json:"Hostname,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -111,6 +112,13 @@ func (x *SecurityEventMessage) GetOriginalRuleID() string {
 func (x *SecurityEventMessage) GetTrack() string {
 	if x != nil {
 		return x.Track
+	}
+	return ""
+}
+
+func (x *SecurityEventMessage) GetHostname() string {
+	if x != nil {
+		return x.Hostname
 	}
 	return ""
 }
@@ -3432,7 +3440,7 @@ var File_pkg_security_proto_api_api_proto protoreflect.FileDescriptor
 
 const file_pkg_security_proto_api_api_proto_rawDesc = "" +
 	"\n" +
-	" pkg/security/proto/api/api.proto\x12\x03api\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto\"\xe8\x01\n" +
+	" pkg/security/proto/api/api.proto\x12\x03api\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto\"\x84\x02\n" +
 	"\x14SecurityEventMessage\x12\x16\n" +
 	"\x06RuleID\x18\x01 \x01(\tR\x06RuleID\x12\x12\n" +
 	"\x04Data\x18\x02 \x01(\fR\x04Data\x12\x12\n" +
@@ -3440,7 +3448,8 @@ const file_pkg_security_proto_api_api_proto_rawDesc = "" +
 	"\aService\x18\x04 \x01(\tR\aService\x128\n" +
 	"\tTimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tTimestamp\x12&\n" +
 	"\x0eOriginalRuleID\x18\x06 \x01(\tR\x0eOriginalRuleID\x12\x14\n" +
-	"\x05Track\x18\a \x01(\tR\x05Track\"L\n" +
+	"\x05Track\x18\a \x01(\tR\x05Track\x12\x1a\n" +
+	"\bHostname\x18\b \x01(\tR\bHostname\"L\n" +
 	"\x16DumpProcessCacheParams\x12\x1a\n" +
 	"\bWithArgs\x18\x01 \x01(\bR\bWithArgs\x12\x16\n" +
 	"\x06Format\x18\x02 \x01(\tR\x06Format\"=\n" +

--- a/pkg/security/proto/api/api.proto
+++ b/pkg/security/proto/api/api.proto
@@ -14,6 +14,7 @@ message SecurityEventMessage {
     google.protobuf.Timestamp Timestamp = 5;
     string OriginalRuleID = 6;
     string Track = 7;
+    string Hostname = 8;
 }
 
 message DumpProcessCacheParams {

--- a/pkg/security/proto/api/api_vtproto.pb.go
+++ b/pkg/security/proto/api/api_vtproto.pb.go
@@ -49,6 +49,13 @@ func (m *SecurityEventMessage) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.Hostname) > 0 {
+		i -= len(m.Hostname)
+		copy(dAtA[i:], m.Hostname)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Hostname)))
+		i--
+		dAtA[i] = 0x42
+	}
 	if len(m.Track) > 0 {
 		i -= len(m.Track)
 		copy(dAtA[i:], m.Track)
@@ -3341,6 +3348,10 @@ func (m *SecurityEventMessage) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	l = len(m.Hostname)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -4852,6 +4863,38 @@ func (m *SecurityEventMessage) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Track = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Hostname", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Hostname = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/security/reporter/reporter.go
+++ b/pkg/security/reporter/reporter.go
@@ -30,13 +30,18 @@ type RuntimeReporter struct {
 	logChan   chan *message.Message
 }
 
-// ReportRaw reports raw (bytes) events to the intake
-func (r *RuntimeReporter) ReportRaw(content []byte, service string, timestamp time.Time, tags ...string) {
+// ReportRaw reports raw (bytes) events to the intake.
+// If hostname is empty, the reporter's default hostname is used.
+func (r *RuntimeReporter) ReportRaw(content []byte, service string, hostname string, timestamp time.Time, tags ...string) {
 	origin := message.NewOrigin(r.logSource)
 	origin.SetTags(tags)
 	origin.SetService(service)
 	msg := message.NewMessage(content, origin, message.StatusInfo, timestamp.UnixNano())
-	msg.Hostname = r.hostname
+	if hostname != "" {
+		msg.Hostname = hostname
+	} else {
+		msg.Hostname = r.hostname
+	}
 	r.logChan <- msg
 }
 


### PR DESCRIPTION
### What does this PR do?

Accept `runtime_security_config.event_grpc_server` to be set to `system-probe` to make the gRPC server run in system-probe instead of the security-agent.

### Motivation

Commit 48459e7e5a3aa7a3a889b09bee52ae16606805af change the order of the connection between security-agent and system-probe. Before this commit,         
security-agent would initiate the connection to system-probe. After this commit, this is - while optional - the contrary. system-probe initiates the    
connection, allowing multiple system-probe to connect to the same security-agent. It added a command server, to still be able to connect to system-probe
to make gRPC calls, while moving the event server to security-agent.                                                                                    
                                                                                                                                                        
Commit 19002ad3e94467409a48e019578f39e5f1370a4f added support for vsock. For this one to work, the event server needs to be running in security-agent. This is orthogonal to the runtime_security_config.direct_send_from_system_probe config flag, that allows system-probe to directly send events to the backend, without relying on the security-agent.

With this PR, system-probe can run the event gRPC server, relaying messages from a system-probe running in a microVM                                                                                                    

### Describe how you validated your changes

### Additional Notes
