### PR TITLE
Re-sign macOS binaries after install_name_tool rpath modifications

### DIFF
--- a/bazel/rules/rewrite_rpath/macos.sh
+++ b/bazel/rules/rewrite_rpath/macos.sh
@@ -24,3 +24,7 @@ ${OTOOL} -L "$OUTPUT" | tail -n +2 | awk '{print $1}' | while read -r dep; do
         install_name_tool -add_rpath "$PREFIX" "$dep" 2>/dev/null || true
     fi
 done
+
+# Re-sign with an ad-hoc signature after modification as install_name_tool invalidates
+# any existing code signature.
+codesign --sign - --force "$OUTPUT"

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -850,6 +850,8 @@ def rpath_edit(ctx, install_path, target_rpath_dd_folder, platform="linux"):
         file, file_type = line.split(":")
         file_type = file_type.strip()
 
+        modified = False
+
         if platform == "linux":
             if file_type not in ["application/x-executable", "inode/symlink", "application/x-sharedlib"]:
                 continue
@@ -869,15 +871,26 @@ def rpath_edit(ctx, install_path, target_rpath_dd_folder, platform="linux"):
             # if a dylib ID use our installation path we replace it with @rpath instead
             if install_path in dylib_id_paths:
                 _replace_dylib_id_paths_with_rpath(ctx, dylib_id_paths, install_path, file)
+                modified = True
 
             # if a dylib use our installation path we replace it with @rpath instead
             if install_path in dylib_paths:
                 _replace_dylib_paths_with_rpath(ctx, dylib_paths, install_path, file)
+                modified = True
 
         # if a binary has an rpath that use our installation path we are patching it
         if install_path in binary_rpath:
             new_rpath = os.path.relpath(target_rpath_dd_folder, os.path.dirname(file))
             _patch_binary_rpath(ctx, new_rpath, install_path, binary_rpath, platform, file)
+            modified = True
+
+        if modified and platform != "linux":
+            # Re-sign with an ad-hoc signature after install_name_tool modifications,
+            # which invalidate any existing code signature. On arm64 Macs, macOS
+            # enforces valid signatures at the kernel level (SIGKILL on tainted pages).
+            # When SIGN_MAC=true, the Developer ID signing in datadog-agent-finalize.rb
+            # overwrites these ad-hoc signatures afterward.
+            ctx.run(f"codesign --sign - --force {file}")
 
 
 @task

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -320,6 +320,7 @@ class TestRpathEdit(unittest.TestCase):
         self.mock_ctx.set_result_for(
             'run', 'install_name_tool -change some/path/somelib.dylib some/path/somelib.dylib some/file', Result()
         )
+        self.mock_ctx.set_result_for('run', 'codesign --sign - --force some/file', Result())
         omnibus.rpath_edit(self.mock_ctx, "some/path", "some/other/path", "macos")
         call_list = self.mock_ctx.run.mock_calls
         assert mock.call('find some/path -type f -exec file --mime-type \\{\\} \\+', hide=True) in call_list
@@ -336,8 +337,9 @@ class TestRpathEdit(unittest.TestCase):
             )
             in call_list
         )
+        assert mock.call('codesign --sign - --force some/file') in call_list
         # We can't assert regex based temporary name in calls, hence we're checking that we get the correct total number of calls
-        assert len(call_list) == 8
+        assert len(call_list) == 9
 
 
 class TestBuildRepackagedAgent(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **bazel/rules/rewrite_rpath/macos.sh**: Add `codesign --sign - --force` after `install_name_tool` modifications, matching the existing pattern in `bazel/rules/replace_prefix.sh`.
- **tasks/omnibus.py** (`rpath_edit`): Re-sign modified macOS Mach-O binaries after `install_name_tool` calls. When `SIGN_MAC=true`, the Developer ID signing in `datadog-agent-finalize.rb` overwrites these ad-hoc signatures.
- Follow up to https://github.com/DataDog/datadog-agent/pull/49608

## Context

The `dd_cc_packaged` migration (commits 7ee917af215, 5c6296f8239) moved rtloader, libdatadog-agent-three, and libpython to use `bazel/rules/rewrite_rpath/macos.sh`, which calls `install_name_tool` to set absolute install paths but does not re-sign afterward. This invalidates the linker-applied ad-hoc signatures. The omnibus `rpath-edit` task then converts those absolute paths to `@rpath`, also without re-signing.

On arm64 Macs, macOS enforces code signature validity at the kernel level — loading a dylib with an invalidated signature causes SIGKILL (`cs_invalid_page` with `tainted:1`). This means 7.79 DMG builds that aren't Developer ID signed (RC builds without `SIGN=true`, feature branch builds) produce binaries that crash immediately on launch.

This was not an issue in 7.78.x because those libraries used `so_symlink` which did not modify binary paths, leaving signatures intact.

This also fixes macOS DMG builds on feature branches, which don't get `SIGN=true` (no Developer ID signing). Without this fix, feature branch DMGs produce binaries with invalidated signatures that crash on launch. With this fix, all builds produce binaries with valid ad-hoc signatures regardless of whether Developer ID signing runs afterward.

## Test plan

- [x] Verify macOS DMG build produces binaries with valid signatures (`codesign --verify` passes on all dylibs)
- [x] Verify agent starts successfully after install from unsigned DMG
- [x] Verify feature branch CI DMG builds produce working binaries

https://datadoghq.atlassian.net/browse/WINA-2600

🤖 Generated with [Claude Code](https://claude.com/claude-code)