### PR TITLE
Run macOS install-script E2E on deploy pipelines

### DIFF
--- a/.gitlab/test/e2e_install_packages/macos.yml
+++ b/.gitlab/test/e2e_install_packages/macos.yml
@@ -7,7 +7,7 @@ new-e2e-agent-platform-install-script-macos-x64:
     - deploy_dmg_testing-a7_x64
   rules:
     - !reference [.except_disable_e2e_tests]
-    - !reference [.on_scheduled_main_on_success]
+    - !reference [.on_deploy]
     - !reference [.manual]
   variables:
     TARGETS: ./tests/agent-platform/tests


### PR DESCRIPTION
### What does this PR do?

Switches the `new-e2e-agent-platform-install-script-macos-x64` job in `.gitlab/test/e2e_install_packages/macos.yml` from `.on_scheduled_main_on_success` to `.on_deploy` so it runs on every deploy pipeline (nightly, beta/RC, and stable) rather than only nightly `main` pipelines.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-2599

### Describe how you validated your changes
Updates when job runs.

### Additional Notes

- No code or test logic changes — CI rule only.
- Keeps the existing `.except_disable_e2e_tests` and `.manual` fallbacks, so the job can still be skipped via `DISABLE_E2E_TESTS` and triggered manually on non-deploy pipelines when needed.