### PR TITLE
Rollback deployment functionality (#49416)

### DIFF
--- a/comp/logs-library/go.mod
+++ b/comp/logs-library/go.mod
@@ -32,7 +32,7 @@ require (
 require gopkg.in/yaml.v3 v3.0.1 // indirect
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.193 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/config v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.79.0-rc.1 // indirect

--- a/comp/logs-library/go.sum
+++ b/comp/logs-library/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/viper v1.15.1 h1:kcdFE+qPndlWkhU4iEf/WpWQMCyVYHTv5HqvVf+SYJs=
 github.com/DataDog/viper v1.15.1/go.mod h1:rDLDREOPd+gpEbA8y4Y/5wTvyLqvUiCmDXX0jRZy8mw=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=

--- a/comp/otelcol/collector-contrib/impl/go.mod
+++ b/comp/otelcol/collector-contrib/impl/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/Code-Hex/go-generics-cache v1.5.1 // indirect
-	github.com/DataDog/agent-payload/v5 v5.0.189 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.193 // indirect
 	github.com/DataDog/datadog-agent/comp/core/config v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.79.0-rc.1 // indirect

--- a/comp/otelcol/collector-contrib/impl/go.sum
+++ b/comp/otelcol/collector-contrib/impl/go.sum
@@ -35,8 +35,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Code-Hex/go-generics-cache v1.5.1 h1:6vhZGc5M7Y/YD8cIUcY8kcuQLB4cHR7U+0KMqAA0KcU=
 github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0 h1:HKcfvAODmJCUw7nfbDKKqkEUgcu7CfxUPA9EFRJrHEI=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/comp/otelcol/ddflareextension/impl/go.mod
+++ b/comp/otelcol/ddflareextension/impl/go.mod
@@ -132,7 +132,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/Code-Hex/go-generics-cache v1.5.1 // indirect
-	github.com/DataDog/agent-payload/v5 v5.0.189 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.193 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/config v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.79.0-rc.1 // indirect

--- a/comp/otelcol/ddflareextension/impl/go.sum
+++ b/comp/otelcol/ddflareextension/impl/go.sum
@@ -36,8 +36,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Code-Hex/go-generics-cache v1.5.1 h1:6vhZGc5M7Y/YD8cIUcY8kcuQLB4cHR7U+0KMqAA0KcU=
 github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0 h1:HKcfvAODmJCUw7nfbDKKqkEUgcu7CfxUPA9EFRJrHEI=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=

--- a/comp/otelcol/logsagentpipeline/go.mod
+++ b/comp/otelcol/logsagentpipeline/go.mod
@@ -32,7 +32,7 @@ require (
 require gopkg.in/yaml.v3 v3.0.1 // indirect
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.193 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.79.0-rc.1 // indirect

--- a/comp/otelcol/logsagentpipeline/go.sum
+++ b/comp/otelcol/logsagentpipeline/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/viper v1.15.1 h1:kcdFE+qPndlWkhU4iEf/WpWQMCyVYHTv5HqvVf+SYJs=
 github.com/DataDog/viper v1.15.1/go.mod h1:rDLDREOPd+gpEbA8y4Y/5wTvyLqvUiCmDXX0jRZy8mw=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.193 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/config v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.79.0-rc.1 // indirect

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.sum
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/viper v1.15.1 h1:kcdFE+qPndlWkhU4iEf/WpWQMCyVYHTv5HqvVf+SYJs=
 github.com/DataDog/viper v1.15.1/go.mod h1:rDLDREOPd+gpEbA8y4Y/5wTvyLqvUiCmDXX0jRZy8mw=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -50,7 +50,7 @@ require (
 )
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.193 // indirect
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/config v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.79.0-rc.1 // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0 h1:HKcfvAODmJCUw7nfbDKKqkEUgcu7CfxUPA9EFRJrHEI=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSqGF5n0s=

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/lo
 go 1.25.0
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189
+	github.com/DataDog/agent-payload/v5 v5.0.193
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.79.0-rc.1

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0 h1:HKcfvAODmJCUw7nfbDKKqkEUgcu7CfxUPA9EFRJrHEI=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -72,7 +72,7 @@ require (
 )
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.193 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.79.0-rc.1

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.9.3
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/DataDog/agent-payload/v5 v5.0.189
+	github.com/DataDog/agent-payload/v5 v5.0.193
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/fx v0.79.0-rc.1

--- a/go.sum
+++ b/go.sum
@@ -2543,8 +2543,8 @@ github.com/CycloneDX/cyclonedx-go v0.9.3 h1:Pyk/lwavPz7AaZNvugKFkdWOm93MzaIyWmBw
 github.com/CycloneDX/cyclonedx-go v0.9.3/go.mod h1:vcK6pKgO1WanCdd61qx4bFnSsDJQ6SbM2ZuMIgq86Jg=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/aptly v1.5.3 h1:oLsRvjuXSVM4ia0N83dU3KiQeiJ6BaszYbTZOkSfDlw=
 github.com/DataDog/aptly v1.5.3/go.mod h1:ZL5TfCso+z4enH03N+s3z8tYUJHhL6DlxIvnnP2TbY4=
 github.com/DataDog/cast v1.8.0 h1:uooY8bMzq+cjgiNP1VTquCWve5emgk8fRspZojJwQa8=

--- a/pkg/clusteragent/kubeactions/executors/rollback_deployment.go
+++ b/pkg/clusteragent/kubeactions/executors/rollback_deployment.go
@@ -1,0 +1,264 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package executors
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/DataDog/agent-payload/v5/kubeactions"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	unset = int64(-1)
+
+	// The following were sourced from https://github.com/kubernetes/kubernetes/blob/45836971f27ca70cd7742e8ee66e99e3c648cf9f/staging/src/k8s.io/kubectl/pkg/util/deployment/deployment.go
+	revisionAnnotation        = "deployment.kubernetes.io/revision"
+	revisionHistoryAnnotation = "deployment.kubernetes.io/revision-history"
+	desiredReplicasAnnotation = "deployment.kubernetes.io/desired-replicas"
+	maxReplicasAnnotation     = "deployment.kubernetes.io/max-replicas"
+)
+
+// Code sourced from https://github.com/kubernetes/kubernetes/blob/186a326fb3a9cd0dd91098cc94b9f1f8f1536ed3/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback.go
+var annotationsToSkip = map[string]bool{
+	corev1.LastAppliedConfigAnnotation: true,
+	revisionAnnotation:                 true,
+	revisionHistoryAnnotation:          true,
+	desiredReplicasAnnotation:          true,
+	maxReplicasAnnotation:              true,
+	appsv1.DeprecatedRollbackTo:        true,
+}
+
+// Code sourced from https://github.com/kubernetes/kubernetes/blob/186a326fb3a9cd0dd91098cc94b9f1f8f1536ed3/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback.go
+func getDeploymentPatch(podTemplate *corev1.PodTemplateSpec, annotations map[string]string) (types.PatchType, []byte, error) {
+	// Create a patch of the Deployment that replaces spec.template
+	patch, err := json.Marshal([]interface{}{
+		map[string]interface{}{
+			"op":    "replace",
+			"path":  "/spec/template",
+			"value": podTemplate,
+		},
+		map[string]interface{}{
+			"op":    "replace",
+			"path":  "/metadata/annotations",
+			"value": annotations,
+		},
+	})
+	return types.JSONPatchType, patch, err
+}
+
+func getPatchAnnotations(deployment *appsv1.Deployment, replicaSet *appsv1.ReplicaSet) map[string]string {
+	merged := make(map[string]string)
+	// grab all the annotationsToSkip from the current deployment
+	for key := range annotationsToSkip {
+		if val, ok := deployment.Annotations[key]; ok {
+			merged[key] = val
+		}
+	}
+
+	// grab everything EXCEPT annotationsToSKip from the replicaset revision
+	for key, val := range replicaSet.Annotations {
+		if !annotationsToSkip[key] {
+			merged[key] = val
+		}
+	}
+	return merged
+}
+
+type RollbackDeploymentExecutor struct {
+	clientset kubernetes.Interface
+}
+
+// NewRollbackDeploymentExecutor creates a new RollbackDeploymentExecutor
+func NewRollbackDeploymentExecutor(clientset kubernetes.Interface) *RollbackDeploymentExecutor {
+	return &RollbackDeploymentExecutor{
+		clientset: clientset,
+	}
+}
+
+// validateTargetDeployment checks that
+// 1. deployment exists
+// 2. deployment's UID matches what was passed
+// 3. deployment is not paused
+func validateTargetDeployment(ctx context.Context, client kubernetes.Interface, name string, namespace string, uid string) (*appsv1.Deployment, error) {
+	deployment, err := client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, log.Errorf("failed to get deployment %s/%s: %v", namespace, name, err)
+	}
+
+	if string(deployment.UID) != uid {
+		return nil, log.Errorf("deployment %s/%s UID mismatch: expected %s, got %s - deployment may have been replaced", namespace, name, uid, deployment.UID)
+	}
+
+	if deployment.Spec.Paused {
+		return nil, log.Errorf("deployment %s/%s is paused, cannot perform a rollback", namespace, name)
+	}
+
+	return deployment, nil
+}
+
+// getReplicaSetByRevision returns a ReplicaSet for a given revision, if nothing is passed (i.e. targetRevision is 0)
+// the default behavior matches kubectl and returns the previous revision
+func getReplicaSetByRevision(ctx context.Context, client kubernetes.Interface, deployment *appsv1.Deployment, targetRevision int64) (int64, *appsv1.ReplicaSet, error) {
+	namespace := deployment.Namespace
+	name := deployment.Name
+
+	// Revisions can never be negative, they start at 1
+	if targetRevision < 0 {
+		return unset, nil, log.Errorf("revision %d is invalid", targetRevision)
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return unset, nil, log.Errorf("failed to build deployment label selector for %s/%s", namespace, name)
+	}
+
+	// List all ReplicaSets with a label selector matching the deployments
+	rsInterface := client.AppsV1().ReplicaSets(namespace)
+	allReplicaSets, err := rsInterface.List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return unset, nil, log.Errorf("failed to list replicasets in namespace %s", namespace)
+	}
+
+	// Revisions are not always sequential or ordered
+	currentRevision := unset
+	previousRevision := unset
+	currentRevisionIndex := int(unset)
+	previousRevisionIndex := int(unset)
+
+	// Loop over all ReplicaSets
+	for i, rs := range allReplicaSets.Items {
+		// Ensure that the owner of the ReplicaSet is the current deployment
+		if !metav1.IsControlledBy(&rs, deployment) {
+			continue
+		}
+
+		// Check and parse the revision from the "deployment.kubernetes.io/revision" annotation
+		revision, found := rs.Annotations[revisionAnnotation]
+		if !found {
+			log.Debugf("annotation \"%s\" is not present on the ReplicaSet", revisionAnnotation)
+			continue
+		}
+
+		// Parse the revision integer from the "deployment.kubernetes.io/revision" annotation
+		rev, err := strconv.ParseInt(revision, 10, 64)
+		if err != nil {
+			log.Errorf("failed to parse replicaset revision from %s", revision)
+			continue
+		}
+
+		// if targetRevision is 0 then the user is requesting a rollback to the previous revision
+		if targetRevision == 0 {
+			// previousRevision < currentRevision < rev
+			if currentRevision < rev {
+				previousRevision = currentRevision
+				previousRevisionIndex = currentRevisionIndex
+
+				currentRevision = rev
+				currentRevisionIndex = i
+			} else if previousRevision < rev {
+				// previousRevision < rev < currentRevision
+				previousRevision = rev
+				previousRevisionIndex = i
+			}
+		} else if targetRevision == rev {
+			// User supplied targetRevision was found, return early
+			return targetRevision, &allReplicaSets.Items[i], nil
+		}
+	}
+
+	// If targetRevision is > 0, and we didn't return early, that means it wasn't found
+	if targetRevision > 0 {
+		return unset, nil, log.Errorf("failed to find revision %d", targetRevision)
+	}
+
+	// If previous index is -1 that means there is one (or none) revisions
+	if previousRevisionIndex == int(unset) {
+		return unset, nil, log.Errorf("failed to find revision %d", targetRevision)
+	}
+
+	// Return the previous revision by default
+	return previousRevision, &allReplicaSets.Items[previousRevisionIndex], nil
+}
+
+// Execute rolls back a deployment to a previous revision by patching the current deployment
+func (r *RollbackDeploymentExecutor) Execute(ctx context.Context, action *kubeactions.KubeAction) ExecutionResult {
+	resource := action.Resource
+	namespace := resource.Namespace
+	name := resource.Name
+	resourceID := resource.ResourceId
+	targetRevision := action.GetRollbackDeployment().GetTargetRevision()
+
+	currentDeployment, err := validateTargetDeployment(ctx, r.clientset, name, namespace, resourceID)
+	if err != nil {
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: err.Error(),
+		}
+	}
+
+	foundRevision, replicaSetForRevision, err := getReplicaSetByRevision(ctx, r.clientset, currentDeployment, targetRevision)
+	if err != nil {
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: err.Error(),
+		}
+	}
+
+	methodMsg := "user-specified"
+	if targetRevision == 0 {
+		methodMsg = "previous (default)"
+	}
+	log.Debugf("[KubeActions] Rolling back to %s revision %d", methodMsg, foundRevision)
+
+	// Delete pod-template-hash label from both the current Deployment Spec and ReplicaSet Spec Templates
+	// These labels interfere with equality evaluation and patching
+	delete(currentDeployment.Spec.Template.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
+	delete(replicaSetForRevision.Spec.Template.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
+	if apiequality.Semantic.DeepEqual(&replicaSetForRevision.Spec.Template, &currentDeployment.Spec.Template) {
+		return ExecutionResult{
+			Status:  StatusSuccess,
+			Message: "current template already matches the previous revision" + strconv.FormatInt(foundRevision, 10),
+		}
+	}
+
+	// Create the patch by merging the current Deployment's annotations with the target revision's
+	patchAnnotations := getPatchAnnotations(currentDeployment, replicaSetForRevision)
+	patchType, patch, err := getDeploymentPatch(&replicaSetForRevision.Spec.Template, patchAnnotations)
+	if err != nil {
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: err.Error(),
+		}
+	}
+
+	// Restore revision by patching the Deployment
+	if _, err = r.clientset.AppsV1().Deployments(namespace).Patch(ctx, name, patchType, patch, metav1.PatchOptions{}); err != nil {
+		msg := "failed restoring revision " + strconv.FormatInt(foundRevision, 10) + ": " + err.Error()
+		log.Error(msg)
+		return ExecutionResult{
+			Status:  StatusFailed,
+			Message: msg,
+		}
+
+	}
+
+	return ExecutionResult{
+		Status:  StatusSuccess,
+		Message: "successfully restored revision " + strconv.FormatInt(foundRevision, 10),
+	}
+}

--- a/pkg/clusteragent/kubeactions/executors/rollback_deployment_test.go
+++ b/pkg/clusteragent/kubeactions/executors/rollback_deployment_test.go
@@ -1,0 +1,556 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package executors
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/DataDog/agent-payload/v5/kubeactions"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestValidateTargetDeployment(t *testing.T) {
+	pausedDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "paused-deploy",
+			Namespace: "default",
+			UID:       k8stypes.UID("uid-paused"),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Paused: true,
+		},
+	}
+
+	activeDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "active-deploy",
+			Namespace: "default",
+			UID:       k8stypes.UID("uid-active"),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Paused: false,
+		},
+	}
+
+	tests := []struct {
+		testName  string
+		name      string
+		namespace string
+		uid       string
+		client    kubernetes.Interface
+		wantErr   bool
+	}{
+		{
+			testName:  "deployment not found",
+			name:      "nonexistent",
+			namespace: "default",
+			uid:       "some-uid",
+			client:    fake.NewSimpleClientset(),
+			wantErr:   true,
+		},
+		{
+			testName:  "UID mismatch",
+			name:      "active-deploy",
+			namespace: "default",
+			uid:       "wrong-uid",
+			client:    fake.NewSimpleClientset(activeDeployment),
+			wantErr:   true,
+		},
+		{
+			testName:  "deployment is paused",
+			name:      "paused-deploy",
+			namespace: "default",
+			uid:       "uid-paused",
+			client:    fake.NewSimpleClientset(pausedDeployment),
+			wantErr:   true,
+		},
+		{
+			testName:  "valid deployment",
+			name:      "active-deploy",
+			namespace: "default",
+			uid:       "uid-active",
+			client:    fake.NewSimpleClientset(activeDeployment),
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			_, err := validateTargetDeployment(context.Background(), tt.client, tt.name, tt.namespace, tt.uid)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("unexpected error %s", err)
+			}
+		})
+	}
+}
+
+func TestGetPatchAnnotations(t *testing.T) {
+	tests := []struct {
+		name       string
+		deploy     *appsv1.Deployment
+		replicaSet *appsv1.ReplicaSet
+		expected   map[string]string
+	}{
+		{
+			name: "skipped annotations preserved from deployment",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: buildAnnotationsToSkip("deploy"),
+				},
+			},
+			replicaSet: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: buildAnnotationsToSkip("replicaset"),
+				},
+			},
+			expected: buildAnnotationsToSkip("deploy"),
+		},
+		{
+			name: "non-skipped annotations taken from replicaset",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: buildAnnotationsToSkip("deploy"),
+				},
+			},
+			replicaSet: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: mergeMaps(buildAnnotationsToSkip("replicaset"), map[string]string{
+						"app":  "nginx",
+						"team": "platform",
+					}),
+				},
+			},
+			expected: mergeMaps(buildAnnotationsToSkip("deploy"), map[string]string{
+				"app":  "nginx",
+				"team": "platform",
+			}),
+		},
+		{
+			name: "mixed: skipped from deployment, non-skipped from replicaset, deployment custom annotations dropped",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: mergeMaps(buildAnnotationsToSkip("deploy"), map[string]string{
+						"deploy-only": "should-be-dropped",
+					}),
+				},
+			},
+			replicaSet: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: mergeMaps(buildAnnotationsToSkip("replicaset"), map[string]string{
+						"app": "nginx",
+					}),
+				},
+			},
+			expected: mergeMaps(buildAnnotationsToSkip("deploy"), map[string]string{
+				"app": "nginx",
+			}),
+		},
+		{
+			name: "both have no annotations",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			replicaSet: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "deployment has no skipped annotations",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			replicaSet: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"app": "nginx",
+					},
+				},
+			},
+			expected: map[string]string{
+				"app": "nginx",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotations := getPatchAnnotations(tt.deploy, tt.replicaSet)
+			assert.Equal(t, tt.expected, annotations)
+		})
+	}
+}
+
+func TestGetReplicaSetByRevision(t *testing.T) {
+	deploy := makeDeployment("my-deploy", "default", "deploy-uid")
+
+	tests := []struct {
+		testName       string
+		targetRevision int64
+		objects        []appsv1.ReplicaSet
+		wantRevision   int64
+		wantRSName     string
+		wantErr        bool
+	}{
+		{
+			testName:       "negative revision returns error",
+			targetRevision: -1,
+			wantErr:        true,
+		},
+		{
+			testName:       "specific revision found",
+			targetRevision: 3,
+			objects: []appsv1.ReplicaSet{
+				*makeReplicaSet("rs-1", "default", "1", "deploy-uid", "my-deploy"),
+				*makeReplicaSet("rs-2", "default", "2", "deploy-uid", "my-deploy"),
+				*makeReplicaSet("rs-3", "default", "3", "deploy-uid", "my-deploy"),
+			},
+			wantRevision: 3,
+			wantRSName:   "rs-3",
+		},
+		{
+			testName:       "specific revision not found",
+			targetRevision: 99,
+			objects: []appsv1.ReplicaSet{
+				*makeReplicaSet("rs-1", "default", "1", "deploy-uid", "my-deploy"),
+				*makeReplicaSet("rs-2", "default", "2", "deploy-uid", "my-deploy"),
+				*makeReplicaSet("rs-3", "default", "3", "deploy-uid", "my-deploy"),
+			},
+			wantErr: true,
+		},
+		{
+			testName:       "default (0) returns previous revision",
+			targetRevision: 0,
+			objects: []appsv1.ReplicaSet{
+				*makeReplicaSet("rs-1", "default", "1", "deploy-uid", "my-deploy"),
+				*makeReplicaSet("rs-2", "default", "2", "deploy-uid", "my-deploy"),
+				*makeReplicaSet("rs-3", "default", "3", "deploy-uid", "my-deploy"),
+			},
+			wantRevision: 2,
+			wantRSName:   "rs-2",
+		},
+		{
+			testName:       "default (0) with only one RS returns error",
+			targetRevision: 0,
+			objects: []appsv1.ReplicaSet{
+				*makeReplicaSet("rs-1", "default", "1", "deploy-uid", "my-deploy"),
+			},
+			wantErr: true,
+		},
+		{
+			testName:       "no ReplicaSets returns error",
+			targetRevision: 0,
+			wantErr:        true,
+		},
+		{
+			testName:       "RS not owned by deployment is ignored",
+			targetRevision: 3,
+			objects: []appsv1.ReplicaSet{
+				*makeReplicaSet("rs-other", "default", "3", "other-uid", "other-deploy"),
+			},
+			wantErr: true,
+		},
+		{
+			testName:       "non-sequential revisions default returns second highest",
+			targetRevision: 0,
+			objects: []appsv1.ReplicaSet{
+				*makeReplicaSet("rs-1", "default", "1", "deploy-uid", "my-deploy"),
+				*makeReplicaSet("rs-5", "default", "5", "deploy-uid", "my-deploy"),
+				*makeReplicaSet("rs-10", "default", "10", "deploy-uid", "my-deploy"),
+			},
+			wantRevision: 5,
+			wantRSName:   "rs-5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			clientObjects := make([]k8sruntime.Object, 0, len(tt.objects))
+			for i := range tt.objects {
+				clientObjects = append(clientObjects, &tt.objects[i])
+			}
+			client := fake.NewSimpleClientset(clientObjects...)
+
+			revision, rs, err := getReplicaSetByRevision(context.Background(), client, deploy, tt.targetRevision)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantRevision, revision)
+			assert.Equal(t, tt.wantRSName, rs.Name)
+		})
+	}
+}
+
+func TestExecute(t *testing.T) {
+	tests := []struct {
+		testName       string
+		deployment     *appsv1.Deployment
+		replicaSets    []appsv1.ReplicaSet
+		targetRevision *int64
+		resourceID     string
+		wantStatus     string
+		wantContains   string
+		wantPatched    bool
+		wantRevision   string // revision annotation of the RS whose template should appear in the patch
+	}{
+		{
+			testName:   "rollback to previous revision",
+			deployment: makeDeploymentWithTemplate("my-deploy", "default", "deploy-uid", "nginx:v3"),
+			replicaSets: []appsv1.ReplicaSet{
+				*makeReplicaSetWithTemplate("rs-1", "default", "1", "deploy-uid", "my-deploy", "nginx:v1"),
+				*makeReplicaSetWithTemplate("rs-2", "default", "2", "deploy-uid", "my-deploy", "nginx:v2"),
+				*makeReplicaSetWithTemplate("rs-3", "default", "3", "deploy-uid", "my-deploy", "nginx:v3"),
+			},
+			targetRevision: nil,
+			resourceID:     "deploy-uid",
+			wantStatus:     StatusSuccess,
+			wantContains:   "successfully restored revision 2",
+			wantPatched:    true,
+			wantRevision:   "2",
+		},
+		{
+			testName:   "rollback to specific revision",
+			deployment: makeDeploymentWithTemplate("my-deploy", "default", "deploy-uid", "nginx:v3"),
+			replicaSets: []appsv1.ReplicaSet{
+				*makeReplicaSetWithTemplate("rs-1", "default", "1", "deploy-uid", "my-deploy", "nginx:v1"),
+				*makeReplicaSetWithTemplate("rs-2", "default", "2", "deploy-uid", "my-deploy", "nginx:v2"),
+				*makeReplicaSetWithTemplate("rs-3", "default", "3", "deploy-uid", "my-deploy", "nginx:v3"),
+			},
+			targetRevision: int64Ptr(1),
+			resourceID:     "deploy-uid",
+			wantStatus:     StatusSuccess,
+			wantContains:   "successfully restored revision 1",
+			wantPatched:    true,
+			wantRevision:   "1",
+		},
+		{
+			testName:   "template already matches previous revision",
+			deployment: makeDeploymentWithTemplate("my-deploy", "default", "deploy-uid", "nginx:v2"),
+			replicaSets: []appsv1.ReplicaSet{
+				*makeReplicaSetWithTemplate("rs-1", "default", "1", "deploy-uid", "my-deploy", "nginx:v1"),
+				*makeReplicaSetWithTemplate("rs-2", "default", "2", "deploy-uid", "my-deploy", "nginx:v2"),
+				*makeReplicaSetWithTemplate("rs-3", "default", "3", "deploy-uid", "my-deploy", "nginx:v2"),
+			},
+			targetRevision: nil,
+			resourceID:     "deploy-uid",
+			wantStatus:     StatusSuccess,
+			wantContains:   "already matches",
+			wantPatched:    false,
+		},
+		{
+			testName:       "deployment UID mismatch",
+			deployment:     makeDeploymentWithTemplate("my-deploy", "default", "deploy-uid", "nginx:v1"),
+			replicaSets:    nil,
+			targetRevision: nil,
+			resourceID:     "wrong-uid",
+			wantStatus:     StatusFailed,
+			wantPatched:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			var objects []k8sruntime.Object
+			if tt.deployment != nil {
+				objects = append(objects, tt.deployment)
+			}
+			for i := range tt.replicaSets {
+				objects = append(objects, &tt.replicaSets[i])
+			}
+
+			clientset := fake.NewSimpleClientset(objects...)
+			executor := NewRollbackDeploymentExecutor(clientset)
+
+			action := makeRollbackAction(tt.deployment.GetNamespace(), tt.deployment.GetName(), tt.resourceID, tt.targetRevision)
+			result := executor.Execute(context.Background(), action)
+
+			assert.Equal(t, tt.wantStatus, result.Status)
+			if tt.wantContains != "" {
+				assert.Contains(t, result.Message, tt.wantContains)
+			}
+
+			if tt.wantPatched {
+				patchAction, foundPatchErr := findPatchAction(clientset, tt.deployment)
+				require.NoError(t, foundPatchErr)
+				require.NotNil(t, patchAction, "expected a patch action on the deployment")
+				assert.Equal(t, k8stypes.JSONPatchType, patchAction.GetPatchType())
+
+				var ops []map[string]interface{}
+				require.NoError(t, json.Unmarshal(patchAction.GetPatch(), &ops))
+				require.Len(t, ops, 2)
+
+				// Verify the template replacement matches the expected RS's spec
+				assert.Equal(t, "replace", ops[0]["op"])
+				assert.Equal(t, "/spec/template", ops[0]["path"])
+				templateBytes, err := json.Marshal(ops[0]["value"])
+				require.NoError(t, err)
+
+				var template corev1.PodTemplateSpec
+				require.NoError(t, json.Unmarshal(templateBytes, &template))
+				expectedTemplate := findRSTemplate(t, tt.replicaSets, tt.wantRevision)
+				assert.Equal(t, expectedTemplate, template)
+
+				// Verify the annotations replacement
+				assert.Equal(t, "replace", ops[1]["op"])
+				assert.Equal(t, "/metadata/annotations", ops[1]["path"])
+			}
+		})
+	}
+}
+
+// Helper functions
+
+func boolPtr(b bool) *bool { return &b }
+
+func int64Ptr(i int64) *int64 { return &i }
+
+func mergeMaps(base, overlay map[string]string) map[string]string {
+	merged := make(map[string]string, len(base)+len(overlay))
+	for k, v := range base {
+		merged[k] = v
+	}
+	for k, v := range overlay {
+		merged[k] = v
+	}
+	return merged
+}
+
+func buildAnnotationsToSkip(val string) map[string]string {
+	annotations := make(map[string]string)
+	for annotation := range annotationsToSkip {
+		annotations[annotation] = val
+	}
+
+	return annotations
+}
+
+func makeDeployment(name, namespace string, uid k8stypes.UID) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       uid,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+		},
+	}
+}
+
+func makeReplicaSet(name, namespace string, revision string, ownerUID k8stypes.UID, ownerName string) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": ownerName},
+			Annotations: map[string]string{
+				revisionAnnotation: revision,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       ownerName,
+					UID:        ownerUID,
+					Controller: boolPtr(true),
+				},
+			},
+		},
+	}
+}
+
+func makeDeploymentWithTemplate(name, namespace string, uid k8stypes.UID, image string) *appsv1.Deployment {
+	d := makeDeployment(name, namespace, uid)
+	d.Spec.Template = corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"app": name},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: image},
+			},
+		},
+	}
+	return d
+}
+
+func makeReplicaSetWithTemplate(name, namespace, revision string, ownerUID k8stypes.UID, ownerName, image string) *appsv1.ReplicaSet {
+	rs := makeReplicaSet(name, namespace, revision, ownerUID, ownerName)
+	rs.Spec.Template = corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"app": ownerName},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: image},
+			},
+		},
+	}
+	return rs
+}
+
+func makeRollbackAction(namespace, name, resourceID string, targetRevision *int64) *kubeactions.KubeAction {
+	return &kubeactions.KubeAction{
+		Resource: &kubeactions.KubeResource{
+			Kind:       "Deployment",
+			Namespace:  namespace,
+			Name:       name,
+			ResourceId: resourceID,
+		},
+		Action: &kubeactions.KubeAction_RollbackDeployment{
+			RollbackDeployment: &kubeactions.RollbackDeploymentParams{
+				TargetRevision: targetRevision,
+			},
+		},
+	}
+}
+
+func findRSTemplate(t *testing.T, replicaSets []appsv1.ReplicaSet, revision string) corev1.PodTemplateSpec {
+	t.Helper()
+	for _, rs := range replicaSets {
+		if rs.Annotations[revisionAnnotation] == revision {
+			return rs.Spec.Template
+		}
+	}
+	t.Fatalf("no ReplicaSet found with revision %s", revision)
+	return corev1.PodTemplateSpec{}
+}
+
+func findPatchAction(clientset *fake.Clientset, deployment *appsv1.Deployment) (k8stesting.PatchAction, error) {
+	if deployment == nil {
+		return nil, errors.New("deployment is nil")
+	}
+	for _, action := range clientset.Actions() {
+		if pa, ok := action.(k8stesting.PatchAction); ok && pa.GetResource().Resource == "deployments" && pa.GetName() == deployment.Name && pa.GetNamespace() == deployment.Namespace {
+			return pa, nil
+		}
+	}
+	return nil, errors.New("no patch was found")
+}

--- a/pkg/clusteragent/kubeactions/setup.go
+++ b/pkg/clusteragent/kubeactions/setup.go
@@ -76,6 +76,10 @@ func registerExecutors(registry *ExecutorRegistry, clientset kubernetes.Interfac
 	registry.Register("patch_deployment", &executorAdapter{exec: executors.NewPatchDeploymentExecutor(clientset)})
 	log.Infof("Registered executor for action type: patch_deployment")
 
+	// Register rollback_deployment executor
+	registry.Register("rollback_deployment", &executorAdapter{exec: executors.NewRollbackDeploymentExecutor(clientset)})
+	log.Infof("Registered executor for action type: rollback_deployment")
+
 	// TODO: Add more executors here as they are implemented:
 	// registry.Register("drain_node", &executorAdapter{exec: executors.NewDrainNodeExecutor(clientset)})
 	// registry.Register("cordon_node", &executorAdapter{exec: executors.NewCordonNodeExecutor(clientset)})

--- a/pkg/clusteragent/kubeactions/types.go
+++ b/pkg/clusteragent/kubeactions/types.go
@@ -15,10 +15,11 @@ import (
 
 // Action type constants
 const (
-	ActionTypeDeletePod         = "delete_pod"
-	ActionTypeRestartDeployment = "restart_deployment"
-	ActionTypePatchDeployment   = "patch_deployment"
-	ActionTypeUnknown           = "unknown"
+	ActionTypeUnknown            = "unknown"
+	ActionTypeDeletePod          = "delete_pod"
+	ActionTypeRestartDeployment  = "restart_deployment"
+	ActionTypePatchDeployment    = "patch_deployment"
+	ActionTypeRollbackDeployment = "rollback_deployment"
 )
 
 // Execution status constants
@@ -55,6 +56,8 @@ func GetActionType(action *kubeactions.KubeAction) string {
 		return ActionTypeRestartDeployment
 	case *kubeactions.KubeAction_PatchDeployment:
 		return ActionTypePatchDeployment
+	case *kubeactions.KubeAction_RollbackDeployment:
+		return ActionTypeRollbackDeployment
 	default:
 		return ActionTypeUnknown
 	}

--- a/pkg/clusteragent/kubeactions/validator.go
+++ b/pkg/clusteragent/kubeactions/validator.go
@@ -132,6 +132,13 @@ func (v *ActionValidator) ValidateAction(action *kubeactions.KubeAction) error {
 				Message: "patch is required for patch_deployment action",
 			}
 		}
+	case ActionTypeRollbackDeployment:
+		if action.Resource.Kind != "Deployment" {
+			return &ValidationError{
+				Action:  action,
+				Message: "resource.kind must be 'Deployment' for rollback_deployment action",
+			}
+		}
 	}
 
 	// Block actions on protected system namespaces

--- a/pkg/logs/processor/go.mod
+++ b/pkg/logs/processor/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/logs/processor
 go 1.25.0
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189
+	github.com/DataDog/agent-payload/v5 v5.0.193
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/pkg/config/model v0.79.0-rc.1

--- a/pkg/logs/processor/go.sum
+++ b/pkg/logs/processor/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/viper v1.15.1 h1:kcdFE+qPndlWkhU4iEf/WpWQMCyVYHTv5HqvVf+SYJs=
 github.com/DataDog/viper v1.15.1/go.mod h1:rDLDREOPd+gpEbA8y4Y/5wTvyLqvUiCmDXX0jRZy8mw=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/logs
 go 1.25.0
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189
+	github.com/DataDog/agent-payload/v5 v5.0.193
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/rum v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.79.0-rc.1

--- a/pkg/opentelemetry-mapping-go/otlp/logs/go.sum
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0 h1:HKcfvAODmJCUw7nfbDKKqkEUgcu7CfxUPA9EFRJrHEI=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=

--- a/pkg/process/util/api/go.mod
+++ b/pkg/process/util/api/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/process/util/api
 go 1.25.0
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189
+	github.com/DataDog/agent-payload/v5 v5.0.193
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.79.0-rc.1
 	github.com/gogo/protobuf v1.3.2

--- a/pkg/process/util/api/go.sum
+++ b/pkg/process/util/api/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/viper v1.15.1 h1:kcdFE+qPndlWkhU4iEf/WpWQMCyVYHTv5HqvVf+SYJs=

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/serializer
 go 1.25.0
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189
+	github.com/DataDog/agent-payload/v5 v5.0.193
 	github.com/DataDog/datadog-agent/comp/core/config v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/comp/core/log/mock v0.79.0-rc.1

--- a/pkg/serializer/go.sum
+++ b/pkg/serializer/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=

--- a/test/e2e-framework/go.mod
+++ b/test/e2e-framework/go.mod
@@ -61,7 +61,7 @@ require (
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
-	github.com/DataDog/agent-payload/v5 v5.0.189 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.193 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/netflow/payload v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/metrics v0.79.0-rc.1 // indirect

--- a/test/e2e-framework/go.sum
+++ b/test/e2e-framework/go.sum
@@ -4,8 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0 h1:HKcfvAODmJCUw7nfbDKKqkEUgcu7CfxUPA9EFRJrHEI=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=

--- a/test/fakeintake/go.mod
+++ b/test/fakeintake/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 // every datadog-agent module replaced in the fakeintake go.mod needs to be copied in the Dockerfile
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189
+	github.com/DataDog/agent-payload/v5 v5.0.193
 	github.com/DataDog/datadog-agent/comp/netflow/payload v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/pkg/metrics v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/pkg/networkpath/payload v0.79.0-rc.1

--- a/test/fakeintake/go.sum
+++ b/test/fakeintake/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent/test/new-e2e
 go 1.25.6
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189
+	github.com/DataDog/agent-payload/v5 v5.0.193
 	github.com/DataDog/datadog-agent/pkg/util/option v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.79.0-rc.1
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.79.0-rc.1 // indirect

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -4,8 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/datadog-api-client-go v1.16.0 h1:5jOZv1m98criCvYTa3qpW8Hzv301nbZX3K9yJtwGyWY=
 github.com/DataDog/datadog-api-client-go v1.16.0/go.mod h1:PgrP2ABuJWL3Auw2iEkemAJ/r72ghG4DQQmb5sgnKW4=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0 h1:HKcfvAODmJCUw7nfbDKKqkEUgcu7CfxUPA9EFRJrHEI=

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -88,7 +88,7 @@ require (
 )
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.189 // indirect
+	github.com/DataDog/agent-payload/v5 v5.0.193 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.79.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.79.0-rc.1 // indirect

--- a/test/otel/go.sum
+++ b/test/otel/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.189 h1:94lYK0BdRhKbpY4mcfTCMr4+R8OMnIK6We9AnJvNTZY=
-github.com/DataDog/agent-payload/v5 v5.0.189/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
+github.com/DataDog/agent-payload/v5 v5.0.193 h1:HeZY0aFY7fxPbuUwrn2B2UWgqemD+L8UjzApNciKQ5w=
+github.com/DataDog/agent-payload/v5 v5.0.193/go.mod h1:GyA1vuCeRywrNNCbYeR0cOYKE8QkOVNAFDqsH8VNF5M=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0 h1:HKcfvAODmJCUw7nfbDKKqkEUgcu7CfxUPA9EFRJrHEI=
 github.com/DataDog/datadog-api-client-go/v2 v2.56.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSqGF5n0s=


### PR DESCRIPTION
Adds the ability to rollback deployments via kubernetes actions

Extend action capabilities

Deployed a custom agent build of this branch and triggered multiple scenarios on a simple deployment that had 3 revisions.

1. Rollback to previous version (`kubectl rollout undo`) ``` 2026-04-17 19:01:53 UTC | CLUSTER | DEBUG | (pkg/clusteragent/kubeactions/executors/rollback_deployment.go:225 in Execute) | [KubeActions] Rolling back to previous (default) revision 2 2026-04-17 19:01:53 UTC | CLUSTER | INFO | (pkg/clusteragent/kubeactions/processor.go:184 in processAction) | [KubeActions] Execution completed: status=success, message=successfully restored revision 2 ```

2. Try to restore a nonexistent version (`kubectl rollout undo --to-version 2`) ``` 2026-04-17 19:05:19 UTC | CLUSTER | INFO | (pkg/clusteragent/kubeactions/processor.go:184 in processAction) | [KubeActions] Execution completed: status=failed, message=failed to find revision 2 ```

3. Restore a specific version (`kubectl rollout undo --to-revision 1`) ``` 2026-04-17 19:08:39 UTC | CLUSTER | DEBUG | (pkg/clusteragent/kubeactions/executors/rollback_deployment.go:225 in Execute) | [KubeActions] Rolling back to user-specified revision 1 2026-04-17 19:08:39 UTC | CLUSTER | INFO | (pkg/clusteragent/kubeactions/processor.go:184 in processAction) | [KubeActions] Execution completed: status=success, message=successfully restored revision 1 ```


(cherry picked from commit b62aa669bc51daaba00ac21e2c85aa3dac77632d)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
