### PR TITLE
Fix zstd C-memory leak in batch sender error paths

### DIFF
--- a/pkg/logs/sender/batch.go
+++ b/pkg/logs/sender/batch.go
@@ -71,6 +71,11 @@ func makeBatch(
 }
 
 func (b *batch) resetBatch() {
+	// Free C-side resources (e.g. ZSTD_CCtx) before replacing the compressor;
+	// error paths skip sendMessages so Close() would never be called otherwise.
+	if b.compressor != nil {
+		b.compressor.Close()
+	}
 	b.buffer.Clear()
 	b.serializer.Reset()
 	var encodedPayload bytes.Buffer
@@ -158,7 +163,9 @@ func (b *batch) flushBuffer(outputChan chan *message.Payload, reason string) {
 func (b *batch) sendMessages(messagesMetadata []*message.MessageMetadata, outputChan chan *message.Payload, reason string) {
 	defer b.resetBatch()
 
-	if err := b.compressor.Close(); err != nil {
+	err := b.compressor.Close()
+	b.compressor = nil // prevent double-free from defer resetBatch
+	if err != nil {
 		log.Warn("Encoding failed - dropping payload", err)
 		b.utilization.Stop()
 		return

--- a/pkg/logs/sender/batch_test.go
+++ b/pkg/logs/sender/batch_test.go
@@ -6,6 +6,10 @@
 package sender
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +19,51 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
 )
+
+// trackingStreamCompressor wraps a bytes.Buffer to satisfy StreamCompressor
+// and counts how many times Close was called.
+type trackingStreamCompressor struct {
+	*bytes.Buffer
+	closeCount *atomic.Int32
+}
+
+func (t *trackingStreamCompressor) Close() error {
+	t.closeCount.Add(1)
+	return nil
+}
+
+func (t *trackingStreamCompressor) wasClosed() bool {
+	return t.closeCount.Load() > 0
+}
+
+func (t *trackingStreamCompressor) Flush() error { return nil }
+
+// trackingCompressor is a compression.Compressor that produces
+// trackingStreamCompressor instances so tests can observe Close calls.
+type trackingCompressor struct {
+	lastCompressor *trackingStreamCompressor
+}
+
+func (tc *trackingCompressor) Compress(src []byte) ([]byte, error)   { return src, nil }
+func (tc *trackingCompressor) Decompress(src []byte) ([]byte, error) { return src, nil }
+func (tc *trackingCompressor) CompressBound(sourceLen int) int       { return sourceLen }
+func (tc *trackingCompressor) ContentEncoding() string               { return "identity" }
+func (tc *trackingCompressor) NewStreamCompressor(buf *bytes.Buffer) compression.StreamCompressor {
+	sc := &trackingStreamCompressor{Buffer: buf, closeCount: &atomic.Int32{}}
+	tc.lastCompressor = sc
+	return sc
+}
+
+// errorSerializer always returns an error, used to trigger error-path resets.
+type errorSerializer struct{}
+
+func (e *errorSerializer) Serialize(_ *message.Message, _ io.Writer) error {
+	return fmt.Errorf("synthetic serialization error")
+}
+func (e *errorSerializer) Finish(_ io.Writer) error {
+	return fmt.Errorf("synthetic finish error")
+}
+func (e *errorSerializer) Reset() {}
 
 func createTestBatch() *batch {
 	return makeBatch(
@@ -212,4 +261,116 @@ func TestBatchSendMessages(t *testing.T) {
 	payload := <-output
 	assert.Equal(t, metadata, payload.MessageMetas)
 	assert.Equal(t, "identity", payload.Encoding)
+}
+
+func makeTrackingBatch() (*batch, *trackingCompressor) {
+	tc := &trackingCompressor{}
+	var encodedPayload bytes.Buffer
+	compressor := tc.NewStreamCompressor(&encodedPayload)
+	wc := newWriterWithCounter(compressor)
+
+	b := &batch{
+		buffer:          NewMessageBuffer(2, 10),
+		serializer:      NewArraySerializer(),
+		compression:     tc,
+		compressor:      compressor,
+		writeCounter:    wc,
+		encodedPayload:  &encodedPayload,
+		pipelineName:    "test",
+		pipelineMonitor: metrics.NewNoopPipelineMonitor(""),
+		instanceID:      "test",
+		utilization:     metrics.NewNoopPipelineMonitor("").MakeUtilizationMonitor("test", "test"),
+		serverlessMeta:  NewMockServerlessMeta(false),
+	}
+	return b, tc
+}
+
+func TestResetBatchClosesCompressorOnSerializeError(t *testing.T) {
+	b, tc := makeTrackingBatch()
+	originalCompressor := tc.lastCompressor
+
+	b.serializer = &errorSerializer{}
+	output := make(chan *message.Payload, 10)
+
+	msg := message.NewMessage([]byte("test"), nil, "", 0)
+	b.processMessage(msg, output)
+
+	assert.True(t, originalCompressor.wasClosed(),
+		"resetBatch must Close the old compressor when processMessage hits a serialize error")
+	assert.NotEqual(t, originalCompressor, b.compressor,
+		"resetBatch must replace the compressor with a new instance")
+}
+
+func TestResetBatchClosesCompressorOnFinishError(t *testing.T) {
+	b, tc := makeTrackingBatch()
+
+	msg := message.NewMessage([]byte("a"), nil, "", 0)
+	b.addMessage(msg)
+
+	compressorBeforeFlush := tc.lastCompressor
+
+	b.serializer = &errorSerializer{}
+	output := make(chan *message.Payload, 10)
+
+	b.flushBuffer(output, "timer")
+
+	assert.True(t, compressorBeforeFlush.wasClosed(),
+		"resetBatch must Close the old compressor when flushBuffer hits a finish error")
+
+	select {
+	case <-output:
+		t.Fatal("no payload should be sent when Finish fails")
+	default:
+	}
+}
+
+func TestResetBatchClosesCompressorOnRetryError(t *testing.T) {
+	tc := &trackingCompressor{}
+	var encodedPayload bytes.Buffer
+	compressor := tc.NewStreamCompressor(&encodedPayload)
+	wc := newWriterWithCounter(compressor)
+
+	b := &batch{
+		buffer:          NewMessageBuffer(1, 100),
+		serializer:      NewArraySerializer(),
+		compression:     tc,
+		compressor:      compressor,
+		writeCounter:    wc,
+		encodedPayload:  &encodedPayload,
+		pipelineName:    "test",
+		pipelineMonitor: metrics.NewNoopPipelineMonitor(""),
+		instanceID:      "test",
+		utilization:     metrics.NewNoopPipelineMonitor("").MakeUtilizationMonitor("test", "test"),
+		serverlessMeta:  NewMockServerlessMeta(false),
+	}
+
+	msg1 := message.NewMessage([]byte("a"), nil, "", 0)
+	b.addMessage(msg1)
+
+	b.serializer = &errorSerializer{}
+
+	msg2 := message.NewMessage([]byte("b"), nil, "", 0)
+	output := make(chan *message.Payload, 10)
+
+	compressorBeforeProcess := tc.lastCompressor
+	b.processMessage(msg2, output)
+
+	assert.True(t, compressorBeforeProcess.wasClosed(),
+		"resetBatch must Close the old compressor when the retry path hits an error")
+}
+
+func TestSendMessagesDoesNotDoubleClose(t *testing.T) {
+	b, tc := makeTrackingBatch()
+
+	msg := message.NewMessage([]byte("a"), nil, "", 0)
+	b.addMessage(msg)
+	b.serializer.Finish(b.writeCounter)
+
+	compressorUsed := tc.lastCompressor
+	output := make(chan *message.Payload, 10)
+
+	b.sendMessages(b.buffer.GetMessages(), output, "timer")
+
+	assert.Equal(t, int32(1), compressorUsed.closeCount.Load(),
+		"compressor must be closed exactly once; sendMessages closes it and defer resetBatch must skip it")
 }

--- a/pkg/logs/sender/batch_test.go
+++ b/pkg/logs/sender/batch_test.go
@@ -7,7 +7,7 @@ package sender
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 	"sync/atomic"
 	"testing"
@@ -58,10 +58,10 @@ func (tc *trackingCompressor) NewStreamCompressor(buf *bytes.Buffer) compression
 type errorSerializer struct{}
 
 func (e *errorSerializer) Serialize(_ *message.Message, _ io.Writer) error {
-	return fmt.Errorf("synthetic serialization error")
+	return errors.New("synthetic serialization error")
 }
 func (e *errorSerializer) Finish(_ io.Writer) error {
-	return fmt.Errorf("synthetic finish error")
+	return errors.New("synthetic finish error")
 }
 func (e *errorSerializer) Reset() {}
 

--- a/releasenotes/notes/fix-zstd-batch-sender-memory-leak-da98a30a47ca61a2.yaml
+++ b/releasenotes/notes/fix-zstd-batch-sender-memory-leak-da98a30a47ca61a2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a C-memory leak in the logs batch sender where ``resetBatch()`` replaced
+    the zstd ``StreamCompressor`` without closing the previous one.


### PR DESCRIPTION
## Summary

- Fix a C-memory leak in `pkg/logs/sender/batch.go` where `resetBatch()` created a new `StreamCompressor` without closing the old one. Three error paths in `processMessage` and `flushBuffer` call `resetBatch()` directly (bypassing `sendMessages`), orphaning the underlying `ZSTD_CCtx` allocated via CGO. Since the Go GC cannot track C-side allocations and no `runtime.SetFinalizer` is registered, these contexts accumulate permanently.
- Nil out `b.compressor` after the explicit `Close()` in `sendMessages` to prevent a double-free from the deferred `resetBatch()`.
- Add four unit tests covering each error path and the double-close guard.

## Context

Heap profiles from cluster-checks-runners show Go heap at ~20 MiB while process RSS grows to multi-GiB. The top cumulative allocator is `zstd.(*Writer).Write` at 5.8 GiB after 4 hours. The leak was introduced in 7.72.0 via [#40166](https://github.com/DataDog/datadog-agent/pull/40166) when the batch struct was refactored to hold a persistent `StreamCompressor` field, coinciding with DBM pipelines switching from gzip to zstd.

Related PR opened in [Datadog/zstd](https://github.com/DataDog/zstd/pull/163) to fix leaks on the C side


## Test plan

- [x] New tests fail without the fix, pass with it (verified via stash round-trip)
- [x] `TestResetBatchClosesCompressorOnSerializeError` — first `addMessage` error path
- [x] `TestResetBatchClosesCompressorOnFinishError` — `flushBuffer` Finish error path
- [x] `TestResetBatchClosesCompressorOnRetryError` — retry `addMessage` error path
- [x] `TestSendMessagesDoesNotDoubleClose` — happy path closes compressor exactly once
- [ ] Deploy to CLCr staging with DBM checks and monitor RSS over 4+ hours to confirm stabilization