### PR TITLE
[USM][Windows] Flush ETW HTTP transactions before reading statkeeper

### DIFF
--- a/pkg/network/usm/monitor_windows.go
+++ b/pkg/network/usm/monitor_windows.go
@@ -112,14 +112,20 @@ func (m *WindowsMonitor) process(transactionBatch []http.WinHttpTransaction) {
 // GetHTTPStats returns a map of HTTP stats stored in the following format:
 // [source, dest tuple, request path] -> RequestStats object
 func (m *WindowsMonitor) GetHTTPStats() map[protocols.ProtocolType]interface{} {
-	// dbtodo  This is now going to cause any pending transactions
-	// to be read and then stuffed into the channel.  Which then I think
-	// creates a race condition that there still could be some mid-
-	// process when we come back
 	m.di.ReadAllPendingTransactions()
 
 	m.mux.Lock()
 	defer m.mux.Unlock()
+
+	// Flush any ETW HTTP transactions that accumulated since the last
+	// 3-second ReadHttpTx poll cycle into the statkeeper before reading.
+	if etwTxs, err := http.ReadHttpTx(); err == nil && len(etwTxs) > 0 {
+		for i := range etwTxs {
+			tx := http.Transaction(&etwTxs[i])
+			m.telemetry.Count(tx)
+			m.statkeeper.Process(tx)
+		}
+	}
 
 	stats := m.statkeeper.GetAndResetAllStats()
 	//removeDuplicates(stats)


### PR DESCRIPTION
## Summary
- Flush ReadHttpTx() inside GetHTTPStats() before GetAndResetAllStats() to sync ETW data with TCP connections
- Without this, ETW transactions accumulated between 3-second poll cycles are missed, causing orphan HTTP aggregations at scale

## Validation (agent 7.77.3, Windows Server 2022)

| Test | client.hits | server.hits | Orphans (before) | Orphans (after) |
|------|:---:|:---:|:---:|:---:|
| localhost 1000 req → IIS | 1000 | 0 → 518 | 1000 | 0 |
| localhost 1000 req → IIS, 50s hold | 1000 | 0 → 518 | 1000 | 0 |
| remote 1000 req → IIS | N/A | 920 → 947 | 80 | 0 |
| remote 2500 req → IIS | N/A | ~2230 → ~2500 | 270 | 0 |
| localhost 1000 req → Python | 1000 | 1000 | 0 | 0 |
| localhost 20 req → IIS | 20 | 20 | 0 | 0 |
| remote 20 req → IIS | N/A | 20 | 0 | 0 |