### PR TITLE
ci(macos): Harden DMG signing (reapply of #49268, fix SIGPIPE in healthcheck)

### DIFF
--- a/.gitlab/build/package_build/build_agent_dmg.sh
+++ b/.gitlab/build/package_build/build_agent_dmg.sh
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+# Ensure the build keychain is destroyed on exit (normal, signal, or timeout).
+# This makes cleanup self-contained so it works from both CI and Bazel.
+trap 'security delete-keychain "$KEYCHAIN_NAME" 2>/dev/null || true' 0 1 2 3 15
+
 if [ "${SIGN:-false}" = true ]; then
     echo "Signing enabled"
 else
@@ -38,12 +42,17 @@ if [ "${SIGN:-false}" = true ]; then
     TEAM_ID=$("$CI_PROJECT_DIR/tools/ci/fetch_secret.sh" "$MACOS_APPLE_DEVELOPER_ACCOUNT" team-id) || exit $?; export TEAM_ID
     APPLE_ACCOUNT=$("$CI_PROJECT_DIR/tools/ci/fetch_secret.sh" "$MACOS_APPLE_DEVELOPER_ACCOUNT" user) || exit $?; export APPLE_ACCOUNT
 
+    # Remove any stale keychain left over from a previous failed/timed-out job.
+    security delete-keychain "$KEYCHAIN_NAME" 2>/dev/null || true
+
     # Create temporary build keychain
     security create-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_NAME"
 
-    # Let the keychain stay unlocked for 1 hour, otherwise the OS might lock
-    # it again after a period of inactivity.
-    security set-keychain-settings -lut 3600 "$KEYCHAIN_NAME"
+    # Disable auto-lock entirely: the keychain is ephemeral and destroyed in
+    # after_script, so there is no security benefit to auto-locking.  The
+    # previous 1-hour timeout could cause errSecInternalComponent if the
+    # omnibus build took longer than expected before reaching the signing step.
+    security set-keychain-settings "$KEYCHAIN_NAME"
 
     # Add the build keychain to the list of active keychains
     security list-keychains -d user -s "$KEYCHAIN_NAME" "login.keychain"

--- a/.gitlab/build/package_build/build_agent_dmg.sh
+++ b/.gitlab/build/package_build/build_agent_dmg.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 # Ensure the build keychain is destroyed on exit (normal, signal, or timeout).
 # This makes cleanup self-contained so it works from both CI and Bazel.
-trap 'security delete-keychain "$KEYCHAIN_NAME" 2>/dev/null || true' 0 1 2 3 15
+trap 'security delete-keychain "$KEYCHAIN_NAME" 2>/dev/null || true' EXIT
 
 if [ "${SIGN:-false}" = true ]; then
     echo "Signing enabled"

--- a/.gitlab/build/package_build/dmg.yml
+++ b/.gitlab/build/package_build/dmg.yml
@@ -64,11 +64,6 @@
     - sudo umount /Volumes/Agent || true
     - rm -rf "$OMNIBUS_GIT_CACHE_DIR" || true
   after_script:
-    # Destroy the keychain used to sign packages
-    - |
-      if [ "${SIGN:-false}" = true ]; then
-        security delete-keychain "build.keychain" || true
-      fi
     - sudo umount /Volumes/Agent || true
   script:
     - set -eo pipefail

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -217,10 +217,15 @@ build do
                 # before the parallel batch.  If securityd or the keychain is
                 # in a bad state this will fail fast (seconds) instead of
                 # burning ~90 minutes retrying hundreds of files.
+                #
+                # Uses `find ... -print -quit` (not `| head -1`): under
+                # `pipefail`, piping to `head` makes `find` exit 141 on SIGPIPE
+                # once `head` closes its stdin, which reliably fails the
+                # healthcheck even when codesign itself succeeds.
                 hardened_runtime = "-o runtime --entitlements #{entitlements_file} "
                 command <<-SH.gsub(/^ {20}/, ""), cwd: Dir.pwd
                     set -euo pipefail
-                    test_file=$(find #{install_dir} -type f -perm +111 ! -path '*/Datadog Agent.app/*' -print | head -1)
+                    test_file=$(find #{install_dir} -type f -perm +111 ! -path '*/Datadog Agent.app/*' -print -quit)
                     if [ -n "$test_file" ]; then
                         echo "Signing healthcheck: codesigning $test_file"
                         codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' "$test_file"

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -203,12 +203,36 @@ build do
             command "dda inv -- omnibus.rpath-edit #{install_dir} #{install_dir} --platform=macos", cwd: Dir.pwd
 
             if code_signing_identity
+                # Re-unlock the keychain right before signing.  The keychain
+                # may have been auto-locked if the build took longer than the
+                # previous timeout, or securityd may have dropped state.  This
+                # is a no-op when the keychain is already unlocked.
+                keychain_name = ENV['KEYCHAIN_NAME']
+                keychain_pwd  = ENV['KEYCHAIN_PWD']
+                if keychain_name && keychain_pwd && !keychain_pwd.empty?
+                    command "security unlock-keychain -p \"$KEYCHAIN_PWD\" \"$KEYCHAIN_NAME\"", cwd: Dir.pwd
+                end
+
+                # Signing healthcheck: attempt a single codesign operation
+                # before the parallel batch.  If securityd or the keychain is
+                # in a bad state this will fail fast (seconds) instead of
+                # burning ~90 minutes retrying hundreds of files.
+                hardened_runtime = "-o runtime --entitlements #{entitlements_file} "
+                command <<-SH.gsub(/^ {20}/, ""), cwd: Dir.pwd
+                    set -euo pipefail
+                    test_file=$(find #{install_dir} -type f -perm +111 ! -path '*/Datadog Agent.app/*' -print | head -1)
+                    if [ -n "$test_file" ]; then
+                        echo "Signing healthcheck: codesigning $test_file"
+                        codesign #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' "$test_file"
+                        echo "Signing healthcheck passed"
+                    fi
+                SH
+
                 # Sometimes the timestamp service is not available, so we retry
                 codesign = "../tools/ci/retry.sh codesign"
                 app = "'#{install_dir}/Datadog Agent.app'"
 
                 # Codesign ~480 files (out of ~28000)
-                hardened_runtime = "-o runtime --entitlements #{entitlements_file} "
                 command <<-SH.gsub(/^ {20}/, ""), cwd: Dir.pwd
                     set -euo pipefail
                     (

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -105,6 +105,8 @@ OS_SPECIFIC_ENV_PASSTHROUGH = {
         'NOTARIZATION_PWD': 'App-specific password for notarization',
         'NOTARIZATION_TIMEOUT': 'Timeout for xcrun notarytool wait',
         'TEAM_ID': 'Apple developer team ID used for notarization',
+        'KEYCHAIN_NAME': 'Name of the ephemeral keychain holding signing certificates',
+        'KEYCHAIN_PWD': 'Password for the ephemeral signing keychain',
     },
 }
 
@@ -127,6 +129,8 @@ def _get_environment_for_cache(env: dict[str, str]) -> dict:
         'GOPROXY',
         'HOME',
         'JARSIGN_JAR',
+        'KEYCHAIN_NAME',
+        'KEYCHAIN_PWD',
         'LD_PRELOAD',
         'LOCALAPPDATA',
         'MY_RUBY_HOME',


### PR DESCRIPTION
### What does this PR do?

Reapplies #49268 (reverted by #49561) with a one-line fix to the signing healthcheck.

### Why the original was reverted

The healthcheck introduced in #49268 used:

```bash
set -euo pipefail
test_file=\$(find \$install_dir -type f -perm +111 ! -path '*/Datadog Agent.app/*' -print | head -1)
```

Under `pipefail`, with a ~28000-file install tree, `find` keeps writing after `head -1` closes its stdin. `find` then dies with SIGPIPE → exit 141, which `pipefail` propagates. Every signing healthcheck therefore failed with exit 141 even though `codesign` itself succeeded — breaking every `agent_dmg-*` job on `main`.

Log confirmation from the broken job (`1607692016`):
```
Signing healthcheck: codesigning ...
codesign -o runtime --entitlements ... -s '...' "\$test_file"
Signing healthcheck passed
The following shell command exited with status 141:
ERROR: Job failed: exit status 1
```

### The fix

Replace `-print | head -1` with `-print -quit`. `find` prints the first match and exits 0 cleanly — no pipe, no SIGPIPE. macOS `find` has supported `-quit` since Leopard.

Verified locally:

```
bash -c 'set -euo pipefail; x=\$(find / -type f -perm +111 -print | head -1)'   # → exit 141
bash -c 'set -euo pipefail; x=\$(find / -type f -perm +111 -print -quit)'       # → exit 0
```

### Why the first PR slipped through

The healthcheck is gated by `if code_signing_identity`, which is only set when omnibus runs with signing enabled. On regular PR branches `agent_dmg-*` runs with `SIGN=false`, so the healthcheck code never executes pre-merge. The original PR description flagged *"Full CI run on a notarization branch is recommended"* — that validation wasn't done.

### How this PR is validated

This branch is named `nschweitzer/notarization-reapply-harden-macos-signing` so the `.agent_dmg:rules` entry `\$CI_COMMIT_BRANCH =~ /notarization/` triggers `SIGN=true` (see `.gitlab/build/package_build/dmg.yml:35-37`). Both `agent_dmg-x64-a7` and `agent_dmg-arm64-a7` will exercise the full keychain + healthcheck + codesign + notarization path end-to-end. **Do not mark ready until both jobs pass on the final commit.**

Sorry @rdesgroppes that I overlooked the tests on the first try

### Additional notes

- Commits are split for reviewability: the first is the literal revert-of-the-revert of #49561; the second is the SIGPIPE fix with the rationale in the commit message and as a comment above the heredoc.
- Motivation / original context: https://datadoghq.atlassian.net/browse/ACIX-1440