### PR TITLE
Improve metric name

### DIFF
--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -557,7 +557,7 @@ func (s *server) handleMessages() {
 	}
 
 	if s.offlineReporter != nil {
-		s.offlineReporter.SendOfflineDuration("datadog.dogstatsd.offline_duration", nil)
+		s.offlineReporter.SendOfflineDuration("datadog.agent.dogstatsd.offline_duration_seconds", nil)
 	}
 
 	// create and start all the workers


### PR DESCRIPTION
### What does this PR do?

Fix dogstatsd offline metric name to indicate that this is agent telemetry, and include units in the name.

### Motivation

Accurate names help interpret metrics correctly.

### Describe how you validated your changes

### Additional Notes
