### PR TITLE
[SINT-5112] Use new docker-credentials-helper token

### DIFF
--- a/.gitlab/windows/deploy/container_build/windows.yml
+++ b/.gitlab/windows/deploy/container_build/windows.yml
@@ -2,12 +2,11 @@
 .docker_build_agent_windows_common:
   stage: container_build
   id_tokens:
-    CI_IDENTITY_GITLAB_JWT:
-      aud: https://vault.us1.ddbuild.io
+    CI_IDENTITIES_GITLAB_ID_TOKEN:
+      aud: ci-identities
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
-    CI_IDENTITY_ROLE_NAME_OVERRIDE: windows-ci-tmp-gitlab-id-token-datadog-agent-all-refs
   script:
     - $ECR_RELEASE_SUFFIX="$(If ($BUCKET_BRANCH -eq `"nightly`") { `"-nightly`" } elseif ($CI_COMMIT_TAG) { `"-release`" } else { `"`" })"
     - $TARGET_TAG="${IMAGE}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}${SERVERCORE}-amd64"


### PR DESCRIPTION
### What does this PR do?

Use new docker-credentials-helper method using CI Identities mechanism

### Motivation

This technique is more reliable and common than the bypass used until now. See [this doc](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/4956889069/Authenticating+to+Datadog+s+Registry+as+a+Windows+CI+Job+Using+CI+Identities)

### Describe how you validated your changes

https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/108740347#:~:text=docker_build_agent7_windows jobs

### Additional Notes
