### PR TITLE
Fix deadlock when unsetting config

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -400,13 +400,16 @@ func (c *ntmConfig) UnsetForSource(key string, source model.Source) {
 
 	c.sequenceID++
 	receivers := slices.Clone(c.notificationReceivers)
+	// Capture the sequenceID here whilst locked to send to the receivers
+	// after unlocking.
+	sequenceID := c.sequenceID
 	c.Unlock()
 
 	// Notify receivers outside the lock. Subscribers commonly read the
 	// config from within their callback, and doing so while the write
 	// lock is still held deadlocks them against this goroutine.
 	for _, receiver := range receivers {
-		receiver(key, source, previousValue, newValue, c.sequenceID)
+		receiver(key, source, previousValue, newValue, sequenceID)
 	}
 }
 

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -337,7 +337,6 @@ func (c *ntmConfig) UnsetForSource(key string, source model.Source) {
 	c.maybeRebuild()
 
 	c.Lock()
-	defer c.Unlock()
 
 	key = strings.ToLower(key)
 	previousValue := c.leafAtPathFromNode(key, c.root).Get()
@@ -346,10 +345,12 @@ func (c *ntmConfig) UnsetForSource(key string, source model.Source) {
 	tree, err := c.getTreeBySource(source)
 	if err != nil {
 		log.Errorf("%s", err)
+		c.Unlock()
 		return
 	}
 	parentNode, childName, err := c.parentOfNode(tree, key)
 	if err != nil {
+		c.Unlock()
 		return
 	}
 	// Only remove if the setting is a leaf
@@ -358,12 +359,14 @@ func (c *ntmConfig) UnsetForSource(key string, source model.Source) {
 			parentNode.RemoveChild(childName)
 		} else {
 			log.Errorf("cannot remove setting %q, not a leaf", key)
+			c.Unlock()
 			return
 		}
 	}
 
 	// If the node in the merged tree doesn't match the source we expect, we're done
 	if c.leafAtPathFromNode(key, c.root).Source() != source {
+		c.Unlock()
 		return
 	}
 
@@ -373,12 +376,14 @@ func (c *ntmConfig) UnsetForSource(key string, source model.Source) {
 	// Get the parent node of the leaf we're unsetting
 	parentNode, childName, err = c.parentOfNode(c.root, key)
 	if err != nil {
+		c.Unlock()
 		return
 	}
 
 	// If there was no previous source with a node of this name, simply remove it from the parent
 	if findPreviousSourceError != nil {
 		parentNode.RemoveChild(childName)
+		c.Unlock()
 		return
 	}
 
@@ -389,13 +394,17 @@ func (c *ntmConfig) UnsetForSource(key string, source model.Source) {
 
 	// Value has not changed, do not notify
 	if reflect.DeepEqual(previousValue, newValue) {
+		c.Unlock()
 		return
 	}
 
 	c.sequenceID++
 	receivers := slices.Clone(c.notificationReceivers)
+	c.Unlock()
 
-	// notifying all receiver about the updated setting
+	// Notify receivers outside the lock. Subscribers commonly read the
+	// config from within their callback, and doing so while the write
+	// lock is still held deadlocks them against this goroutine.
 	for _, receiver := range receivers {
 		receiver(key, source, previousValue, newValue, c.sequenceID)
 	}

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -264,11 +264,14 @@ func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 	}
 
 	c.sequenceID++
+	// Capture the sequenceID here whilst locked to send to the receivers
+	// after unlocking.
+	sequenceID := c.sequenceID
 	c.Unlock()
 
 	// notifying all receiver about the updated setting
 	for _, receiver := range receivers {
-		receiver(key, source, previousValue, newValue, c.sequenceID)
+		receiver(key, source, previousValue, newValue, sequenceID)
 	}
 }
 

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -396,11 +396,10 @@ func (c *ntmConfig) UnsetForSource(key string, source model.Source) {
 		// Replace the child with the node from the previous layer
 		parentNode.InsertChildNode(childName, prevNode)
 
-		newValue := c.leafAtPathFromNode(key, c.root).Get()
+		newValue = c.leafAtPathFromNode(key, c.root).Get()
 
 		// Value has not changed, do not notify
 		if reflect.DeepEqual(previousValue, newValue) {
-			c.Unlock()
 			return false
 		}
 

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -339,74 +339,82 @@ func (c *ntmConfig) findPreviousSourceNode(key string, source model.Source) (*no
 func (c *ntmConfig) UnsetForSource(key string, source model.Source) {
 	c.maybeRebuild()
 
-	c.Lock()
+	var (
+		previousValue interface{}
+		newValue      interface{}
+		receivers     []model.NotificationReceiver
+		sequenceID    uint64
+	)
 
-	key = strings.ToLower(key)
-	previousValue := c.leafAtPathFromNode(key, c.root).Get()
+	ok := func() bool {
+		c.Lock()
+		defer c.Unlock()
 
-	// Remove it from the original source tree
-	tree, err := c.getTreeBySource(source)
-	if err != nil {
-		log.Errorf("%s", err)
-		c.Unlock()
-		return
-	}
-	parentNode, childName, err := c.parentOfNode(tree, key)
-	if err != nil {
-		c.Unlock()
-		return
-	}
-	// Only remove if the setting is a leaf
-	if child, err := parentNode.GetChild(childName); err == nil {
-		if child.IsLeafNode() {
-			parentNode.RemoveChild(childName)
-		} else {
-			log.Errorf("cannot remove setting %q, not a leaf", key)
-			c.Unlock()
-			return
+		key = strings.ToLower(key)
+		previousValue = c.leafAtPathFromNode(key, c.root).Get()
+
+		// Remove it from the original source tree
+		tree, err := c.getTreeBySource(source)
+		if err != nil {
+			log.Errorf("%s", err)
+			return false
 		}
-	}
+		parentNode, childName, err := c.parentOfNode(tree, key)
+		if err != nil {
+			return false
+		}
+		// Only remove if the setting is a leaf
+		if child, err := parentNode.GetChild(childName); err == nil {
+			if child.IsLeafNode() {
+				parentNode.RemoveChild(childName)
+			} else {
+				log.Errorf("cannot remove setting %q, not a leaf", key)
+				return false
+			}
+		}
 
-	// If the node in the merged tree doesn't match the source we expect, we're done
-	if c.leafAtPathFromNode(key, c.root).Source() != source {
-		c.Unlock()
+		// If the node in the merged tree doesn't match the source we expect, we're done
+		if c.leafAtPathFromNode(key, c.root).Source() != source {
+			return false
+		}
+
+		// Find what the previous value used to be, based upon the previous source
+		prevNode, findPreviousSourceError := c.findPreviousSourceNode(key, source)
+
+		// Get the parent node of the leaf we're unsetting
+		parentNode, childName, err = c.parentOfNode(c.root, key)
+		if err != nil {
+			return false
+		}
+
+		// If there was no previous source with a node of this name, simply remove it from the parent
+		if findPreviousSourceError != nil {
+			parentNode.RemoveChild(childName)
+			return false
+		}
+
+		// Replace the child with the node from the previous layer
+		parentNode.InsertChildNode(childName, prevNode)
+
+		newValue := c.leafAtPathFromNode(key, c.root).Get()
+
+		// Value has not changed, do not notify
+		if reflect.DeepEqual(previousValue, newValue) {
+			c.Unlock()
+			return false
+		}
+
+		c.sequenceID++
+		receivers = slices.Clone(c.notificationReceivers)
+		// Capture the sequenceID here whilst locked to send to the receivers
+		// after unlocking.
+		sequenceID = c.sequenceID
+		return true
+	}()
+
+	if !ok {
 		return
 	}
-
-	// Find what the previous value used to be, based upon the previous source
-	prevNode, findPreviousSourceError := c.findPreviousSourceNode(key, source)
-
-	// Get the parent node of the leaf we're unsetting
-	parentNode, childName, err = c.parentOfNode(c.root, key)
-	if err != nil {
-		c.Unlock()
-		return
-	}
-
-	// If there was no previous source with a node of this name, simply remove it from the parent
-	if findPreviousSourceError != nil {
-		parentNode.RemoveChild(childName)
-		c.Unlock()
-		return
-	}
-
-	// Replace the child with the node from the previous layer
-	parentNode.InsertChildNode(childName, prevNode)
-
-	newValue := c.leafAtPathFromNode(key, c.root).Get()
-
-	// Value has not changed, do not notify
-	if reflect.DeepEqual(previousValue, newValue) {
-		c.Unlock()
-		return
-	}
-
-	c.sequenceID++
-	receivers := slices.Clone(c.notificationReceivers)
-	// Capture the sequenceID here whilst locked to send to the receivers
-	// after unlocking.
-	sequenceID := c.sequenceID
-	c.Unlock()
 
 	// Notify receivers outside the lock. Subscribers commonly read the
 	// config from within their callback, and doing so while the write

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
@@ -1505,6 +1506,40 @@ func TestOnUpdate(t *testing.T) {
 	assert.Equal(t, "a", gotSetting)
 	assert.Equal(t, 1, gotOldValue)
 	assert.Equal(t, 2, gotNewValue)
+}
+
+// TestUnsetForSourceListenerCanReadConfig reproduces a deadlock where
+// UnsetForSource notified OnUpdate subscribers while still holding the
+// write lock. Any subscriber that read the config (via the read side of
+// the RWMutex) would block against the held write lock forever.
+func TestUnsetForSourceListenerCanReadConfig(t *testing.T) {
+	cfg := NewNodeTreeConfig("test", "TEST", nil)
+	cfg.SetDefault("log_level", "info")
+	cfg.BuildSchema()
+
+	observed := []string{}
+	cfg.OnUpdate(func(_ string, _ model.Source, _, _ any, _ uint64) {
+		// A realistic listener reads the current config. Before the fix
+		// this call deadlocked because UnsetForSource still held the
+		// config write lock.
+		observed = append(observed, cfg.GetString("log_level"))
+	})
+
+	cfg.Set("log_level", "debug", model.SourceRC)
+
+	done := make(chan struct{})
+	go func() {
+		cfg.UnsetForSource("log_level", model.SourceRC)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("UnsetForSource deadlocked while notifying listeners")
+	}
+
+	assert.Equal(t, []string{"debug", "info"}, observed)
 }
 
 func TestSetInvalidSource(t *testing.T) {

--- a/releasenotes/notes/fix-config-unset-notify-deadlock-ce8f0c68b99e0f32.yaml
+++ b/releasenotes/notes/fix-config-unset-notify-deadlock-ce8f0c68b99e0f32.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a deadlock that could make the Agent become unresponsive after a
+    remote configuration value was cleared.


### PR DESCRIPTION
### What does this PR do?

Fixes a deadlock that was caused in `UnsetForSource`.  The function would keep the mutex locked whilst notifying receivers. If these receivers accessed the config, a deadlock would occur.

This also updates `Set` to capture the value of sequenceID prior to unlocking to prevent a data race on that variable.

### Motivation

[#incident-52752](https://dd.enterprise.slack.com/archives/C0ATDJDNRFS)

### Describe how you validated your changes

Tested manually, and have a unit test reproducing.

### Additional Notes
