### PR TITLE
bazel: make cgo_godefs hermetic by using gcc toolchain

### DIFF
--- a/.cursor/rules/system_probe_modules.mdc
+++ b/.cursor/rules/system_probe_modules.mdc
@@ -409,13 +409,9 @@ dda inv system-probe.test -p <path>
 # Generate runtime compilation files
 go generate ./pkg/collector/corechecks/ebpf/probe/<check>/<check>.go
 
-# Generate CGO types
-cd pkg/collector/corechecks/ebpf/probe/<check> && \
-  CC=clang go tool cgo -godefs -- \
-  -I ../../../../../network/ebpf/c -I ../../../../../ebpf/c \
-  -fsigned-char <check>_kern_types.go | \
-  go run /path/to/genpost.go <check>_kern_types_linux_test <package> \
-  > <check>_kern_types_linux.go
+# Generate CGO types (regenerates the committed *_linux.go / *_linux_test.go files)
+dda bzl run //pkg/collector/corechecks/ebpf/probe/<check>:<target>_godefs
+dda bzl run //pkg/collector/corechecks/ebpf/probe/<check>:<target>_godefs_test_file
 
 # Check for linter errors
 dda inv linter.go --targets=./pkg/collector/corechecks/ebpf/<check>

--- a/bazel/rules/ebpf/cgo_godefs.bzl
+++ b/bazel/rules/ebpf/cgo_godefs.bzl
@@ -73,10 +73,14 @@ def _cgo_godefs_impl(ctx):
         package_name = ctx.label.package.split("/")[-1]
         genpost_args = "$ROOT/{test} {pkg}".format(test = test_path_no_ext, pkg = package_name)
 
-    # TODO(ABLD-410): uses the system clang rather than a hermetic toolchain.
-    # On Windows, Go defaults to gcc (MinGW) — no CC override needed, matching
-    # the old ninja behavior.
-    cc_prefix = "CC=clang " if platform == "linux" else ""
+    # TODO(ABLD-410): CC=gcc uses the hermetic gcc_toolchain (available in
+    # the sandbox PATH via go.cc_toolchain_files) as the "separate host-CC
+    # toolchain" alternative — the llvm_bpf clang is BPF-only, and cgo
+    # -godefs only needs a host-capable C compiler whose struct layouts
+    # match the target ABI. Switching to clang would require shipping one
+    # built with LLVM_TARGETS_TO_BUILD="X86;AArch64".
+    # On Windows, Go defaults to gcc (MinGW) — no CC override needed.
+    cc_prefix = "CC=gcc " if platform == "linux" else ""
 
     cmd = (
         "set -euo pipefail && ROOT=$PWD && cd {src_dir} && " +

--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -73,6 +74,8 @@ func processFile(rdr io.Reader, out io.Writer) error {
 	convertBytePointerToUint64Regex := regexp.MustCompile(`(\s+)(\*(byte|uint64))`)
 	b = convertBytePointerToUint64Regex.ReplaceAll(b, []byte("${1}uint64"))
 
+	b = fixGccUnsignedCharConsts(b)
+
 	b, err = format.Source(b)
 	if err != nil {
 		return err
@@ -80,6 +83,33 @@ func processFile(rdr io.Reader, out io.Writer) error {
 
 	_, err = out.Write(b)
 	return err
+}
+
+// fixGccUnsignedCharConsts rewrites integer-valued "%f"-formatted constants
+// (e.g. `= 24.000000`) back to hex literals matching clang's output.
+//
+// Background: for `static const unsigned char X = 5;`, gcc emits
+// DW_ATE_unsigned_char in DWARF, which Go's debug/dwarf package decodes as
+// *dwarf.UcharType. cgo's godefs fconst handler only special-cases
+// *dwarf.IntType / *dwarf.UintType, so the UcharType falls through to
+// `fmt.Sprintf("%f", floats[i])` and the value is emitted as a float.
+// Clang historically emitted DW_ATE_unsigned for the same declaration,
+// which decoded to *dwarf.UintType and took the matching branch.
+// Converting `N.000000` back to `0xN` keeps committed outputs stable.
+var intAsFloatConstRegex = regexp.MustCompile(`= (-?\d+)\.000000\b`)
+
+func fixGccUnsignedCharConsts(b []byte) []byte {
+	return intAsFloatConstRegex.ReplaceAllFunc(b, func(match []byte) []byte {
+		sub := intAsFloatConstRegex.FindSubmatch(match)
+		n, err := strconv.ParseInt(string(sub[1]), 10, 64)
+		if err != nil {
+			return match
+		}
+		if n < 0 {
+			return fmt.Appendf(nil, "= -%#x", -n)
+		}
+		return fmt.Appendf(nil, "= %#x", n)
+	})
 }
 
 // removeAbsolutePath removes the absolute file path that is automatically output by cgo -godefs

--- a/pkg/ebpf/cgo/genpost_test.go
+++ b/pkg/ebpf/cgo/genpost_test.go
@@ -11,6 +11,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFixGccUnsignedCharConsts(t *testing.T) {
+	cases := []struct {
+		in, out string
+	}{
+		{"X Type = 0.000000", "X Type = 0x0"},
+		{"X Type = 24.000000", "X Type = 0x18"},
+		{"X Type = -1.000000", "X Type = -0x1"},
+		// Exactly 6 zeros after the dot is the cgo %f signature; leave anything else alone.
+		{"X Type = 1.5", "X Type = 1.5"},
+		{"X Type = 1.00000", "X Type = 1.00000"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.out, string(fixGccUnsignedCharConsts([]byte(c.in))))
+	}
+}
+
 func TestRemoveAbsolute(t *testing.T) {
 	linuxStr := `// cgo -godefs -- -fsigned-char /git/datadog-agent/pkg/network/driver/types.go`
 	assert.Equal(t, "// cgo -godefs -- -fsigned-char types.go", string(removeAbsolutePath([]byte(linuxStr), "linux")))


### PR DESCRIPTION
The cgo_godefs rule hardcoded CC=clang, relying on a system clang installation. Switch Linux to CC=gcc so it resolves to the already registered gcc_toolchain, taking the "separate host-CC toolchain" alternative noted in TODO(ABLD-410) (the llvm_bpf clang has no x86_64/aarch64 backends and can't be reused).

gcc emits DW_ATE_unsigned_char for `static const unsigned char`, which Go's debug/dwarf decodes as *dwarf.UcharType. cgo's godefs fconst handler only special-cases IntType/UintType, so such constants render as "%f" ("24.000000") instead of hex. Normalise integer-valued floats back to hex in genpost to keep committed outputs stable.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
