### PR TITLE
fix(assign-issue): Enable triage workflow for issues from external contributors

### DIFF
--- a/.github/workflows/assign-issue-triage.yml
+++ b/.github/workflows/assign-issue-triage.yml
@@ -35,6 +35,7 @@ jobs:
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         claude_args : --allowedTools "Read(issue_details.json),Edit(claude.txt)"
+        github_token: ${{ github.token }}
         prompt: |
           # Datadog Agent - Intelligent Issue Triage System
 


### PR DESCRIPTION
### What does this PR do?

Adds `github_token: ${{ github.token }}` to the `anthropics/claude-code-action` step in `.github/workflows/assign-issue-triage.yml` so the action uses the job-scoped `GITHUB_TOKEN` instead of falling back to OIDC-based app token exchange.

### Motivation

After #47233, the `github_token` input was removed from the Claude step with the intent that Claude would run with a read-only `github.token`. However, the input was not replaced — so `claude-code-action` fell back to its built-in OIDC → GitHub App token exchange. That exchange service enforces a "write access on target repo" check on the workflow actor. For `workflow_run` triggered by `issues: [opened, reopened]`, the actor is the issue opener; when the issue comes from a non-write contributor (the common case for this workflow), the exchange returns `401 Unauthorized - User does not have write access on this repository` and the whole triage job fails.

Observed on `datadog-agent` in run [24710710181](https://github.com/DataDog/datadog-agent/actions/runs/24710710181) (actor `ankitdn`, role `read`):

```
Exchanging OIDC token for app token...
App token exchange failed: 401 Unauthorized - User does not have write access on this repository
```

Passing `github_token` explicitly makes the action use the already-scoped workflow token (`contents: read`, `issues: write`, `actions: read`) and skips the exchange entirely — which matches what #47233's description promised ("Claude now receives a read-only `github.token`").

### Describe how you validated your changes

Reproduced and fixed end-to-end on `DataDog/incident-devx` (same workflow configuration, isolated sandbox):

1. **Reproduction with a non-write actor** — run [24720521978](https://github.com/DataDog/incident-devx/actions/runs/24720521978) fails with the same `App token exchange failed: 401 Unauthorized` error, confirming the root cause is the actor's repo permission and not anything datadog-agent-specific.
2. **Remediation** — after adding `github_token: ${{ github.token }}` to the Claude step, run [24721173488](https://github.com/DataDog/incident-devx/actions/runs/24721173488) completes successfully end-to-end. Logs show `OVERRIDE_GITHUB_TOKEN: ***` is populated and no OIDC exchange is attempted.

### Additional Notes

Follow-up to #47233.