### PR TITLE
test(e2e-framework): recreate on AKS ManagedCluster + dda-linux helm timeouts

### DIFF
--- a/test/e2e-framework/testing/utils/infra/retriable_errors.go
+++ b/test/e2e-framework/testing/utils/infra/retriable_errors.go
@@ -86,5 +86,15 @@ func getKnownErrors() []knownError {
 			retryType:    ReCreate,
 			maxRetry:     stackUpMaxRetry,
 		},
+		{
+			errorMessage: `azure-native:containerservice:ManagedCluster .* \*\*creating failed\*\*`,
+			retryType:    ReCreate,
+			maxRetry:     stackUpMaxRetry,
+		},
+		{
+			errorMessage: `Helm release "datadog/dda-linux" failed to initialize completely`,
+			retryType:    ReCreate,
+			maxRetry:     stackUpMaxRetry,
+		},
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Adds two new retry patterns to `test/e2e-framework/testing/utils/infra/retriable_errors.go`, both with `ReCreate` retry type:

1. `azure-native:containerservice:ManagedCluster .* **creating failed**` — matches when AKS cluster creation itself exceeds Pulumi's deadline.
2. `Helm release "datadog/dda-linux" failed to initialize completely` — matches when the agent helm release (re-)deployed by the SSI suite's `UpdateEnv` calls times out.

### Motivation

Analysis of the last 24 hours of `new-e2e-ssi-aks` job failures on both `main` and PR branches shows ~50+ failures/day, dominated by two systemic Azure flakes:

| Pattern | Share |
|---------|-------|
| `Helm release "datadog/dda-linux" ... context deadline exceeded` during `UpdateEnv` | ~70% |
| `ManagedCluster az-aks creating failed ... context deadline exceeded` | ~15% |

Together these two patterns cover ~85% of today's failures. The patterns are narrowly scoped to the Pulumi resource type and the specific helm release name, so they will not silently swallow real injection regressions — those surface via `workload-selection-expect-*` / `expect-injection` deployment failures, which are intentionally *not* added here.

This is mitigation, not a root-cause fix. A follow-up should investigate whether AKS node pools are undersized for the `dda-linux` chart and whether mid-suite `UpdateEnv` is leaving helm releases stuck in `pending-upgrade`.

### Describe how you validated your changes

Patterns were derived by clustering `@error.message` from `new-e2e-ssi-aks` failures in Datadog CI Visibility over the past 24h and cross-referencing with Pulumi log output captured in the failing jobs (`+ azure-native:containerservice:ManagedCluster az-aks **creating failed**` and `~ kubernetes:helm.sh/v3:Release dda-linux **updating failed**` lines). No behavior change outside the retry classifier.

### Additional Notes

A related PR on `kfairise/recreate-azure-flakes` adds a third Azure AKS pattern (`Failed to get route table object`). This PR is independent and can land ahead of or behind that one.