### PR TITLE
Proof of Concept for an Agent with an optional Python runtime

### DIFF
--- a/.gitlab/build/packaging/oci.yml
+++ b/.gitlab/build/packaging/oci.yml
@@ -174,3 +174,28 @@ ddot_oci:
   artifacts:
     paths:
       - ${OMNIBUS_PACKAGE_DIR}/*.oci.tar
+
+# Python runtime OCI package — ships Python interpreter + integrations for
+# the lite agent. Installable via `installer install <url>` (see
+# pkg/fleet/installer/packages/datadog_agent_python_runtime_linux.go).
+# Note: the omnibus build job for `python-runtime` (producing
+# datadog-agent-python-runtime-*.tar.xz for amd64 and arm64) is a
+# follow-up; this job is defined so the OCI packaging step is ready to
+# consume those artifacts once they exist.
+python_runtime_oci:
+  extends: .package_oci
+  rules:
+    - when: manual
+      allow_failure: true
+  needs:
+    - "go_tools_deps"
+    - job: "datadog-agent-python-runtime-oci-x64"
+      optional: true
+    - job: "datadog-agent-python-runtime-oci-arm64"
+      optional: true
+  variables:
+    OCI_PRODUCT: "datadog-agent-python-runtime"
+    INSTALL_DIR: "/opt/datadog-agent"
+  artifacts:
+    paths:
+      - ${OMNIBUS_PACKAGE_DIR}/*.oci.tar

--- a/omnibus/config/projects/python-runtime.rb
+++ b/omnibus/config/projects/python-runtime.rb
@@ -1,0 +1,88 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https:#www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+require "./lib/ostools.rb"
+require "./lib/project_helpers.rb"
+require "./lib/omnibus/packagers/tarball.rb"
+
+name 'python-runtime'
+package_name 'datadog-agent-python-runtime'
+
+license "Apache-2.0"
+license_file "../LICENSE"
+
+third_party_licenses "../LICENSE-3rdparty.csv"
+
+homepage 'http://www.datadoghq.com'
+
+if ENV.has_key?("OMNIBUS_WORKERS_OVERRIDE")
+  COMPRESSION_THREADS = ENV["OMNIBUS_WORKERS_OVERRIDE"].to_i
+else
+  COMPRESSION_THREADS = 1
+end
+
+if ENV.has_key?("DEPLOY_AGENT") && ENV["DEPLOY_AGENT"] == "true"
+  COMPRESSION_LEVEL = 9
+else
+  COMPRESSION_LEVEL = 5
+end
+
+if ENV.has_key?("OMNIBUS_GIT_CACHE_DIR")
+  Omnibus::Config.use_git_caching true
+  Omnibus::Config.git_cache_dir ENV["OMNIBUS_GIT_CACHE_DIR"]
+end
+
+# Install dir matches the agent's layout so that, when the runtime is
+# installed as an OCI package under /opt/datadog-packages/
+# datadog-agent-python-runtime/<version>/, its embedded/ tree mirrors
+# the agent's embedded/ tree and can be symlinked across by the
+# installer post-install hook.
+INSTALL_DIR = ENV["INSTALL_DIR"] || '/opt/datadog-agent'
+install_dir INSTALL_DIR
+
+json_manifest_path File.join(install_dir, "version-manifest.python-runtime.json")
+text_manifest_path File.join(install_dir, "version-manifest.python-runtime.txt")
+
+# build_version is computed by an invoke command/function and passed through
+# the environment, same pattern as the other omnibus projects.
+build_version ENV['PACKAGE_VERSION']
+
+build_iteration 1
+
+description 'Python runtime and integrations for the Datadog Agent'
+
+maintainer 'Datadog Packages <package@datadoghq.com>'
+
+# ------------------------------------
+# Dependencies
+# ------------------------------------
+dependency 'datadog-agent-python-runtime'
+
+exclude '\.git*'
+exclude 'bundler\/git'
+
+# The Python runtime is currently shipped only as an OCI artifact. Skip
+# the deb/rpm/msi packagers; the .tar.xz produced by the :xz packager is
+# what feeds the `datadog-package create` step in CI.
+package :deb do
+  skip_packager true
+end
+
+package :rpm do
+  skip_packager true
+end
+
+package :msi do
+  skip_packager true
+end
+
+package :xz do
+  skip_packager (ENV["SKIP_PKG_COMPRESSION"] == "true")
+  compression_threads COMPRESSION_THREADS
+  compression_level COMPRESSION_LEVEL
+end
+
+package :tarball do
+  skip_packager !(ENV["SKIP_PKG_COMPRESSION"] == "true")
+end

--- a/omnibus/config/software/datadog-agent-python-runtime.rb
+++ b/omnibus/config/software/datadog-agent-python-runtime.rb
@@ -1,0 +1,39 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https:#www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+require './lib/ostools.rb'
+
+name 'datadog-agent-python-runtime'
+
+license "Apache-2.0"
+license_file "../LICENSE"
+
+# Build Python interpreter and all integrations into the install dir.
+# The resulting embedded/ directory gets packaged as an OCI artifact and,
+# at install time, symlinked into the agent's embedded/ tree by the
+# installer post-install hook (see pkg/fleet/installer/packages/
+# datadog_agent_python_runtime_linux.go).
+dependency 'python3'
+dependency 'datadog-agent-integrations-py3'
+
+# Memory profiler used by the `status py` agent subcommand. Ships with the
+# runtime so it is available whenever Python checks are available.
+dependency 'pympler'
+
+build do
+  # Copy the python-scripts (pre.py / post.py for custom integration
+  # preservation) into the runtime package. These are normally placed
+  # by datadog-agent.rb; for the standalone runtime we do it here so
+  # custom integration save/restore works without the full agent build.
+  python_scripts_src = "#{Omnibus::Config.project_root}/../omnibus/python-scripts"
+  if File.exist?(python_scripts_src)
+    mkdir "#{install_dir}/python-scripts"
+    Dir.glob("#{python_scripts_src}/*").each do |file|
+      unless File.basename(file).end_with?('_tests.py')
+        copy file, "#{install_dir}/python-scripts"
+      end
+    end
+  end
+end

--- a/omnibus/lib/ostools.rb
+++ b/omnibus/lib/ostools.rb
@@ -46,6 +46,10 @@ def heroku_target?()
     return ENV['AGENT_FLAVOR'] == 'heroku'
 end
 
+def lite_target?()
+    return ENV['AGENT_FLAVOR'] == 'lite'
+end
+
 def os
     case RUBY_PLATFORM
     when /linux/

--- a/pkg/collector/python/embed_python.go
+++ b/pkg/collector/python/embed_python.go
@@ -31,7 +31,9 @@ func InitPython(paths ...string) {
 
 func pySetup(paths ...string) (pythonVersion, pythonHome, pythonPath string) {
 	if err := Initialize(paths...); err != nil {
-		log.Errorf("Could not initialize Python: %s", err)
+		log.Errorf("Could not initialize Python: %s. "+
+			"Python checks will not be available. "+
+			"If the python runtime is not bundled, install the python runtime package to enable Python checks", err)
 	}
 	return PythonVersion, PythonHome, PythonPath
 }

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -61,11 +61,12 @@ var (
 )
 
 const (
-	wheelNamespace = "datadog_checks"
-	a7TagReady     = "ready"
-	a7TagNotReady  = "not_ready"
-	a7TagUnknown   = "unknown"
-	a7TagPython3   = "python3" // Already running on python3, linting is disabled
+	wheelNamespace      = "datadog_checks"
+	a7TagReady          = "ready"
+	a7TagNotReady       = "not_ready"
+	a7TagUnknown        = "unknown"
+	a7TagPython3        = "python3" // Already running on python3, linting is disabled
+	rtloaderLibraryName = "libdatadog-agent-rtloader.so"
 )
 
 // PythonCheckLoaderName is the name of the Python check loader
@@ -73,6 +74,11 @@ const PythonCheckLoaderName string = "python"
 
 func init() {
 	factory := func(senderManager sender.SenderManager, logReceiver option.Option[integrations.Component], tagger tagger.Component, filter workloadfilter.Component) (check.Loader, int, error) {
+		if err := checkRtloaderAvailable(); err != nil {
+			return nil, 20, fmt.Errorf("python runtime not available: rtloader library %s not found (%w). "+
+				"Python checks will be disabled. Install the python runtime package to enable them",
+				rtloaderLibraryName, err)
+		}
 		loader, err := NewPythonCheckLoader(senderManager, logReceiver, tagger, filter)
 		return loader, 20, err
 	}

--- a/pkg/collector/python/rtloader_check_linux.go
+++ b/pkg/collector/python/rtloader_check_linux.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build python && linux
+
+package python
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/system"
+)
+
+// checkRtloaderAvailable uses dlopen to verify that the rtloader shared library
+// is present on the system before attempting to initialize it. On Linux the
+// rtloader is a shared library loaded at runtime, so a missing library produces
+// cryptic dlopen errors. This check provides a clear, actionable message.
+func checkRtloaderAvailable() error {
+	return system.CheckLibraryExists(rtloaderLibraryName)
+}

--- a/pkg/collector/python/rtloader_check_other.go
+++ b/pkg/collector/python/rtloader_check_other.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build python && !linux
+
+package python
+
+// checkRtloaderAvailable is a no-op on non-Linux platforms. On Windows,
+// rtloader is statically linked. On macOS, the existing C.make3() failure
+// path provides adequate error reporting.
+func checkRtloaderAvailable() error {
+	return nil
+}

--- a/pkg/fleet/installer/packages/datadog_agent_python_runtime_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_python_runtime_linux.go
@@ -1,0 +1,161 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package packages
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/file"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var datadogAgentPythonRuntimePackage = hooks{
+	postInstall: postInstallPythonRuntime,
+	preRemove:   preRemovePythonRuntime,
+}
+
+const (
+	pythonRuntimePackage = "datadog-agent-python-runtime"
+	agentEmbeddedPath    = "/opt/datadog-agent/embedded"
+)
+
+var pythonRuntimePackagePermissions = file.Permissions{
+	{Path: ".", Owner: "dd-agent", Group: "dd-agent", Recursive: true},
+}
+
+func postInstallPythonRuntime(ctx HookContext) (err error) {
+	span, ctx := ctx.StartSpan("setup_python_runtime")
+	defer func() { span.Finish(err) }()
+
+	if ctx.PackageType != PackageTypeOCI {
+		return fmt.Errorf("unsupported package type for python runtime: %s", ctx.PackageType)
+	}
+
+	if err = user.EnsureAgentUserAndGroup(ctx, "/opt/datadog-agent"); err != nil {
+		return fmt.Errorf("failed to ensure dd-agent user and group: %v", err)
+	}
+
+	if err = pythonRuntimePackagePermissions.Ensure(ctx, ctx.PackagePath); err != nil {
+		return fmt.Errorf("failed to set python runtime package permissions: %v", err)
+	}
+
+	srcEmbedded := filepath.Join(ctx.PackagePath, "embedded")
+	if err = symlinkEmbeddedContents(srcEmbedded, agentEmbeddedPath); err != nil {
+		return fmt.Errorf("failed to symlink python runtime into agent embedded directory: %v", err)
+	}
+
+	log.Infof("Python runtime installed from %s, symlinked into %s", ctx.PackagePath, agentEmbeddedPath)
+	return nil
+}
+
+func preRemovePythonRuntime(ctx HookContext) (err error) {
+	span, ctx := ctx.StartSpan("remove_python_runtime")
+	defer func() { span.Finish(err) }()
+
+	srcEmbedded := filepath.Join(ctx.PackagePath, "embedded")
+	if err = removeEmbeddedSymlinks(srcEmbedded, agentEmbeddedPath); err != nil {
+		return fmt.Errorf("failed to remove python runtime symlinks: %v", err)
+	}
+
+	log.Infof("Python runtime symlinks removed from %s", agentEmbeddedPath)
+	return nil
+}
+
+// symlinkEmbeddedContents creates symlinks from files in srcDir into dstDir.
+// For top-level entries in srcDir (e.g. bin/, lib/), if the entry does not
+// exist in dstDir it is symlinked directly. If a directory with the same name
+// already exists in dstDir (e.g. agent's own embedded/lib/ for OpenSSL),
+// the function recurses one level and symlinks individual files within it.
+func symlinkEmbeddedContents(srcDir, dstDir string) error {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return fmt.Errorf("failed to read source directory %s: %w", srcDir, err)
+	}
+
+	if err := os.MkdirAll(dstDir, 0755); err != nil {
+		return fmt.Errorf("failed to create destination directory %s: %w", dstDir, err)
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(srcDir, entry.Name())
+		dstPath := filepath.Join(dstDir, entry.Name())
+
+		dstInfo, dstErr := os.Lstat(dstPath)
+		if dstErr != nil && !os.IsNotExist(dstErr) {
+			return fmt.Errorf("failed to stat %s: %w", dstPath, dstErr)
+		}
+
+		if os.IsNotExist(dstErr) {
+			if err := os.Symlink(srcPath, dstPath); err != nil {
+				return fmt.Errorf("failed to symlink %s -> %s: %w", dstPath, srcPath, err)
+			}
+			log.Debugf("Symlinked %s -> %s", dstPath, srcPath)
+			continue
+		}
+
+		if dstInfo.IsDir() && entry.IsDir() {
+			if err := symlinkEmbeddedContents(srcPath, dstPath); err != nil {
+				return err
+			}
+			continue
+		}
+
+		log.Debugf("Skipping %s: already exists in destination and is not a directory merge candidate", dstPath)
+	}
+
+	return nil
+}
+
+// removeEmbeddedSymlinks removes symlinks in dstDir that point into srcDir.
+func removeEmbeddedSymlinks(srcDir, dstDir string) error {
+	entries, err := os.ReadDir(dstDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read directory %s: %w", dstDir, err)
+	}
+
+	for _, entry := range entries {
+		dstPath := filepath.Join(dstDir, entry.Name())
+
+		info, err := os.Lstat(dstPath)
+		if err != nil {
+			continue
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(dstPath)
+			if err != nil {
+				continue
+			}
+			if isUnderDir(target, srcDir) {
+				if err := os.Remove(dstPath); err != nil {
+					return fmt.Errorf("failed to remove symlink %s: %w", dstPath, err)
+				}
+				log.Debugf("Removed symlink %s -> %s", dstPath, target)
+			}
+		} else if info.IsDir() {
+			if err := removeEmbeddedSymlinks(srcDir, dstPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func isUnderDir(path, dir string) bool {
+	absPath, err1 := filepath.Abs(path)
+	absDir, err2 := filepath.Abs(dir)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return len(absPath) > len(absDir) && absPath[:len(absDir)+1] == absDir+string(filepath.Separator)
+}

--- a/pkg/fleet/installer/packages/packages_linux.go
+++ b/pkg/fleet/installer/packages/packages_linux.go
@@ -10,9 +10,10 @@ import "github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 var (
 	// packagesHooks is a map of package names to their hooks
 	packagesHooks = map[string]hooks{
-		"datadog-agent":      datadogAgentPackage,
-		"datadog-apm-inject": apmInjectPackage,
-		"datadog-agent-ddot": datadogAgentDDOTPackage,
+		"datadog-agent":                datadogAgentPackage,
+		"datadog-apm-inject":           apmInjectPackage,
+		"datadog-agent-ddot":           datadogAgentDDOTPackage,
+		"datadog-agent-python-runtime": datadogAgentPythonRuntimePackage,
 	}
 
 	// AsyncPreRemoveHooks is called before a package is removed from the disk.

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -97,7 +97,7 @@ def build(
     """
     flavor = AgentFlavor[flavor]
 
-    if not exclude_rtloader and not flavor.is_iot() and sys.platform != "aix":
+    if not exclude_rtloader and not flavor.is_iot() and not flavor.is_lite() and sys.platform != "aix":
         # On AIX, rtloader is built natively in advance as a prerequisite.
         with gitlab_section("Install embedded rtloader", collapsed=True):
             if enable_bazel:

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -163,6 +163,9 @@ DOGSTATSD_TAGS = {"containerd", "docker", "kubelet", "podman", "zlib", "zstd"}
 # IOT_AGENT_TAGS lists the tags needed when building the IoT agent
 IOT_AGENT_TAGS = {"jetson", "systemd", "zlib", "zstd"}
 
+# LITE_AGENT_TAGS lists the tags needed when building the lite agent (no Python)
+LITE_AGENT_TAGS = AGENT_TAGS.difference({"python"})
+
 # INSTALLER_TAGS lists the tags needed when building the installer
 INSTALLER_TAGS = {"ec2"}
 
@@ -381,6 +384,11 @@ build_tags = {
         "dogstatsd": DOGSTATSD_TAGS,
         "lint": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
         "unit-tests": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
+    },
+    AgentFlavor.lite: {
+        "agent": LITE_AGENT_TAGS,
+        "lint": LITE_AGENT_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
+        "unit-tests": LITE_AGENT_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
     },
 }
 

--- a/tasks/flavor.py
+++ b/tasks/flavor.py
@@ -8,9 +8,13 @@ class AgentFlavor(enum.Enum):
     heroku = 3
     dogstatsd = 4
     fips = 5
+    lite = 6
 
     def is_iot(self):
         return self == type(self).iot
 
     def is_fips(self):
         return self == type(self).fips
+
+    def is_lite(self):
+        return self == type(self).lite


### PR DESCRIPTION
# Introduce lite agent flavor and Python runtime as an installable OCI package

## What

  Foundations for splitting the agent into a core part and a Python runtime (interpreter +
  integrations) that can be installed on demand via the agent installer.

## Why

  Today the agent ships as a monolith. Python interpreter + wheels are the bulk of the install
   footprint (~250–450MB), paid by every customer whether or not they run Python checks. This
  PR is the first step toward letting customers install a lightweight agent and pull Python in
   only when needed.

## Scope

  This PR sets up the **packaging split** and **graceful runtime behavior**. It does **not**
  automate the install — the Python runtime must be installed explicitly via `installer
  install` on a stopped agent. Reactive loading (detect Python check config → install in
  background → schedule) is a follow-up.

## Changes by area

### Build flavor (`tasks/`)

  New `lite` flavor that builds the agent without the `python` build tag.

  | File | Change |
  |---|---|
  | `flavor.py` | `AgentFlavor.lite = 6`, `is_lite()` |
  | `build_tags.py` | `LITE_AGENT_TAGS = AGENT_TAGS - {"python"}` and lite flavor build_tags
  entries |
  | `agent.py` | Skip rtloader build for lite (like iot) |

  ```bash
  dda inv agent.build --flavor lite --build-exclude=systemd
  ```

### Agent runtime (`pkg/collector/python/`)

  The Python loader factory checks for `libdatadog-agent-rtloader.so` before initializing
  rtloader. If missing, it returns a clear error and the loader is skipped via the existing
  factory-error path. Agent continues with Go and JMX checks.

  | File | Change |
  |---|---|
  | `loader.go` | Factory calls `checkRtloaderAvailable()` with descriptive error on miss |
  | `embed_python.go` | Improved error message pointing at the runtime package |
  | `rtloader_check_linux.go` (new) | Linux dlopen probe via `system.CheckLibraryExists` |
  | `rtloader_check_other.go` (new) | No-op stub for non-Linux (Windows links statically,
  macOS has adequate errors) |

### Installer package (`pkg/fleet/installer/packages/`)

  New `datadog-agent-python-runtime` package. `postInstall` symlinks the runtime's `embedded/`
   into the agent's `embedded/` tree (following the DDOT precedent); Python packages find
  OpenSSL via existing rpaths without duplication. `preRemove` cleans up the symlinks.

  | File | Change |
  |---|---|
  | `packages_linux.go` | Register hooks in `packagesHooks` |
  | `datadog_agent_python_runtime_linux.go` (new) | `postInstall` / `preRemove` hooks |

  ```bash
  installer install oci://install.datadoghq.com/python-runtime-package:<version>
  ```

### Omnibus build (`omnibus/`)

  Standalone omnibus project producing the Python runtime `.tar.xz` independently of the full
  agent build. Modeled on `ddot.rb`.

  | File | Change |
  |---|---|
  | `lib/ostools.rb` | `lite_target?` helper |
  | `config/software/datadog-agent-python-runtime.rb` (new) | Software def: `python3` +
  `datadog-agent-integrations-py3` + `pympler` + custom-integration scripts |
  | `config/projects/python-runtime.rb` (new) | Omnibus project: `:xz` only; skips
  `:deb`/`:rpm`/`:msi` |

### CI (`.gitlab/build/packaging/oci.yml`)

  New `python_runtime_oci` job extending `.package_oci`. Wraps the omnibus `.tar.xz` as an OCI
   image via `datadog-package create`. Set to `manual` until the upstream omnibus build job
  lands.

## Deliberately deferred

  - **Lite agent omnibus packaging** — you can build a lite binary, but no deb/rpm yet.
  `datadog-agent.rb` / `agent.rb` are in flux with the bzl migration, so we are not touching
  them here.
  - **Python runtime omnibus build job in CI** — the OCI packaging job is in place; the
  upstream omnibus build producing `.tar.xz` for amd64/arm64 is a follow-up.
  - **Auto-install on Python check detection** — reactive deferred scheduling is a separate
  increment.
  - **Windows support** — Linux only for now.
  - **`default_packages.go` entry** — explicit `installer install <url>` is the MVP flow.

## Testing

  - `go vet -tags python ./pkg/collector/python/` and `go vet ./pkg/fleet/installer/packages/`
   pass.
  - Flavor / tag logic verified: `AgentFlavor.lite.is_lite()` returns `True`,
  `LITE_AGENT_TAGS` equals `AGENT_TAGS - {"python"}`.
  - Full `dda inv agent.build --flavor lite` not yet verified locally (requires newer `dda`
  than currently installed).

## How to manually test (Linux, once omnibus build is wired up)

  ```bash
  # Build the lite agent
  dda inv agent.build --flavor lite --build-exclude=systemd

  # Start it — Python checks unavailable, Go checks run
  ./bin/agent/agent run -c bin/agent/dist/datadog.yaml
  # Log output (single line, wrapped here for readability):
  #   "python runtime not available: rtloader library libdatadog-agent-rtloader.so not found.
  #    Python checks will be disabled. Install the python runtime package to enable them"

  # Stop agent, install the Python runtime
  installer install oci://install.datadoghq.com/python-runtime-package:<version>

  # Start agent again — Python checks now work
  ./bin/agent/agent run -c bin/agent/dist/datadog.yaml
  ```
