### PR TITLE
[kubelet] Read container resources from status for in-place resize

### DIFF
--- a/comp/core/workloadmeta/collectors/util/kubelet.go
+++ b/comp/core/workloadmeta/collectors/util/kubelet.go
@@ -17,6 +17,7 @@ package util
 
 import (
 	stdErrors "errors"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -222,7 +223,7 @@ func parsePodContainers(
 		containerSpec := findContainerSpec(container.Name, containerSpecs)
 		if containerSpec != nil {
 			env = extractEnvFromSpec(containerSpec.Env)
-			resources = extractResources(containerSpec)
+			resources = extractResources(containerSpec, &container)
 			resizePolicy = extractResizePolicy(containerSpec)
 
 			podContainer.Image, err = workloadmeta.NewContainerImage(imageID, containerSpec.Image)
@@ -437,40 +438,37 @@ func extractEnvFromSpec(envSpec []kubelet.EnvVar) map[string]string {
 	return env
 }
 
-func extractResources(spec *kubelet.ContainerSpec) workloadmeta.ContainerResources {
+func extractResources(spec *kubelet.ContainerSpec, status *kubelet.ContainerStatus) workloadmeta.ContainerResources {
 	resources := workloadmeta.ContainerResources{}
 
-	if spec.Resources == nil {
+	requests, limits := mergeContainerResources(spec, status)
+	if len(requests) == 0 && len(limits) == 0 {
 		// Ephemeral containers do not have resources defined
 		return resources
 	}
 
-	if cpuReq, found := spec.Resources.Requests[kubelet.ResourceCPU]; found {
+	if cpuReq, found := requests[kubelet.ResourceCPU]; found {
 		resources.CPURequest = kubernetes.FormatCPURequests(cpuReq)
-	}
-
-	if memoryReq, found := spec.Resources.Requests[kubelet.ResourceMemory]; found {
-		resources.MemoryRequest = kubernetes.FormatMemoryRequests(memoryReq)
-	}
-
-	if cpuLimit, found := spec.Resources.Limits[kubelet.ResourceCPU]; found {
-		resources.CPULimit = kubernetes.FormatCPURequests(cpuLimit)
-	}
-
-	if memoryLimit, found := spec.Resources.Limits[kubelet.ResourceMemory]; found {
-		resources.MemoryLimit = kubernetes.FormatMemoryRequests(memoryLimit)
-	}
-
-	// Check if the CPU Requested is a whole core or cores
-	if cpuReq, found := spec.Resources.Requests[kubelet.ResourceCPU]; found {
 		if cpuReq.MilliValue()%1000 == 0 {
 			resources.RequestedWholeCores = pointer.Ptr(true)
 		}
 	}
 
+	if memoryReq, found := requests[kubelet.ResourceMemory]; found {
+		resources.MemoryRequest = kubernetes.FormatMemoryRequests(memoryReq)
+	}
+
+	if cpuLimit, found := limits[kubelet.ResourceCPU]; found {
+		resources.CPULimit = kubernetes.FormatCPURequests(cpuLimit)
+	}
+
+	if memoryLimit, found := limits[kubelet.ResourceMemory]; found {
+		resources.MemoryLimit = kubernetes.FormatMemoryRequests(memoryLimit)
+	}
+
 	// extract GPU resource info from the possible GPU sources
 	uniqueGPUVendor := make(map[string]struct{})
-	for resourceName := range spec.Resources.Requests {
+	for resourceName := range requests {
 		gpuName, found := gpu.ExtractSimpleGPUName(gpu.ResourceGPU(resourceName))
 		if found {
 			uniqueGPUVendor[gpuName] = struct{}{}
@@ -484,16 +482,53 @@ func extractResources(spec *kubelet.ContainerSpec) workloadmeta.ContainerResourc
 	resources.GPUVendorList = gpuVendorList
 
 	resources.RawRequests = make(map[string]string)
-	for resourceName, quantity := range spec.Resources.Requests {
+	for resourceName, quantity := range requests {
 		resources.RawRequests[string(resourceName)] = quantity.String()
 	}
 
 	resources.RawLimits = make(map[string]string)
-	for resourceName, quantity := range spec.Resources.Limits {
+	for resourceName, quantity := range limits {
 		resources.RawLimits[string(resourceName)] = quantity.String()
 	}
 
 	return resources
+}
+
+// mergeContainerResources overlays live values from status.Resources
+// (in-place vertical scaling) on top of the pod spec. Spec keys missing
+// from status (GPU, custom resources) are preserved.
+func mergeContainerResources(spec *kubelet.ContainerSpec, status *kubelet.ContainerStatus) (kubelet.ResourceList, kubelet.ResourceList) {
+	var specRequests, specLimits kubelet.ResourceList
+	if spec != nil && spec.Resources != nil {
+		specRequests = spec.Resources.Requests
+		specLimits = spec.Resources.Limits
+	}
+
+	var statusRequests, statusLimits kubelet.ResourceList
+	if status != nil && status.Resources != nil {
+		statusRequests = status.Resources.Requests
+		statusLimits = status.Resources.Limits
+	}
+
+	return overlayResourceList(specRequests, statusRequests),
+		overlayResourceList(specLimits, statusLimits)
+}
+
+// overlayResourceList returns overlay overlaid on base. When one side is
+// empty the other is returned unchanged — the kubelet ResourceList is
+// JSON-unmarshalled and read-only downstream, so sharing is safe and
+// avoids an allocation on the pre-1.33 hot path.
+func overlayResourceList(base, overlay kubelet.ResourceList) kubelet.ResourceList {
+	if len(overlay) == 0 {
+		return base
+	}
+	if len(base) == 0 {
+		return overlay
+	}
+	out := make(kubelet.ResourceList, len(base)+len(overlay))
+	maps.Copy(out, base)
+	maps.Copy(out, overlay)
+	return out
 }
 
 func extractResizePolicy(spec *kubelet.ContainerSpec) workloadmeta.ContainerResizePolicy {

--- a/comp/core/workloadmeta/collectors/util/kubelet_test.go
+++ b/comp/core/workloadmeta/collectors/util/kubelet_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/DataDog/datadog-agent/comp/core"
@@ -21,6 +22,7 @@ import (
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 // TestParseKubeletPods_ImageFromContainerSpec tests that the image from the container spec is used
@@ -172,4 +174,156 @@ func TestParseKubeletPods_NamespaceMetadataFromCache(t *testing.T) {
 	// Assert that pod's own labels and annotations are still present
 	assert.Equal(t, podLabels, kubePod.Labels)
 	assert.Equal(t, podAnnotations, kubePod.Annotations)
+}
+
+// TestExtractResources_InPlaceResize covers merging pod spec resources with
+// the live values reported by the kubelet for in-place vertical scaling.
+func TestExtractResources_InPlaceResize(t *testing.T) {
+	tests := []struct {
+		name          string
+		spec          *kubelet.ContainerSpec
+		status        *kubelet.ContainerStatus
+		wantCPUReq    *float64
+		wantCPULimit  *float64
+		wantMemReq    *uint64
+		wantMemLimit  *uint64
+		wantRawReqs   map[string]string
+		wantRawLimits map[string]string
+	}{
+		{
+			name: "status.resources overrides spec (resized down)",
+			spec: &kubelet.ContainerSpec{
+				Name: "c",
+				Resources: &kubelet.ContainerResourcesSpec{
+					Requests: kubelet.ResourceList{
+						kubelet.ResourceCPU:              resource.MustParse("500m"),
+						kubelet.ResourceMemory:           resource.MustParse("1Gi"),
+						kubelet.ResourceGenericNvidiaGPU: resource.MustParse("1"),
+					},
+					Limits: kubelet.ResourceList{
+						kubelet.ResourceCPU:    resource.MustParse("500m"),
+						kubelet.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+			status: &kubelet.ContainerStatus{
+				Name: "c",
+				Resources: &kubelet.ContainerResourcesSpec{
+					Requests: kubelet.ResourceList{
+						kubelet.ResourceCPU:    resource.MustParse("200m"),
+						kubelet.ResourceMemory: resource.MustParse("512Mi"),
+					},
+					Limits: kubelet.ResourceList{
+						kubelet.ResourceCPU:    resource.MustParse("200m"),
+						kubelet.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+			},
+			wantCPUReq:   pointer.Ptr(20.0),
+			wantCPULimit: pointer.Ptr(20.0),
+			wantMemReq:   pointer.Ptr(uint64(512 * 1024 * 1024)),
+			wantMemLimit: pointer.Ptr(uint64(512 * 1024 * 1024)),
+			wantRawReqs: map[string]string{
+				"cpu":            "200m",
+				"memory":         "512Mi",
+				"nvidia.com/gpu": "1",
+			},
+			wantRawLimits: map[string]string{
+				"cpu":    "200m",
+				"memory": "512Mi",
+			},
+		},
+		{
+			name: "legacy cluster (no status resources) falls back to spec",
+			spec: &kubelet.ContainerSpec{
+				Name: "c",
+				Resources: &kubelet.ContainerResourcesSpec{
+					Requests: kubelet.ResourceList{
+						kubelet.ResourceCPU:    resource.MustParse("100m"),
+						kubelet.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: kubelet.ResourceList{
+						kubelet.ResourceCPU:    resource.MustParse("200m"),
+						kubelet.ResourceMemory: resource.MustParse("512Mi"),
+					},
+				},
+			},
+			status:       &kubelet.ContainerStatus{Name: "c"},
+			wantCPUReq:   pointer.Ptr(10.0),
+			wantCPULimit: pointer.Ptr(20.0),
+			wantMemReq:   pointer.Ptr(uint64(256 * 1024 * 1024)),
+			wantMemLimit: pointer.Ptr(uint64(512 * 1024 * 1024)),
+			wantRawReqs: map[string]string{
+				"cpu":    "100m",
+				"memory": "256Mi",
+			},
+			wantRawLimits: map[string]string{
+				"cpu":    "200m",
+				"memory": "512Mi",
+			},
+		},
+		{
+			name: "status.resources with partial keys falls through to spec for missing keys",
+			spec: &kubelet.ContainerSpec{
+				Name: "c",
+				Resources: &kubelet.ContainerResourcesSpec{
+					Requests: kubelet.ResourceList{
+						kubelet.ResourceCPU:              resource.MustParse("500m"),
+						kubelet.ResourceMemory:           resource.MustParse("1Gi"),
+						kubelet.ResourceEphemeralStorage: resource.MustParse("500Mi"),
+					},
+					Limits: kubelet.ResourceList{
+						kubelet.ResourceCPU:    resource.MustParse("500m"),
+						kubelet.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+			status: &kubelet.ContainerStatus{
+				Name: "c",
+				Resources: &kubelet.ContainerResourcesSpec{
+					Requests: kubelet.ResourceList{
+						kubelet.ResourceCPU: resource.MustParse("300m"),
+					},
+				},
+			},
+			wantCPUReq:   pointer.Ptr(30.0),
+			wantCPULimit: pointer.Ptr(50.0),
+			wantMemReq:   pointer.Ptr(uint64(1024 * 1024 * 1024)),
+			wantMemLimit: pointer.Ptr(uint64(1024 * 1024 * 1024)),
+			wantRawReqs: map[string]string{
+				"cpu":               "300m",
+				"memory":            "1Gi",
+				"ephemeral-storage": "500Mi",
+			},
+			wantRawLimits: map[string]string{
+				"cpu":    "500m",
+				"memory": "1Gi",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractResources(tc.spec, tc.status)
+
+			if tc.wantCPUReq != nil {
+				require.NotNil(t, got.CPURequest)
+				assert.InDelta(t, *tc.wantCPUReq, *got.CPURequest, 0.001)
+			}
+			if tc.wantCPULimit != nil {
+				require.NotNil(t, got.CPULimit)
+				assert.InDelta(t, *tc.wantCPULimit, *got.CPULimit, 0.001)
+			}
+			if tc.wantMemReq != nil {
+				require.NotNil(t, got.MemoryRequest)
+				assert.Equal(t, *tc.wantMemReq, *got.MemoryRequest)
+			}
+			if tc.wantMemLimit != nil {
+				require.NotNil(t, got.MemoryLimit)
+				assert.Equal(t, *tc.wantMemLimit, *got.MemoryLimit)
+			}
+			assert.Equal(t, tc.wantRawReqs, got.RawRequests)
+			assert.Equal(t, tc.wantRawLimits, got.RawLimits)
+		})
+	}
 }

--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -88,7 +88,7 @@ func StartWorkloadAutoscaling(
 	maxDatadogPodAutoscalerObjects := pkgconfigsetup.Datadog().GetInt("autoscaling.workload.limit")
 	limitHeap := autoscaling.NewHashHeap(maxDatadogPodAutoscalerObjects, store, (*model.PodAutoscalerInternal).CreationTimestamp)
 
-	controller, err := workload.NewController(clock, clusterID, eventRecorder, apiCl.RESTMapper, apiCl.ScaleCl, apiCl.Cl, apiCl.DynamicInformerCl, apiCl.DynamicInformerFactory, isLeaderFunc, store, podWatcher, sender, limitHeap, globalTagsFunc)
+	controller, err := workload.NewController(clock, clusterID, eventRecorder, apiCl.RESTMapper, apiCl.ScaleCl, apiCl.Cl, apiCl.DynamicCl, apiCl.DynamicInformerFactory, isLeaderFunc, store, podWatcher, sender, limitHeap, globalTagsFunc)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to start workload autoscaling controller: %w", err)
 	}
@@ -96,7 +96,7 @@ func StartWorkloadAutoscaling(
 	profileStore := autoscaling.NewStore[model.PodAutoscalerProfileInternal]()
 	profileController, err := profile.NewController(
 		clock,
-		apiCl.DynamicInformerCl,
+		apiCl.DynamicCl,
 		apiCl.DynamicInformerFactory,
 		isLeaderFunc,
 		profileStore,

--- a/pkg/collector/corechecks/containers/kubelet/common/testing/utils.go
+++ b/pkg/collector/corechecks/containers/kubelet/common/testing/utils.go
@@ -117,6 +117,11 @@ var (
 			"persistentvolumeclaim:www2-web-3",
 			"pod_phase:running",
 		},
+		"container_id://resized-container-id": {
+			"kube_container_name:resized-container",
+			"kube_namespace:default",
+		},
+		"kubernetes_pod_uid://resized-pod-uid-0001": {"pod_name:resized-pod"},
 	}
 
 	// InstanceTags are default tags that should be applied to all metrics at the instance level

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -241,6 +241,26 @@ func (suite *ProviderTestSuite) TestTransformPodsRequestsLimits() {
 	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"ephemeral-storage.limits", 2147483648.0, "", append(config.Tags, "pod_name:cassandra-0"))
 }
 
+// TestTransformPodsInPlaceResize verifies that request/limit metrics
+// reflect containerStatuses[].resources (in-place vertical scaling) when
+// set, and fall back to the spec for keys status does not report.
+func (suite *ProviderTestSuite) TestTransformPodsInPlaceResize() {
+	config := suite.provider.config
+
+	testDataFile := "../../testdata/pods_in_place_resize.json"
+	err := suite.fillWorkloadmetaStore(testDataFile)
+	require.Nil(suite.T(), err)
+
+	err = suite.provider.Provide(nil, suite.mockSender)
+	require.Nil(suite.T(), err)
+
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.requests", 0.2, "", append(config.Tags, "kube_container_name:resized-container", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.requests", 536870912.0, "", append(config.Tags, "kube_container_name:resized-container", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"cpu.limits", 0.2, "", append(config.Tags, "kube_container_name:resized-container", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.limits", 536870912.0, "", append(config.Tags, "kube_container_name:resized-container", "kube_namespace:default"))
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"nvidia.com/gpu.requests", 1.0, "", append(config.Tags, "kube_container_name:resized-container", "kube_namespace:default"))
+}
+
 func (suite *ProviderTestSuite) TestNoMetricNoKubeletData() {
 	config := suite.provider.config
 

--- a/pkg/collector/corechecks/containers/kubelet/testdata/pods_in_place_resize.json
+++ b/pkg/collector/corechecks/containers/kubelet/testdata/pods_in_place_resize.json
@@ -1,0 +1,79 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "metadata": {
+        "name": "resized-pod",
+        "namespace": "default",
+        "uid": "resized-pod-uid-0001",
+        "resourceVersion": "100",
+        "creationTimestamp": "2026-04-21T09:00:00Z",
+        "labels": {
+          "app": "resized"
+        }
+      },
+      "spec": {
+        "nodeName": "test-node",
+        "containers": [
+          {
+            "name": "resized-container",
+            "image": "nginx:1.25.2",
+            "resources": {
+              "requests": {
+                "cpu": "500m",
+                "memory": "1Gi",
+                "nvidia.com/gpu": "1"
+              },
+              "limits": {
+                "cpu": "500m",
+                "memory": "1Gi"
+              }
+            }
+          }
+        ]
+      },
+      "status": {
+        "phase": "Running",
+        "hostIP": "10.0.0.1",
+        "podIP": "10.0.0.2",
+        "startTime": "2026-04-21T09:00:10Z",
+        "qosClass": "Guaranteed",
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastTransitionTime": "2026-04-21T09:00:15Z"
+          }
+        ],
+        "containerStatuses": [
+          {
+            "name": "resized-container",
+            "state": {
+              "running": {
+                "startedAt": "2026-04-21T09:00:15Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "nginx:1.25.2",
+            "imageID": "docker-pullable://nginx@sha256:deadbeef",
+            "containerID": "docker://resized-container-id",
+            "resources": {
+              "requests": {
+                "cpu": "200m",
+                "memory": "512Mi"
+              },
+              "limits": {
+                "cpu": "200m",
+                "memory": "512Mi"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -253,6 +253,9 @@ type ContainerStatus struct {
 	State                      ContainerState               `json:"state"`
 	LastState                  ContainerState               `json:"lastState"`
 	ResolvedAllocatedResources []ContainerAllocatedResource `json:"resolvedAllocatedResources,omitempty"`
+
+	// Resources may not be the same as spec due to in-place vertical sizing
+	Resources *ContainerResourcesSpec `json:"resources,omitempty"`
 }
 
 // ContainerAllocatedResource contains the fields for an assigned resource to a container

--- a/releasenotes/notes/kubelet-in-place-resize-027e0535ccaaeb04.yaml
+++ b/releasenotes/notes/kubelet-in-place-resize-027e0535ccaaeb04.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The kubelet core check now reports container ``kubernetes.containers.cpu.requests``, ``kubernetes.containers.cpu.limits``, ``kubernetes.containers.memory.requests``, and ``kubernetes.containers.memory.limits`` metrics using the live values from ``pod.status.containerStatuses[].resources`` when available, so the metrics reflect the effective runtime values after an in-place vertical resize. Resources declared only in the pod spec (for example GPUs or custom resources) are preserved, and clusters where the kubelet does not yet populate ``status.resources`` continue to report the spec values as before.


### PR DESCRIPTION
### What does this PR do?

Two changes on the Cluster Agent / kubelet path related to in-place vertical scaling:

- **[kubelet]** In the workloadmeta kubelet collector, read `pod.status.containerStatuses[].resources` and overlay it on top of `pod.spec.containers[].resources` when building `workloadmeta.ContainerResources`. This flows into the `kubernetes.containers.{cpu,memory}.{requests,limits}` metrics emitted by the kubelet core check.
- **[autoscaling]** Fix the Kubernetes client used by the autoscaling pod patcher to perform updates (commit `264b8ff`).

The kubelet change preserves spec-only resource keys (GPU, custom resources) so they remain visible even when the status only reports cpu/memory. Pre-1.33 kubelets — where `status.resources` is not populated — continue to use spec values exactly as before.

`status.allocatedResources` is intentionally not read: per the Kubernetes docs it is kubelet-internal scheduling state, and `status.resources` already mirrors admitted values for non-running containers.

### Motivation

When in-place vertical scaling resizes a container, the new requests/limits appear in `status.containerStatuses[].resources` while `spec.containers[].resources` keeps the original values until the next pod mutation. Reading only from spec caused Datadog's container request/limit metrics to drift from the live, effective values.

### Describe how you validated your changes

Deploy Node agent + DCA in K8S with Workload scaling enabled.
Deploy a workload that's going to use more memory than the machine size, so that the in-place vertical sizing is `Infeasible`.
The value reported by `kubernetes.memory.limit` should follow the actual Pod value, not the desired in `spec`.

### Additional Notes

Adding the new `Resources *ContainerResourcesSpec` field to `kubelet.ContainerStatus` (`pkg/util/kubernetes/kubelet/types_kubelet.go`) is backward-compatible: older kubelets simply omit it and the existing spec-only code path remains.