### PR TITLE
[ABLD-387] Bazelify `sync_secl_win_pkg`

### DIFF
--- a/pkg/security/secl/BUILD.bazel
+++ b/pkg/security/secl/BUILD.bazel
@@ -1,5 +1,10 @@
 load("@rules_go//go:def.bzl", "go_library")
 
+exports_files(
+    ["doc.go"],
+    visibility = ["//pkg/security/seclwin:__pkg__"],
+)
+
 go_library(
     name = "secl",
     srcs = ["doc.go"],

--- a/pkg/security/secl/model/BUILD.bazel
+++ b/pkg/security/secl/model/BUILD.bazel
@@ -1,6 +1,22 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 load("//bazel/rules/go_stringer:defs.bzl", "go_stringer")
 
+exports_files(
+    glob(
+        ["*.go"],
+        exclude = ["model_string.go"],
+    ),
+    visibility = ["//pkg/security/seclwin/model:__pkg__"],
+)
+
+go_stringer(
+    name = "model_string",
+    src = "model.go",
+    linecomment = True,
+    output = "model_string.go",
+    types = ["HashState"],
+)
+
 go_library(
     name = "model",
     srcs = [
@@ -203,12 +219,4 @@ go_test(
         ],
         "//conditions:default": [],
     }),
-)
-
-go_stringer(
-    name = "model_string",
-    src = "model.go",
-    linecomment = True,
-    output = "model_string.go",
-    types = ["HashState"],
 )

--- a/pkg/security/seclwin/BUILD.bazel
+++ b/pkg/security/seclwin/BUILD.bazel
@@ -1,4 +1,11 @@
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
 load("@rules_go//go:def.bzl", "go_library")
+
+write_source_file(
+    name = "sync",
+    in_file = "//pkg/security/secl:doc.go",
+    out_file = "doc.go",
+)
 
 go_library(
     name = "seclwin",

--- a/pkg/security/seclwin/README.md
+++ b/pkg/security/seclwin/README.md
@@ -1,3 +1,9 @@
 # DO NOT EDIT
 
 This package has been auto-generated from the windows file in `pkg/security/secl`. Please do not edit those manually.
+
+To regenerate:
+```sh
+bazel run //pkg/security/seclwin:sync
+bazel run //pkg/security/seclwin/model:sync
+```

--- a/pkg/security/seclwin/model/BUILD.bazel
+++ b/pkg/security/seclwin/model/BUILD.bazel
@@ -1,6 +1,39 @@
+load("@bazel_lib//lib:expand_template.bzl", "expand_template")
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@rules_go//go:def.bzl", "go_library")
 
 # gazelle:go_stringer off
+
+[
+    expand_template(
+        name = "strip_go_build_windows_from_{}".format(src),
+        out = src,
+        substitutions = {"//go:build windows\n\n": ""},
+        template = "//pkg/security/secl/model:{}".format(src),
+    )
+    for src in [
+        "accessors_windows.go",
+        "field_handlers_windows.go",
+    ]
+]
+
+write_source_files(
+    name = "sync",
+    files = {
+        "accessors_helpers.go": "//pkg/security/secl/model:accessors_helpers.go",
+        "accessors_win.go": ":strip_go_build_windows_from_accessors_windows.go",
+        "args_envs.go": "//pkg/security/secl/model:args_envs.go",
+        "consts_common.go": "//pkg/security/secl/model:consts_common.go",
+        "consts_win.go": "//pkg/security/secl/model:consts_windows.go",
+        "events.go": "//pkg/security/secl/model:events.go",
+        "field_handlers_win.go": ":strip_go_build_windows_from_field_handlers_windows.go",
+        "iterator.go": "//pkg/security/secl/model:iterator.go",
+        "legacy_secl.go": "//pkg/security/secl/model:legacy_secl.go",
+        "model.go": "//pkg/security/secl/model:model.go",
+        "model_win.go": "//pkg/security/secl/model:model_windows.go",
+        "security_profile.go": "//pkg/security/secl/model:security_profile.go",
+    },
+)
 
 go_library(
     name = "model",

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -16,7 +16,7 @@ import tasks.libs.cws.secl_doc_gen as secl_doc_gen
 from tasks.build_tags import get_default_build_tags
 from tasks.flavor import AgentFlavor
 from tasks.go import run_golangci_lint
-from tasks.libs.build.bazel import BazelTools
+from tasks.libs.build.bazel import BazelTools, bazel
 from tasks.libs.build.ninja import NinjaWriter
 from tasks.libs.common.git import get_commit_sha, get_common_ancestor, get_current_branch
 from tasks.libs.common.go import go_build
@@ -549,7 +549,8 @@ def cws_go_generate(ctx, verbose=False):
     ctx.run("go generate -tags=linux_bpf,cws_go_generate ./pkg/security/...")
 
     # synchronize the seclwin package from the secl package
-    sync_secl_win_pkg(ctx)
+    bazel(ctx, "run", "//pkg/security/seclwin:sync")
+    bazel(ctx, "run", "//pkg/security/seclwin/model:sync")
 
     # generate documentation
     generate_cws_documentation(ctx)
@@ -776,46 +777,3 @@ def print_fentry_stats(ctx):
 
     for kind in ["kprobe", "kretprobe", "fentry", "fexit"]:
         ctx.run(f"readelf -W -S {fentry_o_path} 2> /dev/null | grep PROGBITS | grep {kind} | wc -l")
-
-
-@task
-def sync_secl_win_pkg(ctx):
-    files_to_copy = [
-        ("model.go", None),
-        ("events.go", None),
-        ("args_envs.go", None),
-        ("consts_common.go", None),
-        ("consts_windows.go", "consts_win.go"),
-        ("model_windows.go", "model_win.go"),
-        ("field_handlers_windows.go", "field_handlers_win.go"),
-        ("accessors_helpers.go", None),
-        ("accessors_windows.go", "accessors_win.go"),
-        ("legacy_secl.go", None),
-        ("security_profile.go", None),
-        ("iterator.go", None),
-    ]
-
-    seclwin_model = "pkg/security/seclwin/model"
-    build_bazel = os.path.join(seclwin_model, "BUILD.bazel")
-    preserve_build = os.path.exists(build_bazel)
-    if preserve_build:
-        build_bazel_content = open(build_bazel).read()
-
-    ctx.run(f"rm -r {seclwin_model}")
-    ctx.run(f"mkdir -p {seclwin_model}")
-    ctx.run("cp pkg/security/secl/doc.go pkg/security/seclwin/doc.go")
-
-    if preserve_build:
-        with open(build_bazel, "w") as f:
-            f.write(build_bazel_content)
-
-    for ffrom, fto in files_to_copy:
-        if not fto:
-            fto = ffrom
-
-        ctx.run(f"cp pkg/security/secl/model/{ffrom} pkg/security/seclwin/model/{fto}")
-        if sys.platform == "darwin":
-            ctx.run(f"sed -i '' '/^\\/\\/go:build/d' pkg/security/seclwin/model/{fto}")
-        else:
-            ctx.run(f"sed -i '/^\\/\\/go:build/d' pkg/security/seclwin/model/{fto}")
-        ctx.run(f"gofmt -s -w pkg/security/seclwin/model/{fto}")


### PR DESCRIPTION
### What does this PR do?
- add `exports_files` in `pkg/security/secl` and `secl/model` so `seclwin` packages can reference sources across package boundaries,
- wire `pkg/security/seclwin` with `write_source_file` (syncs `doc.go` from `secl`),
- wire `pkg/security/seclwin/model` with `write_source_files` (syncs 12 source files from `secl/model`) and `expand_template` (strips `//go:build windows` from the 2 files that carry it),
- remove `sync_secl_win_pkg` and replace its call site in `cws_go_generate` with 2 `bazel run` invocations.

### Motivation
`sync_secl_win_pkg` was a bespoke invoke task doing ad-hoc file-copying with `sed` and `gofmt`.
Moving the sync to Bazel makes it hermetic, repeatable, and verifiable (`diff_test`s).

### Describe how you validated your changes
`dda inv security-agent.cws-go-generate`