### PR TITLE
[NDM] Fix SNMP IP metadata rendered as "<nil>"

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/metadata/store.go
+++ b/pkg/collector/corechecks/snmp/internal/metadata/store.go
@@ -6,6 +6,8 @@
 package metadata
 
 import (
+	"net"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -78,6 +80,41 @@ func (s Store) GetColumnAsByteArray(field string, index string) []byte {
 		return value.Value.([]byte)
 	}
 	return nil
+}
+
+// GetColumnAsIPString gets a column value formatted as an IP address string.
+// Handles both decoder outputs: []byte for OCTET STRING fields (e.g. cdpCacheAddress)
+// and string for IpAddress fields (e.g. cipSecTunLocalAddr). Returns "" on
+// missing field/index or unparseable value.
+func (s Store) GetColumnAsIPString(field string, index string) string {
+	column, ok := s.columnValues[field]
+	if !ok {
+		return ""
+	}
+	value, ok := column[index]
+	if !ok {
+		return ""
+	}
+	switch v := value.Value.(type) {
+	case []byte:
+		ip := net.IP(v)
+		if len(ip) != net.IPv4len && len(ip) != net.IPv6len {
+			log.Debugf("unexpected IP byte length for field `%s` index `%s`: %d", field, index, len(ip))
+			return ""
+		}
+		return ip.String()
+	case string:
+		if v == "" {
+			return ""
+		}
+		if ip := net.ParseIP(v); ip != nil {
+			return ip.String()
+		}
+		log.Debugf("unparseable IP string for field `%s` index `%s`: %q", field, index, v)
+		return ""
+	}
+	log.Debugf("unexpected IP value type for field `%s` index `%s`: %T", field, index, value.Value)
+	return ""
 }
 
 // GetColumnAsFloat get column value as float

--- a/pkg/collector/corechecks/snmp/internal/metadata/store_test.go
+++ b/pkg/collector/corechecks/snmp/internal/metadata/store_test.go
@@ -80,6 +80,30 @@ func TestStore_Column(t *testing.T) {
 	assert.Equal(t, []byte(nil), store.GetColumnAsByteArray("interface.does_not_exist", "1"))
 }
 
+func TestStore_GetColumnAsIPString(t *testing.T) {
+	store := NewMetadataStore()
+	// upstream decoders may store IPs either as raw bytes or as dotted-decimal strings
+	store.AddColumnValue("ip.from_bytes_v4", "1", valuestore.ResultValue{Value: []byte{199, 47, 37, 5}})
+	store.AddColumnValue("ip.from_bytes_v6", "1", valuestore.ResultValue{Value: []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}})
+	store.AddColumnValue("ip.from_string_v4", "1", valuestore.ResultValue{Value: "199.47.37.5"})
+	store.AddColumnValue("ip.from_string_v6", "1", valuestore.ResultValue{Value: "2001:db8::1"})
+	store.AddColumnValue("ip.bad_bytes", "1", valuestore.ResultValue{Value: []byte{1, 2, 3}})
+	store.AddColumnValue("ip.bad_string", "1", valuestore.ResultValue{Value: "not an ip"})
+	store.AddColumnValue("ip.empty_string", "1", valuestore.ResultValue{Value: ""})
+	store.AddColumnValue("ip.wrong_type", "1", valuestore.ResultValue{Value: float64(1)})
+
+	assert.Equal(t, "199.47.37.5", store.GetColumnAsIPString("ip.from_bytes_v4", "1"))
+	assert.Equal(t, "2001:db8::1", store.GetColumnAsIPString("ip.from_bytes_v6", "1"))
+	assert.Equal(t, "199.47.37.5", store.GetColumnAsIPString("ip.from_string_v4", "1"))
+	assert.Equal(t, "2001:db8::1", store.GetColumnAsIPString("ip.from_string_v6", "1"))
+	assert.Equal(t, "", store.GetColumnAsIPString("ip.bad_bytes", "1"))
+	assert.Equal(t, "", store.GetColumnAsIPString("ip.bad_string", "1"))
+	assert.Equal(t, "", store.GetColumnAsIPString("ip.empty_string", "1"))
+	assert.Equal(t, "", store.GetColumnAsIPString("ip.wrong_type", "1"))
+	assert.Equal(t, "", store.GetColumnAsIPString("ip.does_not_exist", "1"))
+	assert.Equal(t, "", store.GetColumnAsIPString("ip.from_bytes_v4", "99"))
+}
+
 func TestStore_IDTags(t *testing.T) {
 	store := NewMetadataStore()
 	store.AddIDTags("interface", "1", []string{"aa"})

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -8,7 +8,6 @@ package report
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -520,7 +519,7 @@ func getRemDeviceAddressByCDPRemIndex(store *metadata.Store, strIndex string) st
 func getRemDeviceAddressIfIPType(store *metadata.Store, strIndex string, addressTypeField string, addressField string) string {
 	remoteDeviceAddressType := store.GetColumnAsString("cdp_remote."+addressTypeField, strIndex)
 	if remoteDeviceAddressType == ciscoNetworkProtocolIPv4 || remoteDeviceAddressType == ciscoNetworkProtocolIPv6 {
-		return net.IP(store.GetColumnAsByteArray("cdp_remote."+addressField, strIndex)).String()
+		return store.GetColumnAsIPString("cdp_remote."+addressField, strIndex)
 	}
 	return ""
 }
@@ -656,8 +655,8 @@ func buildCiscoIPsecVPNTunnelsMetadata(vpnTunnelIndexes []string, deviceID strin
 			continue
 		}
 
-		localOutsideIP := net.IP(store.GetColumnAsByteArray("cisco_ipsec_tunnel.local_outside_ip", strIndex)).String()
-		remoteOutsideIP := net.IP(store.GetColumnAsByteArray("cisco_ipsec_tunnel.remote_outside_ip", strIndex)).String()
+		localOutsideIP := store.GetColumnAsIPString("cisco_ipsec_tunnel.local_outside_ip", strIndex)
+		remoteOutsideIP := store.GetColumnAsIPString("cisco_ipsec_tunnel.remote_outside_ip", strIndex)
 
 		statusValue := store.GetColumnAsString("cisco_ipsec_tunnel.status", strIndex)
 		status, exists := ciscoIPsecStatusByValue[statusValue]

--- a/releasenotes/notes/ndm-fix-ip-metadata-as-nil-cc7aefc830d88dd3.yaml
+++ b/releasenotes/notes/ndm-fix-ip-metadata-as-nil-cc7aefc830d88dd3.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    NDM SNMP: fix IP metadata fields rendered as ``<nil>`` for OIDs declared
+    with SYNTAX ``IpAddress`` (e.g. Cisco IPsec tunnel local/remote outside IPs,
+    CDP remote addresses). gosnmp decodes these values as Go strings, but the
+    metadata store previously only handled the raw-bytes path.


### PR DESCRIPTION
### What does this PR do?

Fixes IP metadata fields rendered as `"<nil>"` in NDM device metadata payloads for OIDs with SYNTAX `IpAddress`. Specifically affects:

- `cisco_ipsec_tunnel.local_outside_ip` / `remote_outside_ip` (Cisco IPsec tunnel metadata)
- `cdp_remote.device_*_address` (CDP remote device addresses)

Adds a new `Store.GetColumnAsIPString` helper that handles both value shapes produced by `gosnmplib.GetValueFromPDU`:

- `[]byte` for `OCTET STRING` fields (e.g. `cdpCacheAddress`)
- `string` for `IpAddress` fields (e.g. `cipSecTunLocalAddr`)

Switches the three IP callers in `report_device_metadata.go` to use the new helper.

### Motivation

Support case: customer reports IP metadata appearing as the literal string `"<nil>"`.

Root cause: `gosnmplib.GetValueFromPDU` returns dotted-decimal Go strings for PDUs of type `gosnmp.IPAddress`, but `Store.GetColumnAsByteArray` only handled the `[]byte` case. It returned `nil`, and the caller's `net.IP(nil).String()` renders `"<nil>"`.

A naive `case string: return []byte(v)` fix was rejected because `net.IP([]byte("199.47.37.5")).String()` returns `"?3139392e34372e33372e35"` (net.IP only formats 4- or 16-byte slices as dotted-decimal). The fix must happen at the caller level, which is what this PR does.

### Describe how you validated your changes

- Added `TestStore_GetColumnAsIPString` covering IPv4/IPv6 via both `[]byte` and `string`, plus error paths (bad bytes, bad string, empty string, wrong type, missing field/index).
- `dda inv test --targets=./pkg/collector/corechecks/snmp/internal/metadata` → 5/5 pass.
- `dda inv test --targets=./pkg/collector/corechecks/snmp/internal/report` → 164/164 pass.

### Additional Notes

Incidental improvement: `getRemDeviceAddressIfIPType` no longer returns `"<nil>"` when an IP is missing (returns `""` instead), so the caller's `!= ""` check now correctly falls through to the secondary/cache address as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AGENT-16023]: https://datadoghq.atlassian.net/browse/AGENT-16023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ