### PR TITLE
cpu check: use gopsutil to read context switches on Linux

### DIFF
--- a/pkg/collector/corechecks/system/cpu/cpu/context_switches_linux.go
+++ b/pkg/collector/corechecks/system/cpu/cpu/context_switches_linux.go
@@ -8,15 +8,24 @@
 package cpu
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"context"
+
+	"github.com/shirou/gopsutil/v4/common"
 	"github.com/shirou/gopsutil/v4/load"
+
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // GetContextSwitches retrieves the number of context switches for the current process.
 // It returns an integer representing the count and an error if the retrieval fails.
 func GetContextSwitches() (int64, error) {
 	log.Debug("collecting ctx switches")
-	misc, err := load.Misc()
+	ctx := context.Background()
+	if procfsPath := pkgconfigsetup.Datadog().GetString("procfs_path"); procfsPath != "" {
+		ctx = context.WithValue(ctx, common.EnvKey, common.EnvMap{common.HostProcEnvKey: procfsPath})
+	}
+	misc, err := load.MiscWithContext(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/collector/corechecks/system/cpu/cpu/context_switches_linux.go
+++ b/pkg/collector/corechecks/system/cpu/cpu/context_switches_linux.go
@@ -8,43 +8,17 @@
 package cpu
 
 import (
-	"bufio"
-	"errors"
-	"fmt"
-	"os"
-	"strconv"
-	"strings"
-
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/shirou/gopsutil/v4/load"
 )
 
 // GetContextSwitches retrieves the number of context switches for the current process.
 // It returns an integer representing the count and an error if the retrieval fails.
-func GetContextSwitches() (ctxSwitches int64, err error) {
+func GetContextSwitches() (int64, error) {
 	log.Debug("collecting ctx switches")
-	procfsPath := "/proc"
-	if v := pkgconfigsetup.Datadog().GetString("procfs_path"); v != "" {
-		procfsPath = v
-	}
-	filePath := procfsPath + "/stat"
-	file, err := os.Open(filePath)
+	misc, err := load.Misc()
 	if err != nil {
 		return 0, err
 	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for i := 0; scanner.Scan(); i++ {
-		txt := scanner.Text()
-		if strings.HasPrefix(txt, "ctxt") {
-			elemts := strings.Split(txt, " ")
-			ctxSwitches, err = strconv.ParseInt(elemts[1], 10, 64)
-			if err != nil {
-				return 0, fmt.Errorf("%s in '%s' at line %d", err, filePath, i)
-			}
-			return ctxSwitches, nil
-		}
-	}
-	return 0, errors.New("could not find the context switches in stat file")
+	return int64(misc.Ctxt), nil
 }


### PR DESCRIPTION
### What does this PR do?

Replace the hand-rolled `/proc/stat` parser in `GetContextSwitches` with `load.MiscWithContext()` from gopsutil, which reads the same `ctxt` field from the same file.

The `procfs_path` agent config setting is forwarded to gopsutil via context (`common.HostProcEnvKey`), preserving the existing override mechanism.

### Motivation

Removes duplicated kernel-file parsing logic. `load.Misc()` reads `/proc/stat` and extracts `ctxt` identically to the previous implementation, and also reads `processes`, `procs_running`, `procs_blocked` in the same pass (more efficient).

### Describe how you validated your changes

No behavior change for the common cases. Existing unit tests (`TestContextSwitchesOk`, `TestContextSwitchesError`) continue to pass unchanged since they mock `getContextSwitches` at the call-site level.

### Additional Notes

Path resolution precedence (explicitly coded, matches or improves on the old behavior):

| | Old | New |
|---|---|---|
| `procfs_path` set | used directly | injected into gopsutil context — wins over `HOST_PROC` |
| `procfs_path` not set, `HOST_PROC` set | `/proc` (ignored `HOST_PROC`) | `HOST_PROC` used by gopsutil fallback |
| neither set | `/proc` | `/proc` |

The second row is a deliberate improvement: if `HOST_PROC` is set but `procfs_path` is not explicitly configured, gopsutil now respects it. This matches the pattern used by the disk check (`disk_nix.go`) and is consistent with how gopsutil is used elsewhere in the agent.