### PR TITLE
Fix macOS Agent.app classified as "iOS" in System Information

### DIFF
--- a/packages/macos/app/Info.plist.in
+++ b/packages/macos/app/Info.plist.in
@@ -20,10 +20,16 @@
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
     <string>{build_version}</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
     <key>CFBundleVersion</key>
     <string>{build_version}</string>
     <key>LSHasLocalizedDisplayName</key>
     <false/>
+    <key>LSMinimumSystemVersion</key>
+    <string>12.0</string>
     <key>LSUIElement</key>
     <true/>
     <key>NSAppleScriptEnabled</key>


### PR DESCRIPTION
### What does this PR do?

Adds two keys to `packages/macos/app/Info.plist.in`:

- `CFBundleSupportedPlatforms = [MacOSX]` — the change that actually flips the classification.
- `LSMinimumSystemVersion = 12.0` — declares the macOS version floor that's already enforced by the build (matches `swiftc -target ...-apple-macos12.0` at `omnibus/config/software/datadog-agent.rb:286`, `MACOSX_DEPLOYMENT_TARGET=12.0` at `tasks/omnibus.py:141`, and `MIN_ACCEPTABLE_VERSION=12.0` enforced by `omnibus/scripts/check_macos_version.sh`).

### Motivation

`System Information -> Software -> Applications` displays **Kind: iOS** for the installed Datadog Agent, which is wrong and user-visible. The bundle is a native macOS app.

| Column | Before | After |
|---|---|---|
| Kind | iOS | Apple Silicon |

<img width="1672" height="566" alt="image" src="https://github.com/user-attachments/assets/7ede8e78-eab8-42da-92f9-0cb4d5ccba16" />

https://datadoghq.atlassian.net/browse/WINA-2620

#### Root cause

System Information (`system_profiler SPApplicationsDataType`) classifies an installed `.app` by asking Launch Services. For **universal** bundles (x86_64 + arm64) LS can decide "Universal" from the Mach-O slices alone — there's no x86_64 iOS, so the presence of that slice is proof of macOS. For **arm64-thin** bundles the arch is ambiguous (macOS 11+ and iOS both exist on arm64), so LS falls back to Info.plist hints. If the plist contains no positive macOS marker, LS defaults to **iOS** — even though the Mach-O's `LC_BUILD_VERSION platform` is `MACOS`.

Our `Datadog Agent.app` is arm64-thin (we dropped Intel) and its `Info.plist.in` is hand-written rather than Xcode-generated, so it ships without any of the Xcode-injected platform keys (`CFBundleSupportedPlatforms`, `DTSDKName`, `DTPlatformName`). That combination is what trips the misclassification.

Survey of other apps on the same machine:

| App | `CFBundleSupportedPlatforms` | `DTSDKName` | Slices | Kind |
|---|---|---|---|---|
| Safari (Apple) | `MacOSX` | `macosx26.3.internal` | arm64e | Apple Silicon |
| Cursor / Chrome / Slack | — | `macosx15.5` / `macosx26.2` | arm64 | Apple Silicon |
| DB Browser for SQLite | — | — | **x86_64+arm64** | Universal (short-circuits) |
| **Datadog Agent 7.78.1-rc.2** | — | — | arm64 | **iOS** |

Xcode auto-injects at least one of these keys for normal macOS builds; our `swiftc`-direct pipeline doesn't.

### Describe how you validated your changes

Empirical narrowing on `/Applications/Datadog Agent.app` (version 7.78.1-rc.2, arm64-thin, `LC_BUILD_VERSION platform=MACOS`, `minos 11.0`, `sdk 15.2`). For each candidate key I restored the original plist, added the single key, re-signed ad-hoc, re-registered with `lsregister -f`, and re-queried `system_profiler`:

| Key added (alone) | Kind |
|---|---|
| *(baseline — no extra keys)* | iOS |
| `LSMinimumSystemVersion=12.0` | iOS |
| `DTPlatformName=macosx` | iOS |
| `DTSDKName=macosx` | Apple Silicon ✅ |
| `CFBundleSupportedPlatforms=[MacOSX]` | Apple Silicon ✅ |

Either `CFBundleSupportedPlatforms` or `DTSDKName` alone is sufficient. Picked `CFBundleSupportedPlatforms` because its value is stable (no SDK-version drift) and it's Apple's documented key for this purpose. `LSMinimumSystemVersion` doesn't affect Kind but is included as the proper macOS-version-floor declaration — it also gives Finder a clean "requires macOS 12" error for users on unsupported macOS versions.

Also verified the template expands and lints cleanly:

```
$ sed -e 's/{executable}/gui/g' -e 's/{build_version}/7.80.0/g' -e 's/{year}/2026/g' \
    packages/macos/app/Info.plist.in > /tmp/Info.plist
$ plutil -lint /tmp/Info.plist
/tmp/Info.plist: OK
```

### Additional Notes

- **No runtime/launchd impact.** The agent's `gui` binary is started by `launchd` via the LaunchAgent plist at `packages/macos/app/gui.launchd.plist.example.in` using the binary's absolute path. That path bypasses Launch Services entirely, so launchd doesn't consult `Info.plist` when starting the GUI. The new keys are purely bundle metadata consumed by Finder / Spotlight / System Information.
- **Backport candidate for 7.78.x?** The install I verified against (7.78.1-rc.2) hits this issue because `7.78.x` predates commit `78f61abd755` (the `swiftc` 11.0 → 12.0 bump) *and* this plist fix. Happy to backport if we want the next 7.78.x patch to ship without the "iOS" label; otherwise 7.79+ inherits the fix from `main`.
- **Why not also add `DTSDKName`/`DTPlatformName`?** Either alone would fix Kind, but they're Xcode-injected build-environment metadata and their values (especially `DTSDKName=macosx<version>`) drift with whatever SDK the CI runner has. `CFBundleSupportedPlatforms=[MacOSX]` is stable and carries the same classifier signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)