### PR TITLE
dyninst/decode: nest evaluationErrors under snapshot

### DIFF
--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -303,16 +303,16 @@ func (s *message) init(
 	s.ProcessTags = event.ProcessTags
 	s.Debugger = debuggerData{
 		Snapshot: snapshotData{
-			ID:       uuid.New(),
-			Language: "go",
+			ID:               uuid.New(),
+			Language:         "go",
+			EvaluationErrors: []evaluationError{},
 		},
-		EvaluationErrors: []evaluationError{},
 	}
 	if event.EntryOrLine == nil {
 		return nil, errors.New("entry event is nil")
 	}
 	if err := decoder.entryOrLine.init(
-		event.EntryOrLine, decoder.program.Types, &s.Debugger.EvaluationErrors,
+		event.EntryOrLine, decoder.program.Types, &s.Debugger.Snapshot.EvaluationErrors,
 	); err != nil {
 		return nil, err
 	}
@@ -337,8 +337,8 @@ func (s *message) init(
 		if header.Condition_eval_error == 2 {
 			msg = errNilPointerEvaluating.Error()
 		}
-		s.Debugger.EvaluationErrors = append(
-			s.Debugger.EvaluationErrors,
+		s.Debugger.Snapshot.EvaluationErrors = append(
+			s.Debugger.Snapshot.EvaluationErrors,
 			evaluationError{
 				Expression: whenDSL,
 				Message:    msg,
@@ -357,7 +357,7 @@ func (s *message) init(
 	var durationMissingReason *string
 	if event.Return != nil {
 		if err := decoder._return.init(
-			event.Return, decoder.program.Types, &s.Debugger.EvaluationErrors,
+			event.Return, decoder.program.Types, &s.Debugger.Snapshot.EvaluationErrors,
 		); err != nil {
 			return nil, fmt.Errorf("error initializing return event: %w", err)
 		}
@@ -378,8 +378,8 @@ func (s *message) init(
 			if returnHeader.Condition_eval_error == 2 {
 				msg = errNilPointerEvaluating.Error()
 			}
-			s.Debugger.EvaluationErrors = append(
-				s.Debugger.EvaluationErrors,
+			s.Debugger.Snapshot.EvaluationErrors = append(
+				s.Debugger.Snapshot.EvaluationErrors,
 				evaluationError{
 					Expression: whenDSL,
 					Message:    msg,
@@ -416,8 +416,8 @@ func (s *message) init(
 		const missingReturnReasonExpression = "@duration"
 		if reason != "" {
 			message := "not available: " + reason
-			s.Debugger.EvaluationErrors = append(
-				s.Debugger.EvaluationErrors,
+			s.Debugger.Snapshot.EvaluationErrors = append(
+				s.Debugger.Snapshot.EvaluationErrors,
 				evaluationError{
 					Expression: missingReturnReasonExpression,
 					Message:    message,
@@ -449,7 +449,7 @@ func (s *message) init(
 		}
 		stackPCs, ok := decoder.stackPCs[stackHeader.Stack_hash]
 		if !ok {
-			s.Debugger.EvaluationErrors = append(s.Debugger.EvaluationErrors,
+			s.Debugger.Snapshot.EvaluationErrors = append(s.Debugger.Snapshot.EvaluationErrors,
 				evaluationError{
 					Expression: "Stacktrace",
 					Message:    "no stack pcs found",
@@ -464,7 +464,7 @@ func (s *message) init(
 				} else {
 					log.Tracef("error symbolicating stack for probe %s: %v", probe.GetID(), err)
 				}
-				s.Debugger.EvaluationErrors = append(s.Debugger.EvaluationErrors,
+				s.Debugger.Snapshot.EvaluationErrors = append(s.Debugger.Snapshot.EvaluationErrors,
 					evaluationError{
 						Expression: "Stacktrace",
 						Message:    err.Error(),

--- a/pkg/dyninst/decode/decoder_test.go
+++ b/pkg/dyninst/decode/decoder_test.go
@@ -72,12 +72,15 @@ func FuzzDecoder(f *testing.F) {
 
 type (
 	captures struct{ Entry struct{ Arguments any } }
-	debugger struct {
-		Snapshot         struct{ Captures captures }
+	snapshot struct {
+		Captures         captures
 		EvaluationErrors []struct {
 			Expression string `json:"expr"`
 			Message    string `json:"message"`
 		} `json:"evaluationErrors,omitempty"`
+	}
+	debugger struct {
+		Snapshot snapshot
 	}
 	eventCaptures struct {
 		Debugger    debugger
@@ -1558,10 +1561,10 @@ func TestDecoderMissingReturnEventEvaluationError(t *testing.T) {
 			require.NoError(t, json.Unmarshal(buf, &e))
 
 			if tt.shouldHaveError {
-				require.NotEmpty(t, e.Debugger.EvaluationErrors,
+				require.NotEmpty(t, e.Debugger.Snapshot.EvaluationErrors,
 					"expected evaluation error but none found")
 				found := false
-				for _, evalErr := range e.Debugger.EvaluationErrors {
+				for _, evalErr := range e.Debugger.Snapshot.EvaluationErrors {
 					if evalErr.Expression == tt.expectedErrorExpression &&
 						evalErr.Message == tt.expectedErrorMessage {
 						found = true
@@ -1571,10 +1574,10 @@ func TestDecoderMissingReturnEventEvaluationError(t *testing.T) {
 				require.True(t, found,
 					"expected evaluation error with expression %q and message %q, got errors: %+v",
 					tt.expectedErrorExpression, tt.expectedErrorMessage,
-					e.Debugger.EvaluationErrors)
+					e.Debugger.Snapshot.EvaluationErrors)
 			} else {
 				// Check that there's no return-related error
-				require.Empty(t, e.Debugger.EvaluationErrors)
+				require.Empty(t, e.Debugger.Snapshot.EvaluationErrors)
 			}
 		})
 	}
@@ -1610,15 +1613,15 @@ func TestDecoderNilPointerCaptureExpression(t *testing.T) {
 	require.Nil(t, e.Debugger.Snapshot.Captures.Entry.Arguments)
 
 	// An evaluation error should be reported for the nil pointer.
-	require.NotEmpty(t, e.Debugger.EvaluationErrors)
+	require.NotEmpty(t, e.Debugger.Snapshot.EvaluationErrors)
 	found := false
-	for _, evalErr := range e.Debugger.EvaluationErrors {
+	for _, evalErr := range e.Debugger.Snapshot.EvaluationErrors {
 		if evalErr.Message == "nil pointer dereference" {
 			found = true
 			break
 		}
 	}
-	require.True(t, found, "expected nil pointer evaluation error, got: %+v", e.Debugger.EvaluationErrors)
+	require.True(t, found, "expected nil pointer evaluation error, got: %+v", e.Debugger.Snapshot.EvaluationErrors)
 }
 
 // TestDecoderNilPointerTemplateExpression tests that a nil pointer dereference

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -41,9 +41,8 @@ const (
 )
 
 type debuggerData struct {
-	Snapshot         snapshotData      `json:"snapshot,omitempty"`
-	Type             payloadType       `json:"type,omitempty"`
-	EvaluationErrors []evaluationError `json:"evaluationErrors,omitempty"`
+	Snapshot snapshotData `json:"snapshot,omitempty"`
+	Type     payloadType  `json:"type,omitempty"`
 }
 
 type messageData struct {
@@ -213,9 +212,10 @@ type snapshotData struct {
 	Language  string    `json:"language"`
 
 	// dynamic fields:
-	Stack    *stackData   `json:"stack,omitempty"`
-	Probe    probeData    `json:"probe"`
-	Captures *captureData `json:"captures,omitempty"`
+	Stack            *stackData        `json:"stack,omitempty"`
+	Probe            probeData         `json:"probe"`
+	Captures         *captureData      `json:"captures,omitempty"`
+	EvaluationErrors []evaluationError `json:"evaluationErrors,omitempty"`
 
 	stack    stackData
 	captures captureData

--- a/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayEmptyStructs.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[{}, {}]",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
@@ -86,15 +86,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[[1, 2], [3, 4]]",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
@@ -126,15 +126,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -110,15 +110,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[map[foo: 1, bar: 2], map[foo: 1, bar: 2]]",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[first, second]",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStructs.json
@@ -84,15 +84,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[{anotherInt: 42, anotherString: foo}, {anotherInt: 24, anotherString: bar}]",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct_geq_go1.26rc1.json
@@ -81,15 +81,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{x: [abc], z: 5, writer: {pointer: not captured at 0x[addr]}}",

--- a/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[true, true]",

--- a/pkg/dyninst/testdata/decoded/sample/testByteArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteArray.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 1]",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember_geq_go1.26rc1.json
@@ -56,14 +56,14 @@
               }
             }
           }
-        }
-      },
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
+      }
     },
     "timestamp": "[ts]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprSimple.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprSimple.json
@@ -60,14 +60,14 @@
               }
             }
           }
-        }
-      },
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
+      }
     },
     "timestamp": "[ts]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprWithTemplate.json
@@ -60,14 +60,14 @@
               }
             }
           }
-        }
-      },
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
+      }
     },
     "timestamp": "[ts]",
     "message": "x=boo",

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureTenStringsMethodEntryCond.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureTenStringsMethodEntryCond.json
@@ -19,15 +19,15 @@
           "location": {
             "method": "main.testTenStrings"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "x={first: one, second: two, third: three, fourth: four, fifth: five, ...}}",

--- a/pkg/dyninst/testdata/decoded/sample/testChannel.json
+++ b/pkg/dyninst/testdata/decoded/sample/testChannel.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{chan}",

--- a/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
@@ -60,15 +60,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "2, 3, {error: failed to resolve reference \"y\"}",

--- a/pkg/dyninst/testdata/decoded/sample/testCycle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCycle.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "nil",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
@@ -73,15 +73,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{a: map[2: {pointer: not captured at 0x[addr]}]}",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
@@ -98,15 +98,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{a: map[8: {a: map[9: {a: {pointer: not captured at 0x[addr]}}]}]}",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
@@ -67,15 +67,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{a: {a: {pointer: not captured at 0x[addr]}}}",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
@@ -79,15 +79,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{a: {a: {a: {interface: unknown type *main.deepPtr1}}}}",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
@@ -79,15 +79,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{a: [{a: [{pointer: not captured at 0x[addr]}]}]}",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
@@ -97,15 +97,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{a: [{a: [{a: [{interface: unknown type *main.deepSlice1}]}]}]}",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
@@ -57,15 +57,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[]",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
@@ -61,15 +61,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[], 2",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
@@ -126,15 +126,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{}",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStructPointer.json
@@ -57,15 +57,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{pointer: not captured at 0x[addr]}",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -67,15 +67,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{s: blah}",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
@@ -56,15 +56,15 @@
           "location": {
             "method": "main.testInlinedBBB"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testInlinedBBB",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
@@ -56,15 +56,15 @@
           "location": {
             "method": "main.testInlinedBCA"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testInlinedBCA",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
@@ -56,15 +56,15 @@
           "location": {
             "method": "main.testInlinedBCB"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testInlinedBCB",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
@@ -46,15 +46,15 @@
           "location": {
             "method": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testInlinedFuncFromOtherPackage",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
@@ -61,15 +61,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "25",
@@ -142,15 +142,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "3",
@@ -223,15 +223,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "150",
@@ -309,15 +309,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "150",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
@@ -61,15 +61,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "10",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
@@ -78,15 +78,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2, 3, ...]",
@@ -176,15 +176,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2, 3, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testIntArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testIntArray.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{s: foo}",
@@ -148,15 +148,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{s: foo}",
@@ -229,15 +229,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{i: 42}",
@@ -311,15 +311,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{i: 42}",
@@ -387,15 +387,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "nil",
@@ -458,15 +458,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "nil",

--- a/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
@@ -85,15 +85,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{val: 1, b: {val: 2, b: {val: 3, b: nil}}}",

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -172,15 +172,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]: [5, 6]]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -643,15 +643,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKey.json
@@ -68,15 +68,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{}: 1]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyKeyAndValue.json
@@ -68,15 +68,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{}: {}]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmptyValue.json
@@ -68,15 +68,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[1: {}]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -158,15 +158,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -518,15 +518,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -142,15 +142,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]: 3]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -58,15 +58,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassiveWithSizeLimit.json
@@ -58,15 +58,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -142,15 +142,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -158,15 +158,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -158,15 +158,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -98,15 +98,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[foo: [one, two], bar: [three, four]]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -96,15 +96,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[foo: {anotherInt: 1, anotherString: one}, bar: {anotherInt: 2, anotherString: two}]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -267,15 +267,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[true: {val: 1, b: {val: 2, b: {val: 3, b: {val: 4, b: {val: 5, b: {val: 6, b: {val: 7, b: {val: 8, b: {val: 9, b: {val: 10, b: {val: 11, b: {val: 12, b: {val: 13, b: {val: 14, b: {val: 15, b: {val: 16, b: {val: 17, b: {val: 18, b: {val: 19, b: {val: 20, b: nil}}}}}}}}}}}}}}}}}}}}]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -158,15 +158,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -2608,15 +2608,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -158,15 +158,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -58,15 +58,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[{redacted-entries}, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
@@ -58,15 +58,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...",

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveStringWithSizeLimit.json
@@ -58,15 +58,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "xxxxxxxxxxx...",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
@@ -72,15 +72,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "false, 42, 122, 1337, xyz",

--- a/pkg/dyninst/testdata/decoded/sample/testNestedPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNestedPointer.json
@@ -72,15 +72,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{nested: {anotherInt: 42, anotherString: xyz}}",

--- a/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots.json
@@ -19,15 +19,15 @@
           "location": {
             "method": "main.testNestedPointer"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "xyz",

--- a/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots_bad_expr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots_bad_expr.json
@@ -19,15 +19,15 @@
           "location": {
             "method": "main.testNestedPointer"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{error: cannot access member \"anotherInt\" on type *ir.GoStringHeaderType (\"string\") in expression \"x.nested.anotherString.anotherInt\"} {error: failed to resolve field \"notAMember\" in expression \"x.notAMember\": type \"main.anotherStruct\" has no notAMember field}",

--- a/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots_low_limit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNestedPointer_expression_with_dots_low_limit.json
@@ -19,15 +19,15 @@
           "location": {
             "method": "main.testNestedPointer"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{anotherInt: 42, anotherString: xyz}",

--- a/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
@@ -60,15 +60,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "nil, 1",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[]",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
@@ -60,15 +60,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[], 5",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
@@ -64,15 +64,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "1, [], 5",

--- a/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
@@ -62,15 +62,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{a: omg}",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
@@ -67,15 +67,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{val: 1, b: {cycle}}",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -79,15 +79,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[foo: 1, bar: 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{a: 9, b: true}",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
@@ -72,15 +72,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@return.r1 == 42.5",
+            "message": "error evaluating condition"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@return.r1 == 42.5",
-          "message": "error evaluating condition"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "true",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "97",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
@@ -46,15 +46,15 @@
           "location": {
             "method": "main.testSingleFloat32"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{error: failed to resolve reference \"x\"}",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
@@ -46,15 +46,15 @@
           "location": {
             "method": "main.testSingleFloat64"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{error: failed to resolve reference \"x\"}",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "-1512",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "parameter = -16",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "-32",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "-64",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "parameter = -8-8-8",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "1",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleString.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "abc",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "1512",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "16",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "32",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "64",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "8",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceEmptyStructs.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[{}, {}]",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
@@ -100,15 +100,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[[4], [5, 6], [7, 8, 9]]",

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -78,15 +78,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "map[AAA: 1, BBB: 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testStringArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringArray.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[one, two]",

--- a/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
@@ -57,15 +57,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "abc",

--- a/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
@@ -70,15 +70,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[abc, xyz, 123]",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType1.json
@@ -57,15 +57,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "s1",

--- a/pkg/dyninst/testdata/decoded/sample/testStringType2.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType2.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{pointer: not captured at 0x[addr]}",

--- a/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
@@ -88,15 +88,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[{aUint8: 42, aBool: true}, {aUint8: 24, aBool: true}], 3",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithAny.json
@@ -76,15 +76,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{a: {a: {pointer: not captured at 0x[addr]}}}",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicMaps_geq_go1.26rc1.json
@@ -81,15 +81,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{m1: nil, m2: nil, m3: nil, m4: nil, m5: nil, ...}}",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
@@ -486,15 +486,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{s1: [{s1: [], s2: [], s3: [], s4: [], s5: [], ...}}], s2: [[], [{s1: [], s2: [], s3: [], s4: [], s5: [], ...}}]], s3: [[], [[]], [[{s1: [], s2: [], s3: [], s4: [], s5: [], ...}}]]], s4: [[], [[]], [[[]]], ...], s5: [[], [[]], [[[]]], ...], ...}}",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -73,15 +73,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{m: map[1: 1]} {error: not available: function has no body}",

--- a/pkg/dyninst/testdata/decoded/sample/testStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct_geq_go1.26rc1.json
@@ -82,15 +82,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{aBool: true, aString: one, aNumber: 2, nested: {anotherInt: 3, anotherString: four}}",

--- a/pkg/dyninst/testdata/decoded/sample/testSubslices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubslices.json
@@ -94,15 +94,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2], [1], [1, 2, 3]",

--- a/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSubstrings.json
@@ -64,15 +64,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "abcd, ab, abcdef",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
@@ -64,15 +64,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "abc, def, ghi",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructExpr_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructExpr_geq_go1.26rc1.json
@@ -19,15 +19,15 @@
           "location": {
             "method": "main.testThreeStringsInStruct"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "abc def ghi",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
@@ -70,15 +70,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{a: abc, b: def, c: ghi}",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer_expression_with_dots.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer_expression_with_dots.json
@@ -19,15 +19,15 @@
           "location": {
             "method": "main.testThreeStringsInStructPointer"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "abc def ghi",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct_geq_go1.26rc1.json
@@ -69,15 +69,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "{a: abc, b: def, c: ghi}",

--- a/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "3",

--- a/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testUintArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintArray.json
@@ -66,15 +66,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2]",

--- a/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
@@ -57,15 +57,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "1",

--- a/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
@@ -70,15 +70,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2, 3]",

--- a/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"

--- a/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
@@ -56,15 +56,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "0x[addr]",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
@@ -458,15 +458,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[1, 2, 3, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
@@ -315,15 +315,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[0, 1, 2, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSliceWithSizeLimit.json
@@ -315,15 +315,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "[0, 1, 2, ...]",

--- a/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
@@ -145,15 +145,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testWhollyInlinedSubroutine",
@@ -221,15 +221,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "testWhollyInlinedSubroutine",

--- a/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
@@ -51,15 +51,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "message": "ptr: {pointer: not captured at 0x[addr]}",

--- a/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
@@ -52,15 +52,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"

--- a/pkg/dyninst/testdata/decoded/simple/condNilPtr_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condNilPtr_cond.json
@@ -48,15 +48,15 @@
           "location": {
             "method": "main.condNilPtrStruct"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "x.I32 == 300",
+            "message": "nil pointer dereference"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "x.I32 == 300",
-          "message": "nil pointer dereference"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/indexErr_slice_oob_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexErr_slice_oob_capture.json
@@ -41,14 +41,14 @@
           "location": {
             "method": "main.intSliceArg"
           }
-        }
-      },
-      "evaluationErrors": [
-        {
-          "expr": "s_5",
-          "message": "index out of bounds"
-        }
-      ]
+        },
+        "evaluationErrors": [
+          {
+            "expr": "s_5",
+            "message": "index out of bounds"
+          }
+        ]
+      }
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/indexErr_slice_oob_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexErr_slice_oob_cond.json
@@ -19,15 +19,15 @@
           "location": {
             "method": "main.intSliceArg"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "s[5] == 42",
+            "message": "error evaluating condition"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "s[5] == 42",
-          "message": "error evaluating condition"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/indexErr_slice_oob_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexErr_slice_oob_template.json
@@ -19,15 +19,15 @@
           "location": {
             "method": "main.intSliceArg"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "s[5]",
+            "message": "index out of bounds"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "s[5]",
-          "message": "index out of bounds"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/indexNilPtr_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexNilPtr_capture.json
@@ -100,14 +100,14 @@
           "location": {
             "method": "main.indexNilPtrSlice"
           }
-        }
-      },
-      "evaluationErrors": [
-        {
-          "expr": "items_0",
-          "message": "nil pointer dereference"
-        }
-      ]
+        },
+        "evaluationErrors": [
+          {
+            "expr": "items_0",
+            "message": "nil pointer dereference"
+          }
+        ]
+      }
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/indexNilPtr_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexNilPtr_cond.json
@@ -48,15 +48,15 @@
           "location": {
             "method": "main.indexNilPtrSlice"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "x.Items[0] == 10",
+            "message": "nil pointer dereference"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "x.Items[0] == 10",
-          "message": "nil pointer dereference"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/indexNilPtr_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexNilPtr_template.json
@@ -48,15 +48,15 @@
           "location": {
             "method": "main.indexNilPtrSlice"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "x.Items[0]",
+            "message": "nil pointer dereference"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "x.Items[0]",
-          "message": "nil pointer dereference"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/indexPtrStructSliceField_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexPtrStructSliceField_capture.json
@@ -100,14 +100,14 @@
           "location": {
             "method": "main.lenPtrStructFields"
           }
-        }
-      },
-      "evaluationErrors": [
-        {
-          "expr": "items_0",
-          "message": "index out of bounds"
-        }
-      ]
+        },
+        "evaluationErrors": [
+          {
+            "expr": "items_0",
+            "message": "index out of bounds"
+          }
+        ]
+      }
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/indexStructSliceField_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/indexStructSliceField_capture.json
@@ -100,18 +100,18 @@
           "location": {
             "method": "main.lenStructFields"
           }
-        }
-      },
-      "evaluationErrors": [
-        {
-          "expr": "items_2",
-          "message": "index out of bounds"
         },
-        {
-          "expr": "@duration",
-          "message": "not available: maximum call count exceeded"
-        }
-      ]
+        "evaluationErrors": [
+          {
+            "expr": "items_2",
+            "message": "index out of bounds"
+          },
+          {
+            "expr": "@duration",
+            "message": "not available: maximum call count exceeded"
+          }
+        ]
+      }
     },
     "timestamp": "[ts]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"

--- a/pkg/dyninst/testdata/decoded/simple/inlined.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlined.json
@@ -51,15 +51,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"

--- a/pkg/dyninst/testdata/decoded/simple/inlinedMethod.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlinedMethod.json
@@ -62,15 +62,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function was inlined"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function was inlined"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
@@ -65,15 +65,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: function has no body"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_cond.json
@@ -19,15 +19,15 @@
           "location": {
             "method": "main.lenMap"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "isEmpty(m)",
+            "message": "nil pointer dereference"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "isEmpty(m)",
-          "message": "nil pointer dereference"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_template.json
@@ -48,15 +48,15 @@
           "location": {
             "method": "main.lenMap"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "isEmpty(m)",
+            "message": "nil pointer dereference"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "isEmpty(m)",
-          "message": "nil pointer dereference"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_len_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_len_capture.json
@@ -100,14 +100,14 @@
           "location": {
             "method": "main.lenMap"
           }
-        }
-      },
-      "evaluationErrors": [
-        {
-          "expr": "m_len",
-          "message": "nil pointer dereference"
-        }
-      ]
+        },
+        "evaluationErrors": [
+          {
+            "expr": "m_len",
+            "message": "nil pointer dereference"
+          }
+        ]
+      }
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_len_eq_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_len_eq_cond.json
@@ -48,15 +48,15 @@
           "location": {
             "method": "main.lenMap"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "len(m) == 3",
+            "message": "nil pointer dereference"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "len(m) == 3",
-          "message": "nil pointer dereference"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_len_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_len_template.json
@@ -48,15 +48,15 @@
           "location": {
             "method": "main.lenMap"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "len(m)",
+            "message": "nil pointer dereference"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "len(m)",
-          "message": "nil pointer dereference"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/lenPtrStruct_field_map.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenPtrStruct_field_map.json
@@ -48,15 +48,15 @@
           "location": {
             "method": "main.lenPtrStructFields"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "len(x.Dict)",
+            "message": "nil pointer dereference"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "len(x.Dict)",
-          "message": "nil pointer dereference"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/lenStructFields_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStructFields_nocond.json
@@ -250,15 +250,15 @@
               }
             }
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "@duration",
+            "message": "not available: maximum call count exceeded"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: maximum call count exceeded"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "process_tags": "entrypoint.name:sample,svc.user:sample"

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_field_map.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_field_map.json
@@ -48,15 +48,15 @@
           "location": {
             "method": "main.lenStructFields"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "len(x.Dict)",
+            "message": "nil pointer dereference"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "len(x.Dict)",
-          "message": "nil pointer dereference"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_field_ptrslice.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_field_ptrslice.json
@@ -48,15 +48,15 @@
           "location": {
             "method": "main.lenStructFields"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "len(x.PtrSlice)",
+            "message": "nil pointer dereference"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "len(x.PtrSlice)",
-          "message": "nil pointer dereference"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_isEmpty_map_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_isEmpty_map_cond.json
@@ -19,15 +19,15 @@
           "location": {
             "method": "main.lenStructFields"
           }
-        }
+        },
+        "evaluationErrors": [
+          {
+            "expr": "isEmpty(x.Dict)",
+            "message": "nil pointer dereference"
+          }
+        ]
       },
-      "type": "snapshot",
-      "evaluationErrors": [
-        {
-          "expr": "isEmpty(x.Dict)",
-          "message": "nil pointer dereference"
-        }
-      ]
+      "type": "snapshot"
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_missing_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_missing_capture.json
@@ -41,14 +41,14 @@
           "location": {
             "method": "main.mapIndexMissing"
           }
-        }
-      },
-      "evaluationErrors": [
-        {
-          "expr": "m_missing",
-          "message": "index out of bounds"
-        }
-      ]
+        },
+        "evaluationErrors": [
+          {
+            "expr": "m_missing",
+            "message": "index out of bounds"
+          }
+        ]
+      }
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/pkg/dyninst/testdata/decoded/simple/mapIndex_nilPtrVal_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapIndex_nilPtrVal_capture.json
@@ -41,14 +41,14 @@
           "location": {
             "method": "main.mapIndexNilPtrVal"
           }
-        }
-      },
-      "evaluationErrors": [
-        {
-          "expr": "nil_field",
-          "message": "nil pointer dereference"
-        }
-      ]
+        },
+        "evaluationErrors": [
+          {
+            "expr": "nil_field",
+            "message": "nil pointer dereference"
+          }
+        ]
+      }
     },
     "timestamp": "[ts]",
     "duration": "[duration]",

--- a/releasenotes/notes/dyninst-evaluation-errors-placement-b0cc447da36ff4b1.yaml
+++ b/releasenotes/notes/dyninst-evaluation-errors-placement-b0cc447da36ff4b1.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Dynamic Instrumentation: Fix a bug where ``evaluationErrors`` were reported
+    in the wrong location in snapshot payloads, causing them to not appear
+    properly in the UI.


### PR DESCRIPTION
### What does this PR do?

The evaluationErrors array was emitted as a sibling of snapshot under debugger, but the Datadog Dynamic Instrumentation snapshot schema places it inside snapshot alongside captures, stack, and probe. It has been in the wrong place since it was introduced in #39454.

### Motivation

Eval errors for conditions are particularly important to surface for conditions because otherwise it'll look like the condition was met.

### Describe how you validated your changes

There's testing.

### Additional Notes

https://datadoghq.atlassian.net/browse/DEBUG-5475