### PR TITLE
gosymname: fix infinite loop on cross-package method names

### DIFF
--- a/pkg/dyninst/gosymname/parse.go
+++ b/pkg/dyninst/gosymname/parse.go
@@ -454,8 +454,16 @@ func buildInterpretations(s *Symbol) {
 // allocation for small segment counts.
 func decomposeChain(dst []segment, local string) []segment {
 	segments := dst
+	prev := -1
 	i := 0
 	for i < len(local) {
+		if i == prev {
+			// Defensive: every branch below must advance i. If a future
+			// change introduces a non-advancing path, panic loudly rather
+			// than spin forever.
+			panic("gosymname: decomposeChain failed to advance at " + local[i:])
+		}
+		prev = i
 		// Skip leading dots between segments.
 		if local[i] == '.' {
 			i++
@@ -597,7 +605,11 @@ func parsePtrRecvSegment(local string, start int) (segment, int) {
 			i = bracketEnd + 1
 			break
 		}
-		if local[i] == '.' || local[i] == '-' {
+		if local[i] == '.' {
+			methName = local[methStart:i]
+			break
+		}
+		if local[i] == '-' && i > methStart && isWrapperSuffixStart(local, i) {
 			methName = local[methStart:i]
 			break
 		}
@@ -661,12 +673,34 @@ func parseNameSegment(local string, start int) (string, *GenericParams, int) {
 			}
 			return name, gen, bracketEnd + 1
 		}
-		if local[i] == '.' || local[i] == '-' {
+		if local[i] == '.' {
+			return local[start:i], nil, i
+		}
+		// A '-' terminates the name only when it introduces a recognized
+		// suffix (-range, -fm). Otherwise it is part of the identifier, e.g.
+		// an embedded import path containing a module name like "antlr4-go".
+		if local[i] == '-' && i > start && isWrapperSuffixStart(local, i) {
 			return local[start:i], nil, i
 		}
 		i++
 	}
 	return local[start:i], nil, i
+}
+
+// isWrapperSuffixStart reports whether the '-' at position i introduces one
+// of the recognised wrapper suffixes handled by decomposeChain (-rangeN or
+// -fm[.]).
+func isWrapperSuffixStart(local string, i int) bool {
+	rest := local[i+1:]
+	if strings.HasPrefix(rest, "range") {
+		end := i + 1 + len("range")
+		return end < len(local) && local[end] >= '0' && local[end] <= '9'
+	}
+	if strings.HasPrefix(rest, "fm") {
+		end := i + 1 + len("fm")
+		return end >= len(local) || local[end] == '.'
+	}
+	return false
 }
 
 // splitClosureChain separates trailing closure/nesting/wrapper segments from

--- a/pkg/dyninst/gosymname/testdata/symbols.yaml
+++ b/pkg/dyninst/gosymname/testdata/symbols.yaml
@@ -717,3 +717,18 @@
           function: Handle
           closure: func1
           depth: 1
+  - name: promoted method from embedded type in different package
+    input:
+      symbol: github.com/google/cel-go/parser/gen.(*CELParser).github.com/antlr4-go/antlr/v4.reset
+      source: pclntab
+    output:
+      pkg: github.com/google/cel-go/parser/gen
+      local: (*CELParser).github.com/antlr4-go/antlr/v4.reset
+      class: function
+      interps:
+        - qualified_name: (*CELParser).github
+          receiver: "*CELParser"
+          function: github
+          inlined:
+            - com/antlr4-go/antlr/v4
+            - reset


### PR DESCRIPTION
### What does this PR do?

parseNameSegment and parsePtrRecvSegment's method-scan previously treated any '-' as a segment terminator. When a '-' was not followed by the recognised "range"/"fm" wrapper suffixes (e.g. inside an embedded import path containing a module name like "antlr4-go"), parseNameSegment returned without advancing i, causing decomposeChain to spin forever.

Only terminate at `'-'` when isWrapperSuffixStart reports a real `-rangeN` / `-fm[.] suffix`; otherwise treat '-' as part of the identifier. Add a defensive progress check at the top of decomposeChain so any future non-advancing branch panics loudly instead of hanging — the FuzzParse corpus now turns that class of regression into a fuzz failure.

Adds a golden test case for
  `github.com/google/cel-go/parser/gen.(*CELParser).github.com/antlr4-go/antlr/v4.reset`
to cover the promoted-method-from-embedded-type shape that triggered the original hang.

### Motivation

We saw a hung symdb upload with the RC in staging.

### Describe how you validated your changes

There's testing.

### Additional Notes

This code was introduced in the 7.79 cycle.

https://datadoghq.atlassian.net/browse/DEBUG-5477
