### PR TITLE
[CNM] Improve reliability of TestTCPRecoveryCount using tc netem jitter and reorder.

### DIFF
--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -3691,10 +3691,12 @@ func runNetemCongestionTest(
 	}, 30*time.Second, 200*time.Millisecond)
 }
 
-// TestTCPRecoveryCount validates the recovery_count signal. Uses escalating
-// netem configs to handle test variability — delay keeps enough segments
-// in-flight for SACK to detect gaps, while moderate loss triggers fast
-// recovery rather than full RTO timeout.
+// TestTCPRecoveryCount validates the recovery_count signal. To stay reliable
+// across the CI kernel matrix, the test tries a sequence of netem configs
+// until one triggers fast recovery. Each attempt runs in a fresh network
+// namespace with a fresh TCP connection, so kernel per-connection and
+// per-peer adaptive state (notably tp->reordering, which the kernel raises
+// when it sees reordering without loss) starts from defaults every time.
 func (s *TracerSuite) TestTCPRecoveryCount() {
 	t := s.T()
 	cfg := testConfig()
@@ -3708,35 +3710,51 @@ func (s *TracerSuite) TestTCPRecoveryCount() {
 	tr := setupTracer(t, cfg)
 
 	netemConfigs := [][]string{
+		{"delay", "20ms", "2ms"},
+		{"delay", "20ms", "10ms"},
+		{"delay", "20ms", "reorder", "3%", "25%"},
+		{"delay", "50ms", "reorder", "75%"},
 		{"delay", "50ms", "loss", "15%", "50%"},
 		{"delay", "50ms", "loss", "20%", "50%"},
-		{"delay", "50ms", "loss", "25%", "75%"},
 	}
-	for _, netemArgs := range netemConfigs {
+
+	for i, netemArgs := range netemConfigs {
+		t.Logf("TestTCPRecoveryCount attempt %d/%d: netem %v", i+1, len(netemConfigs), netemArgs)
 		c := setupNetemCongestionTest(t, netemArgs, nil)
 		triggered := false
 		deadline := time.Now().Add(20 * time.Second)
 		for time.Now().Before(deadline) {
 			c.SetWriteDeadline(time.Now().Add(2 * time.Second))
 			c.Write(make([]byte, 64*1024)) //nolint:errcheck
-			time.Sleep(200 * time.Millisecond)
 
 			conns, cleanup := getConnections(t, tr)
 			conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-			if ok && conn.Last.TCPRecoveryCount > 0 {
-				triggered = true
-				cleanup()
-				break
+			if ok {
+				if conn.Last.TCPRecoveryCount > 0 {
+					triggered = true
+					cleanup()
+					break
+				}
+				// Once RTO fires cwnd collapses and fast recovery is
+				// very unlikely to fire in the remaining budget — bail
+				// out and try the next config.
+				if conn.Monotonic.TCPRTOCount > 0 {
+					t.Logf("  RTO fired, cwnd collapsed; abandoning config early")
+					cleanup()
+					break
+				}
 			}
 			cleanup()
+
+			time.Sleep(200 * time.Millisecond)
 		}
 		c.Close()
 		if triggered {
+			t.Logf("recovery_count > 0 reached with config %v", netemArgs)
 			return
 		}
-		t.Logf("netem config %v did not trigger recovery, trying next", netemArgs)
 	}
-	require.Fail(t, "no netem configuration triggered recovery_count > 0")
+	t.Fatalf("no netem config triggered recovery_count > 0 after %d attempts", len(netemConfigs))
 }
 
 // TestTCPReordSeen validates the reord_seen signal by introducing packet


### PR DESCRIPTION
### What does this PR do?

Updates the netem configurations in `TestTCPRecoveryCount` with an escalation chain that tries up to six configurations in sequence until one triggers SACK-based fast recovery. Each attempt runs in a fresh network namespace with a fresh TCP connection, so kernel per-connection and per-peer adaptive state (notably `tp->reordering`) starts from defaults every time. Each attempt has a 20s budget and bails out early if RTO fires — once `cwnd` collapses, fast recovery is very unlikely in the remaining time.

The chain covers three mechanisms so at least one lands on each CI kernel:
1. Jitter-only (`delay 20ms 2ms`, `delay 20ms 10ms`) — relies on netem's time-ordered dequeue causing packets to swap when jitter values cross. Works on kernel ≥4.4.
2. Explicit `reorder` directive (`delay 20ms reorder 3% 25%`, `delay 50ms reorder 75%`) — bypasses the delay queue P% of the time, works on all kernels including 3.10/4.9 where jitter alone doesn't reorder.
3. Loss-based fallback (`delay 50ms loss 15% 50%`, `delay 50ms loss 20% 50%`) — SACK-based fast recovery also fires on real loss. Last-resort because loss walks the line between too little (no recovery) and too much (RTO preempts recovery).

### Motivation

The previous version was flaky on both CO-RE and runtime-compiled tracers across multiple distros.

### Describe how you validated your changes

Ran the test 100 times on the dev VM (kernel 5.15, Ubuntu 22.04) on runtime-compiled tracer prior to the final config-set:

- **Success rate:** 100/100
- **Per-iteration average:** ~2.8s (config 1 succeeds on this kernel)

Successfully ran full KMT tests in CI.

### Additional Notes

Worst-case wall time is now 6 × 20s = 120s when every config fails; on the happy path the first config succeeds in a few seconds. Each attempt logs which config is being tried and whether RTO caused an early bail-out, so failures in CI will tell us which kernel behavior is winning on each distro.