### PR TITLE
chore(renovate): Disable updates on gomod replace directives

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,6 +84,11 @@
       },
       {
         "matchManagers": ["gomod"],
+        "matchDepTypes": ["replace"],
+        "enabled": false
+      },
+      {
+        "matchManagers": ["gomod"],
         "matchDepNames": ["github.com/twmb/franz-go{,/**}"],
         "groupName": "franz-go"
       },


### PR DESCRIPTION
### What does this PR do?

Adds a Renovate package rule that disables updates for dependencies whose gomod `depType` is `replace`. Renovate will no longer propose bumps for the right-hand side of `replace … => …` directives in any `go.mod` file in the repo.

### Motivation

The repository pins a number of public forks (e.g. `DataDog/netlink`, `DataDog/trivy`, `DataDog/opa`, `DataDog/opentelemetry-ebpf-profiler`, `DataDog/gopacket`, `DataDog/vault/api/auth/aws`, `DataDog/go-grpc-bidirectional-streaming-example`, `DataDog/go-cmp`, `DataDog/cast`) through `replace` directives in the main `go.mod`. These versions are chosen deliberately — usually to pull in a specific patched commit — so automated bumps from Renovate are undesirable noise rather than actionable updates.

### Describe how you validated your changes

Configuration-only change; no runtime behavior. Validation on merge will be observing that Renovate no longer opens PRs touching `replace` lines. The rule uses the documented `depType: replace` assigned by the Renovate `gomod` manager (see https://docs.renovatebot.com/modules/manager/gomod/).

### Additional Notes

There is already an existing rule disabling `github.com/spf13/cast` by name (which is replaced by `DataDog/cast`). That rule remains useful because it also covers non-replace scenarios, but the new broader rule subsumes it for replace directives and extends the protection to all other forks.