### PR TITLE
feat: add autodiscovery for kata containers integration

### DIFF
--- a/cmd/agent/dist/conf.d/kata_containers.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/kata_containers.d/conf.yaml.default
@@ -1,0 +1,22 @@
+ad_identifiers:
+  - _kata_containers
+init_config:
+instances:
+  -
+    ## @param sandbox_storage_paths - list of strings - optional - default: ["/run/vc/sbs", "/run/kata"]
+    ## Directories to scan for Kata shim sockets. When running the Agent in a container,
+    ## host paths are typically mounted under /host — both variants are listed here so the
+    ## check works without manual configuration in either deployment mode.
+    #
+    sandbox_storage_paths:
+      - /host/run/vc/sbs
+      - /host/run/kata
+
+    ## @param tags - list of strings following the pattern: "key:value" - optional
+    ## List of tags to attach to every metric, event, and service check emitted by this integration.
+    ##
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>

--- a/comp/core/autodiscovery/listeners/environment.go
+++ b/comp/core/autodiscovery/listeners/environment.go
@@ -55,6 +55,7 @@ func (l *EnvironmentListener) createServices() {
 		"kube_orchestrator":           env.KubeOrchestratorExplorer,
 		"kubelet_config_orchestrator": env.KubeletConfigOrchestratorCheck,
 		"ecs_orchestrator":            env.ECSOrchestratorExplorer,
+		"kata_containers":             env.KataContainers,
 	}
 
 	for name, feature := range features {

--- a/pkg/config/env/environment_container_features.go
+++ b/pkg/config/env/environment_container_features.go
@@ -44,4 +44,6 @@ const (
 	// NonstandardCRIRuntime is a fallback value for when customers supply a CRI compliant runtime via the
 	// cri_socket_path configuration field
 	NonstandardCRIRuntime = "nonstandard-cri-runtime"
+	// KataContainers sandbox storage paths present
+	KataContainers Feature = "kata_containers"
 )

--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -54,6 +54,7 @@ func init() {
 	registerFeature(KubernetesDevicePlugins)
 	registerFeature(NVML)
 	registerFeature(NonstandardCRIRuntime)
+	registerFeature(KataContainers)
 }
 
 // IsAnyContainerFeaturePresent checks if any of known container features is present
@@ -82,6 +83,7 @@ func detectContainerFeatures(features FeatureMap, cfg model.Reader) {
 	detectPodResources(features, cfg)
 	detectDevicePlugins(features, cfg)
 	detectNVML(features, cfg)
+	detectKata(features)
 }
 
 func detectKubernetes(features FeatureMap, cfg model.Reader) {
@@ -342,6 +344,16 @@ func detectNVML(features FeatureMap, cfg model.Reader) {
 	log.Debugf("Agent did not find NVML library in any of the default paths: %v", defaultPaths)
 }
 
+func detectKata(features FeatureMap) {
+	for _, basePath := range getDefaultKataPaths() {
+		if _, err := os.Stat(basePath); err == nil {
+			features[KataContainers] = struct{}{}
+			log.Infof("Agent found Kata Containers sandbox path at: %s", basePath)
+			return
+		}
+	}
+}
+
 func getHostMountPrefixes() []string {
 	if IsContainerized() {
 		return []string{"", defaultHostMountPrefix}
@@ -419,6 +431,18 @@ func getDefaultNvmlPaths() []string {
 	paths := make([]string, 0, len(systemPaths))
 	for _, p := range systemPaths {
 		paths = append(paths, path.Join(hostRoot, p))
+	}
+	return paths
+}
+
+func getDefaultKataPaths() []string {
+	var defaultKataSandboxPaths = []string{"/host/run/vc/sbs", "/host/run/kata"}
+
+	paths := make([]string, 0, len(getHostMountPrefixes())*len(defaultKataSandboxPaths))
+	for _, prefix := range getHostMountPrefixes() {
+		for _, p := range defaultKataSandboxPaths {
+			paths = append(paths, path.Join(prefix, p))
+		}
 	}
 	return paths
 }

--- a/releasenotes/notes/kata-containers-autodiscovery-f654d29fe08482c7.yaml
+++ b/releasenotes/notes/kata-containers-autodiscovery-f654d29fe08482c7.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add automatic discovery of Kata Containers environments. The Agent now detects
+    the presence of Kata sandbox paths (``/host/run/vc/sbs``, ``/host/run/kata``) at startup
+    and automatically enables the ``kata_containers`` check without manual
+    configuration.


### PR DESCRIPTION
### What does this PR do?

Auto discovery for kata integration.

### Motivation

Simplify management for user. With auto discovery the user dont need to specify their `sandbox_storage_paths` they just enable some feature in either datadog-agent helm-charts or the operator and it works OOTB.

Other PRs:
- helm-charts: https://github.com/DataDog/helm-charts/pull/2590
- operator: https://github.com/DataDog/datadog-operator/pull/2917
- integrations-core: https://github.com/DataDog/integrations-core/pull/23465

Note: the objective of these PRs is to mount the `/run` folder to the `/host/run` in the agent container whenever the kata integration is enabled hence the PRs above.

### Describe how you validated your changes

Tested in squirtle-a cluster having kata containers running. This config used in `squirtle-a` is sufficient to validate the changes:
```yaml
config:
  kata_containers:
    enabled: true

agent:
  image:
    tag: dev-mateo.lelong-kata-autodiscovery-f869b2c1-jmx
```

The configuration would have failed without autodiscovery because:
- the default `sandbox_storage_paths` would have stayed  "/run/vc/sbs" and "/run/kata" (See [this](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/containers/kata/check.go#L49))
- the `/run` folder is always mounted as `/host/run` in the container agent

In other word, a valid configuration without autodiscovery would have been:

```yaml
config:
  kata_containers:
    enabled: true
    sandbox_storage_paths: [/host/run/vc/sbs, host/run/kata] # this becomes optional
```

<img width="1747" height="552" alt="image" src="https://github.com/user-attachments/assets/9706cd2f-35ea-4d20-922a-b1cb72c71dc7" />

### Additional Notes

Follow up: https://github.com/DataDog/datadog-agent/pull/47816
