### PR TITLE
[WP] Use Peek instead of Get when looking for SBOM

### DIFF
--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -661,7 +661,7 @@ func (r *Resolver) getSBOM(containerID containerutils.ContainerID) *SBOM {
 
 	sbom := r.hostSBOM
 	if containerID != "" {
-		sbom, _ = r.sboms.Get(containerID)
+		sbom, _ = r.sboms.Peek(containerID)
 	}
 	return sbom
 }
@@ -898,7 +898,7 @@ func (r *Resolver) Delete(id containerutils.ContainerID) {
 	r.sbomsLock.Lock()
 	defer r.sbomsLock.Unlock()
 
-	sbom, ok := r.sboms.Get(id)
+	sbom, ok := r.sboms.Peek(id)
 	if !ok {
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

Use Peek instead of Get when looking for SBOM

### Motivation

`Get` modifies the LRU, causing race when looking for a SBOM in the LRU like:

panic: runtime error: index out of range [119] with length 119
goroutine 1404 [running]:
github.com/hashicorp/golang-lru/v2/simplelru.(*LRU[...]).Values(...)
	github.com/hashicorp/golang-lru/v2@v2.0.7/simplelru/lru.go:139
github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom.(*Resolver).enrichSBOMsWithUsage(0x40031cea20)
	github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/resolver.go:518 +0x35c
github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom.(*Resolver).Start.func1()
	github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/resolver.go:279 +0x11c
created by github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom.(*Resolver).Start in goroutine 1
	github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/resolver.go:255 +0x1f0

### Describe how you validated your changes

### Additional Notes
