### PR TITLE
Add host-level PSI (Pressure Stall Information) check

### DIFF
--- a/cmd/agent/dist/conf.d/pressure.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/pressure.d/conf.yaml.default
@@ -1,0 +1,2 @@
+instances:
+- {}

--- a/cmd/agent/dist/core_checks.bzl
+++ b/cmd/agent/dist/core_checks.bzl
@@ -22,6 +22,7 @@ AGENT_CORECHECKS = [
     "oom_kill",
     "oracle",
     "oracle-dbm",
+    "pressure",
     "sbom",
     "systemd",
     "tcp_queue_length",

--- a/pkg/collector/corechecks/system/pressure/README.md
+++ b/pkg/collector/corechecks/system/pressure/README.md
@@ -1,0 +1,121 @@
+# Pressure Check — Host-Level PSI (Pressure Stall Information)
+
+## What This Check Does
+
+This check reads Linux Pressure Stall Information from `/proc/pressure/{cpu,memory,io}` and emits host-wide metrics that quantify how much time tasks spend **stalled waiting for resources**. PSI is fundamentally different from utilization: a host at 100% CPU with 5% PSI is healthy (fully utilized, minimal contention), while a host at 40% CPU with 60% PSI has severe scheduling bottlenecks.
+
+### Metrics Emitted
+
+| Metric | Type | Unit | Description |
+|---|---|---|---|
+| `system.pressure.cpu.some.total` | MonotonicCount | microseconds | Cumulative time at least one task was stalled waiting for CPU |
+| `system.pressure.memory.some.total` | MonotonicCount | microseconds | Cumulative time at least one task was stalled on memory (reclaim, swap-in, refaults) |
+| `system.pressure.memory.full.total` | MonotonicCount | microseconds | Cumulative time ALL tasks were stalled on memory — indicates thrashing |
+| `system.pressure.io.some.total` | MonotonicCount | microseconds | Cumulative time at least one task was stalled on IO |
+| `system.pressure.io.full.total` | MonotonicCount | microseconds | Cumulative time ALL tasks were stalled on IO — indicates saturation |
+
+CPU "full" is not emitted because by kernel design it is always zero (there's always at least one task running on CPU when contention exists).
+
+### Requirements
+
+- Linux kernel >= 4.20 (PSI introduced December 2018)
+- PSI must be enabled (default in most distributions; can be disabled via `psi=0` boot parameter)
+- On kernels that don't support PSI, the check gracefully disables itself at startup with no error spam
+
+### Using the Metrics in Datadog
+
+The raw values are cumulative microseconds. As MonotonicCount, Datadog computes the delta per collection interval automatically.
+
+To get **percentage of wall-clock time spent stalled** (equivalent to the kernel's `avg` values):
+```
+system.pressure.cpu.some.total / 10000
+```
+
+To smooth over longer windows:
+```
+system.pressure.memory.full.total.rollup(avg, 60) / 10000    # ~60s average
+system.pressure.io.some.total.rollup(avg, 300) / 10000       # ~5min average
+```
+
+### Interpreting "some" vs "full"
+
+- **"some"**: At least one task was stalled while others continued running. Indicates **added latency** — workloads are slower but the system is still doing productive work.
+- **"full"**: ALL non-idle tasks were stalled simultaneously. The CPU was doing kernel housekeeping (reclaim, swapping) but **zero user work progressed**. Any non-trivial "full" value for memory is a serious concern.
+
+---
+
+## What Existed Before This Check
+
+### Container-Level PSI (cgroupv2 only)
+
+The agent already collects per-container PSI from cgroupv2 pressure files, but with significant gaps:
+
+| Source | What's Parsed | What's Emitted | What's Dropped |
+|---|---|---|---|
+| `<cgroup>/cpu.pressure` | some: Avg10, Avg60, Avg300, Total | `container.cpu.partial_stall` (Rate, from some.Total only) | Avg10, Avg60, Avg300 |
+| `<cgroup>/memory.pressure` | some + full: all 4 fields each | `container.memory.partial_stall` (Rate, from some.Total only) | All full data, all avg values |
+| `<cgroup>/io.pressure` | some + full: all 4 fields each | `container.io.partial_stall` (Rate, from some.Total only) | All full data, all avg values |
+
+**20 PSI values are parsed per container, but only 3 reach metrics.** The "full" pressure data (memory thrashing, IO saturation) is parsed and then silently dropped at the conversion layer in `pkg/util/containers/metrics/system/collector_linux.go`.
+
+The code path is:
+```
+cgroupv2 *.pressure files
+  → parsePSI() (pkg/util/cgroups/file.go:136)
+  → CPUStats / MemoryStats / IOStats (pkg/util/cgroups/stats.go)
+  → convertFieldAndUnit() — only PSISome.Total mapped (collector_linux.go:366,391 + collector_disk_linux.go:39)
+  → ContainerCPUStats.PartialStallTime / ContainerMemStats.PartialStallTime / ContainerIOStats.PartialStallTime
+  → container.{cpu,memory,io}.partial_stall (processor.go:153,174,211)
+```
+
+### Host-Level PSI
+
+**Did not exist.** No code read `/proc/pressure/{cpu,memory,io}` before this check. The memory check's `collect_memory_pressure` option reads `/proc/vmstat` for `allocstall_*` and `pgscan_*` counters — those are older memory pressure indicators, not PSI.
+
+---
+
+## What This Check Adds
+
+This check fills the **host-level PSI gap**. It reads directly from `/proc/pressure/*` (procfs, not cgroups) and provides a system-wide view of resource contention.
+
+### Why Host-Level PSI Matters
+
+Container-level PSI tells you *which container* is experiencing pressure. Host-level PSI tells you *whether the system as a whole* is contended — which is critical for:
+
+1. **Infrastructure capacity planning**: Detect when a node is approaching contention limits before containers start degrading. A host with rising `system.pressure.cpu.some.total` needs more CPU or fewer workloads, regardless of which container is feeling it.
+
+2. **Noisy neighbor detection**: When multiple containers share a host, host-level PSI spikes without corresponding per-container spikes indicate **shared resource contention** (kernel locks, page allocator, VFS) that can't be attributed to a single container.
+
+3. **Correlation with utilization**: PSI adds a dimension that utilization metrics miss. High CPU utilization with low PSI = healthy saturation. Moderate CPU utilization with high PSI = lock contention or scheduling pathology. This distinction is invisible with utilization alone.
+
+4. **"Full" pressure visibility**: The existing container metrics only emit "some" pressure. This check adds "full" for memory and IO — the **critical severity signal** indicating total system stalls. Any non-trivial `system.pressure.memory.full.total` rate means the host is thrashing.
+
+5. **Baseline for Kernel Sentinel**: Host-level PSI is the foundational signal for the broader kernel-level observability initiative. Combined with future eBPF-based lock contention and scheduler metrics, it enables root-cause attribution for performance degradation.
+
+---
+
+## Expanding Visibility — Future Opportunities
+
+### Short-term: Fill the Container PSI Gaps
+
+The existing cgroup PSI infrastructure already parses `PSIFull` and `Avg10/60/300` but drops them. Adding these would require:
+- New fields in `ContainerMemStats`, `ContainerIOStats` (e.g., `FullStallTime *float64`)
+- Additional `convertFieldAndUnit` calls in `collector_linux.go`
+- New `sendMetric` calls in `processor.go`
+
+This would add `container.memory.full_stall`, `container.io.full_stall` — per-container "full" pressure that doesn't exist today.
+
+### Medium-term: Kernel Lock Contention (eBPF)
+
+PSI tells you *that* the system is stalled. Lock contention monitoring tells you *why* — which specific kernel locks are causing delays. Using the `contention_begin`/`contention_end` tracepoints (kernel 5.19+) with eBPF in-kernel aggregation, this can be done at <1-3% overhead.
+
+See: `dev/analysis/lock-contention-monitoring-linux-research.md`
+
+### Long-term: Unified Kernel Signals Pipeline
+
+Combining PSI + lock contention + scheduler tracepoints into a single system-probe module enables:
+- Automated root-cause attribution ("high IO PSI is caused by contention on `journal_lock` in ext4")
+- Predictive degradation detection (rising PSI trend → alert before containers start failing)
+- Cross-container interference analysis ("container A's memory reclaim is causing IO stalls in container B via shared page allocator locks")
+
+See: `dev/analysis/kernel-sentinel-strategy-and-codebase-analysis.md`

--- a/pkg/collector/corechecks/system/pressure/doc.go
+++ b/pkg/collector/corechecks/system/pressure/doc.go
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package pressure implements the PSI (Pressure Stall Information) check.
+// It reads host-level pressure data from /proc/pressure/{cpu,memory,io}
+// and emits cumulative stall time metrics.
+package pressure

--- a/pkg/collector/corechecks/system/pressure/pressure_linux.go
+++ b/pkg/collector/corechecks/system/pressure/pressure_linux.go
@@ -1,0 +1,199 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package pressure
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+const (
+	// CheckName is the name of the check
+	CheckName = "pressure"
+)
+
+// For testing
+var openFile = func(path string) (*os.File, error) {
+	return os.Open(path)
+}
+
+// pressureStats holds the parsed total stall time from a PSI line
+type pressureStats struct {
+	total uint64 // cumulative microseconds of stall time
+}
+
+// Check collects PSI metrics from /proc/pressure/{cpu,memory,io}
+type Check struct {
+	core.CheckBase
+	procPath string
+}
+
+// Factory creates a new check factory
+func Factory() option.Option[func() check.Check] {
+	return option.New(newCheck)
+}
+
+func newCheck() check.Check {
+	return &Check{
+		CheckBase: core.NewCheckBase(CheckName),
+	}
+}
+
+// Configure sets up the check
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, data integration.Data, initConfig integration.Data, source string, provider string) error {
+	err := c.CommonConfigure(senderManager, initConfig, data, source, provider)
+	if err != nil {
+		return err
+	}
+
+	c.procPath = "/proc"
+	if v := pkgconfigsetup.Datadog().GetString("procfs_path"); v != "" {
+		c.procPath = v
+	}
+
+	// Skip the check if PSI is not available (kernel < 4.20 or psi=0 boot param).
+	// This avoids error spam on every check interval for unsupported systems.
+	if !c.psiAvailable() {
+		log.Infof("pressure: PSI not available at %s/pressure/, skipping check", c.procPath)
+		return check.ErrSkipCheckInstance
+	}
+
+	return nil
+}
+
+// psiAvailable returns true if at least one PSI file exists and is readable.
+func (c *Check) psiAvailable() bool {
+	for _, resource := range []string{"cpu", "memory", "io"} {
+		if f, err := openFile(c.procPath + "/pressure/" + resource); err == nil {
+			f.Close()
+			return true
+		}
+	}
+	return false
+}
+
+// Run executes the check
+func (c *Check) Run() error {
+	s, err := c.GetSender()
+	if err != nil {
+		return err
+	}
+
+	var anyMetricEmitted bool
+
+	// CPU: only "some" is meaningful — "full" is always 0 per kernel design
+	// (matches cgroup pattern in pkg/util/cgroups/file.go, which allows a nil fullPsi for CPU)
+	if some, _, err := parsePressureFile(c.procPath + "/pressure/cpu"); err != nil {
+		log.Debugf("pressure: could not read cpu pressure: %v", err)
+	} else if some == nil {
+		log.Debugf("pressure: %s/pressure/cpu opened but no parseable stats", c.procPath)
+	} else {
+		s.MonotonicCount("system.pressure.cpu.some.total", float64(some.total), "", nil)
+		anyMetricEmitted = true
+	}
+
+	// Memory: both "some" and "full" are meaningful
+	if some, full, err := parsePressureFile(c.procPath + "/pressure/memory"); err != nil {
+		log.Debugf("pressure: could not read memory pressure: %v", err)
+	} else if some == nil && full == nil {
+		log.Debugf("pressure: %s/pressure/memory opened but no parseable stats", c.procPath)
+	} else {
+		if some != nil {
+			s.MonotonicCount("system.pressure.memory.some.total", float64(some.total), "", nil)
+		}
+		if full != nil {
+			s.MonotonicCount("system.pressure.memory.full.total", float64(full.total), "", nil)
+		}
+		anyMetricEmitted = true
+	}
+
+	// IO: both "some" and "full" are meaningful
+	if some, full, err := parsePressureFile(c.procPath + "/pressure/io"); err != nil {
+		log.Debugf("pressure: could not read io pressure: %v", err)
+	} else if some == nil && full == nil {
+		log.Debugf("pressure: %s/pressure/io opened but no parseable stats", c.procPath)
+	} else {
+		if some != nil {
+			s.MonotonicCount("system.pressure.io.some.total", float64(some.total), "", nil)
+		}
+		if full != nil {
+			s.MonotonicCount("system.pressure.io.full.total", float64(full.total), "", nil)
+		}
+		anyMetricEmitted = true
+	}
+
+	if !anyMetricEmitted {
+		return fmt.Errorf("pressure: no PSI metrics emitted from %s/pressure/", c.procPath)
+	}
+
+	s.Commit()
+	return nil
+}
+
+// parsePressureFile reads a /proc/pressure/{cpu,memory,io} file and returns
+// parsed stats for "some" and "full" lines. Either pointer may be nil if the
+// line is not present (e.g., CPU has no "full" line on kernels < 5.13).
+func parsePressureFile(path string) (some *pressureStats, full *pressureStats, err error) {
+	f, err := openFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+
+		total, parseErr := extractTotal(fields[1:])
+		if parseErr != nil {
+			log.Debugf("pressure: error parsing line in %s: %v", path, parseErr)
+			continue
+		}
+
+		stats := &pressureStats{total: total}
+		switch fields[0] {
+		case "some":
+			some = stats
+		case "full":
+			full = stats
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	return some, full, nil
+}
+
+// extractTotal extracts the total=N value from PSI key=value fields.
+// Fields are like: ["avg10=0.50", "avg60=1.20", "avg300=2.30", "total=1234567890"]
+func extractTotal(fields []string) (uint64, error) {
+	const prefix = "total="
+	for _, field := range fields {
+		if strings.HasPrefix(field, prefix) {
+			return strconv.ParseUint(field[len(prefix):], 10, 64)
+		}
+	}
+	return 0, errors.New("total field not found")
+}

--- a/pkg/collector/corechecks/system/pressure/pressure_linux_test.go
+++ b/pkg/collector/corechecks/system/pressure/pressure_linux_test.go
@@ -1,0 +1,345 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package pressure
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+)
+
+// mockFileByPath returns a mock openFile function that serves content based on path suffix
+func mockFileByPath(files map[string]string) func(string) (*os.File, error) {
+	return func(path string) (*os.File, error) {
+		for suffix, content := range files {
+			if strings.HasSuffix(path, suffix) {
+				r, w, _ := os.Pipe()
+				go func() {
+					w.WriteString(content)
+					w.Close()
+				}()
+				return r, nil
+			}
+		}
+		return nil, errors.New("file not found")
+	}
+}
+
+// patchOpenFile installs a mock openFile for the duration of the test and
+// restores the package-level function when the test completes.
+func patchOpenFile(t *testing.T, fn func(string) (*os.File, error)) {
+	t.Helper()
+	orig := openFile
+	openFile = fn
+	t.Cleanup(func() { openFile = orig })
+}
+
+func TestPressureCheckAllResources(t *testing.T) {
+	patchOpenFile(t, mockFileByPath(map[string]string{
+		"/pressure/cpu":    "some avg10=0.50 avg60=1.20 avg300=2.30 total=1234567890\n",
+		"/pressure/memory": "some avg10=1.00 avg60=2.00 avg300=3.00 total=5000000\nfull avg10=0.25 avg60=0.60 avg300=1.15 total=987654321\n",
+		"/pressure/io":     "some avg10=5.00 avg60=10.00 avg300=15.00 total=9999999\nfull avg10=2.50 avg60=5.00 avg300=7.50 total=8888888\n",
+	}))
+
+	pressureCheck := &Check{procPath: "/proc"}
+	mock := mocksender.NewMockSender(pressureCheck.ID())
+	mock.On("FinalizeCheckServiceTag").Return()
+	pressureCheck.Configure(mock.GetSenderManager(), 0, nil, nil, "", "")
+
+	// CPU: only some (full is deliberately skipped)
+	mock.On("MonotonicCount", "system.pressure.cpu.some.total", float64(1234567890), "", []string(nil)).Return().Times(1)
+
+	// Memory: some + full
+	mock.On("MonotonicCount", "system.pressure.memory.some.total", float64(5000000), "", []string(nil)).Return().Times(1)
+	mock.On("MonotonicCount", "system.pressure.memory.full.total", float64(987654321), "", []string(nil)).Return().Times(1)
+
+	// IO: some + full
+	mock.On("MonotonicCount", "system.pressure.io.some.total", float64(9999999), "", []string(nil)).Return().Times(1)
+	mock.On("MonotonicCount", "system.pressure.io.full.total", float64(8888888), "", []string(nil)).Return().Times(1)
+
+	mock.On("Commit").Return().Times(1)
+
+	err := pressureCheck.Run()
+	require.NoError(t, err)
+
+	mock.AssertNumberOfCalls(t, "MonotonicCount", 5)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestPressureCheckWithKernel513CPUFullLine(t *testing.T) {
+	// On kernel >= 5.13, /proc/pressure/cpu contains a "full" line (always zero).
+	// The parser returns it, but Run() structurally ignores the CPU full value
+	// via _ discard — only "some" is emitted for CPU. This matches the cgroup
+	// pattern in pkg/util/cgroups/file.go, which allows a nil fullPsi for CPU.
+	patchOpenFile(t, mockFileByPath(map[string]string{
+		"/pressure/cpu":    "some avg10=0.50 avg60=1.20 avg300=2.30 total=1234567890\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\n",
+		"/pressure/memory": "some avg10=0.00 avg60=0.00 avg300=0.00 total=100\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=200\n",
+		"/pressure/io":     "some avg10=0.00 avg60=0.00 avg300=0.00 total=300\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=400\n",
+	}))
+
+	// Verify parsePressureFile does parse the CPU full line
+	some, full, err := parsePressureFile("/proc/pressure/cpu")
+	require.NoError(t, err)
+	require.NotNil(t, some)
+	require.NotNil(t, full, "parser should return CPU full line even though Run() ignores it")
+	assert.Equal(t, uint64(0), full.total)
+
+	// Re-install the mock for Run() — the previous parsePressureFile call
+	// consumed the pipes, so fresh file handles are needed.
+	patchOpenFile(t, mockFileByPath(map[string]string{
+		"/pressure/cpu":    "some avg10=0.50 avg60=1.20 avg300=2.30 total=1234567890\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\n",
+		"/pressure/memory": "some avg10=0.00 avg60=0.00 avg300=0.00 total=100\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=200\n",
+		"/pressure/io":     "some avg10=0.00 avg60=0.00 avg300=0.00 total=300\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=400\n",
+	}))
+
+	pressureCheck := &Check{procPath: "/proc"}
+	mock := mocksender.NewMockSender(pressureCheck.ID())
+	mock.On("FinalizeCheckServiceTag").Return()
+	pressureCheck.Configure(mock.GetSenderManager(), 0, nil, nil, "", "")
+
+	// CPU: only some emitted — Run() discards the full return value via _
+	mock.On("MonotonicCount", "system.pressure.cpu.some.total", float64(1234567890), "", []string(nil)).Return().Times(1)
+	mock.On("MonotonicCount", "system.pressure.memory.some.total", float64(100), "", []string(nil)).Return().Times(1)
+	mock.On("MonotonicCount", "system.pressure.memory.full.total", float64(200), "", []string(nil)).Return().Times(1)
+	mock.On("MonotonicCount", "system.pressure.io.some.total", float64(300), "", []string(nil)).Return().Times(1)
+	mock.On("MonotonicCount", "system.pressure.io.full.total", float64(400), "", []string(nil)).Return().Times(1)
+	mock.On("Commit").Return().Times(1)
+
+	err = pressureCheck.Run()
+	require.NoError(t, err)
+
+	// Still 5 metrics — CPU full is not emitted even though it exists in the file
+	mock.AssertNumberOfCalls(t, "MonotonicCount", 5)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestPressureCheckPartialAvailability(t *testing.T) {
+	// Only CPU available, memory and io fail
+	patchOpenFile(t, mockFileByPath(map[string]string{
+		"/pressure/cpu": "some avg10=0.50 avg60=1.20 avg300=2.30 total=1234567890\n",
+	}))
+
+	pressureCheck := &Check{procPath: "/proc"}
+	mock := mocksender.NewMockSender(pressureCheck.ID())
+	mock.On("FinalizeCheckServiceTag").Return()
+	pressureCheck.Configure(mock.GetSenderManager(), 0, nil, nil, "", "")
+
+	mock.On("MonotonicCount", "system.pressure.cpu.some.total", float64(1234567890), "", []string(nil)).Return().Times(1)
+	mock.On("Commit").Return().Times(1)
+
+	err := pressureCheck.Run()
+	require.NoError(t, err)
+
+	mock.AssertNumberOfCalls(t, "MonotonicCount", 1)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestPressureCheckAllFilesFail(t *testing.T) {
+	patchOpenFile(t, func(_ string) (*os.File, error) {
+		return nil, errors.New("file not found")
+	})
+
+	pressureCheck := &Check{procPath: "/proc"}
+	mock := mocksender.NewMockSender(pressureCheck.ID())
+	mock.On("FinalizeCheckServiceTag").Return()
+	pressureCheck.Configure(mock.GetSenderManager(), 0, nil, nil, "", "")
+
+	err := pressureCheck.Run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no PSI metrics emitted")
+
+	mock.AssertNumberOfCalls(t, "MonotonicCount", 0)
+	mock.AssertNumberOfCalls(t, "Commit", 0)
+}
+
+func TestPressureCheckAllFilesEmptyEmitsNothing(t *testing.T) {
+	// If /proc/pressure/* all open successfully but contain no parseable lines,
+	// Run() must return an error rather than silently reporting success with
+	// zero metrics emitted — otherwise a kernel regression or bind-mount bug
+	// would be indistinguishable from a healthy run.
+	patchOpenFile(t, mockFileByPath(map[string]string{
+		"/pressure/cpu":    "",
+		"/pressure/memory": "",
+		"/pressure/io":     "",
+	}))
+
+	pressureCheck := &Check{procPath: "/proc"}
+	mock := mocksender.NewMockSender(pressureCheck.ID())
+	mock.On("FinalizeCheckServiceTag").Return()
+	pressureCheck.Configure(mock.GetSenderManager(), 0, nil, nil, "", "")
+
+	err := pressureCheck.Run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no PSI metrics emitted")
+
+	mock.AssertNumberOfCalls(t, "MonotonicCount", 0)
+	mock.AssertNumberOfCalls(t, "Commit", 0)
+}
+
+func TestPressureCheckSkipsWhenPSIUnavailable(t *testing.T) {
+	// On kernels < 4.20 or with psi=0, /proc/pressure/ doesn't exist.
+	// Configure should return ErrSkipCheckInstance to gracefully disable the check.
+	patchOpenFile(t, func(_ string) (*os.File, error) {
+		return nil, errors.New("file not found")
+	})
+
+	pressureCheck := &Check{CheckBase: core.NewCheckBase(CheckName)}
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+
+	err := pressureCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test", "provider")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, check.ErrSkipCheckInstance)
+}
+
+func TestPressureCheckPSIAvailablePartial(t *testing.T) {
+	// If at least one PSI file exists, psiAvailable returns true.
+	patchOpenFile(t, mockFileByPath(map[string]string{
+		"/pressure/io": "some avg10=0.00 avg60=0.00 avg300=0.00 total=100\n",
+	}))
+
+	pressureCheck := &Check{procPath: "/proc"}
+	assert.True(t, pressureCheck.psiAvailable())
+}
+
+func TestPressureCheckPSIAvailableAllPresent(t *testing.T) {
+	patchOpenFile(t, mockFileByPath(map[string]string{
+		"/pressure/cpu":    "some avg10=0.00 avg60=0.00 avg300=0.00 total=100\n",
+		"/pressure/memory": "some avg10=0.00 avg60=0.00 avg300=0.00 total=100\n",
+		"/pressure/io":     "some avg10=0.00 avg60=0.00 avg300=0.00 total=100\n",
+	}))
+
+	pressureCheck := &Check{procPath: "/proc"}
+	assert.True(t, pressureCheck.psiAvailable())
+}
+
+func TestParsePressureFile(t *testing.T) {
+	patchOpenFile(t, mockFileByPath(map[string]string{
+		"/pressure/memory": "some avg10=0.50 avg60=1.20 avg300=2.30 total=1234567890\nfull avg10=0.25 avg60=0.60 avg300=1.15 total=987654321\n",
+	}))
+
+	some, full, err := parsePressureFile("/proc/pressure/memory")
+	require.NoError(t, err)
+
+	require.NotNil(t, some)
+	assert.Equal(t, uint64(1234567890), some.total)
+
+	require.NotNil(t, full)
+	assert.Equal(t, uint64(987654321), full.total)
+}
+
+func TestParsePressureFileCPUOnly(t *testing.T) {
+	patchOpenFile(t, mockFileByPath(map[string]string{
+		"/pressure/cpu": "some avg10=0.50 avg60=1.20 avg300=2.30 total=1234567890\n",
+	}))
+
+	some, full, err := parsePressureFile("/proc/pressure/cpu")
+	require.NoError(t, err)
+
+	require.NotNil(t, some)
+	assert.Equal(t, uint64(1234567890), some.total)
+	assert.Nil(t, full)
+}
+
+func TestPressureCheckMalformedContent(t *testing.T) {
+	// Verify graceful degradation with corrupt/malformed PSI content.
+	// The check should emit what it can and skip unparseable lines.
+	patchOpenFile(t, mockFileByPath(map[string]string{
+		"/pressure/cpu":    "some avg10=0.50 avg60=1.20 avg300=2.30 total=notanumber\n",
+		"/pressure/memory": "",
+		"/pressure/io":     "garbage line\nsome avg10=0.00 avg60=0.00 avg300=0.00 total=500\nunknown_type avg10=0.00 total=0\n",
+	}))
+
+	pressureCheck := &Check{procPath: "/proc"}
+	mock := mocksender.NewMockSender(pressureCheck.ID())
+	mock.On("FinalizeCheckServiceTag").Return()
+	pressureCheck.Configure(mock.GetSenderManager(), 0, nil, nil, "", "")
+
+	// CPU: malformed total — line skipped, no metric emitted
+	// Memory: empty file — no lines parsed, no metrics
+	// IO: garbage line skipped, "some" parsed OK, unknown_type skipped
+	mock.On("MonotonicCount", "system.pressure.io.some.total", float64(500), "", []string(nil)).Return().Times(1)
+	mock.On("Commit").Return().Times(1)
+
+	err := pressureCheck.Run()
+	require.NoError(t, err)
+
+	mock.AssertNumberOfCalls(t, "MonotonicCount", 1)
+}
+
+func TestParsePressureFileMissingTotal(t *testing.T) {
+	// PSI line with avg fields but no total= field
+	patchOpenFile(t, mockFileByPath(map[string]string{
+		"/pressure/memory": "some avg10=0.50 avg60=1.20 avg300=2.30\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=100\n",
+	}))
+
+	some, full, err := parsePressureFile("/proc/pressure/memory")
+	require.NoError(t, err)
+
+	// "some" line has no total= field — skipped
+	assert.Nil(t, some)
+	// "full" line has total — parsed
+	require.NotNil(t, full)
+	assert.Equal(t, uint64(100), full.total)
+}
+
+func TestExtractTotal(t *testing.T) {
+	tests := []struct {
+		name     string
+		fields   []string
+		expected uint64
+		wantErr  bool
+	}{
+		{
+			name:     "standard PSI fields",
+			fields:   []string{"avg10=0.50", "avg60=1.20", "avg300=2.30", "total=1234567890"},
+			expected: 1234567890,
+		},
+		{
+			name:     "total only",
+			fields:   []string{"total=42"},
+			expected: 42,
+		},
+		{
+			name:    "no total field",
+			fields:  []string{"avg10=0.50", "avg60=1.20"},
+			wantErr: true,
+		},
+		{
+			name:    "empty fields",
+			fields:  []string{},
+			wantErr: true,
+		},
+		{
+			name:    "malformed total value",
+			fields:  []string{"avg10=0.50", "total=notanumber"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := extractTotal(tt.fields)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, val)
+			}
+		})
+	}
+}

--- a/pkg/collector/corechecks/system/pressure/pressure_stub.go
+++ b/pkg/collector/corechecks/system/pressure/pressure_stub.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+package pressure
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+const (
+	// CheckName is the name of the check
+	CheckName = "pressure"
+)
+
+// Factory returns None on non-Linux platforms since PSI is Linux-only
+func Factory() option.Option[func() check.Check] {
+	return option.None[func() check.Check]()
+}

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -62,6 +62,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/disk/io"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/filehandles"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/memory"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/pressure"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/uptime"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/wincrashdetect"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/windowscertificate"
@@ -79,6 +80,7 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	// Required checks
 	corecheckLoader.RegisterCheck(cpu.CheckName, cpu.Factory())
 	corecheckLoader.RegisterCheck(memory.CheckName, memory.Factory())
+	corecheckLoader.RegisterCheck(pressure.CheckName, pressure.Factory())
 	corecheckLoader.RegisterCheck(uptime.CheckName, uptime.Factory())
 	corecheckLoader.RegisterCheck(hostinfo.CheckName, hostinfo.Factory())
 	corecheckLoader.RegisterCheck(telemetryCheck.CheckName, telemetryCheck.Factory(telemetry))

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1205,6 +1205,7 @@ func agent(config pkgconfigmodel.Setup) {
 		"memory",
 		"network",
 		"ntp",
+		"pressure",
 		"process",
 		"service_discovery",
 		"snmp",

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -343,6 +343,7 @@ const (
 	MetricSourceDellPowerFlex
 	MetricSourceHPEArubaEdgeConnect
 	MetricSourceNiFi
+	MetricSourcePressure
 	// OpenTelemetry Collector receivers
 	MetricSourceOpenTelemetryCollectorUnknown
 	MetricSourceOpenTelemetryCollectorDockerstatsReceiver
@@ -1140,6 +1141,8 @@ func (ms MetricSource) String() string {
 		return "hpe_aruba_edgeconnect"
 	case MetricSourceNiFi:
 		return "nifi"
+	case MetricSourcePressure:
+		return "pressure"
 	default:
 		return "<unknown>"
 	}
@@ -1834,6 +1837,8 @@ func CheckNameToMetricSource(name string) MetricSource {
 		return MetricSourceHPEArubaEdgeConnect
 	case "nifi":
 		return MetricSourceNiFi
+	case "pressure":
+		return MetricSourcePressure
 	default:
 		return MetricSourceUnknown
 	}

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -369,7 +369,8 @@ func metricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 		metrics.MetricSourcePinot,
 		metrics.MetricSourceDellPowerFlex,
 		metrics.MetricSourceHPEArubaEdgeConnect,
-		metrics.MetricSourceNiFi:
+		metrics.MetricSourceNiFi,
+		metrics.MetricSourcePressure:
 		return 11 // integrationMetrics
 	case metrics.MetricSourceGPU:
 		return 72 // ref: https://github.com/DataDog/dd-source/blob/276882b71d84785ec89c31973046ab66d5a01807/domains/metrics/shared/libs/proto/origin/origin.proto#L427

--- a/releasenotes/notes/add-psi-host-metrics-f3245e013f698aa9.yaml
+++ b/releasenotes/notes/add-psi-host-metrics-f3245e013f698aa9.yaml
@@ -1,0 +1,29 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add a new ``pressure`` core check that collects host-level Linux
+    Pressure Stall Information (PSI) from ``/proc/pressure/{cpu,memory,io}``.
+    New metrics, all cumulative microseconds of stall time reported as
+    monotonic counts:
+    ``system.pressure.cpu.some.total``,
+    ``system.pressure.memory.some.total``, ``system.pressure.memory.full.total``,
+    ``system.pressure.io.some.total``, ``system.pressure.io.full.total``.
+
+    The check is shipped enabled by default on Linux via an empty
+    ``pressure.d/conf.yaml`` instance, so upgraded agents start emitting
+    these metrics automatically without requiring a configuration change.
+    On kernels older than 4.20 or with PSI disabled (``psi=0`` boot
+    parameter), the check disables its instance at startup without
+    running on each schedule tick. It is also included in the
+    ``infrastructure_mode: basic`` allowlist alongside cpu/memory/uptime.
+other:
+  - |
+    Register a metric origin for the ``pressure`` core check so its
+    ``system.pressure.*`` samples are attributable via sender origin.

--- a/tasks/core_checks.py
+++ b/tasks/core_checks.py
@@ -22,6 +22,7 @@ AGENT_CORECHECKS = [
     "oom_kill",
     "oracle",
     "oracle-dbm",
+    "pressure",
     "sbom",
     "systemd",
     "tcp_queue_length",


### PR DESCRIPTION
### What does this PR do?

Adds a new host-level `pressure` core check that reads `/proc/pressure/{cpu,memory,io}` on Linux and emits five new `MonotonicCount` metrics:

- `system.pressure.cpu.some.total`
- `system.pressure.memory.some.total`
- `system.pressure.memory.full.total`
- `system.pressure.io.some.total`
- `system.pressure.io.full.total`

Values are cumulative microseconds of stall time. Requires kernel ≥ 4.20 with PSI enabled; on unsupported kernels the check returns `ErrSkipCheckInstance` at startup and is never scheduled. Containerized agents (`/host/proc` mounted) read host-level PSI, not the container's.

Packaging wiring (`core_checks.bzl`, `tasks/core_checks.py`), registration in `pkg/commonchecks/corechecks.go` as a Required check, inclusion in `infrastructure_mode: basic`, and metric-origin registration (`MetricSourcePressure`) are all in the PR.

### Motivation

The agent already collects **container-level** PSI from cgroupv2 (`container.{cpu,memory,io}.partial_stall`) but has **no host-level PSI**. That leaves several blind spots:

- **Capacity planning** — per-container PSI says *which* container is stalled, not whether the host as a whole is contended. Rising host `system.pressure.cpu.some.total` indicates node-level scheduling pressure regardless of which workload is feeling it.
- **Noisy-neighbor detection** — host PSI spiking without corresponding per-container spikes means shared-resource contention (kernel locks, page allocator, VFS) that can't be attributed to a single container.
- **"Full" pressure visibility** — the existing container metrics emit only `some` (partial stall). The `full` pressure signal (all non-idle tasks simultaneously stalled) is the critical severity indicator for memory thrashing and IO saturation. Before this PR, no code path in the agent emitted `full` pressure at any scope. This PR adds it for memory and IO at host level.
- **Complementing utilization** — high CPU utilization with low PSI is healthy saturation; moderate utilization with high PSI is lock contention or scheduling pathology. Utilization alone can't tell them apart.

### Describe how you validated your changes

**Unit tests** (13 cases in `pressure_linux_test.go`):
- Happy path for all three resources, CPU-only partial availability, all-files-fail, kernel ≥ 5.13 "cpu full" line handling, malformed content, all-files-open-but-empty, `ErrSkipCheckInstance` driven through real `Configure()` with `mocksender.CreateDefaultDemultiplexer()`, plus parser-level coverage of `parsePressureFile` and `extractTotal`.
- `dda inv test --targets=./pkg/collector/corechecks/system/pressure` on a Linux VM (tests are gated by `//go:build linux`): all pass.

**Manual end-to-end on a dev VM**:
- Rebuilt the agent, verified `pressure` loads (`Scheduling check pressure with an interval of 15s`), runs without errors (142+ check runs across multiple sessions, 0 errors), and emits exactly 5 metrics per invocation with `sudo -u dd-agent datadog-agent check pressure --check-rate --json`.
- Confirmed values match `/proc/pressure/*` `total=` fields and grow monotonically across the `--check-rate` window.
- Confirmed `cpu.full` is intentionally absent from the output.

### Additional Notes

**Companion PRs** (in sister repos):
- [integrations-core] — new `pressure/` integration directory (metadata.csv + manifest.json + README) so metrics show up in the Metrics Explorer with descriptions and units.
- [dd-analytics] — `standard_metric_allowlist.json` updated to add `product_detail: "pressure"` under the `system.` prefix so `system.pressure.*` is classified as a standard metric for billing, not custom.

Both need to land before the first release that includes this check so customers see first-class documentation and correct billing from day one.

**Intentionally out of scope**:
- **Container-level `full` pressure** (`container.{memory,io}.full_stall`). The cgroup layer in `pkg/util/cgroups/file.go` already parses `PSIFull` but the container-check conversion layer drops it. Filling that gap is a separate small PR and doesn't belong with a host-level check.
- **Avg10/60/300 gauges**. The kernel exposes them and the parser could too; Datadog rollups give similar shape. Can be added later behind an instance flag.
- **E2E fakeintake assertion**. Host-metrics E2E requires a fixed-kernel provisioner; unit tests + manual VM validation cover functional correctness for now.

**Behavior worth flagging for reviewers**:
- Check is shipped **enabled by default** (empty `instances: - {}` in `pressure.d/conf.yaml.default`). On upgrade, every Linux agent with a supported kernel starts emitting the 5 metrics automatically. No user action required.
- On kernels without `/proc/pressure/`, the `ErrSkipCheckInstance` path produces one persistent "loader error" entry on `agent status`. This is inherited scheduler behaviour shared with battery/disk/network and is not introduced by this PR; mentioning for awareness.

**Review pointers**:
- Main logic: `pkg/collector/corechecks/system/pressure/pressure_linux.go`
- Tests: `pkg/collector/corechecks/system/pressure/pressure_linux_test.go`
- 2-commit stack: feature + metric-origin registration, both self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)