### PR TITLE
Disable ECS task collection for infrastructure_mode none (APM standalone)

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3522,6 +3522,8 @@ api_key:
 ## @env DD_ECS_TASK_COLLECTION_ENABLED - boolean - optional - default: true
 ## The Agent can collect detailed task information from the metadata API exposed by the ECS Agent,
 ## which is used for the orchestrator ECS check.
+## When ``infrastructure_mode`` is ``none``, task collection is disabled unless overridden
+## (for example set ``DD_ECS_TASK_COLLECTION_ENABLED`` to ``true``).
 #
 # ecs_task_collection_enabled: true
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1443,6 +1443,8 @@ func applyInfrastructureModeOverrides(config pkgconfigmodel.Config) {
 	} else if infraMode == "none" {
 		// Disable integrations (no host metrics collection)
 		config.Set("integration.enabled", false, pkgconfigmodel.SourceInfraMode)
+		// Avoid detailed ECS task metadata collection when not collecting infrastructure.
+		config.Set("ecs_task_collection_enabled", false, pkgconfigmodel.SourceInfraMode)
 	}
 }
 

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -674,6 +674,17 @@ func TestNetworkPathDefaults(t *testing.T) {
 	assert.Equal(t, false, config.GetBool("network_path.collector.disable_windows_driver"))
 }
 
+func TestInfrastructureModeNoneDisablesECSTaskCollection(t *testing.T) {
+	datadogYaml := `
+infrastructure_mode: none
+`
+	config := confFromYAML(t, datadogYaml)
+	applyInfrastructureModeOverrides(config)
+
+	assert.False(t, config.GetBool("ecs_task_collection_enabled"))
+	assert.False(t, config.GetBool("integration.enabled"))
+}
+
 func TestInfrastructureModeLegacyAliases(t *testing.T) {
 	// Test that legacy allowed_additional_checks is aliased to mode-specific
 	// key via applyInfrastructureModeOverrides

--- a/releasenotes/notes/ecs-task-collection-infra-mode-none-7c4a9e2b1d8f0a3c.yaml
+++ b/releasenotes/notes/ecs-task-collection-infra-mode-none-7c4a9e2b1d8f0a3c.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    When ``infrastructure_mode`` is set to ``none``, ECS task metadata collection is now disabled by default (see ``ecs_task_collection_enabled``). Set ``DD_ECS_TASK_COLLECTION_ENABLED`` to ``true`` to override.


### PR DESCRIPTION
### What does this PR do?

- When `infrastructure_mode` is `none`, `applyInfrastructureModeOverrides` sets `ecs_task_collection_enabled` to `false` via `SourceInfraMode`, so the Agent does not perform detailed ECS task metadata collection in that mode unless overridden.
- Documents this next to `ecs_task_collection_enabled` / `DD_ECS_TASK_COLLECTION_ENABLED` in `config_template.yaml`.
- Adds `TestInfrastructureModeNoneDisablesECSTaskCollection` and a release note.

### Motivation

`none` exists for **APM standalone** (APM-only, no infrastructure monitoring): integrations are disabled and infrastructure payloads are not the goal. ECS task collection remained on by default and could still trigger ECS metadata work on relevant hosts. Disabling it under `none` matches that mode’s intent.

### Describe how you validated your changes

- Pre-commit (including `rst-releasenotes`, `go-fmt`, `copyright`) passed on commit.
- `dda inv test --targets=./pkg/config/setup` (recommended for the new unit test).

### Additional Notes

- `ecs_task_collection_enabled` in the config file or `DD_ECS_TASK_COLLECTION_ENABLED` can still override this, because `SourceFile` and `SourceEnvVar` outrank `SourceInfraMode` in the config merge order.