### PR TITLE
ci(windows): migrate secret fetching from SSM to Vault

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -322,13 +322,8 @@ variables:
 
   # Start aws ssm variables
   # They must be defined as environment variables in the GitLab CI/CD settings, to ease rotation if needed
-  API_KEY_ORG2: ci.datadog-agent.datadog_api_key_org2 # agent-devx
   CHANGELOG_COMMIT_SHA: ci.datadog-agent.gitlab_changelog_commit_sha # agent-devx
-  CHOCOLATEY_API_KEY: ci.datadog-agent.chocolatey_api_key # windows-products
-  CODECOV_TOKEN: ci.datadog-agent.codecov_token # agent-devx
   CRC_PULL_SECRET: ci.datadog-agent.crc-pull-secret # container-integrations
-  VCPKG_BLOB_SAS_URL: ci.datadog-agent-buildimages.vcpkg_blob_sas_url # windows-products
-  WINGET_PAT: ci.datadog-agent.winget_pat # windows-products
   # End aws ssm variables
 
   # Start vault variables
@@ -348,7 +343,9 @@ variables:
   MACOS_KEYCHAIN_PWD: ci-keychain # agent-delivery
   SLACK_AGENT: slack-agent-ci # agent-devx
   SMP_ACCOUNT: smp # single-machine-performance
+  VCPKG_BLOB_SAS_URL: vcpkg-blob-sas # windows-products
   VIRUS_TOTAL: virus-total # windows-products
+  WINGET_PAT: winget-pat # windows-products
   # End vault variables
 
   # dda configuration variables

--- a/.gitlab/.pre/common/shared.yml
+++ b/.gitlab/.pre/common/shared.yml
@@ -67,10 +67,9 @@
   - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $DOCKER_REGISTRY_RO token | crane auth login --username "$DOCKER_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
   - EXIT="${PIPESTATUS[0]}"; if [ $EXIT -ne 0 ]; then echo "Unable to locate credentials needs gitlab runner restart"; exit $EXIT; fi
 
-
 .docker_pull_winbuildimage_instrumented:
   - $tmpfile = [System.IO.Path]::GetTempFileName()
-  - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$API_KEY_ORG2" -parameterField token -tempFile "$tmpfile")
+  - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$AGENT_API_KEY_ORG2" -parameterField token -tempFile "$tmpfile")
   - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
   - $Env:DATADOG_API_KEY=$(cat "$tmpfile")
   - C:\datadog-ci.exe trace -- docker pull ${WINBUILDIMAGE}

--- a/.gitlab/.pre/common/shared.yml
+++ b/.gitlab/.pre/common/shared.yml
@@ -70,7 +70,7 @@
 
 .docker_pull_winbuildimage_instrumented:
   - $tmpfile = [System.IO.Path]::GetTempFileName()
-  - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$API_KEY_ORG2" -tempFile "$tmpfile")
+  - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$API_KEY_ORG2" -parameterField token -tempFile "$tmpfile")
   - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
   - $Env:DATADOG_API_KEY=$(cat "$tmpfile")
   - C:\datadog-ci.exe trace -- docker pull ${WINBUILDIMAGE}

--- a/.gitlab/windows/build/package_build/windows.yml
+++ b/.gitlab/windows/build/package_build/windows.yml
@@ -44,7 +44,7 @@
       -e INTEGRATION_WHEELS_CACHE_BUCKET
       -e BUNDLE_MIRROR__RUBYGEMS__ORG
       -e PIP_INDEX_URL
-      -e API_KEY_ORG2
+      -e AGENT_API_KEY_ORG2
       -e OMNIBUS_GIT_CACHE_DIR=${Env:TEMP}/${CI_PIPELINE_ID}/omnibus-git-cache
       -e AGENT_FLAVOR
       -e OMNIBUS_RUBY_VERSION
@@ -132,7 +132,7 @@ windows_msi_and_bosh_zip_x64-a7-fips:
       -e USE_S3_CACHING
       -e BUNDLE_MIRROR__RUBYGEMS__ORG
       -e PIP_INDEX_URL
-      -e API_KEY_ORG2
+      -e AGENT_API_KEY_ORG2
       -e CI_IDENTITIES_GITLAB_ID_TOKEN
       ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-OmnibusTarget.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1"

--- a/.gitlab/windows/build/source_test/windows.yml
+++ b/.gitlab/windows/build/source_test/windows.yml
@@ -47,8 +47,8 @@
       -e EXTRA_OPTS="${FAST_TESTS_FLAG}"
       -e TEST_WASHER=true
       -e GO_TEST_SKIP_FLAKE
-      -e API_KEY_ORG2
-      -e CODECOV_TOKEN
+      -e AGENT_API_KEY_ORG2
+      -e CODECOV
       -e S3_PERMANENT_ARTIFACTS_URI
       -e COVERAGE_CACHE_FLAG
       -e FLAKY_PATTERNS_CONFIG="\mnt\flaky-patterns-runtime.yaml"

--- a/.gitlab/windows/distribute/winget/windows.yml
+++ b/.gitlab/windows/distribute/winget/windows.yml
@@ -11,7 +11,7 @@ publish_winget_7_x64:
     ARCH: "x64"
   before_script:
     - $tmpfile = [System.IO.Path]::GetTempFileName()
-    - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:WINGET_PAT" -tempFile "$tmpfile")
+    - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:WINGET_PAT" -parameterField token -tempFile "$tmpfile")
     - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
     - $wingetPat=$(cat "$tmpfile")
     - Remove-Item "$tmpfile"

--- a/.gitlab/windows/test/integration_test/windows.yml
+++ b/.gitlab/windows/test/integration_test/windows.yml
@@ -8,7 +8,7 @@
   extends: .windows_docker_default
   before_script:
     - $tmpfile = [System.IO.Path]::GetTempFileName()
-    - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:VCPKG_BLOB_SAS_URL" -tempFile "$tmpfile")
+    - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:VCPKG_BLOB_SAS_URL" -parameterField url -tempFile "$tmpfile")
     - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
     - $vcpkgBlobSaSUrl=$(cat "$tmpfile")
     - Remove-Item "$tmpfile"

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -202,7 +202,7 @@ def _hash_paths(hasher, paths: list[str]):
 
 def get_dd_api_key(ctx):
     if sys.platform == 'win32':
-        cmd = f'aws.exe ssm get-parameter --region us-east-1 --name {os.environ["API_KEY_ORG2"]} --with-decryption --query "Parameter.Value" --out text'
+        cmd = f'C:\\devtools\\ci-identities-gitlab-job-client.exe secrets read {os.environ["AGENT_API_KEY_ORG2"]} token'
     elif sys.platform == 'darwin':
         cmd = f'vault kv get -field=token kv/aws/arn:aws:iam::486234852809:role/ci-datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
     else:

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -55,7 +55,7 @@ class TestOmnibusCache(unittest.TestCase):
             for platform, get_dd_api_key_env in {
                 "darwin": {"AGENT_API_KEY_ORG2": "agent-api-key"},
                 "linux": {"AGENT_API_KEY_ORG2": "agent-api-key", "POD_NAMESPACE": "pod-ns"},
-                "win32": {"API_KEY_ORG2": "api-key"},
+                "win32": {"AGENT_API_KEY_ORG2": "api-key"},
             }.items():
                 with (
                     self.subTest(platform=platform),
@@ -80,6 +80,7 @@ class TestOmnibusCache(unittest.TestCase):
             (r'grep .*', Result()),
             (r'aws(\.exe)? ssm .*', Result()),
             (r'vault kv get .*', Result()),
+            (r'C:\\devtools\\ci-identities-gitlab-job-client\.exe secrets read .*', Result()),
         ]
         for pattern, result in patterns:
             self.mock_ctx.set_result_for('run', re.compile(pattern), result)

--- a/tasks/unit_tests/testdata/variables.yml
+++ b/tasks/unit_tests/testdata/variables.yml
@@ -107,12 +107,9 @@ variables:
   # Start aws ssm variables
   # They must be defined as environment variables in the GitLab CI/CD settings, to ease rotation if needed
   AGENT_QA_PROFILE: ci.datadog-agent.agent-qa-profile  # agent-devx
-  API_KEY_ORG2: ci.datadog-agent.datadog_api_key_org2  # agent-devx
   API_KEY_DDDEV: ci.datadog-agent.datadog_api_key  # agent-devx
   APP_KEY_ORG2: ci.datadog-agent.datadog_app_key_org2  # agent-devx
   CHANGELOG_COMMIT_SHA: ci.datadog-agent.gitlab_changelog_commit_sha  # agent-devx
-  CHOCOLATEY_API_KEY: ci.datadog-agent.chocolatey_api_key  # windows-products
-  CODECOV_TOKEN: ci.datadog-agent.codecov_token  # agent-devx
   DEB_GPG_KEY: ci.datadog-agent.deb_signing_private_key_${DEB_GPG_KEY_ID}  # agent-delivery
   DEB_SIGNING_PASSPHRASE: ci.datadog-agent.deb_signing_key_passphrase_${DEB_GPG_KEY_ID}  # agent-delivery
   E2E_TESTS_API_KEY: ci.datadog-agent.e2e_tests_api_key  # agent-devx
@@ -140,8 +137,6 @@ variables:
   SSH_KEY: ci.datadog-agent.ssh_key  # system-probe
   SSH_KEY_RSA: ci.datadog-agent.ssh_key_rsa  # agent-devx
   SSH_PUBLIC_KEY_RSA: ci.datadog-agent.ssh_public_key_rsa  # agent-devx
-  VCPKG_BLOB_SAS_URL: ci.datadog-agent-buildimages.vcpkg_blob_sas_url  # windows-products
-  WINGET_PAT: ci.datadog-agent.winget_pat  # windows-products
   # End aws ssm variables
 
   # Start vault variables
@@ -152,6 +147,8 @@ variables:
   DOCKER_REGISTRY_RO: dockerhub-readonly  # agent-delivery
   INSTALL_SCRIPT_API_KEY_ORG2: install-script-api-key-org-2  # agent-devx
   SLACK_AGENT: slack-agent-ci  # agent-devx
+  VCPKG_BLOB_SAS_URL: vcpkg-blob-sas  # windows-products
+  WINGET_PAT: winget-pat  # windows-products
   # End vault variables
 
   # Job stage attempts (see https://docs.gitlab.com/ee/ci/runners/configure_runners.html#job-stages-attempts)

--- a/tasks/winbuildscripts/Invoke-UnitTests.ps1
+++ b/tasks/winbuildscripts/Invoke-UnitTests.ps1
@@ -164,7 +164,7 @@ Invoke-BuildScript `
 
     if ($UploadCoverage) {
         try {
-            $Env:CODECOV_TOKEN = Get-VaultSecret -parameterName "$Env:CODECOV_TOKEN" -ErrorAction Stop
+            $Env:CODECOV_TOKEN = Get-VaultSecret -parameterName "$Env:CODECOV_TOKEN" -parameterField token -ErrorAction Stop
             & dda inv -- -e coverage.upload-to-codecov $Env:COVERAGE_CACHE_FLAG
             if ($LASTEXITCODE -ne 0) {
                 throw "coverage upload failed with exit code $LASTEXITCODE"
@@ -192,7 +192,7 @@ Invoke-BuildScript `
             Get-ChildItem -Filter "junit-out-*.xml" -Recurse | ForEach-Object {
                 Copy-Item -Path $_.FullName -Destination C:\mnt
             }
-            $Env:DATADOG_API_KEY = Get-VaultSecret -parameterName "$Env:API_KEY_ORG2" -ErrorAction Stop
+            $Env:DATADOG_API_KEY = Get-VaultSecret -parameterName "$Env:API_KEY_ORG2" -parameterField token -ErrorAction Stop
             & dda inv -- -e junit-upload --tgz-path $Env:JUNIT_TAR --result-json $internal_result_json
             if($LASTEXITCODE -ne 0){
                 throw "junit upload failed with exit code $LASTEXITCODE"

--- a/tasks/winbuildscripts/Invoke-UnitTests.ps1
+++ b/tasks/winbuildscripts/Invoke-UnitTests.ps1
@@ -24,12 +24,12 @@ Specifies whether to check the Go version. If not provided, it defaults to the v
 .PARAMETER UploadCoverage
 Specifies whether to upload coverage reports to Codecov. Default is $false.
 
-Requires the CODECOV_TOKEN environment variable to be set.
+Requires the CODECOV environment variable to be set.
 
 .PARAMETER UploadTestResults
 Specifies whether to upload test results to Datadog CI. Default is $false.
 
-Requires the API_KEY_ORG2 environment variable to be set.
+Requires the AGENT_API_KEY_ORG2 environment variable to be set.
 
 Requires JUNIT_TAR environment variable to be set.
 
@@ -64,14 +64,14 @@ Invoke-BuildScript `
             exit 1
         }
         if ($UploadCoverage) {
-            if ([string]::IsNullOrEmpty($Env:CODECOV_TOKEN)) {
-                Write-Host -ForegroundColor Red "CODECOV_TOKEN environment variable is required for uploading coverage reports to Codecov"
+            if ([string]::IsNullOrEmpty($Env:CODECOV)) {
+                Write-Host -ForegroundColor Red "CODECOV environment variable is required for uploading coverage reports to Codecov"
                 exit 1
             }
         }
         if ($UploadTestResults) {
-            if ([string]::IsNullOrEmpty($Env:API_KEY_ORG2)) {
-                Write-Host -ForegroundColor Red "API_KEY_ORG2 environment variable is required for junit upload to Datadog CI"
+            if ([string]::IsNullOrEmpty($Env:AGENT_API_KEY_ORG2)) {
+                Write-Host -ForegroundColor Red "AGENT_API_KEY_ORG2 environment variable is required for junit upload to Datadog CI"
                 exit 1
             }
             if ([string]::IsNullOrEmpty($Env:JUNIT_TAR)) {
@@ -164,7 +164,7 @@ Invoke-BuildScript `
 
     if ($UploadCoverage) {
         try {
-            $Env:CODECOV_TOKEN = Get-VaultSecret -parameterName "$Env:CODECOV_TOKEN" -parameterField token -ErrorAction Stop
+            $Env:CODECOV_TOKEN = Get-VaultSecret -parameterName "$Env:CODECOV" -parameterField token -ErrorAction Stop
             & dda inv -- -e coverage.upload-to-codecov $Env:COVERAGE_CACHE_FLAG
             if ($LASTEXITCODE -ne 0) {
                 throw "coverage upload failed with exit code $LASTEXITCODE"
@@ -176,7 +176,7 @@ Invoke-BuildScript `
         }
         # Upload coverage to Datadog Code Coverage (side-by-side with Codecov)
         try {
-            $Env:DD_API_KEY = Get-VaultSecret -parameterName "$Env:API_KEY_ORG2" -ErrorAction Stop
+            $Env:DD_API_KEY = Get-VaultSecret -parameterName "$Env:AGENT_API_KEY_ORG2" -parameterField token -ErrorAction Stop
             & datadog-ci.exe coverage upload --format=go-coverprofile coverage.out
             if ($LASTEXITCODE -ne 0) {
                 throw "Datadog coverage upload failed with exit code $LASTEXITCODE"
@@ -192,7 +192,7 @@ Invoke-BuildScript `
             Get-ChildItem -Filter "junit-out-*.xml" -Recurse | ForEach-Object {
                 Copy-Item -Path $_.FullName -Destination C:\mnt
             }
-            $Env:DATADOG_API_KEY = Get-VaultSecret -parameterName "$Env:API_KEY_ORG2" -parameterField token -ErrorAction Stop
+            $Env:DATADOG_API_KEY = Get-VaultSecret -parameterName "$Env:AGENT_API_KEY_ORG2" -parameterField token -ErrorAction Stop
             & dda inv -- -e junit-upload --tgz-path $Env:JUNIT_TAR --result-json $internal_result_json
             if($LASTEXITCODE -ne 0){
                 throw "junit upload failed with exit code $LASTEXITCODE"

--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -200,7 +200,7 @@ The name of the secret to fetch
 The field of the secret to fetch. Only used with vault secrets.
 
 .EXAMPLE
-$Env:CODECOV_TOKEN=$(Get-VaultSecret -parameterName "$Env:CODECOV_TOKEN")
+$Env:CODECOV_TOKEN=$(Get-VaultSecret -parameterName "$Env:CODECOV_TOKEN" -parameterField token)
 
 Fetch a secret and store it in an environment variable
 
@@ -213,7 +213,7 @@ function Get-VaultSecret() {
     $tmpFile = [System.IO.Path]::GetTempFileName()
     try {
         # Use Out-Null to suppress the output of the fetch_secret script
-        & "$PSScriptRoot\..\..\tools\ci\fetch_secret.ps1" -parameterName $parameterName -tempFile "$tmpfile" | Out-Null
+        & "$PSScriptRoot\..\..\tools\ci\fetch_secret.ps1" -parameterName $parameterName -parameterField $parameterField -tempFile "$tmpfile" | Out-Null
         $err = $LASTEXITCODE
         If ($LASTEXITCODE -ne "0") {
             throw "Failed to fetch ${parameterName}: $err"

--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -200,7 +200,7 @@ The name of the secret to fetch
 The field of the secret to fetch. Only used with vault secrets.
 
 .EXAMPLE
-$Env:CODECOV_TOKEN=$(Get-VaultSecret -parameterName "$Env:CODECOV_TOKEN" -parameterField token)
+$Env:CODECOV_TOKEN=$(Get-VaultSecret -parameterName "$Env:CODECOV" -parameterField token)
 
 Fetch a secret and store it in an environment variable
 

--- a/tools/ci/fetch_secret.ps1
+++ b/tools/ci/fetch_secret.ps1
@@ -9,10 +9,15 @@ $maxRetries = 4
 
 # To catch the error message from aws cli
 $ErrorActionPreference = "Continue"
+if ($Env:CI_COMMIT_BRANCH -match '^(main|\d+\.\d+\.x|mq-working-branch-main-.*)$') {
+    $VaultPath = "ci/datadog/datadog-agent/trusted-jobs"
+} else {
+    $VaultPath = "ci/datadog/datadog-agent/untrusted-jobs"
+}
 
 while ($retryCount -lt $maxRetries) {
     if ($parameterField) {
-        $result = (vault kv get -field="$parameterField" kv/k8s/gitlab-runner/datadog-agent/"$parameterName" 2> errorFile.txt)
+        $result = (vault kv get -field="$parameterField" "$VaultPath"/"$parameterName" 2> errorFile.txt)
     } else {
         $result = (aws ssm get-parameter --region us-east-1 --name $parameterName --with-decryption --query "Parameter.Value" --output text 2> errorFile.txt)
     }
@@ -27,7 +32,7 @@ while ($retryCount -lt $maxRetries) {
         # This error needs a restart of the job
         Write-Error "Permanent error: unable to locate credentials, not retrying"
         exit 42
-    } 
+    }
     $retryCount++
     Start-Sleep -Seconds ([math]::Pow(2, $retryCount))
 }

--- a/tools/ci/fetch_secret.ps1
+++ b/tools/ci/fetch_secret.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = "Continue"
 
 while ($retryCount -lt $maxRetries) {
     if ($parameterField) {
-        $result = (ci-identities-gitlab-job-client secrets read "$parameterName" "$parameterField" 2> errorFile.txt)
+        $result = (C:\devtools\ci-identities-gitlab-job-client.exe secrets read "$parameterName" "$parameterField" 2> errorFile.txt)
     } else {
         $result = (aws ssm get-parameter --region us-east-1 --name $parameterName --with-decryption --query "Parameter.Value" --output text 2> errorFile.txt)
     }

--- a/tools/ci/fetch_secret.ps1
+++ b/tools/ci/fetch_secret.ps1
@@ -17,7 +17,7 @@ if ($Env:CI_COMMIT_BRANCH -match '^(main|\d+\.\d+\.x|mq-working-branch-main-.*)$
 
 while ($retryCount -lt $maxRetries) {
     if ($parameterField) {
-        $result = (vault kv get -field="$parameterField" "$VaultPath"/"$parameterName" 2> errorFile.txt)
+        $result = (vault kv get -field="$parameterField" "$VaultPath/$parameterName" 2> errorFile.txt)
     } else {
         $result = (aws ssm get-parameter --region us-east-1 --name $parameterName --with-decryption --query "Parameter.Value" --output text 2> errorFile.txt)
     }

--- a/tools/ci/fetch_secret.ps1
+++ b/tools/ci/fetch_secret.ps1
@@ -9,15 +9,10 @@ $maxRetries = 4
 
 # To catch the error message from aws cli
 $ErrorActionPreference = "Continue"
-if ($Env:CI_COMMIT_BRANCH -match '^(main|\d+\.\d+\.x|mq-working-branch-main-.*)$') {
-    $VaultPath = "ci/datadog/datadog-agent/trusted-jobs"
-} else {
-    $VaultPath = "ci/datadog/datadog-agent/untrusted-jobs"
-}
 
 while ($retryCount -lt $maxRetries) {
     if ($parameterField) {
-        $result = (vault kv get -field="$parameterField" "$VaultPath/$parameterName" 2> errorFile.txt)
+        $result = (ci-identities-gitlab-job-client secrets read "$parameterName" "$parameterField" 2> errorFile.txt)
     } else {
         $result = (aws ssm get-parameter --region us-east-1 --name $parameterName --with-decryption --query "Parameter.Value" --output text 2> errorFile.txt)
     }

--- a/tools/ci/fetch_secret.ps1
+++ b/tools/ci/fetch_secret.ps1
@@ -10,9 +10,14 @@ $maxRetries = 4
 # To catch the error message from aws cli
 $ErrorActionPreference = "Continue"
 
+$ciIdentitiesExe = "C:\devtools\ci-identities-gitlab-job-client.exe"
+if (-not (Test-Path $ciIdentitiesExe)) {
+    $ciIdentitiesExe = "C:\ci-identities-gitlab-job-client.exe"
+}
+
 while ($retryCount -lt $maxRetries) {
     if ($parameterField) {
-        $result = (C:\devtools\ci-identities-gitlab-job-client.exe secrets read "$parameterName" "$parameterField" 2> errorFile.txt)
+        $result = (& $ciIdentitiesExe secrets read "$parameterName" "$parameterField" 2> errorFile.txt)
     } else {
         $result = (aws ssm get-parameter --region us-east-1 --name $parameterName --with-decryption --query "Parameter.Value" --output text 2> errorFile.txt)
     }


### PR DESCRIPTION
### What does this PR do?

Migrates every Windows `fetch_secret.ps1` call site from AWS SSM to Vault.

- Adds `-parameterField token` (or `url` for the VCPKG SAS URL) to every Windows caller so the PowerShell helper hits the Vault branch instead of the SSM fallback.
- Fixes `Get-VaultSecret` in `tasks/winbuildscripts/common.ps1`, which accepted a `$parameterField` argument but silently dropped it before invoking `fetch_secret.ps1`.
- Call `ci-identities-gitlab-job-client` in windows context to automatically reach the correct vault
- Remove the no-more used ssm params from the config.


### Motivation

Windows CI jobs were still using AWS SSM for secret retrieval while Linux/macOS had migrated to Vault. No `fetch_secret.ps1` caller was passing `-parameterField`, so every Windows call silently fell through to the SSM branch. This PR closes that gap.

### Describe how you validated your changes

Validation will happen via this PR's CI pipeline, which will exercise each Windows secret fetch through the new Vault path. Any missing Vault entries or mis-labelled fields will surface as job failures.

### Additional Notes

- Field defaults were chosen to match Linux conventions (`token` for credentials, `url` for the VCPKG SAS URL). If a Vault entry stores a value under a different field, that call site will need an adjustment.
