### PR TITLE
[clusteragent/autoscaling] Defer pod reflector startup until first DPA

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -90,6 +90,7 @@ import (
 	apidca "github.com/DataDog/datadog-agent/pkg/clusteragent/api"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/cluster"
 	clusterspot "github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/cluster/spot"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/podcollectiongate"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/provider"
 	pkgclusterchecks "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
@@ -155,11 +156,17 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "Start the Cluster Agent",
 		Long:  `Runs Datadog Cluster agent in the foreground`,
 		RunE: func(_ *cobra.Command, _ []string) error {
+			// Shared gate: enabled by the workload autoscaling controller on the
+			// first DatadogPodAutoscaler observation, waited on by the kubeapiserver
+			// workloadmeta collector to lazily start its pod reflector.
+			podCollectionGate := podcollectiongate.New()
+
 			// TODO: once the cluster-agent is represented as a component, and
 			// not a function (start), this will use `fxutil.Run` instead of
 			// `fxutil.OneShot`.
 			return fxutil.OneShot(start,
 				fx.Supply(globalParams),
+				fx.Supply(podCollectionGate),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewClusterAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
 					LogParams:    log.ForDaemon(command.LoggerName, "log_file", defaultpaths.DCALogFile),
@@ -287,6 +294,7 @@ func start(log log.Component,
 	_ metadatarunner.Component,
 	tracerouteComp traceroute.Component,
 	eventPlatform eventplatform.Component,
+	podCollectionGate *podcollectiongate.Gate,
 ) error {
 	stopCh := make(chan struct{})
 	validatingStopCh := make(chan struct{})
@@ -546,7 +554,7 @@ func start(log log.Component,
 			log.Error("Admission controller is disabled, vertical autoscaling requires the admission controller to be enabled. Vertical scaling will be disabled.")
 		}
 
-		if patcher, err := provider.StartWorkloadAutoscaling(mainCtx, clusterID, clusterName, le.IsLeader, apiCl, rcClient, wmeta, taggerComp, demultiplexer); err == nil {
+		if patcher, err := provider.StartWorkloadAutoscaling(mainCtx, clusterID, clusterName, le.IsLeader, apiCl, rcClient, wmeta, taggerComp, demultiplexer, podCollectionGate); err == nil {
 			pp = patcher
 		} else {
 			return fmt.Errorf("Error while starting workload autoscaling: %v", err)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"go.uber.org/fx"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -22,9 +21,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/podcollectiongate"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -38,17 +39,26 @@ type dependencies struct {
 	fx.In
 
 	Config config.Component
+
+	// Gate is optional because this collector is pulled into many binaries via
+	// the shared wmeta catalog, but it only runs in the DCA, which is the only
+	// binary that supplies the gate.
+	Gate *podcollectiongate.Gate `optional:"true"`
 }
 
 // storeGenerator returns a new store specific to a given resource
 type storeGenerator func(context.Context, workloadmeta.Component, config.Reader, kubernetes.Interface) (*cache.Reflector, *reflectorStore)
 
-func shouldHavePodStore(cfg config.Reader) bool {
+func shouldStartPodStoreEagerly(cfg config.Reader, gateWired bool) bool {
 	metadataAsTags := configutils.GetMetadataAsTags(cfg)
 	hasPodLabelsAsTags := len(metadataAsTags.GetPodLabelsAsTags()) > 0
 	hasPodAnnotationsAsTags := len(metadataAsTags.GetPodAnnotationsAsTags()) > 0
 
-	return cfg.GetBool("cluster_agent.collect_kubernetes_tags") || cfg.GetBool("autoscaling.workload.enabled") || cfg.GetBool("autoscaling.cluster.spot.enabled") || hasPodLabelsAsTags || hasPodAnnotationsAsTags
+	return cfg.GetBool("cluster_agent.collect_kubernetes_tags") ||
+		cfg.GetBool("autoscaling.cluster.spot.enabled") ||
+		hasPodLabelsAsTags ||
+		hasPodAnnotationsAsTags ||
+		(cfg.GetBool("autoscaling.workload.enabled") && !gateWired)
 }
 
 func shouldHaveDeploymentStore(cfg config.Reader) bool {
@@ -59,10 +69,10 @@ func shouldHaveDeploymentStore(cfg config.Reader) bool {
 	return cfg.GetBool("language_detection.enabled") && cfg.GetBool("language_detection.reporting.enabled") || hasDeploymentsLabelsAsTags || hasDeploymentsAnnotationsAsTags
 }
 
-func storeGenerators(cfg config.Reader) []storeGenerator {
+func storeGenerators(cfg config.Reader, gateWired bool) []storeGenerator {
 	var generators []storeGenerator
 
-	if shouldHavePodStore(cfg) {
+	if shouldStartPodStoreEagerly(cfg, gateWired) {
 		generators = append(generators, newPodStore)
 	}
 
@@ -173,6 +183,7 @@ type collector struct {
 	id      string
 	catalog workloadmeta.AgentType
 	config  config.Reader
+	gate    *podcollectiongate.Gate
 }
 
 // NewCollector returns a kubeapiserver CollectorProvider that instantiates its colletor
@@ -182,6 +193,7 @@ func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 			id:      collectorID,
 			catalog: workloadmeta.ClusterAgent,
 			config:  deps.Config,
+			gate:    deps.Gate,
 		},
 	}, nil
 }
@@ -218,10 +230,17 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Componen
 		}
 	}
 
-	for _, storeBuilder := range storeGenerators(c.config) {
+	gateProvided := c.gate != nil
+	for _, storeBuilder := range storeGenerators(c.config, gateProvided) {
 		reflector, store := storeBuilder(ctx, wlmetaStore, c.config, client)
 		objectStores = append(objectStores, store)
 		go reflector.Run(ctx.Done())
+	}
+
+	// With a gate provided, defer starting the pod reflector until the first
+	// DatadogPodAutoscaler is observed.
+	if gateProvided && c.config.GetBool("autoscaling.workload.enabled") && !shouldStartPodStoreEagerly(c.config, true) {
+		go c.startPodStoreOnGate(ctx, wlmetaStore, client, newPodStore)
 	}
 
 	if c.config.GetBool("cluster_checks.crd_collection") {
@@ -239,6 +258,19 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Componen
 	go runStartupCheck(ctx, objectStores)
 
 	return nil
+}
+
+// startPodStoreOnGate blocks until either the gate is enabled (signalling that
+// at least one DatadogPodAutoscaler has been observed) or the context is
+// cancelled. On gate enable, it starts the pod reflector.
+func (c *collector) startPodStoreOnGate(ctx context.Context, wlmetaStore workloadmeta.Component, client kubernetes.Interface, newStore storeGenerator) {
+	if !c.gate.WaitForEnable(ctx) {
+		return
+	}
+
+	log.Debug("First DatadogPodAutoscaler observed. Starting workloadmeta pod reflector lazily")
+	reflector, _ := newStore(ctx, wlmetaStore, c.config, client)
+	go reflector.Run(ctx.Done())
 }
 
 func (c *collector) Pull(_ context.Context) error {

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -8,16 +8,27 @@
 package kubeapiserver
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/podcollectiongate"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestStoreGenerators(t *testing.T) {
@@ -25,6 +36,7 @@ func TestStoreGenerators(t *testing.T) {
 	tests := []struct {
 		name                    string
 		cfg                     map[string]interface{}
+		gateWired               bool
 		expectedStoresGenerator []storeGenerator
 	}{
 		{
@@ -81,6 +93,22 @@ func TestStoreGenerators(t *testing.T) {
 			},
 			expectedStoresGenerator: []storeGenerator{newPodStore, newDeploymentStore},
 		},
+		{
+			name: "Workload autoscaling enabled with gate wired does not force pod store",
+			cfg: map[string]interface{}{
+				"autoscaling.workload.enabled": true,
+			},
+			gateWired:               true,
+			expectedStoresGenerator: []storeGenerator{},
+		},
+		{
+			name: "Workload autoscaling enabled without gate wired forces eager pod store",
+			cfg: map[string]interface{}{
+				"autoscaling.workload.enabled": true,
+			},
+			gateWired:               false,
+			expectedStoresGenerator: []storeGenerator{newPodStore},
+		},
 	}
 
 	// Run test for each testcase
@@ -88,7 +116,7 @@ func TestStoreGenerators(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := config.NewMockWithOverrides(t, tt.cfg)
 			expectedStores := collectResultStoreGenerator(tt.expectedStoresGenerator, cfg)
-			stores := collectResultStoreGenerator(storeGenerators(cfg), cfg)
+			stores := collectResultStoreGenerator(storeGenerators(cfg, tt.gateWired), cfg)
 
 			assert.Equal(t, expectedStores, stores)
 		})
@@ -566,4 +594,60 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			assert.ElementsMatch(t, test.expectedResources, resourcesWithMetadataCollectionEnabled(cfg))
 		})
 	}
+}
+
+func TestStartPodStoreOnGate(t *testing.T) {
+	testPodUID := "test-pod-uid"
+
+	client := fakeclientset.NewClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       types.UID(testPodUID),
+		},
+	})
+
+	gate := podcollectiongate.New()
+
+	wmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	testCollector := &collector{
+		id:      collectorID,
+		catalog: workloadmeta.ClusterAgent,
+		config:  wmeta.GetConfig(),
+		gate:    gate,
+	}
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		testCollector.startPodStoreOnGate(ctx, wmeta, client, newPodStoreWithTypedClient)
+		close(done)
+	}()
+
+	// Before enabling the gate, no pod should appear in workloadmeta.
+	assert.Never(t, func() bool {
+		_, err := wmeta.GetKubernetesPod(testPodUID)
+		return err == nil
+	}, 100*time.Millisecond, 20*time.Millisecond)
+
+	gate.Enable()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startPodStoreOnGate did not return after gate enabled")
+	}
+
+	// The pod reflector should eventually populate workloadmeta after enabling
+	// the gate.
+	require.Eventually(t, func() bool {
+		_, err := wmeta.GetKubernetesPod(testPodUID)
+		return err == nil
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/pkg/clusteragent/autoscaling/podcollectiongate/gate.go
+++ b/pkg/clusteragent/autoscaling/podcollectiongate/gate.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package podcollectiongate provides a gate to enable pod collection in
+// workloadmeta. Collecting all pods in a large cluster can use a lot of
+// memory, so we only start once a feature needs them.
+// For autoscaling, that means waiting until the cluster has at least one
+// DatadogPodAutoscaler object.
+package podcollectiongate
+
+import (
+	"context"
+	"sync"
+)
+
+// Gate implements a gate to enable pod collection.
+type Gate struct {
+	ch   chan struct{}
+	once sync.Once
+}
+
+// New returns a new Gate.
+func New() *Gate {
+	return &Gate{ch: make(chan struct{})}
+}
+
+// Enable marks the gate as enabled. Only the first call has any effect.
+func (g *Gate) Enable() {
+	g.once.Do(func() { close(g.ch) })
+}
+
+// WaitForEnable blocks until the gate is enabled or ctx is cancelled.
+// Returns true if the gate was enabled, false if the context was cancelled
+// first.
+func (g *Gate) WaitForEnable(ctx context.Context) bool {
+	select {
+	case <-g.ch:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}

--- a/pkg/clusteragent/autoscaling/podcollectiongate/gate_test.go
+++ b/pkg/clusteragent/autoscaling/podcollectiongate/gate_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package podcollectiongate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnable(t *testing.T) {
+	gate := New()
+
+	gate.Enable()
+	gate.Enable() // can be called multiple times safely
+
+	assert.True(t, gate.WaitForEnable(context.TODO()))
+}
+
+func TestWaitForEnable(t *testing.T) {
+	t.Run("unblocks on Enable", func(t *testing.T) {
+		gate := New()
+
+		done := make(chan bool, 1)
+		go func() {
+			done <- gate.WaitForEnable(context.TODO())
+		}()
+
+		gate.Enable()
+
+		select {
+		case result := <-done:
+			assert.True(t, result)
+		case <-time.After(time.Second):
+			t.Fatal("WaitForEnable did not unblock after Enable")
+		}
+	})
+
+	t.Run("returns false on cancelled context", func(t *testing.T) {
+		gate := New()
+
+		ctx, cancel := context.WithCancel(context.TODO())
+		cancel()
+
+		assert.False(t, gate.WaitForEnable(ctx))
+	})
+}

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -24,12 +24,14 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	k8sclient "k8s.io/client-go/kubernetes"
 	scaleclient "k8s.io/client-go/scale"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/podcollectiongate"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/metrics"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/metricsstore"
@@ -103,6 +105,7 @@ func NewController(
 	localSender sender.Sender,
 	limitHeap *limitHeap,
 	globalTagsFunc func() []string,
+	podCollectionGate *podcollectiongate.Gate,
 ) (*Controller, error) {
 	c := &Controller{
 		clusterID:         clusterID,
@@ -123,6 +126,17 @@ func NewController(
 	baseController, err := autoscaling.NewController(controllerID, c, dynamicClient, dynamicInformer, podAutoscalerGVR, isLeader, store, autoscalingWorkqueue)
 	if err != nil {
 		return nil, err
+	}
+
+	if podCollectionGate != nil {
+		_, err := dynamicInformer.ForResource(podAutoscalerGVR).Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(_ any) {
+				podCollectionGate.Enable()
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("cannot add pod-collection gate handler to DPA informer: %w", err)
+		}
 	}
 
 	c.Controller = baseController

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -8,6 +8,7 @@
 package workload
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/fake"
+	kscheme "k8s.io/client-go/kubernetes/scheme"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
@@ -36,6 +38,7 @@ import (
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/podcollectiongate"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
@@ -66,7 +69,7 @@ func newFixture(t *testing.T, testTime time.Time) *fixture {
 		ControllerFixture: autoscaling.NewFixture(
 			t, podAutoscalerGVR,
 			func(fakeClient *fake.FakeDynamicClient, informer dynamicinformer.DynamicSharedInformerFactory, isLeader func() bool) (*autoscaling.Controller, error) {
-				c, err := NewController(clock, "cluster-id1", recorder, nil, nil, nil, fakeClient, informer, isLeader, store, podWatcher, nil, hashHeap, nil)
+				c, err := NewController(clock, "cluster-id1", recorder, nil, nil, nil, fakeClient, informer, isLeader, store, podWatcher, nil, hashHeap, nil, nil)
 				if err != nil {
 					return nil, err
 				}
@@ -1645,6 +1648,54 @@ func TestProfileManagedDPA(t *testing.T) {
 		f.ExpectUpdateAction(mustUnstructured(t, expectedUpdate))
 		f.RunControllerSync(true, "prod/web-app-a1b2c3d4")
 	})
+}
+
+func TestPodCollectionGateEnabledOnFirstDPA(t *testing.T) {
+	testScheme := kscheme.Scheme
+	require.NoError(t, datadoghq.AddToScheme(testScheme))
+
+	spec := datadoghq.DatadogPodAutoscalerSpec{
+		TargetRef: autoscalingv2.CrossVersionObjectReference{
+			Kind:       "Deployment",
+			Name:       "app-0",
+			APIVersion: "apps/v1",
+		},
+		Owner: datadoghqcommon.DatadogPodAutoscalerLocalOwner,
+	}
+	dpa, _ := newFakePodAutoscaler("default", "dpa-0", 1, time.Time{}, spec, datadoghqcommon.DatadogPodAutoscalerStatus{})
+
+	fakeClient := fake.NewSimpleDynamicClient(testScheme, dpa)
+	informer := dynamicinformer.NewDynamicSharedInformerFactory(fakeClient, 0)
+
+	gate := podcollectiongate.New()
+	testStore := autoscaling.NewStore[model.PodAutoscalerInternal]()
+
+	_, err := NewController(
+		clock.NewFakeClock(time.Now()),
+		"cluster-id1",
+		record.NewFakeRecorder(100),
+		nil,
+		nil,
+		nil,
+		fakeClient,
+		informer,
+		func() bool { return true },
+		testStore,
+		newFakePodWatcher(),
+		nil,
+		autoscaling.NewHashHeap(testMaxAutoscalerObjects, testStore, (*model.PodAutoscalerInternal).CreationTimestamp),
+		nil,
+		gate,
+	)
+	require.NoError(t, err)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	informer.Start(stopCh)
+
+	waitCtx, waitCancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer waitCancel()
+	assert.True(t, gate.WaitForEnable(waitCtx))
 }
 
 func mustUnstructured(t *testing.T, structIn any) *unstructured.Unstructured {

--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -25,6 +25,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/podcollectiongate"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/external"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/local"
@@ -47,6 +48,7 @@ func StartWorkloadAutoscaling(
 	wlm workloadmeta.Component,
 	taggerComp tagger.Component,
 	senderManager sender.SenderManager,
+	podCollectionGate *podcollectiongate.Gate,
 ) (workload.PodPatcher, error) {
 	if apiCl == nil {
 		return nil, errors.New("Impossible to start workload autoscaling without valid APIClient")
@@ -88,7 +90,7 @@ func StartWorkloadAutoscaling(
 	maxDatadogPodAutoscalerObjects := pkgconfigsetup.Datadog().GetInt("autoscaling.workload.limit")
 	limitHeap := autoscaling.NewHashHeap(maxDatadogPodAutoscalerObjects, store, (*model.PodAutoscalerInternal).CreationTimestamp)
 
-	controller, err := workload.NewController(clock, clusterID, eventRecorder, apiCl.RESTMapper, apiCl.ScaleCl, apiCl.Cl, apiCl.DynamicInformerCl, apiCl.DynamicInformerFactory, isLeaderFunc, store, podWatcher, sender, limitHeap, globalTagsFunc)
+	controller, err := workload.NewController(clock, clusterID, eventRecorder, apiCl.RESTMapper, apiCl.ScaleCl, apiCl.Cl, apiCl.DynamicInformerCl, apiCl.DynamicInformerFactory, isLeaderFunc, store, podWatcher, sender, limitHeap, globalTagsFunc, podCollectionGate)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to start workload autoscaling controller: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to allow enabling workload autoscaling without extra cost when it's not in use.

Right now, when autoscaling is enabled, the kubeapiserver workloadmeta collector starts a pod reflector. In large clusters, this can use a lot of memory. This happens even if no DPA is deployed.

We want to avoid this memory usage when no DPAs are deployed.

This will let us enable workload autoscaling by default without extra cost when it's not in use. Users who want it will be able to create DPAs directly, without having to enable the option in the Cluster Agent.

This PR does not flip the `autoscaling.workload.enabled` default to true. That will be done in a separate PR so it can be reverted independently if needed.

### Describe how you validated your changes

Unit tests plus tests on a local kind cluster.

For the kind tests, I used kwok to simulate a large number of pods so the memory impact of the pod reflector would be measurable.

First, I deployed with autoscaling disabled to get a memory baseline. Then I deployed with autoscaling enabled but no DPAs, and checked that memory usage stayed close to the baseline. Finally, I created a DPA and checked that memory usage went up as expected.