### PR TITLE
[EBPF-1090] gpu: implement SRAM ECC detail metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -198,6 +198,89 @@ func processDetailListSample(device ddnvml.Device) ([]Metric, uint64, error) {
 	return processMemoryUsage(device, usage, High), 0, err
 }
 
+func shouldSkipLegacyEccMetric(device ddnvml.Device, errorType nvml.MemoryErrorType, memoryLocation nvml.MemoryLocation) bool {
+	if device.GetDeviceInfo().Architecture < nvml.DEVICE_ARCH_AMPERE {
+		return false
+	}
+
+	if memoryLocation == nvml.MEMORY_LOCATION_SRAM {
+		return true
+	}
+
+	return errorType == nvml.MEMORY_ERROR_TYPE_UNCORRECTED && memoryLocation == nvml.MEMORY_LOCATION_L2_CACHE
+}
+
+func sramEccErrorStatusSample(device ddnvml.Device) ([]Metric, uint64, error) {
+	// SRAM ECC error status is only supported on Ampere and later. Some of the metrics
+	// overlap with the legacy ECC metrics, so we need to check the architecture and return an error
+	if device.GetDeviceInfo().Architecture < nvml.DEVICE_ARCH_AMPERE {
+		return nil, 0, ddnvml.NewNvmlAPIErrorOrNil("GetSramEccErrorStatus", nvml.ERROR_NOT_SUPPORTED)
+	}
+
+	status, err := device.GetSramEccErrorStatus()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	metricsOut := []Metric{
+		{
+			Name:  "errors.ecc.corrected.total",
+			Value: float64(status.AggregateCor),
+			Type:  metrics.GaugeType,
+			Tags:  []string{"memory_location:sram"},
+		},
+		{
+			Name:  "errors.ecc.sram.uncorrected_by_subtype.total",
+			Value: float64(status.AggregateUncParity),
+			Type:  metrics.GaugeType,
+			Tags:  []string{"memory_location:sram", "error_subtype:parity"},
+		},
+		{
+			Name:  "errors.ecc.sram.uncorrected_by_subtype.total",
+			Value: float64(status.AggregateUncSecDed),
+			Type:  metrics.GaugeType,
+			Tags:  []string{"memory_location:sram", "error_subtype:secded"},
+		},
+		{
+			Name:  "errors.ecc.uncorrected.total",
+			Value: float64(status.AggregateUncBucketL2),
+			Type:  metrics.GaugeType,
+			Tags:  []string{"memory_location:l2_cache"},
+		},
+		{
+			Name:  "errors.ecc.uncorrected.total",
+			Value: float64(status.AggregateUncBucketSm),
+			Type:  metrics.GaugeType,
+			Tags:  []string{"memory_location:sm"},
+		},
+		{
+			Name:  "errors.ecc.uncorrected.total",
+			Value: float64(status.AggregateUncBucketPcie),
+			Type:  metrics.GaugeType,
+			Tags:  []string{"memory_location:pcie"},
+		},
+		{
+			Name:  "errors.ecc.uncorrected.total",
+			Value: float64(status.AggregateUncBucketMcu),
+			Type:  metrics.GaugeType,
+			Tags:  []string{"memory_location:microcontroller"},
+		},
+		{
+			Name:  "errors.ecc.uncorrected.total",
+			Value: float64(status.AggregateUncBucketOther),
+			Type:  metrics.GaugeType,
+			Tags:  []string{"memory_location:other"},
+		},
+		{
+			Name:  "errors.ecc.sram.threshold_exceeded",
+			Value: boolToFloat(status.BThresholdExceeded != 0),
+			Type:  metrics.GaugeType,
+		},
+	}
+
+	return metricsOut, 0, nil
+}
+
 // createStatelessAPIs creates API call definitions for all stateless metrics on demand
 func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 	apis := []apiCallInfo{
@@ -524,6 +607,12 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 				}, 0, nil
 			},
 		},
+		{
+			Name: "sram_ecc_error_status",
+			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+				return sramEccErrorStatusSample(device)
+			},
+		},
 		// Process memory APIs (stateless - just current snapshot)
 		{
 			Name: "process_memory_usage",
@@ -553,6 +642,10 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 			apis = append(apis, apiCallInfo{
 				Name: fmt.Sprintf("ecc_errors.%s.%s", errorTypeName, memoryLocationName),
 				Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+					if shouldSkipLegacyEccMetric(device, errorType, memoryLocation) {
+						return nil, 0, ddnvml.NewNvmlAPIErrorOrNil("GetMemoryErrorCounter", nvml.ERROR_NOT_SUPPORTED)
+					}
+
 					count, err := device.GetMemoryErrorCounter(errorType, nvml.AGGREGATE_ECC, memoryLocation)
 					if err != nil {
 						return nil, 0, err

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -23,6 +23,97 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
+func TestSramEccErrorStatusSample(t *testing.T) {
+	mockDevice := setupMockDevice(t, func(device *mock.Device) *mock.Device {
+		testutil.WithMockAllDeviceFunctions()(device)
+		device.GetArchitectureFunc = func() (nvml.DeviceArchitecture, nvml.Return) {
+			return nvml.DEVICE_ARCH_AMPERE, nvml.SUCCESS
+		}
+		device.GetSramEccErrorStatusFunc = func() (nvml.EccSramErrorStatus, nvml.Return) {
+			return nvml.EccSramErrorStatus{
+				AggregateCor:            11,
+				AggregateUncParity:      13,
+				AggregateUncSecDed:      17,
+				AggregateUncBucketL2:    19,
+				AggregateUncBucketSm:    23,
+				AggregateUncBucketPcie:  29,
+				AggregateUncBucketMcu:   31,
+				AggregateUncBucketOther: 37,
+				BThresholdExceeded:      1,
+			}, nvml.SUCCESS
+		}
+		return device
+	})
+
+	metricsOut, _, err := sramEccErrorStatusSample(mockDevice)
+	require.NoError(t, err)
+	require.Len(t, metricsOut, 9)
+
+	assertMetric := func(name string, value float64, tags ...string) {
+		t.Helper()
+		for _, metric := range metricsOut {
+			if metric.Name == name && slices.Equal(metric.Tags, tags) {
+				require.Equal(t, value, metric.Value)
+				require.Equal(t, metrics.GaugeType, metric.Type)
+				return
+			}
+		}
+		require.Failf(t, "metric not found", "expected metric %s with tags %v", name, tags)
+	}
+
+	assertMetric("errors.ecc.corrected.total", 11, "memory_location:sram")
+	assertMetric("errors.ecc.sram.uncorrected_by_subtype.total", 13, "memory_location:sram", "error_subtype:parity")
+	assertMetric("errors.ecc.sram.uncorrected_by_subtype.total", 17, "memory_location:sram", "error_subtype:secded")
+	assertMetric("errors.ecc.uncorrected.total", 19, "memory_location:l2_cache")
+	assertMetric("errors.ecc.uncorrected.total", 23, "memory_location:sm")
+	assertMetric("errors.ecc.uncorrected.total", 29, "memory_location:pcie")
+	assertMetric("errors.ecc.uncorrected.total", 31, "memory_location:microcontroller")
+	assertMetric("errors.ecc.uncorrected.total", 37, "memory_location:other")
+	assertMetric("errors.ecc.sram.threshold_exceeded", 1)
+}
+
+func TestSramEccErrorStatusSampleArchitectureSupport(t *testing.T) {
+	device := setupMockDevice(t, func(device *mock.Device) *mock.Device {
+		testutil.WithMockAllDeviceFunctions()(device)
+		device.GetArchitectureFunc = func() (nvml.DeviceArchitecture, nvml.Return) {
+			return nvml.DEVICE_ARCH_TURING, nvml.SUCCESS
+		}
+		return device
+	})
+
+	metricsOut, _, err := sramEccErrorStatusSample(device)
+	require.Error(t, err)
+	require.Empty(t, metricsOut)
+	require.True(t, safenvml.IsUnsupported(err))
+}
+
+func TestLegacyEccMetricOverlapRules(t *testing.T) {
+	ampereDevice := setupMockDevice(t, func(device *mock.Device) *mock.Device {
+		testutil.WithMockAllDeviceFunctions()(device)
+		device.GetArchitectureFunc = func() (nvml.DeviceArchitecture, nvml.Return) {
+			return nvml.DEVICE_ARCH_AMPERE, nvml.SUCCESS
+		}
+		return device
+	})
+
+	require.True(t, shouldSkipLegacyEccMetric(ampereDevice, nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.MEMORY_LOCATION_SRAM))
+	require.True(t, shouldSkipLegacyEccMetric(ampereDevice, nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.MEMORY_LOCATION_SRAM))
+	require.True(t, shouldSkipLegacyEccMetric(ampereDevice, nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.MEMORY_LOCATION_L2_CACHE))
+	require.False(t, shouldSkipLegacyEccMetric(ampereDevice, nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.MEMORY_LOCATION_L2_CACHE))
+	require.False(t, shouldSkipLegacyEccMetric(ampereDevice, nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.MEMORY_LOCATION_DEVICE_MEMORY))
+
+	preAmpereDevice := setupMockDevice(t, func(device *mock.Device) *mock.Device {
+		testutil.WithMockAllDeviceFunctions()(device)
+		device.GetArchitectureFunc = func() (nvml.DeviceArchitecture, nvml.Return) {
+			return nvml.DEVICE_ARCH_TURING, nvml.SUCCESS
+		}
+		return device
+	})
+
+	require.False(t, shouldSkipLegacyEccMetric(preAmpereDevice, nvml.MEMORY_ERROR_TYPE_CORRECTED, nvml.MEMORY_LOCATION_SRAM))
+	require.False(t, shouldSkipLegacyEccMetric(preAmpereDevice, nvml.MEMORY_ERROR_TYPE_UNCORRECTED, nvml.MEMORY_LOCATION_L2_CACHE))
+}
+
 // TestNewStatelessCollector tests stateless collector-specific initialization with dynamic API creation
 func TestNewStatelessCollector(t *testing.T) {
 	device := setupMockDevice(t, nil)

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -351,6 +351,45 @@ metrics:
         mig: false
         physical: true
         vgpu: true
+  errors.ecc.sram.threshold_exceeded:
+    metadata:
+      metric_type: gauge
+      description: Whether the SRAM ECC error threshold has been exceeded
+    tagsets:
+      - device
+    support:
+      unsupported_architectures:
+        - fermi
+        - kepler
+        - maxwell
+        - pascal
+        - volta
+        - turing
+      device_modes:
+        mig: false
+        physical: true
+        vgpu: true
+  errors.ecc.sram.uncorrected_by_subtype.total:
+    metadata:
+      metric_type: gauge
+      description: Aggregate SRAM uncorrectable ECC errors split by subtype
+    tagsets:
+      - device
+    custom_tags:
+      - memory_location
+      - error_subtype
+    support:
+      unsupported_architectures:
+        - fermi
+        - kepler
+        - maxwell
+        - pascal
+        - volta
+        - turing
+      device_modes:
+        mig: false
+        physical: true
+        vgpu: true
   ecc.repair_pending.channel:
     metadata:
       metric_type: gauge

--- a/pkg/collector/corechecks/gpu/spec/tags.yaml
+++ b/pkg/collector/corechecks/gpu/spec/tags.yaml
@@ -36,7 +36,9 @@ tags:
   kube_container_name: {}
   memory_location:
     regex: "^(l1_cache|l2_cache|device_memory|register_file|texture_memory|texture_\
-      shm|cbu|sram)$"
+      shm|cbu|sram|sm|pcie|microcontroller|other)$"
+  error_subtype:
+    regex: "^(parity|secded)$"
   nvlink_port:
     regex: "^\\d+$"
 

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -116,6 +116,8 @@ type SafeDevice interface {
 	RegisterEvents(evtTypes uint64, evtSet nvml.EventSet) error
 	// GetMemoryErrorCounter retrieves the requested memory error counter for the device.
 	GetMemoryErrorCounter(errorType nvml.MemoryErrorType, eccCounterType nvml.EccCounterType, memoryLocation nvml.MemoryLocation) (uint64, error)
+	// GetSramEccErrorStatus retrieves the detailed SRAM ECC error status for the device.
+	GetSramEccErrorStatus() (nvml.EccSramErrorStatus, error)
 }
 
 // DeviceEventData holds basic information about a device event

--- a/pkg/gpu/safenvml/device_impl.go
+++ b/pkg/gpu/safenvml/device_impl.go
@@ -405,6 +405,14 @@ func (d *safeDeviceImpl) GetMemoryErrorCounter(errorType nvml.MemoryErrorType, e
 	return count, NewNvmlAPIErrorOrNil("GetMemoryErrorCounter", ret)
 }
 
+func (d *safeDeviceImpl) GetSramEccErrorStatus() (nvml.EccSramErrorStatus, error) {
+	if err := d.lib.lookup(toNativeName("GetSramEccErrorStatus")); err != nil {
+		return nvml.EccSramErrorStatus{}, err
+	}
+	status, ret := d.nvmlDevice.GetSramEccErrorStatus()
+	return status, NewNvmlAPIErrorOrNil("GetSramEccErrorStatus", ret)
+}
+
 func (d *safeDeviceImpl) GetRunningProcessDetailList() (nvml.ProcessDetailList, error) {
 	if err := d.lib.lookup(toNativeName("GetRunningProcessDetailList")); err != nil {
 		return nvml.ProcessDetailList{}, err

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -97,6 +97,7 @@ func getNonCriticalAPIs() []string {
 		toNativeName("GetSupportedEventTypes"),
 		toNativeName("RegisterEvents"),
 		toNativeName("GetMemoryErrorCounter"),
+		toNativeName("GetSramEccErrorStatus"),
 		toNativeName("GetRunningProcessDetailList"),
 	}
 }

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -416,6 +416,12 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 			}
 			return 0, nvml.SUCCESS
 		},
+		GetSramEccErrorStatusFunc: func() (nvml.EccSramErrorStatus, nvml.Return) {
+			if isMIGUnsupported || arch < nvml.DEVICE_ARCH_AMPERE {
+				return nvml.EccSramErrorStatus{}, nvml.ERROR_NOT_SUPPORTED
+			}
+			return nvml.EccSramErrorStatus{}, nvml.SUCCESS
+		},
 		GetIndexFunc: func() (int, nvml.Return) {
 			return deviceIdx, nvml.SUCCESS
 		},


### PR DESCRIPTION
### What does this PR do?

Implements SRAM ECC detail metrics using a Ampere+ API 

New metrics: `gpu.errors.ecc.sram.threshold_exceeded` and `gpu.errors.ecc.sram.uncorrected_by_subtype.total`.

This PR also emits extra locations for the `gpu.errors.ecc.uncorrected.total` metric based on the SRAM detail API.

### Motivation

Better support for ECC error APIs.

### Describe how you validated your changes

Tests passing, manually tested in GPU instance. 

### Additional Notes
