### PR TITLE
[observer/logssource] Add kubelet log collection via journald

### DIFF
--- a/comp/observer/logssource/impl/component.go
+++ b/comp/observer/logssource/impl/component.go
@@ -119,6 +119,7 @@ func NewComponent(deps Requires) (Provides, error) {
 	kubeletSource := sources.NewLogSource("kubelet", &logsconfig.LogsConfig{
 		Type:               logsconfig.JournaldType,
 		IncludeSystemUnits: logsconfig.StringSliceField{"kubelet.service"},
+		Tags:               logsconfig.StringSliceField{"source:kubelet"},
 	})
 	logSources.AddSource(kubeletSource)
 

--- a/comp/observer/logssource/impl/component.go
+++ b/comp/observer/logssource/impl/component.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
 	containerLauncher "github.com/DataDog/datadog-agent/pkg/logs/launchers/container"
 	filelauncher "github.com/DataDog/datadog-agent/pkg/logs/launchers/file"
+	journaldlauncher "github.com/DataDog/datadog-agent/pkg/logs/launchers/journald"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
 	fileTailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/file"
@@ -113,6 +114,14 @@ func NewComponent(deps Requires) (Provides, error) {
 	launchersMgr := launchers.NewLaunchers(logSources, pipeline, deps.Auditor, tracker)
 	launchersMgr.AddLauncher(fileLauncher)
 	launchersMgr.AddLauncher(launcher)
+	launchersMgr.AddLauncher(journaldlauncher.NewLauncher(flare.NewFlareController(), deps.Tagger))
+
+	kubeletSource := sources.NewLogSource("kubelet", &logsconfig.LogsConfig{
+		Type:               logsconfig.JournaldType,
+		IncludeSystemUnits: logsconfig.StringSliceField{"kubelet.service"},
+	})
+	logSources.AddSource(kubeletSource)
+
 	sp := newSourceProvider(wmeta, logSources, pauseFilter)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/test/e2e-framework/scenarios/aws/gensim-eks/agent-values.yaml.tmpl
+++ b/test/e2e-framework/scenarios/aws/gensim-eks/agent-values.yaml.tmpl
@@ -88,12 +88,18 @@ agents:
     - name: logcontainerpath
       hostPath:
         path: /var/log/containers
+    - name: logjournal
+      hostPath:
+        path: /var/log/journal
   volumeMounts:
     - name: logpodpath
       mountPath: /var/log/pods
       readOnly: true
     - name: logcontainerpath
       mountPath: /var/log/containers
+      readOnly: true
+    - name: logjournal
+      mountPath: /var/log/journal
       readOnly: true
   containers:
     agent:


### PR DESCRIPTION
## Summary

- Adds a journald launcher to the logssource component to tail kubelet process logs alongside container logs
- Hardcodes a `kubelet.service` log source so the observer ingests node-level kubelet events (lease failures, scheduling decisions, etc.)
- Mounts `/var/log/journal` as a hostPath in gensim-eks Helm values

The journald launcher is already built into the main agent binary (`systemd` is in `AGENT_TAGS`). On non-systemd builds, `journaldlauncher.NewLauncher` resolves to a no-op, so this compiles safely without the `systemd` tag.

## Why

Container logs only surface application-level symptoms. Kubelet logs provide node-level signals — lease failures, scheduling rejections, resource pressure — that precede container-level anomalies and can be used for root cause attribution.

## Test plan

- [x] Rebuild and deploy to gensim-eks
- [ ] Verify `Start tailing journal` log line appears in agent logs on startup
- [ ] Confirm kubelet logs appear in observer parquets tagged with `source:kubelet`