### PR TITLE
[AGNTLOG-461] Fix connection_reset_interval not applied to additional/MRF endpoints

### DIFF
--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -419,6 +419,7 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 		e.BackoffFactor = main.BackoffFactor
 		e.RecoveryInterval = main.RecoveryInterval
 		e.RecoveryReset = main.RecoveryReset
+		e.ConnectionResetInterval = main.ConnectionResetInterval
 		e.Version = main.Version
 		e.TrackType = intakeTrackType
 		e.Protocol = intakeProtocol

--- a/comp/logs/agent/config/endpoints.go
+++ b/comp/logs/agent/config/endpoints.go
@@ -98,6 +98,11 @@ type unmarshalEndpoint struct {
 	IsReliable *bool  `mapstructure:"is_reliable" json:"is_reliable"`
 	UseSSL     *bool  `mapstructure:"use_ssl" json:"use_ssl"`
 
+	// ConnectionResetIntervalSeconds is the per-endpoint connection reset interval in seconds.
+	// A nil value means "not set" and will inherit the main endpoint's value.
+	// A zero value explicitly disables connection resets for this endpoint.
+	ConnectionResetIntervalSeconds *int `mapstructure:"connection_reset_interval" json:"connection_reset_interval"`
+
 	Endpoint `mapstructure:",squash"`
 }
 
@@ -188,7 +193,11 @@ func loadTCPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, registerCallba
 		newE.CompressionLevel = e.CompressionLevel
 		newE.ProxyAddress = l.socks5ProxyAddress()
 		newE.isReliable = e.IsReliable == nil || *e.IsReliable
-		newE.ConnectionResetInterval = e.ConnectionResetInterval
+		if e.ConnectionResetIntervalSeconds != nil {
+			newE.ConnectionResetInterval = time.Duration(*e.ConnectionResetIntervalSeconds) * time.Second
+		} else {
+			newE.ConnectionResetInterval = main.ConnectionResetInterval
+		}
 		newE.BackoffFactor = e.BackoffFactor
 		newE.BackoffBase = e.BackoffBase
 		newE.BackoffMax = e.BackoffMax
@@ -229,7 +238,11 @@ func loadHTTPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, intakeTrackTy
 		newE.CompressionLevel = main.CompressionLevel
 		newE.ProxyAddress = e.ProxyAddress
 		newE.isReliable = e.IsReliable == nil || *e.IsReliable
-		newE.ConnectionResetInterval = e.ConnectionResetInterval
+		if e.ConnectionResetIntervalSeconds != nil {
+			newE.ConnectionResetInterval = time.Duration(*e.ConnectionResetIntervalSeconds) * time.Second
+		} else {
+			newE.ConnectionResetInterval = main.ConnectionResetInterval
+		}
 		newE.BackoffFactor = main.BackoffFactor
 		newE.BackoffBase = main.BackoffBase
 		newE.BackoffMax = main.BackoffMax

--- a/comp/logs/agent/config/endpoints_test.go
+++ b/comp/logs/agent/config/endpoints_test.go
@@ -993,6 +993,139 @@ func (suite *EndpointsTestSuite) TestMRFApiKeyUpdate() {
 	}
 }
 
+func (suite *EndpointsTestSuite) TestConnectionResetIntervalInheritedByAdditionalEndpoints() {
+	suite.config.SetWithoutSource("logs_config.connection_reset_interval", 600)
+
+	suite.config.SetWithoutSource("logs_config.additional_endpoints", []map[string]interface{}{
+		{
+			"host":    "additional.endpoint",
+			"api_key": "456",
+		},
+	})
+
+	logsConfig := defaultLogsConfigKeys(suite.config)
+
+	suite.Run("TCP additional endpoints inherit connection_reset_interval from main", func() {
+		main := newTCPEndpoint(logsConfig, false)
+		suite.Equal(600*time.Second, main.ConnectionResetInterval)
+
+		endpoints := loadTCPAdditionalEndpoints(main, logsConfig, false)
+		suite.Require().Len(endpoints, 1)
+		suite.Equal(600*time.Second, endpoints[0].ConnectionResetInterval)
+	})
+
+	suite.Run("HTTP additional endpoints inherit connection_reset_interval from main", func() {
+		main := newHTTPEndpoint(logsConfig, false)
+		suite.Equal(600*time.Second, main.ConnectionResetInterval)
+
+		endpoints := loadHTTPAdditionalEndpoints(main, logsConfig, "", "", "", false)
+		suite.Require().Len(endpoints, 1)
+		suite.Equal(600*time.Second, endpoints[0].ConnectionResetInterval)
+	})
+}
+
+func (suite *EndpointsTestSuite) TestConnectionResetIntervalPerEndpointOverride() {
+	suite.config.SetWithoutSource("logs_config.connection_reset_interval", 600)
+
+	suite.config.SetWithoutSource("logs_config.additional_endpoints", `[
+		{"api_key": "456", "host": "additional.endpoint", "connection_reset_interval": 300}
+	]`)
+
+	logsConfig := defaultLogsConfigKeys(suite.config)
+
+	suite.Run("TCP additional endpoint overrides connection_reset_interval", func() {
+		main := newTCPEndpoint(logsConfig, false)
+		endpoints := loadTCPAdditionalEndpoints(main, logsConfig, false)
+		suite.Require().Len(endpoints, 1)
+		suite.Equal(300*time.Second, endpoints[0].ConnectionResetInterval)
+	})
+
+	suite.Run("HTTP additional endpoint overrides connection_reset_interval", func() {
+		main := newHTTPEndpoint(logsConfig, false)
+		endpoints := loadHTTPAdditionalEndpoints(main, logsConfig, "", "", "", false)
+		suite.Require().Len(endpoints, 1)
+		suite.Equal(300*time.Second, endpoints[0].ConnectionResetInterval)
+	})
+}
+
+func (suite *EndpointsTestSuite) TestConnectionResetIntervalZeroWhenNotConfigured() {
+	suite.config.SetWithoutSource("logs_config.additional_endpoints", []map[string]interface{}{
+		{
+			"host":    "additional.endpoint",
+			"api_key": "456",
+		},
+	})
+
+	logsConfig := defaultLogsConfigKeys(suite.config)
+
+	suite.Run("TCP additional endpoints get zero when main is zero", func() {
+		main := newTCPEndpoint(logsConfig, false)
+		suite.Equal(time.Duration(0), main.ConnectionResetInterval)
+
+		endpoints := loadTCPAdditionalEndpoints(main, logsConfig, false)
+		suite.Require().Len(endpoints, 1)
+		suite.Equal(time.Duration(0), endpoints[0].ConnectionResetInterval)
+	})
+
+	suite.Run("HTTP additional endpoints get zero when main is zero", func() {
+		main := newHTTPEndpoint(logsConfig, false)
+		suite.Equal(time.Duration(0), main.ConnectionResetInterval)
+
+		endpoints := loadHTTPAdditionalEndpoints(main, logsConfig, "", "", "", false)
+		suite.Require().Len(endpoints, 1)
+		suite.Equal(time.Duration(0), endpoints[0].ConnectionResetInterval)
+	})
+}
+
+func (suite *EndpointsTestSuite) TestConnectionResetIntervalExplicitZeroDisables() {
+	suite.config.SetWithoutSource("logs_config.connection_reset_interval", 600)
+
+	suite.config.SetWithoutSource("logs_config.additional_endpoints", `[
+		{"api_key": "456", "host": "additional.endpoint", "connection_reset_interval": 0}
+	]`)
+
+	logsConfig := defaultLogsConfigKeys(suite.config)
+
+	suite.Run("TCP additional endpoint with explicit zero disables reset", func() {
+		main := newTCPEndpoint(logsConfig, false)
+		suite.Equal(600*time.Second, main.ConnectionResetInterval)
+
+		endpoints := loadTCPAdditionalEndpoints(main, logsConfig, false)
+		suite.Require().Len(endpoints, 1)
+		suite.Equal(time.Duration(0), endpoints[0].ConnectionResetInterval)
+	})
+
+	suite.Run("HTTP additional endpoint with explicit zero disables reset", func() {
+		main := newHTTPEndpoint(logsConfig, false)
+		suite.Equal(600*time.Second, main.ConnectionResetInterval)
+
+		endpoints := loadHTTPAdditionalEndpoints(main, logsConfig, "", "", "", false)
+		suite.Require().Len(endpoints, 1)
+		suite.Equal(time.Duration(0), endpoints[0].ConnectionResetInterval)
+	})
+}
+
+func (suite *EndpointsTestSuite) TestMRFHTTPEndpointConnectionResetInterval() {
+	suite.config.SetWithoutSource("api_key", "123")
+	suite.config.SetWithoutSource("logs_config.connection_reset_interval", 600)
+	suite.config.SetWithoutSource("multi_region_failover.enabled", true)
+	suite.config.SetWithoutSource("multi_region_failover.site", "mrf_fake_site.com:12")
+	suite.config.SetWithoutSource("multi_region_failover.api_key", "mrf_key")
+
+	endpoints, err := BuildHTTPEndpoints(suite.config, "", "", "")
+	suite.Nil(err)
+
+	mrfFound := false
+	for _, endpoint := range endpoints.Endpoints {
+		if endpoint.IsMRF {
+			mrfFound = true
+			suite.Equal(600*time.Second, endpoint.ConnectionResetInterval,
+				"HTTP MRF endpoint should inherit connection_reset_interval from config")
+		}
+	}
+	suite.True(mrfFound, "MRF endpoint not found")
+}
+
 func TestEndpointsTestSuite(t *testing.T) {
 	suite.Run(t, new(EndpointsTestSuite))
 }

--- a/releasenotes/notes/fix-connection-reset-additional-endpoints-50c65183fc167460.yaml
+++ b/releasenotes/notes/fix-connection-reset-additional-endpoints-50c65183fc167460.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fix the ``connection_reset_interval`` setting not being applied to additional
+    log endpoints and HTTP MRF endpoints. Previously, only the main log endpoint
+    would periodically reset its connection, which could cause additional endpoints
+    to send logs to stale destinations after a DNS failover. Additional endpoints
+    now inherit the global ``logs_config.connection_reset_interval`` value by
+    default, and can also be overridden per-endpoint in the
+    ``additional_endpoints`` configuration.


### PR DESCRIPTION
### What does this PR do?

Fixes `logs_config.connection_reset_interval` not being applied to additional log endpoints and HTTP MRF endpoints.

Previously, only the main log endpoint would periodically reset its connection based on the `connection_reset_interval` setting. Additional endpoints (from `logs_config.additional_endpoints`) and HTTP MRF endpoints always had `ConnectionResetInterval = 0` (disabled), causing them to hold stale connections indefinitely after a DNS failover.

This PR makes three changes:
- **Add `mapstructure`/`json` tags** to the `ConnectionResetInterval` field so per-endpoint overrides in `additional_endpoints` config are deserialized correctly.
- **Fall back to the main endpoint's `ConnectionResetInterval`** for additional endpoints that don't specify their own value (both TCP and HTTP).
- **Set `ConnectionResetInterval` on HTTP MRF endpoints** from the global config, matching the existing TCP MRF behavior.

### Motivation

During DR tests, a DNS failover on a custom log endpoint (CNAME switching between sites) caused the Agent to continue sending logs to the old region for hours until restarted. Metrics redirected immediately because they use a different connection path. The root cause was that `connection_reset_interval` only applied to the main endpoint, not additional endpoints.

Fixes: https://datadoghq.atlassian.net/browse/AGNTLOG-461

### Describe how you validated your changes

- Added unit tests verifying additional endpoints (TCP and HTTP) inherit `ConnectionResetInterval` from the main endpoint when not explicitly configured per-endpoint.
- Added unit tests verifying per-endpoint `connection_reset_interval` overrides take precedence over the global value.
- Added unit tests verifying `ConnectionResetInterval` remains zero when the global config is unset (preserving existing behavior).
- Added a unit test verifying the HTTP MRF endpoint now receives `ConnectionResetInterval` from the global config.
- All existing tests in `EndpointsTestSuite` and `ConfigTestSuite` continue to pass.

### Additional Notes

The `ConnectionResetInterval` field on `Endpoint` was missing `mapstructure:"connection_reset_interval"` and `json:"connection_reset_interval"` tags. Without these, `mapstructure` v2 cannot match the snake_case config key to the PascalCase Go field (it does case-insensitive matching but does not strip underscores), so per-endpoint overrides were silently ignored.