### PR TITLE
pkg/clusteragent/autoscaling/cluster/spot: fix flaky scheduler tests

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/spot/cluster_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/cluster_test.go
@@ -214,6 +214,10 @@ func (c *fakeCluster) DeletePod(pod *workloadmeta.KubernetesPod) {
 	async(c.wlm.Set, podCopy)
 }
 
+func (c *fakeCluster) T() *testing.T {
+	return c.t
+}
+
 // WLM returns the underlying workloadmeta mock store.
 func (c *fakeCluster) WLM() workloadmetamock.Mock {
 	return c.wlm
@@ -221,14 +225,6 @@ func (c *fakeCluster) WLM() workloadmetamock.Mock {
 
 func (c *fakeCluster) DynamicClient() dynamic.Interface {
 	return c.dynamicClient
-}
-
-// AssertOwnerPods checks that all pods owned by ownerKind/namespace/ownerName eventually satisfy check.
-func (c *fakeCluster) AssertOwnerPods(ownerKind, namespace, ownerName string, check func(wlm []*workloadmeta.KubernetesPod) bool) {
-	const assertWaitFor = 1 * time.Second
-	require.Eventuallyf(c.t, func() bool {
-		return check(c.ListOwnerPods(ownerKind, namespace, ownerName))
-	}, assertWaitFor, assertWaitFor/10, "%s %s/%s", ownerKind, namespace, ownerName)
 }
 
 // runPodScheduler simulates a Kubernetes scheduler for testing.

--- a/pkg/clusteragent/autoscaling/cluster/spot/scheduler_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/scheduler_test.go
@@ -11,9 +11,11 @@ import (
 	"context"
 	"encoding/json"
 	"math/rand/v2"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -84,7 +86,7 @@ func TestScenarios(t *testing.T) {
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(100, 2), 1)
 
 		// Then
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", d.ReplicaSet(), expectRunningOnDemand(1))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", d.ReplicaSet(), expectRunningOnDemand(1))
 	})
 
 	t.Run("Rolling update preserves ratio", func(t *testing.T) {
@@ -101,8 +103,8 @@ func TestScenarios(t *testing.T) {
 		rs2 := d.Rollout(spotEnabledLabels(), spotAnnotations(60, 2), replicas)
 
 		// Then: 60% spot / 40% on-demand
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs2, expectRunningSpot(6))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs2, expectRunningOnDemand(4))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs2, expectRunningSpot(6))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs2, expectRunningOnDemand(4))
 	})
 
 	t.Run("Scale-up preserves ratio", func(t *testing.T) {
@@ -119,15 +121,15 @@ func TestScenarios(t *testing.T) {
 		d := cluster.CreateDeployment("default", "nginx", labels, annotations, 5)
 
 		// Then: 2 on-demand (minOnDemand=2), 3 spot
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", d.ReplicaSet(), expectRunningOnDemand(2))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", d.ReplicaSet(), expectRunningSpot(3))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", d.ReplicaSet(), expectRunningOnDemand(2))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", d.ReplicaSet(), expectRunningSpot(3))
 
 		// When: scale up to 10 replicas
 		rs := d.Rollout(labels, annotations, 10)
 
 		// Then: 4 on-demand, 6 spot (60% of 10, minOnDemand=2)
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
 	})
 
 	t.Run("Changing spot percentage updates ratio", func(t *testing.T) {
@@ -146,7 +148,7 @@ func TestScenarios(t *testing.T) {
 
 		// Then
 		rsName := d.ReplicaSet()
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rsName, expectRunningOnDemand(replicas))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rsName, expectRunningOnDemand(replicas))
 
 		// When
 		steps := []struct {
@@ -170,8 +172,8 @@ func TestScenarios(t *testing.T) {
 			rsName = d.Rollout(labels, spotAnnotations(step.percentage, minOnDemand), replicas)
 
 			// Then
-			cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rsName, expectRunningOnDemand(replicas-step.spot))
-			cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rsName, expectRunningSpot(step.spot))
+			requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rsName, expectRunningOnDemand(replicas-step.spot))
+			requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rsName, expectRunningSpot(step.spot))
 		}
 	})
 
@@ -188,21 +190,21 @@ func TestScenarios(t *testing.T) {
 		rs := d.ReplicaSet()
 
 		// Then
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectPending(6))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectPending(6))
 
 		// When
 		// Schedule timeout
 		clk.Step(s.Config().ScheduleTimeout)
 
 		// Then
-		require.Eventually(t, func() bool {
+		requireEventually(t, func() bool {
 			return s.IsSpotSchedulingDisabled("apps", kubernetes.DeploymentKind, d.namespace, d.name)
-		}, 1*time.Second, 50*time.Millisecond)
+		})
 
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
 		// Pending pods evicted
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectPending(0))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectPending(0))
 
 		// When
 		// ReplicaSet recreates pods
@@ -212,15 +214,15 @@ func TestScenarios(t *testing.T) {
 
 		// Then
 		// Fallback to on-demand
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(10))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(10))
 
 		// When
 		cluster.AddSpotNode("new-spot")
 		// Advance past disabled interval to re-enable spot scheduling
 		clk.Step(s.Config().FallbackDuration)
-		require.Eventually(t, func() bool {
+		requireEventually(t, func() bool {
 			return !s.IsSpotSchedulingDisabled("apps", kubernetes.DeploymentKind, d.namespace, d.name)
-		}, 1*time.Second, 50*time.Millisecond)
+		})
 
 		// Rebalancing
 		for i := range 6 {
@@ -228,17 +230,17 @@ func TestScenarios(t *testing.T) {
 			clk.Step(s.Config().RebalanceStabilizationPeriod)
 
 			// Then: excess on-demand pod evicted
-			cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(10-1-i))
+			requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(10-1-i))
 
 			// ReplicaSet recreates pod
 			cluster.CreatePod(newPod("default", kubernetes.ReplicaSetKind, rs, nil))
 			// Important: wait for it to be Running before next step
-			cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(i+1))
+			requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(i+1))
 		}
 
 		// Then
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
 	})
 
 	t.Run("Pod replacement preserves ratio", func(t *testing.T) {
@@ -257,8 +259,8 @@ func TestScenarios(t *testing.T) {
 
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(spotPercentage, minOnDemand), replicas)
 		rs := d.ReplicaSet()
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(expectedSpot))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(expectedOnDemand))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(expectedSpot))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(expectedOnDemand))
 
 		for range 10 {
 			// When
@@ -278,11 +280,11 @@ func TestScenarios(t *testing.T) {
 			}
 
 			// Important: wait until deletion is complete before checking expectations to avoid counting deleted pods.
-			cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectHasNoneOf(deleted))
+			requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectHasNoneOf(deleted))
 
 			// Then
-			cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(expectedSpot))
-			cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(expectedOnDemand))
+			requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(expectedSpot))
+			requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(expectedOnDemand))
 		}
 	})
 
@@ -296,22 +298,22 @@ func TestScenarios(t *testing.T) {
 
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 2), 10)
 		rs := d.ReplicaSet()
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
 
 		// When: scale down to 5 replicas leaving 2 spot / 3 on-demand — ratio is off
 		scaleDown(t, cluster, kubernetes.ReplicaSetKind, "default", rs, 2, 3)
 
 		// When: rebalancing evicts the excess on-demand pod
 		clk.Step(s.Config().RebalanceStabilizationPeriod)
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(2))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(2))
 
 		// ReplicaSet recreates the evicted pod as spot
 		cluster.CreatePod(newPod("default", kubernetes.ReplicaSetKind, rs, nil))
 
 		// Then: 3 spot / 2 on-demand (60% of 5, minOnDemand=2 satisfied)
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(2))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(2))
 	})
 
 	t.Run("Rebalancing after scale-down evicts excess spot pod to satisfy min-on-demand", func(t *testing.T) {
@@ -324,8 +326,8 @@ func TestScenarios(t *testing.T) {
 
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 2), 10)
 		rs := d.ReplicaSet()
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
 
 		// When: scale down to 5 replicas leaving 5 spot / 0 on-demand — on-demand count is below minOnDemand=2
 		scaleDown(t, cluster, kubernetes.ReplicaSetKind, "default", rs, 5, 0)
@@ -334,16 +336,16 @@ func TestScenarios(t *testing.T) {
 		// Each evicted spot pod is recreated by the ReplicaSet as on-demand.
 		for i := range 2 {
 			clk.Step(s.Config().RebalanceStabilizationPeriod)
-			cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(4-i))
+			requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(4-i))
 
 			// ReplicaSet recreates the evicted pod as on-demand (on-demand count still below minOnDemand)
 			cluster.CreatePod(newPod("default", kubernetes.ReplicaSetKind, rs, nil))
-			cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(i+1))
+			requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(i+1))
 		}
 
 		// Then: 3 spot / 2 on-demand (60% of 5, minOnDemand=2 satisfied)
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(2))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(2))
 	})
 
 	t.Run("Rebalancing after scale-down evicts excess spot pod (min-on-demand already satisfied)", func(t *testing.T) {
@@ -357,8 +359,8 @@ func TestScenarios(t *testing.T) {
 
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 1), 10)
 		rs := d.ReplicaSet()
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
 
 		// When: scale down to 5 replicas leaving 4 spot / 1 on-demand — on-demand satisfies minOnDemand=1
 		// but spot count exceeds the desired 3 (60% of 5).
@@ -366,14 +368,14 @@ func TestScenarios(t *testing.T) {
 
 		// When: rebalancing evicts the excess spot pod
 		clk.Step(s.Config().RebalanceStabilizationPeriod)
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
 
 		// ReplicaSet recreates the evicted pod as on-demand
 		cluster.CreatePod(newPod("default", kubernetes.ReplicaSetKind, rs, nil))
 
 		// Then: 3 spot / 2 on-demand (60% of 5, minOnDemand=1 satisfied)
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(2))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(2))
 	})
 
 	t.Run("Rebalancing after scale-down when ratio is already correct", func(t *testing.T) {
@@ -386,16 +388,16 @@ func TestScenarios(t *testing.T) {
 
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 2), 10)
 		rs := d.ReplicaSet()
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
 
 		// When: scale down to 5 replicas preserving the ratio — 3 spot / 2 on-demand (60% of 5)
 		scaleDown(t, cluster, kubernetes.ReplicaSetKind, "default", rs, 3, 2)
 
 		// Then: ratio is already correct; rebalancing does not evict any pod
 		clk.Step(s.Config().RebalanceStabilizationPeriod)
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(2))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(2))
 	})
 
 	t.Run("Pods not eligible for spot are scheduled onto on-demand node", func(t *testing.T) {
@@ -410,8 +412,8 @@ func TestScenarios(t *testing.T) {
 		d := cluster.CreateDeployment("default", "nginx", nil, nil, 5)
 
 		// Then
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", d.ReplicaSet(), expectRunningOnDemand(5))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", d.ReplicaSet(), expectRunningSpot(0))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", d.ReplicaSet(), expectRunningOnDemand(5))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", d.ReplicaSet(), expectRunningSpot(0))
 	})
 
 	t.Run("Opt-in to spot scheduling after initial deployment converges via rebalancing", func(t *testing.T) {
@@ -429,27 +431,27 @@ func TestScenarios(t *testing.T) {
 		// When: create deployment without spot label — all pods go on-demand
 		d := cluster.CreateDeployment("default", "nginx", nil, nil, replicas)
 		rs := d.ReplicaSet()
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(replicas))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(replicas))
 
 		// When: opt in to spot scheduling (no new pods created)
 		d.UpdateMetadata(spotEnabledLabels(), spotAnnotations(spotPercentage, 2))
 
 		// Wait for pod fetcher backfill: tracker must know all 10 pods before advancing the clock.
-		require.Eventually(t, func() bool {
+		requireEventually(t, func() bool {
 			total, _ := s.TrackedCounts("apps", kubernetes.DeploymentKind, d.namespace, d.name)
 			return total == replicas
-		}, 1*time.Second, 10*time.Millisecond)
+		})
 
 		// Then: rebalancer evicts one on-demand pod per cycle; RS recreates it as spot.
 		for i := range expectedSpot {
 			clk.Step(s.Config().RebalanceStabilizationPeriod)
-			cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(replicas-1-i))
+			requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(replicas-1-i))
 			cluster.CreatePod(newPod("default", kubernetes.ReplicaSetKind, rs, nil))
-			cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(i+1))
+			requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(i+1))
 		}
 
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(expectedSpot))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(replicas-expectedSpot))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(expectedSpot))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(replicas-expectedSpot))
 	})
 
 	t.Run("Opt-out via label removal clears config store and pod tracker", func(t *testing.T) {
@@ -463,26 +465,26 @@ func TestScenarios(t *testing.T) {
 		const replicas = 5
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 1), replicas)
 		rs := d.ReplicaSet()
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
 
-		require.Eventually(t, func() bool {
+		requireEventually(t, func() bool {
 			return s.HasConfig("apps", kubernetes.DeploymentKind, d.namespace, d.name)
-		}, 1*time.Second, 10*time.Millisecond)
-		require.Eventually(t, func() bool {
+		})
+		requireEventually(t, func() bool {
 			total, _ := s.TrackedCounts("apps", kubernetes.DeploymentKind, d.namespace, d.name)
 			return total == replicas
-		}, 1*time.Second, 10*time.Millisecond)
+		})
 
 		// When: remove the spot label (opt-out)
 		d.RemoveLabels(spot.SpotEnabledLabelKey)
 
 		// Then: config store and pod tracker are cleared
-		require.Eventually(t, func() bool {
+		requireEventually(t, func() bool {
 			return !s.HasConfig("apps", kubernetes.DeploymentKind, d.namespace, d.name)
-		}, 1*time.Second, 10*time.Millisecond)
-		require.Eventually(t, func() bool {
+		})
+		requireEventually(t, func() bool {
 			return !s.HasTrackedPods("apps", kubernetes.DeploymentKind, d.namespace, d.name)
-		}, 1*time.Second, 10*time.Millisecond)
+		})
 	})
 
 	t.Run("Opt-out via deployment deletion clears config store and pod tracker", func(t *testing.T) {
@@ -496,26 +498,26 @@ func TestScenarios(t *testing.T) {
 		const replicas = 5
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 1), replicas)
 		rs := d.ReplicaSet()
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(3))
 
-		require.Eventually(t, func() bool {
+		requireEventually(t, func() bool {
 			return s.HasConfig("apps", kubernetes.DeploymentKind, d.namespace, d.name)
-		}, 1*time.Second, 10*time.Millisecond)
-		require.Eventually(t, func() bool {
+		})
+		requireEventually(t, func() bool {
 			total, _ := s.TrackedCounts("apps", kubernetes.DeploymentKind, d.namespace, d.name)
 			return total == replicas
-		}, 1*time.Second, 10*time.Millisecond)
+		})
 
 		// When: delete the deployment and its pods
 		d.Delete()
 
 		// Then: config store and pod tracker are cleared
-		require.Eventually(t, func() bool {
+		requireEventually(t, func() bool {
 			return !s.HasConfig("apps", kubernetes.DeploymentKind, d.namespace, d.name)
-		}, 1*time.Second, 10*time.Millisecond)
-		require.Eventually(t, func() bool {
+		})
+		requireEventually(t, func() bool {
 			return !s.HasTrackedPods("apps", kubernetes.DeploymentKind, d.namespace, d.name)
-		}, 1*time.Second, 10*time.Millisecond)
+		})
 	})
 
 	t.Run("Pods not eligible for spot are not tracked", func(t *testing.T) {
@@ -531,7 +533,7 @@ func TestScenarios(t *testing.T) {
 		rs := d.ReplicaSet()
 
 		// Then
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(5))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(5))
 		total, spot := s.TrackedCounts("apps", kubernetes.DeploymentKind, d.namespace, d.name)
 		assert.Zero(t, total)
 		assert.Zero(t, spot)
@@ -543,7 +545,7 @@ func TestScenarios(t *testing.T) {
 			deleted[pod.ID] = struct{}{}
 		}
 		// Then
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectHasNoneOf(deleted))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectHasNoneOf(deleted))
 	})
 
 	t.Run("Restarted scheduler tracks existing pods", func(t *testing.T) {
@@ -561,8 +563,8 @@ func TestScenarios(t *testing.T) {
 		d := cluster.CreateDeployment("default", "nginx", spotEnabledLabels(), spotAnnotations(60, 2), replicas)
 		rs := d.ReplicaSet()
 
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
-		cluster.AssertOwnerPods(kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningSpot(6))
+		requireOwnerPods(cluster, kubernetes.ReplicaSetKind, "default", rs, expectRunningOnDemand(4))
 
 		// When
 		stopScheduler()
@@ -570,10 +572,10 @@ func TestScenarios(t *testing.T) {
 		s2, _ := runTestScheduler(t.Context(), cluster)
 
 		// Then
-		assert.Eventually(t, func() bool {
+		requireEventually(t, func() bool {
 			total, spotCount := s2.TrackedCounts("apps", kubernetes.DeploymentKind, d.namespace, d.name)
 			return total == replicas && spotCount == 6
-		}, 1*time.Second, 10*time.Millisecond)
+		})
 	})
 }
 
@@ -613,9 +615,42 @@ func scaleDown(t *testing.T, cluster *fakeCluster, ownerKind, namespace, name st
 		}
 	}
 
-	cluster.AssertOwnerPods(ownerKind, namespace, name, expectHasNoneOf(deleted))
-	cluster.AssertOwnerPods(ownerKind, namespace, name, expectRunningSpot(expectSpot))
-	cluster.AssertOwnerPods(ownerKind, namespace, name, expectRunningOnDemand(expectOnDemand))
+	requireOwnerPods(cluster, ownerKind, namespace, name, expectHasNoneOf(deleted))
+	requireOwnerPods(cluster, ownerKind, namespace, name, expectRunningSpot(expectSpot))
+	requireOwnerPods(cluster, ownerKind, namespace, name, expectRunningOnDemand(expectOnDemand))
+}
+
+func requireEventually(t *testing.T, condition func() bool, msgAndArgs ...any) {
+	t.Helper()
+	const (
+		waitFor = 5 * time.Second
+		tick    = 100 * time.Millisecond
+	)
+	require.Eventually(t, condition, waitFor, tick, msgAndArgs...)
+}
+
+type spewStringer[T any] struct {
+	v atomic.Pointer[T]
+}
+
+func (h *spewStringer[T]) set(v T) T {
+	h.v.Store(&v)
+	return v
+}
+
+func (h *spewStringer[T]) String() string {
+	if p := h.v.Load(); p != nil {
+		return spew.Sdump(*p)
+	}
+	return "<nil>"
+}
+
+// requireOwnerPods checks that all pods owned by ownerKind/namespace/ownerName eventually satisfy check.
+func requireOwnerPods(c *fakeCluster, ownerKind, namespace, ownerName string, check func(wlm []*workloadmeta.KubernetesPod) bool) {
+	pods := new(spewStringer[[]*workloadmeta.KubernetesPod])
+	requireEventually(c.T(), func() bool {
+		return check(pods.set(c.ListOwnerPods(ownerKind, namespace, ownerName)))
+	}, "%s %s/%s, pods: %s", ownerKind, namespace, ownerName, pods)
 }
 
 func expectRunningSpot(count int) func([]*workloadmeta.KubernetesPod) bool {


### PR DESCRIPTION
### What does this PR do?

* convert cluster.AssertOwnerPods into a function and move to the scheduler tests file
* log owner pods on check timeout
* add requireEventually helper with a predefined timeout
* use requireEventually helper in all tests
* increase timeout to fix flaky tests on presumably slow CI runners

### Motivation

Fix flaky tests on presumably slow CI runners

### Describe how you validated your changes

I could not reproduce the failure locally, the tests still pass with this change.

### Additional Notes

Updates https://datadoghq.atlassian.net/browse/CASCL-1274
