### PR TITLE
[Backport 7.78.x] Use OCI image digest in fleet extension install logic (#49621)

### DIFF
--- a/pkg/fleet/installer/packages/extensions/db.go
+++ b/pkg/fleet/installer/packages/extensions/db.go
@@ -19,9 +19,9 @@ var (
 )
 
 type dbPackage struct {
-	Name       string              `json:"pkg"`
-	Version    string              `json:"version"`
-	Extensions map[string]struct{} `json:"extensions"`
+	Name       string            `json:"pkg"`
+	Version    string            `json:"version"`
+	Extensions map[string]string `json:"extensions"` // extension name → OCI image digest
 }
 
 // extensionsDB is a database that stores information about extensions.
@@ -66,9 +66,16 @@ func (p *extensionsDB) GetPackage(pkg string, isExperiment bool) (dbPackage, err
 		if len(v) == 0 {
 			return errPackageNotFound
 		}
-		err := json.Unmarshal(v, &dbPkg)
-		if err != nil {
-			return fmt.Errorf("could not unmarshal package: %w", err)
+		if err := json.Unmarshal(v, &dbPkg); err != nil {
+			// The old schema stored Extensions as map[string]struct{}, whose JSON
+			// values are {}. json.Unmarshal returns an UnmarshalTypeError but still
+			// fills Name/Version and sets each extension key to "" in the map.
+			// Treat this as a successful partial decode: empty digest strings will
+			// cause Install to reinstall every extension, self-healing the migration.
+			var typeErr *json.UnmarshalTypeError
+			if !errors.As(err, &typeErr) || dbPkg.Name == "" {
+				return fmt.Errorf("could not unmarshal package: %w", err)
+			}
 		}
 		return nil
 	})
@@ -137,21 +144,20 @@ func (p *extensionsDB) SetPackageVersion(pkg string, version string, isExperimen
 		}
 		if existing := b.Get(getKey(pkg, isExperiment)); len(existing) > 0 {
 			var existingPkg dbPackage
-			if err := json.Unmarshal(existing, &existingPkg); err == nil && existingPkg.Version == version {
+			unmarshalErr := json.Unmarshal(existing, &existingPkg)
+			if unmarshalErr != nil {
+				// Apply the same legacy tolerance as GetPackage: an UnmarshalTypeError
+				// from the old map[string]struct{} schema still populates Name/Version.
+				var typeErr *json.UnmarshalTypeError
+				if errors.As(unmarshalErr, &typeErr) && existingPkg.Name != "" {
+					unmarshalErr = nil
+				}
+			}
+			if unmarshalErr == nil && existingPkg.Version == version {
 				return nil
 			}
 		}
-		dbPkg := dbPackage{
-			Name:    pkg,
-			Version: version,
-		}
-		if existing := b.Get(getKey(pkg, isExperiment)); len(existing) > 0 {
-			var existingPkg dbPackage
-			if err := json.Unmarshal(existing, &existingPkg); err == nil && existingPkg.Version == version {
-				return nil
-			}
-		}
-		rawPkg, err := json.Marshal(&dbPkg)
+		rawPkg, err := json.Marshal(&dbPackage{Name: pkg, Version: version})
 		if err != nil {
 			return fmt.Errorf("could not marshal package: %w", err)
 		}

--- a/pkg/fleet/installer/packages/extensions/extensions.go
+++ b/pkg/fleet/installer/packages/extensions/extensions.go
@@ -22,6 +22,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// errExtensionNotInPackage is returned by installSingle when the requested extension
+// layer is absent from the package image.
+var errExtensionNotInPackage = errors.New("extension not in package")
+
 // ExtensionsDBDir is the path to the extensions database, overridden in tests
 var ExtensionsDBDir = paths.RunPath
 
@@ -157,23 +161,31 @@ func Install(ctx context.Context, downloader *oci.Downloader, url string, extens
 			return fmt.Errorf("package %s is installed at version %s, requested version is %s", pkg.Name, dbPkg.Version, pkg.Version)
 		}
 		if dbPkg.Extensions == nil {
-			dbPkg.Extensions = make(map[string]struct{})
+			dbPkg.Extensions = make(map[string]string)
 		}
+
+		newDigest, err := pkg.Image.Digest()
+		if err != nil {
+			return fmt.Errorf("could not get digest for package %s: %w", pkg.Name, err)
+		}
+		newDigestStr := newDigest.String()
 
 		// Process each extension in this group
 		for _, extension := range group.extensions {
-			if _, exists := dbPkg.Extensions[extension]; exists {
-				log.Debugf("Extension %s already installed, skipping", extension)
+			if stored, exists := dbPkg.Extensions[extension]; exists && stored == newDigestStr {
+				log.Debugf("Extension %s already installed at digest %s, skipping", extension, stored)
 				continue
 			}
 
 			err := installSingle(ctx, pkg, extension, isExperiment, hooks)
 			if err != nil {
-				installErrors = append(installErrors, fmt.Errorf("extension %s: %w", extension, err))
+				if !errors.Is(err, errExtensionNotInPackage) {
+					installErrors = append(installErrors, fmt.Errorf("extension %s: %w", extension, err))
+				}
 				continue
 			}
 
-			dbPkg.Extensions[extension] = struct{}{}
+			dbPkg.Extensions[extension] = newDigestStr
 		}
 
 		// Update DB with successfully installed extensions
@@ -215,7 +227,7 @@ func installSingle(ctx context.Context, pkg *oci.DownloadedPackage, extension st
 			// The extension is not available in the package, skip it.
 			// This might be a version where the extension doesn't exist and shouldn't block other methods.
 			fmt.Printf("no layer matches the requested annotations for %s, skipping\n", extension)
-			return nil
+			return errExtensionNotInPackage
 		}
 		return fmt.Errorf("could not extract layers for %s: %w", extension, err)
 	}
@@ -489,8 +501,8 @@ func getExtensionsPath(pkg, version string) string {
 	return filepath.Join(basePath, "ext")
 }
 
-// keys returns the keys of a map[string]struct{}.
-func keys(m map[string]struct{}) []string {
+// keys returns the keys of a map[string]string.
+func keys(m map[string]string) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/pkg/fleet/installer/packages/extensions/extensions_digest_test.go
+++ b/pkg/fleet/installer/packages/extensions/extensions_digest_test.go
@@ -1,0 +1,180 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package extensions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/fixtures"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
+)
+
+// The extension embedded in FixtureSimpleV1WithExtension (see fixtures/server.go).
+const fixtureExtensionName = "simple-extension"
+
+// legacyDBPackage is the pre-digest-tracking schema where extension presence was
+// stored as map[string]struct{} (no digest). Used only to seed test DBs.
+type legacyDBPackage struct {
+	Name       string              `json:"pkg"`
+	Version    string              `json:"version"`
+	Extensions map[string]struct{} `json:"extensions"`
+}
+
+// countingHooks counts PreInstallExtension invocations and can inject an error.
+type countingHooks struct {
+	preInstallCount int
+	preInstallErr   error
+}
+
+func (c *countingHooks) PreInstallExtension(_ context.Context, _ string, _ string) error {
+	c.preInstallCount++
+	return c.preInstallErr
+}
+
+func (c *countingHooks) PostInstallExtension(_ context.Context, _ string, _ string, _ bool) error {
+	return nil
+}
+
+func (c *countingHooks) PreRemoveExtension(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+// realDigestForFixture downloads FixtureSimpleV1WithExtension and returns its OCI image digest.
+func realDigestForFixture(t *testing.T, s *fixtures.Server) string {
+	t.Helper()
+	d := oci.NewDownloader(&env.Env{}, http.DefaultClient)
+	pkg, err := d.Download(context.Background(), s.PackageURL(fixtures.FixtureSimpleV1WithExtension))
+	require.NoError(t, err)
+	digest, err := pkg.Image.Digest()
+	require.NoError(t, err)
+	return digest.String()
+}
+
+// seedExtensionDB writes a "simple/v1" entry with a single extension at the given digest.
+func seedExtensionDB(t *testing.T, dir, extensionDigest string) {
+	t.Helper()
+	db, err := newExtensionsDB(filepath.Join(dir, "extensions.db"))
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.SetPackage(dbPackage{
+		Name:       "simple",
+		Version:    "v1",
+		Extensions: map[string]string{fixtureExtensionName: extensionDigest},
+	}, false))
+}
+
+// TestSkipExtensionInstallWhenDigestMatches verifies that Install does not call
+// installSingle when the stored digest already matches the current OCI image digest.
+func TestSkipExtensionInstallWhenDigestMatches(t *testing.T) {
+	tmpDir := t.TempDir()
+	ExtensionsDBDir = tmpDir
+
+	s := fixtures.NewServer(t)
+	realDigest := realDigestForFixture(t, s)
+	seedExtensionDB(t, tmpDir, realDigest)
+
+	hooks := &countingHooks{}
+	err := Install(
+		context.Background(),
+		oci.NewDownloader(&env.Env{}, http.DefaultClient),
+		s.PackageURL(fixtures.FixtureSimpleV1WithExtension),
+		[]string{fixtureExtensionName},
+		false,
+		hooks,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, hooks.preInstallCount, "PreInstallExtension must not be called when digest matches")
+}
+
+// TestReinstallExtensionWhenDigestChanges verifies that Install triggers
+// reinstallation when the stored digest differs from the current image digest.
+func TestReinstallExtensionWhenDigestChanges(t *testing.T) {
+	tmpDir := t.TempDir()
+	ExtensionsDBDir = tmpDir
+
+	s := fixtures.NewServer(t)
+	seedExtensionDB(t, tmpDir, "sha256:outdated")
+
+	sentinel := errors.New("reinstall-triggered")
+	hooks := &countingHooks{preInstallErr: sentinel}
+	err := Install(
+		context.Background(),
+		oci.NewDownloader(&env.Env{}, http.DefaultClient),
+		s.PackageURL(fixtures.FixtureSimpleV1WithExtension),
+		[]string{fixtureExtensionName},
+		false,
+		hooks,
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reinstall-triggered")
+	assert.Equal(t, 1, hooks.preInstallCount, "PreInstallExtension must be called when digest differs")
+}
+
+// seedExtensionDBLegacy writes a "simple/v1" entry using the pre-digest schema
+// (map[string]struct{}), exactly as old installer versions stored it.
+func seedExtensionDBLegacy(t *testing.T, dir string) {
+	t.Helper()
+	db, err := bbolt.Open(filepath.Join(dir, "extensions.db"), 0644, &bbolt.Options{
+		FreelistType: bbolt.FreelistArrayType,
+	})
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(bucketExtensions)
+		if err != nil {
+			return err
+		}
+		data, err := json.Marshal(legacyDBPackage{
+			Name:       "simple",
+			Version:    "v1",
+			Extensions: map[string]struct{}{fixtureExtensionName: {}},
+		})
+		if err != nil {
+			return err
+		}
+		return b.Put(getKey("simple", false), data)
+	}))
+}
+
+// TestReinstallExtensionWithLegacyFormat verifies that an extension stored in
+// the old map[string]struct{} schema is always reinstalled after the digest upgrade.
+// The old JSON encodes each extension value as {}, which triggers a migration path in
+// GetPackage that preserves Name/Version and returns empty digest strings, causing
+// Install to treat every extension as needing reinstallation.
+func TestReinstallExtensionWithLegacyFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	ExtensionsDBDir = tmpDir
+
+	s := fixtures.NewServer(t)
+	seedExtensionDBLegacy(t, tmpDir)
+
+	sentinel := errors.New("reinstall-triggered")
+	hooks := &countingHooks{preInstallErr: sentinel}
+	err := Install(
+		context.Background(),
+		oci.NewDownloader(&env.Env{}, http.DefaultClient),
+		s.PackageURL(fixtures.FixtureSimpleV1WithExtension),
+		[]string{fixtureExtensionName},
+		false,
+		hooks,
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reinstall-triggered")
+	assert.Equal(t, 1, hooks.preInstallCount, "PreInstallExtension must be called for legacy format")
+}

--- a/pkg/fleet/installer/packages/extensions/extensions_test.go
+++ b/pkg/fleet/installer/packages/extensions/extensions_test.go
@@ -7,6 +7,7 @@ package extensions
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
@@ -56,7 +58,7 @@ func TestPackageKeyDifferentiation(t *testing.T) {
 	stablePkg := dbPackage{
 		Name:       packageName,
 		Version:    "7.50.0",
-		Extensions: map[string]struct{}{"python": {}},
+		Extensions: map[string]string{"python": "sha256:stable"},
 	}
 	err = db.SetPackage(stablePkg, false) // isExperiment=false
 	require.NoError(t, err)
@@ -65,7 +67,7 @@ func TestPackageKeyDifferentiation(t *testing.T) {
 	expPkg := dbPackage{
 		Name:       packageName,
 		Version:    "7.51.0",
-		Extensions: map[string]struct{}{"ruby": {}},
+		Extensions: map[string]string{"ruby": "sha256:experiment"},
 	}
 	err = db.SetPackage(expPkg, true) // isExperiment=true
 	require.NoError(t, err)
@@ -97,7 +99,7 @@ func TestSetPackageVersionIdempotent(t *testing.T) {
 	pkg := dbPackage{
 		Name:       "datadog-agent",
 		Version:    "7.50.0",
-		Extensions: map[string]struct{}{"python": {}, "ruby": {}},
+		Extensions: map[string]string{"python": "sha256:abc", "ruby": "sha256:def"},
 	}
 	err = db.SetPackage(pkg, false)
 	require.NoError(t, err)
@@ -107,7 +109,41 @@ func TestSetPackageVersionIdempotent(t *testing.T) {
 
 	got, err := db.GetPackage("datadog-agent", false)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]struct{}{"python": {}, "ruby": {}}, got.Extensions, "extensions should be preserved after idempotent SetPackageVersion")
+	assert.Equal(t, map[string]string{"python": "sha256:abc", "ruby": "sha256:def"}, got.Extensions, "extensions should be preserved after idempotent SetPackageVersion")
+}
+
+// TestSetPackageVersionIdempotentWithLegacyFormat verifies that SetPackageVersion is a no-op
+// when the stored entry uses the old map[string]struct{} schema and the version matches,
+// preserving the legacy data so GetPackage can later migrate it to trigger reinstalls.
+func TestSetPackageVersionIdempotentWithLegacyFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a legacy-format entry directly via bbolt.
+	db, err := newExtensionsDB(filepath.Join(tmpDir, "extensions.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketExtensions)
+		type legacyPkg struct {
+			Name       string              `json:"pkg"`
+			Version    string              `json:"version"`
+			Extensions map[string]struct{} `json:"extensions"`
+		}
+		data, err := json.Marshal(legacyPkg{Name: "datadog-agent", Version: "7.50.0", Extensions: map[string]struct{}{"python": {}}})
+		if err != nil {
+			return err
+		}
+		return b.Put(getKey("datadog-agent", false), data)
+	}))
+
+	err = db.SetPackageVersion("datadog-agent", "7.50.0", false)
+	require.NoError(t, err)
+
+	// The legacy entry must still be readable via GetPackage (not wiped to empty).
+	got, err := db.GetPackage("datadog-agent", false)
+	require.NoError(t, err)
+	assert.Equal(t, "7.50.0", got.Version)
+	assert.Contains(t, got.Extensions, "python", "legacy extension key must survive SetPackageVersion no-op")
+	db.Close()
 }
 
 // TestSetPackageVersionWipesExtensionsOnVersionChange verifies that calling SetPackageVersion
@@ -121,7 +157,7 @@ func TestSetPackageVersionWipesExtensionsOnVersionChange(t *testing.T) {
 	pkg := dbPackage{
 		Name:       "datadog-agent",
 		Version:    "7.50.0",
-		Extensions: map[string]struct{}{"python": {}},
+		Extensions: map[string]string{"python": "sha256:abc"},
 	}
 	err = db.SetPackage(pkg, false)
 	require.NoError(t, err)
@@ -150,7 +186,7 @@ func TestInstallGroupsByRegistry(t *testing.T) {
 	pkg := dbPackage{
 		Name:       "datadog-agent",
 		Version:    "7.50.0-1",
-		Extensions: map[string]struct{}{},
+		Extensions: map[string]string{},
 	}
 	err = db.SetPackage(pkg, false)
 	require.NoError(t, err)
@@ -190,7 +226,7 @@ func TestInstallNilOverridesBackwardsCompat(t *testing.T) {
 	pkg := dbPackage{
 		Name:       "datadog-agent",
 		Version:    "7.50.0-1",
-		Extensions: map[string]struct{}{},
+		Extensions: map[string]string{},
 	}
 	err = db.SetPackage(pkg, false)
 	require.NoError(t, err)


### PR DESCRIPTION
Backport f7415ac538fe0bce076c710a063cefa3ed5e73c5 from #49621.

 ___

Adds support for storing extension digests in `extensions/db.go` so that installing an extension with the same version but a different digest (e.g. a different custom build for the same version) still triggers an extension reinstall.

- Change `dbPackage.Extensions` from `map[string]struct{}` to `map[string]string`, storing the OCI image digest per extension instead of just presence
- In `Install`, compute the image digest after download and skip reinstallation only when the stored digest matches. A changed digest (or any new extension) always triggers `installSingle`
- Add a migration path in `GetPackage`: the old JSON format encodes extension values as `{}`, which `json.Unmarshal` partially decodes into empty strings while returning an `UnmarshalTypeError`; we accept the partial result so existing DBs self-heal on the next install (empty digest ≠ any real digest → reinstall triggered)

`datadog-installer extension install` silently skipped reinstallation whenever an extension name was already present in the DB, regardless of whether the extension content had changed. This meant installing a newer build of an extension at the same package version (e.g. a custom ddot build) had no effect.

Unit tests and validate on rc


(cherry picked from commit f7415ac538fe0bce076c710a063cefa3ed5e73c5)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
