### PR TITLE
Fix catalog owners for DCA components

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -110,13 +110,13 @@ extensions:
 ---
 schema-version: v2.1
 dd-service: datadog-cluster-agent
-team: container-integrations
+team: container-platform
 contacts:
   - type: slack
-    # #container-integrations
-    contact: https://dd.slack.com/archives/C4TQDFK1P
+    # #container-platform
+    contact: https://dd.slack.com/archives/C0702JHC7G8
   - type: email
-    contact: team-containerintegrations@datadoghq.com
+    contact: team-containerplatform@datadoghq.com
 links:
   - name: datadog-agent
     type: repo
@@ -150,19 +150,19 @@ links:
     provider: confluence
     url: https://datadoghq.atlassian.net/wiki/spaces/agent/pages/2530706500/Agent+Components+in+Kubernetes#Datadog-Cluster-Agent
 tags:
-  - team:container-integrations
+  - team:container-platform
   - service:datadog-cluster-agent
   - app:datadog-cluster-agent
 ---
 schema-version: v2.1
 dd-service: datadog-agent-cluster-worker
-team: container-integrations
+team: container-platform
 contacts:
   - type: slack
-    # #container-integrations
-    contact: https://dd.slack.com/archives/C4TQDFK1P
+    # #container-platform
+    contact: https://dd.slack.com/archives/C0702JHC7G8
   - type: email
-    contact: team-containerintegrations@datadoghq.com
+    contact: team-containerplatform@datadoghq.com
 links:
   - name: datadog-agent
     type: repo
@@ -196,7 +196,7 @@ links:
     type: doc
     url: https://datadoghq.atlassian.net/wiki/spaces/agent/pages/2530706500/Agent+Components+in+Kubernetes#Datadog-Agent-Cluster-Worker
 tags:
-  - team:container-integrations
+  - team:container-platform
   - service:datadog-agent-cluster-worker
   - app:datadog-agent-cluster-worker
 ---


### PR DESCRIPTION
<!-- dd-meta {"pullId":"48245766-6f3f-41d7-b0bb-8f063aeb347f","source":"chat","resourceId":"e0908c8e-5f27-4683-8e09-56c296dfbd8b","workflowId":"39199384-44c6-4f0d-8843-4b1d76015274","codeChangeId":"39199384-44c6-4f0d-8843-4b1d76015274","sourceType":"chat"} -->
### What does this PR do?

Update Software Catalog ownership metadata in `service.datadog.yaml` so Container Platform-owned components no longer route to Container Integrations.

- Updated `dd-service: datadog-cluster-agent` ownership metadata:
  - `team` from `container-integrations` to `container-platform`
  - Slack contact to `#container-platform` (`C0702JHC7G8`)
  - Email contact to `team-containerplatform@datadoghq.com`
  - `team:` tag from `container-integrations` to `container-platform`
- Updated `dd-service: datadog-agent-cluster-worker` with the same ownership/routing changes.
- Left all non-ownership metadata untouched (links, docs, service/app tags).

### Motivation

Cluster Agent and cluster-worker entries were pointing to Container Integrations ownership metadata, which made Software Catalog ownership and routing (alerts/issues/oncall) inaccurate for Container Platform-owned components.

### Describe how you validated your changes

- Reviewed the diff to confirm only the two targeted service blocks were modified.
- Parsed `service.datadog.yaml` successfully with Python/PyYAML (`YAML parse ok`).
- Confirmed the file is already included in change detection (`datadoghq.com/change-detection -> source_patterns: service.datadog.yaml`), so ingestion automation can pick up this update.

### Additional Notes

- Scope intentionally limited to `datadog/datadog-agent` per ticket direction; `k8s-datadog-agent-ops` will be handled separately.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e0908c8e-5f27-4683-8e09-56c296dfbd8b)

Comment @datadog to request changes