### PR TITLE
Use pipeline-built install_mac_os.sh in macOS install E2E

### DIFF
--- a/.gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml
@@ -249,6 +249,7 @@ export_testing_public_key:
       dmg_src=$(ls -1 "$OMNIBUS_PACKAGE_DIR"/datadog-agent-7.*.dmg 2>/dev/null)
       echo "Found single DMG file: $dmg_src"
       $S3_CP_CMD --acl public-read "$dmg_src" "s3://$MACOS_S3_BUCKET/ci/datadog-agent/pipeline-$CI_PIPELINE_ID-$ARCH/datadog-agent-7-latest.dmg"
+      $S3_CP_CMD --acl public-read --content-type "text/x-shellscript" "cmd/agent/macos/install_mac_os.sh" "s3://$MACOS_S3_BUCKET/ci/datadog-agent/pipeline-$CI_PIPELINE_ID-$ARCH/install_mac_os.sh"
 
 
 deploy_dmg_testing-a7_arm64:

--- a/test/new-e2e/tests/agent-platform/install/install.go
+++ b/test/new-e2e/tests/agent-platform/install/install.go
@@ -95,15 +95,18 @@ func MacOS(t *testing.T, client ExecutorWithRetry, options ...installparams.Opti
 		scriptURL = repoURL + "/install_mac_os.sh"
 	}
 
-	var apikey string
-	if params.APIKey == "" {
+	apikey := params.APIKey
+	if apikey == "" {
 		apikey = "aaaaaaaaaa"
-	} else {
-		apikey = params.APIKey
 	}
+	exports = append(exports, "DD_API_KEY="+apikey)
 	env := strings.Join(exports, " ")
-	// Retry curl few times
-	cmd := fmt.Sprintf(`for i in {1..5}; do curl -fsSL %s -o install-script.sh && break || sleep $((2**$i)); done && for i in {1..3}; do DD_API_KEY=%s %s DD_INSTALL_ONLY=true bash install-script.sh && exit 0 || sleep $((2**$i)); done; exit 1`, scriptURL, apikey, env)
+	// Download the install script (up to 5 attempts), then run it (up to 3 attempts), with exponential backoff.
+	cmd := fmt.Sprintf(`
+for i in {1..5}; do curl -fsSL %s -o install-script.sh && break || sleep $((2**i)); done
+for i in {1..3}; do %s bash install-script.sh && exit 0 || sleep $((2**i)); done
+exit 1
+`, scriptURL, env)
 
 	t.Run("Installing the agent", func(tt *testing.T) {
 		_, err := client.ExecuteWithRetry(cmd)

--- a/test/new-e2e/tests/agent-platform/install/install.go
+++ b/test/new-e2e/tests/agent-platform/install/install.go
@@ -88,8 +88,11 @@ func MacOS(t *testing.T, client ExecutorWithRetry, options ...installparams.Opti
 	params := installparams.NewParams(options...)
 	exports := []string{}
 
+	scriptURL := "https://install.datadoghq.com/scripts/install_mac_os.sh"
 	if params.PipelineID != "" {
-		exports = append(exports, fmt.Sprintf("DD_REPO_URL=https://dd-agent-macostesting.s3.amazonaws.com/ci/datadog-agent/pipeline-%s-%s", params.PipelineID, params.Arch))
+		repoURL := fmt.Sprintf("https://dd-agent-macostesting.s3.amazonaws.com/ci/datadog-agent/pipeline-%s-%s", params.PipelineID, params.Arch)
+		exports = append(exports, "DD_REPO_URL="+repoURL)
+		scriptURL = repoURL + "/install_mac_os.sh"
 	}
 
 	var apikey string
@@ -100,7 +103,7 @@ func MacOS(t *testing.T, client ExecutorWithRetry, options ...installparams.Opti
 	}
 	env := strings.Join(exports, " ")
 	// Retry curl few times
-	cmd := fmt.Sprintf(`for i in {1..5}; do curl -fsSL https://install.datadoghq.com/scripts/install_mac_os.sh -o install-script.sh && break || sleep $((2**$i)); done && for i in {1..3}; do DD_API_KEY=%s %s DD_INSTALL_ONLY=true bash install-script.sh && exit 0 || sleep $((2**$i)); done; exit 1`, apikey, env)
+	cmd := fmt.Sprintf(`for i in {1..5}; do curl -fsSL %s -o install-script.sh && break || sleep $((2**$i)); done && for i in {1..3}; do DD_API_KEY=%s %s DD_INSTALL_ONLY=true bash install-script.sh && exit 0 || sleep $((2**$i)); done; exit 1`, scriptURL, apikey, env)
 
 	t.Run("Installing the agent", func(tt *testing.T) {
 		_, err := client.ExecuteWithRetry(cmd)


### PR DESCRIPTION
## What does this PR do?

Makes the `TestMacosInstallScript` E2E test fetch `install_mac_os.sh` from the pipeline's S3 bucket (alongside the DMG) instead of the published version at `install.datadoghq.com`.

## Motivation

The test pulls the DMG from the pipeline-specific bucket via `DD_REPO_URL`, while fetching the install script from `install.datadoghq.com/scripts/install_mac_os.sh`. Changes to `cmd/agent/macos/install_mac_os.sh` in a PR are never exercised by the test.

https://datadoghq.atlassian.net/browse/WINA-2628

## Changes

- `.gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml`: the `.deploy_dmg_testing-a7` job now also uploads `cmd/agent/macos/install_mac_os.sh` from the checkout to `s3://$MACOS_S3_BUCKET/ci/datadog-agent/pipeline-$CI_PIPELINE_ID-$ARCH/install_mac_os.sh`.
- `test/new-e2e/tests/agent-platform/install/install.go`: `MacOS` now derives the install-script URL from the pipeline prefix when `PipelineID` is set, and falls back to `install.datadoghq.com` otherwise (dev/local runs unchanged).

## Describe how to test/QA your changes

After this lands, the deploy pipeline's `new-e2e-install-script-agent7-deploy-macos` job should curl the script from the pipeline bucket rather than `install.datadoghq.com`. To verify:

1. On a deploy pipeline, check the job's install step — the `curl` URL should be `https://dd-agent-macostesting.s3.amazonaws.com/ci/datadog-agent/pipeline-<ID>-<arch>/install_mac_os.sh`.
2. Spot-check the upload: `curl -I https://dd-agent-macostesting.s3.amazonaws.com/ci/datadog-agent/pipeline-<ID>-x64/install_mac_os.sh` should return 200.
3. An observable edit to `cmd/agent/macos/install_mac_os.sh` (e.g. a unique `echo`) should appear in the E2E job log, confirming the branch's script ran.

## Known limitations / out of scope

- The E2E job still only runs on deploy pipelines (main/release/manual). Per-PR coverage for script edits would need `.on_macos_files_change` to include `cmd/agent/macos/install_mac_os.sh` — intentionally not done here.
- If the downstream DMG URL construction inside `install_mac_os.sh` doesn't match the pipeline upload path, that's a separate issue unaffected by this PR.