### PR TITLE
macos: support DD_INFRASTRUCTURE_MODE at install time

### DIFF
--- a/cmd/agent/macos/install_mac_os.sh
+++ b/cmd/agent/macos/install_mac_os.sh
@@ -82,6 +82,11 @@ if [ "$DD_GUI_APP_MENU_ENABLED" = "true" ]; then
     gui_app_menu_enabled=true
 fi
 
+infrastructure_mode=
+if [ -n "$DD_INFRASTRUCTURE_MODE" ]; then
+    infrastructure_mode="$DD_INFRASTRUCTURE_MODE"
+fi
+
 if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
   # Examples:
   #  - 20        = defaults to highest patch version x.20.2
@@ -211,6 +216,7 @@ $sudo_cmd chmod 700 "$install_staging_dir"
     [ -n "$apikey" ] && echo "DD_API_KEY=$apikey"
     [ -n "$site" ] && echo "DD_SITE=$site"
     [ "$gui_app_menu_enabled" = true ] && echo "DD_GUI_APP_MENU_ENABLED=true"
+    [ -n "$infrastructure_mode" ] && echo "DD_INFRASTRUCTURE_MODE=$infrastructure_mode"
     echo "DD_INSTALL_METHOD=install_script_mac"
     echo "DD_INSTALL_SCRIPT_VERSION=$install_script_version"
 } | $sudo_cmd tee "$install_env_file" > /dev/null

--- a/omnibus/package-scripts/agent-dmg/postinst
+++ b/omnibus/package-scripts/agent-dmg/postinst
@@ -127,7 +127,13 @@ if [ -f "$INSTALL_ENV_FILE" ]; then
         sed -i '' "s/^#* *site:.*/site: $dd_site/" "$CONF_DIR/datadog.yaml"
     fi
     if [ -n "$dd_infra_mode" ]; then
-        sed -i '' "s/^#* *infrastructure_mode:.*/infrastructure_mode: $dd_infra_mode/" "$CONF_DIR/datadog.yaml"
+        if grep -Eq '^#* *infrastructure_mode:' "$CONF_DIR/datadog.yaml"; then
+            sed -i '' "s/^#* *infrastructure_mode:.*/infrastructure_mode: $dd_infra_mode/" "$CONF_DIR/datadog.yaml"
+        else
+            # The restored datadog.yaml predates the infrastructure_mode entry
+            # (older Agent versions had no example line to replace).
+            printf '\ninfrastructure_mode: %s\n' "$dd_infra_mode" >> "$CONF_DIR/datadog.yaml"
+        fi
     fi
     if [ -n "$dd_install_method" ]; then
         install_method="$dd_install_method"

--- a/omnibus/package-scripts/agent-dmg/postinst
+++ b/omnibus/package-scripts/agent-dmg/postinst
@@ -116,6 +116,7 @@ if [ -f "$INSTALL_ENV_FILE" ]; then
     dd_api_key=$(grep '^DD_API_KEY=' "$INSTALL_ENV_FILE" | cut -d= -f2-)
     dd_site=$(grep '^DD_SITE=' "$INSTALL_ENV_FILE" | cut -d= -f2-)
     dd_gui_menu=$(grep '^DD_GUI_APP_MENU_ENABLED=' "$INSTALL_ENV_FILE" | cut -d= -f2-)
+    dd_infra_mode=$(grep '^DD_INFRASTRUCTURE_MODE=' "$INSTALL_ENV_FILE" | cut -d= -f2-)
     dd_install_method=$(grep '^DD_INSTALL_METHOD=' "$INSTALL_ENV_FILE" | cut -d= -f2-)
     dd_install_version=$(grep '^DD_INSTALL_SCRIPT_VERSION=' "$INSTALL_ENV_FILE" | cut -d= -f2-)
 
@@ -124,6 +125,9 @@ if [ -f "$INSTALL_ENV_FILE" ]; then
     fi
     if [ -n "$dd_site" ]; then
         sed -i '' "s/^#* *site:.*/site: $dd_site/" "$CONF_DIR/datadog.yaml"
+    fi
+    if [ -n "$dd_infra_mode" ]; then
+        sed -i '' "s/^#* *infrastructure_mode:.*/infrastructure_mode: $dd_infra_mode/" "$CONF_DIR/datadog.yaml"
     fi
     if [ -n "$dd_install_method" ]; then
         install_method="$dd_install_method"

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -31,6 +31,17 @@ api_key:
 #
 # site: datadoghq.com
 
+## @param infrastructure_mode - string - optional - default: "full"
+## @env DD_INFRASTRUCTURE_MODE - string - optional - default: "full"
+## Controls which integrations and metadata the Agent collects.
+## Valid values:
+##   - full: default server/host-monitoring behavior (all checks allowed).
+##   - basic: minimal host-level metrics only.
+##   - end_user_device: tuned for end-user-device (EUDM) laptops and desktops.
+##   - none: disables infrastructure checks.
+#
+# infrastructure_mode: full
+
 ## @param dd_url - string - optional - default: "https://app.datadoghq.com"
 ## @env DD_DD_URL - string - optional - default: "https://app.datadoghq.com"
 ## @env DD_URL - string - optional - default: "https://app.datadoghq.com"

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -40,7 +40,7 @@ api_key:
 ##   - end_user_device: tuned for end-user-device (EUDM) laptops and desktops.
 ##   - none: disables infrastructure checks.
 #
-# infrastructure_mode: full
+# infrastructure_mode: "full"
 
 ## @param dd_url - string - optional - default: "https://app.datadoghq.com"
 ## @env DD_DD_URL - string - optional - default: "https://app.datadoghq.com"

--- a/releasenotes/notes/macos-install-infrastructure-mode-7200bc49066b4367.yaml
+++ b/releasenotes/notes/macos-install-infrastructure-mode-7200bc49066b4367.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The macOS install script now accepts ``DD_INFRASTRUCTURE_MODE`` to set
+    the Agent's ``infrastructure_mode`` at install time.


### PR DESCRIPTION
### What does this PR do?

Lets the macOS install script accept `DD_INFRASTRUCTURE_MODE` and persist it to `datadog.yaml` via the existing staging-env/postinst plumbing.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-2630

### Describe how you validated your changes

`bash -n` on both modified shell scripts. Manual DMG install and verified config.

### Additional Notes

N/A.