### PR TITLE
[clusteragent/autoscaling/cluster] Set templateMetadata from new field in schema

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
@@ -53,6 +53,7 @@ func buildKarpenterNodePoolFromManifest(kv1 *KarpenterV1NodePool) *karpenterv1.N
 		log.Debugf("KarpenterV1NodePool %q has nil spec, skipping manifest path", kv1.Metadata.Name)
 		return nil
 	}
+
 	labels := make(map[string]string, len(kv1.Metadata.Labels))
 	for _, kv := range kv1.Metadata.Labels {
 		labels[kv.Key] = kv.Value
@@ -61,27 +62,24 @@ func buildKarpenterNodePoolFromManifest(kv1 *KarpenterV1NodePool) *karpenterv1.N
 	for _, kv := range kv1.Metadata.Annotations {
 		annotations[kv.Key] = kv.Value
 	}
-	// Merge top-level metadata into template metadata. Top-level acts as defaults;
-	// any keys already set in spec.Template.ObjectMeta take precedence.
+
+	// Handle template metadata labels/annotations
 	spec := *kv1.Spec
-	mergedTemplateLabels := make(map[string]string, len(labels))
-	for k, v := range labels {
-		mergedTemplateLabels[k] = v
+	if kv1.TemplateMetadata != nil {
+		templateLabels := make(map[string]string, len(kv1.TemplateMetadata.Labels))
+		for _, kv := range kv1.TemplateMetadata.Labels {
+			templateLabels[kv.Key] = kv.Value
+		}
+		templateAnnotations := make(map[string]string, len(kv1.TemplateMetadata.Annotations))
+		for _, kv := range kv1.TemplateMetadata.Annotations {
+			templateAnnotations[kv.Key] = kv.Value
+		}
+		spec.Template.ObjectMeta = karpenterv1.ObjectMeta{
+			Labels:      templateLabels,
+			Annotations: templateAnnotations,
+		}
 	}
-	for k, v := range spec.Template.ObjectMeta.Labels {
-		mergedTemplateLabels[k] = v
-	}
-	mergedTemplateAnnotations := make(map[string]string, len(annotations))
-	for k, v := range annotations {
-		mergedTemplateAnnotations[k] = v
-	}
-	for k, v := range spec.Template.ObjectMeta.Annotations {
-		mergedTemplateAnnotations[k] = v
-	}
-	spec.Template.ObjectMeta = karpenterv1.ObjectMeta{
-		Labels:      mergedTemplateLabels,
-		Annotations: mergedTemplateAnnotations,
-	}
+
 	return &karpenterv1.NodePool{
 		TypeMeta: metav1.TypeMeta{Kind: "NodePool", APIVersion: "karpenter.sh/v1"},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
@@ -55,8 +55,8 @@ func TestNewNodePoolInternal_KarpenterV1(t *testing.T) {
 	assert.Equal(t, map[string]string{"env": "prod"}, knp.Labels)
 	assert.Equal(t, map[string]string{"note": "managed"}, knp.Annotations)
 	assert.Equal(t, &weight, knp.Spec.Weight)
-	assert.Equal(t, map[string]string{"env": "prod"}, knp.Spec.Template.ObjectMeta.Labels)
-	assert.Equal(t, map[string]string{"note": "managed"}, knp.Spec.Template.ObjectMeta.Annotations)
+	assert.Empty(t, knp.Spec.Template.ObjectMeta.Labels)
+	assert.Empty(t, knp.Spec.Template.ObjectMeta.Annotations)
 }
 
 func TestNewNodePoolInternal_MissingManifest(t *testing.T) {
@@ -116,9 +116,32 @@ func TestBuildKarpenterNodePoolFromManifest(t *testing.T) {
 	assert.Equal(t, map[string]string{"foo": "bar"}, knp.Labels)
 	assert.Equal(t, map[string]string{"ann-key": "ann-val"}, knp.Annotations)
 	assert.Equal(t, &weight, knp.Spec.Weight)
-	assert.Equal(t, map[string]string{"foo": "bar"}, knp.Spec.Template.ObjectMeta.Labels)
-	assert.Equal(t, map[string]string{"ann-key": "ann-val"}, knp.Spec.Template.ObjectMeta.Annotations)
+	assert.Empty(t, knp.Spec.Template.ObjectMeta.Labels)
+	assert.Empty(t, knp.Spec.Template.ObjectMeta.Annotations)
 	assert.NotContains(t, knp.Labels, DatadogCreatedLabelKey)
+}
+
+func TestBuildKarpenterNodePoolFromManifest_WithTemplateMetadata(t *testing.T) {
+	kv1 := &KarpenterV1NodePool{
+		Metadata: Metadata{
+			Name:        "test-pool",
+			Labels:      Labels{{Key: "foo", Value: "bar"}},
+			Annotations: Annotations{{Key: "ann-key", Value: "ann-val"}},
+		},
+		TemplateMetadata: &Metadata{
+			Labels:      Labels{{Key: "node-label", Value: "node-val"}},
+			Annotations: Annotations{{Key: "node-ann", Value: "node-ann-val"}},
+		},
+		Spec: &karpenterv1.NodePoolSpec{},
+	}
+
+	knp := buildKarpenterNodePoolFromManifest(kv1)
+
+	require.NotNil(t, knp)
+	assert.Equal(t, map[string]string{"foo": "bar"}, knp.Labels)
+	assert.Equal(t, map[string]string{"ann-key": "ann-val"}, knp.Annotations)
+	assert.Equal(t, map[string]string{"node-label": "node-val"}, knp.Spec.Template.ObjectMeta.Labels)
+	assert.Equal(t, map[string]string{"node-ann": "node-ann-val"}, knp.Spec.Template.ObjectMeta.Annotations)
 }
 
 func TestBuildKarpenterNodePoolFromManifest_NilSpec(t *testing.T) {

--- a/pkg/clusteragent/autoscaling/cluster/model/rc_schema.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/rc_schema.go
@@ -60,15 +60,16 @@ type Manifest struct {
 }
 
 type KarpenterV1NodePool struct {
-	Metadata Metadata                  `json:"metadata"`
-	Spec     *karpenterv1.NodePoolSpec `json:"spec"`
+	Metadata         Metadata                  `json:"metadata"`
+	TemplateMetadata *Metadata                 `json:"template_metadata,omitempty"`
+	Spec             *karpenterv1.NodePoolSpec `json:"spec"`
 }
 
 type Labels []KeyValue
 type Annotations []KeyValue
 
 type Metadata struct {
-	Name        string      `json:"name"`
+	Name        string      `json:"name,omitempty"`
 	Labels      Labels      `json:"labels,omitempty"`
 	Annotations Annotations `json:"annotations,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?

Allow setting a NodePool's `spec.template.metadata` from a new field in the RC schema.

### Motivation

Previously, the template metadata was merged from the `Metadata` field that holds labels/annotations that should apply to the entire NodePool object. We would like to be able to control these separately so the backend can pass in different sets of labels/annotations that should be applied at the NodePool vs. node level

### Describe how you validated your changes

### Additional Notes
