### PR TITLE
[observer] Tag log-derived anomalies with AnomalyTypeLog

### DIFF
--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -699,12 +699,13 @@ func (tb *TestBench) rerunDetectorsLocked() {
 		tb.handleTelemetry([]observerdef.ObserverTelemetry{t}, detName, dataTime)
 	}
 
-	// Populate tb.logAnomalies from AnomalyTypeLog anomalies produced by detectors.
-	// These are distinct from metric anomalies and are served via /api/log-anomalies.
+	// Populate tb.logAnomalies: direct log anomalies (AnomalyTypeLog) and
+	// metric detector anomalies on log-derived series (isLogDerivedAnomaly),
+	// mirroring the live observer's notify.go classification logic.
 	tb.logAnomalies = []observerdef.Anomaly{}
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
 	for _, a := range result.anomalies {
-		if a.Type == observerdef.AnomalyTypeLog {
+		if a.Type == observerdef.AnomalyTypeLog || isLogDerivedAnomaly(a) {
 			tb.logAnomalies = append(tb.logAnomalies, a)
 			tb.logAnomaliesByDetector[a.DetectorName] = append(tb.logAnomaliesByDetector[a.DetectorName], a)
 		}


### PR DESCRIPTION
## Summary

The testbench's `GetLogAnomalies()` only matched anomalies with `AnomalyTypeLog`, so bocpd/scanmw/scanwelch detections on `log_pattern_extractor` and `log_metrics_extractor` series never appeared in `/api/log-anomalies` or `logAnomalyCount` — even though the live observer's `notify.go` already treats them as log anomalies via `isLogDerivedAnomaly()`.

Apply the same `|| isLogDerivedAnomaly(a)` pattern the live path uses, keeping testbench and live observer classification logic in sync. No changes to detectors or `AnomalyType` assignments.

## Changes

- `testbench.go`: extend log anomaly filter to include `isLogDerivedAnomaly(a)` alongside `AnomalyTypeLog`

## Test plan

- [x] Builds clean (`go build ./comp/observer/...`)
- [x] Loaded 221_base_kubelet parquet in testbench — `logAnomalyCount` went from 0 to 21, `/api/log-anomalies` returns bocpd detections on `log_pattern_extractor` series