### PR TITLE
fix(serverless-init): update azure container apps metric prefix to azure.app_containerapps

### DIFF
--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -52,9 +52,9 @@ const (
 	// ContainerAppOrigin origin tag value
 	ContainerAppOrigin = "containerapp"
 
-	containerAppPrefix             = "azure.app_containerapp."
-	containerAppShutdownMetricName = "azure.app_containerapp.enhanced.shutdown"
-	containerAppStartMetricName    = "azure.app_containerapp.enhanced.cold_start"
+	containerAppPrefix             = "azure.app_containerapps."
+	containerAppShutdownMetricName = "azure.app_containerapps.enhanced.shutdown"
+	containerAppStartMetricName    = "azure.app_containerapps.enhanced.cold_start"
 
 	containerAppLegacyShutdownMetricName = "azure.containerapp.enhanced.shutdown"
 	containerAppLegacyStartMetricName    = "azure.containerapp.enhanced.cold_start"


### PR DESCRIPTION
### What does this PR do?

Update the Azure Container Apps metric prefix from `azure.app_containerapp` to `azure.app_containerapps`.

### Motivation

Metric prefix should match that of the integration metrics in https://docs.datadoghq.com/integrations/azure-container-apps/.

### Describe how you validated your changes

Deployed to Azure Container App and verified metric metadata is picked up correctly.

<p align="center">
  <img width="40%" height="40%" alt="Screenshot 2026-04-22 at 4 00 55 PM" src="https://github.com/user-attachments/assets/73b04e74-a2d6-4ab0-81de-fb2f9f6e02fa" />
&nbsp; &nbsp; &nbsp; &nbsp;
  <img width="40%" height="40%" alt="Screenshot 2026-04-22 at 4 00 44 PM" src="https://github.com/user-attachments/assets/bf35eb4b-3be8-4621-8b9c-858612c78ef5" />
</p>

### Additional Notes

Follows https://github.com/DataDog/datadog-agent/pull/47421