### PR TITLE
Quality Gates: Adjust limits for trace agent socket activation by default

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 217 MiB
+  memory_allotment: 171 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -38,7 +38,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher
-      upper_bound: "181 MiB"
+      upper_bound: "143 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 660 MiB
+  memory_allotment: 594 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -64,7 +64,7 @@ checks:
       #
       # When updating this, update the memory_allotment in the target section to
       # 20% higher
-      upper_bound: "550 MiB"
+      upper_bound: "495 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 264 MiB
+  memory_allotment: 234 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -31,7 +31,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher
-      upper_bound: "220 MiB"
+      upper_bound: "195 MiB"
 
   - name: missed_bytes
     description: "Allowable bytes not polled by log Agent"

--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 570 MiB
+  memory_allotment: 516 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -33,7 +33,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher
-      upper_bound: 475 MiB
+      upper_bound: 430 MiB
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."


### PR DESCRIPTION
### What does this PR do?

Adjusts the limits for `quality_gate_idle`, `quality_gate_idle_all_features`, `quality_gate_logs`, and `quality_gate_metrics_logs`

### Motivation

Changes made [here](https://github.com/DataDog/datadog-agent/pull/49655) significantly reduce memory usage when traces are not being processed 

### Additional Notes

Quantile gates incoming soon which will require us to recalibrate these limits.
