### PR TITLE
macos: default WLAN request_location_permission to false

### DIFF
--- a/cmd/agent/dist/conf.d/wlan.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/wlan.d/conf.yaml.default
@@ -1,5 +1,14 @@
 ad_identifiers:
   - _end_user_device
 init_config:
+
+  ## @param request_location_permission - boolean - optional - default: false
+  ## On macOS, controls whether the Agent GUI prompts the user for Location
+  ## Services permission so the WLAN check can collect WiFi SSID/BSSID
+  ## metadata. Default is false (no prompt). Set to true to re-enable the
+  ## prompt.
+  #
+  # request_location_permission: false
+
 instances:
   - {}

--- a/cmd/agent/dist/conf.d/wlan.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/wlan.d/conf.yaml.example
@@ -4,5 +4,13 @@
 
 init_config:
 
+  ## @param request_location_permission - boolean - optional - default: false
+  ## On macOS, controls whether the Agent GUI prompts the user for Location
+  ## Services permission so the WLAN check can collect WiFi SSID/BSSID
+  ## metadata. Default is false (no prompt). Set to true to re-enable the
+  ## prompt.
+  #
+  # request_location_permission: false
+
 instances:
   - {}

--- a/comp/core/gui/guiimpl/systray/Sources/WiFiDataProvider.swift
+++ b/comp/core/gui/guiimpl/systray/Sources/WiFiDataProvider.swift
@@ -59,8 +59,8 @@ class WiFiDataProvider: NSObject, CLLocationManagerDelegate {
     /// Default when agent configcheck wlan fails (e.g. agent not running). Case 2: do not show prompt.
     private static let defaultRequestLocationPermissionWhenFetchFails = false
 
-    /// Default when configcheck succeeds but request_location_permission is missing or unparseable in WLAN config. Case 1: show prompt.
-    private static let defaultRequestLocationPermissionWhenMissing = true
+    /// Default when configcheck succeeds but request_location_permission is missing or unparseable in WLAN config. Case 1: do not show prompt (opt-in via WLAN conf.yaml).
+    private static let defaultRequestLocationPermissionWhenMissing = false
 
     /// Returns the path to the agent binary (uses DD_INSTALL_PATH from LaunchAgent plist or default).
     private static func agentBinaryPath() -> String {

--- a/releasenotes/notes/macos-wlan-default-no-location-prompt-da248f99d040f3e1.yaml
+++ b/releasenotes/notes/macos-wlan-default-no-location-prompt-da248f99d040f3e1.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    On macOS, the WLAN check's ``request_location_permission`` default is now
+    ``false`` when the flag is absent from ``conf.d/wlan.d/conf.yaml``. The
+    Agent GUI no longer prompts for Location Services permission by default.
+    To keep the previous behavior, set ``request_location_permission: true``
+    under ``init_config`` in ``/opt/datadog-agent/etc/conf.d/wlan.d/conf.yaml``.


### PR DESCRIPTION
### What does this PR do?

On macOS, flips the WLAN check default so the Agent GUI no longer prompts for Location Services permission when `request_location_permission` is absent from `conf.d/wlan.d/conf.yaml`. The prompt becomes opt-in.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-2631

### Describe how you validated your changes

Swift constant change + doc updates. End-to-end validation of DMG from pipeline.

### Additional Notes

Behavior change — release note under `upgrade:` calls this out. Operators who want prompts set `request_location_permission: true` under `init_config:` in `wlan.d/conf.yaml`.