### PR TITLE
USM: don't log warnings for binaries that are not Go

### DIFF
--- a/pkg/network/usm/ebpf_gotls_helpers.go
+++ b/pkg/network/usm/ebpf_gotls_helpers.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
+	"github.com/DataDog/datadog-agent/pkg/network/go/binversion"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls/lookup"
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
@@ -106,6 +107,9 @@ func (p *goTLSBinaryInspector) Inspect(fpath utils.FilePath, requestSets map[int
 	if err != nil {
 		if errors.Is(err, safeelf.ErrNoSymbols) {
 			p.binNoSymbolsMetric.Add(1)
+		}
+		if errors.Is(err, binversion.ErrNotGoExe) {
+			return map[int]*uprobes.InspectionResult{0: {Error: err}}, nil
 		}
 		return nil, fmt.Errorf("error extracting inspection data from %s: %w", path, err)
 	}


### PR DESCRIPTION
### What does this PR do?

Does not log errors reading the Go version from non-Go binaries. That is not an error.

### Motivation

Reduce log spam like the following:
```
could not attach to process 706: unexpected error: error inspecting /host/proc/706/root/usr/sbin/sshd: error extracting inspection data from /host/proc/706/root/usr/sbin/sshd: could not get Go toolchain version from ELF binary file: not a Go executable
```

### Describe how you validated your changes

### Additional Notes
