### PR TITLE
USM: don't log warnings if path already registered

### DIFF
--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -1104,7 +1104,7 @@ func (ua *UprobeAttacher) attachToLibrariesOfPID(pid uint32) error {
 
 		if err == nil {
 			successfulMatches = append(successfulMatches, libpath)
-		} else if !errors.Is(err, ErrNoMatchingRule) {
+		} else if !errors.Is(err, ErrNoMatchingRule) && !errors.Is(err, utils.ErrPathIsAlreadyRegistered) {
 			registerErrors = append(registerErrors, err)
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Does not treat `path is already registered` as a registration error, because it isn't.

### Motivation

Reduce log spam like the following:
```
could not attach to process 706: unexpected error: no rules matched for pid 706, errors: [path is already registered]
```

### Describe how you validated your changes

### Additional Notes
