### PR TITLE
Report backport failures on source PR

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Comment on backport failure
         if: steps.cherry-pick.outcome == 'failure'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}
           script: |

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -68,10 +68,47 @@ jobs:
 
       - name: Run cherry-pick script
         id: cherry-pick
+        continue-on-error: true
         env:
             GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
             GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: dda gh cherry-pick-pr --target-branch "${{ steps.target.outputs.target_branch }}"
+
+      - name: Comment on backport failure
+        if: steps.cherry-pick.outcome == 'failure'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.octo-sts.outputs.token }}
+          script: |
+            const targetBranch = `${{ steps.target.outputs.target_branch }}`;
+            const mergeCommitSHA = `${{ github.event.pull_request.merge_commit_sha }}`;
+            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const commentBody = `⚠️ Automatic backport to \`${targetBranch}\` failed.
+
+            This usually happens when the cherry-pick has merge conflicts and needs manual resolution.
+
+            To backport manually, run:
+            \`\`\`bash
+            git fetch
+            git worktree add .worktrees/backport-${targetBranch} ${targetBranch}
+            cd .worktrees/backport-${targetBranch}
+            git switch --create backport-${context.payload.pull_request.number}-to-${targetBranch}
+            git cherry-pick -x --mainline 1 ${mergeCommitSHA}
+            git push --set-upstream origin backport-${context.payload.pull_request.number}-to-${targetBranch}
+            \`\`\`
+
+            Workflow logs: ${runUrl}`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: commentBody,
+            });
+
+      - name: Fail workflow when cherry-pick failed
+        if: steps.cherry-pick.outcome == 'failure'
+        run: exit 1
 
       - name: Reset cherry-pick
         if: steps.cherry-pick.outputs.base != ''

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -77,12 +77,16 @@ jobs:
       - name: Comment on backport failure
         if: steps.cherry-pick.outcome == 'failure'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TARGET_BRANCH: ${{ steps.target.outputs.target_branch }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
-            const targetBranch = `${{ steps.target.outputs.target_branch }}`;
-            const mergeCommitSHA = `${{ github.event.pull_request.merge_commit_sha }}`;
-            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const targetBranch = process.env.TARGET_BRANCH;
+            const mergeCommitSHA = process.env.MERGE_COMMIT_SHA;
+            const runUrl = process.env.RUN_URL;
             const commentBody = `⚠️ Automatic backport to \`${targetBranch}\` failed.
 
             This usually happens when the cherry-pick has merge conflicts and needs manual resolution.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"213299c5-adfc-49d2-a7ba-7e2e4616659e","source":"chat","resourceId":"26a49399-2494-4361-8a23-6f353105fa93","workflowId":"590b635f-07ef-4ced-be28-ebb465bf693d","codeChangeId":"590b635f-07ef-4ced-be28-ebb465bf693d","sourceType":"slack"} -->
### What does this PR do?
Adds explicit failure feedback to the backport workflow when the cherry-pick step fails, by posting a comment on the original labeled PR with manual recovery commands and a link to the workflow run.

### Motivation
Backport failures caused by cherry-pick conflicts currently fail silently from the PR author’s perspective. This makes it unclear why no backport PR was created and increases manual triage time.
https://datadoghq.atlassian.net/browse/ACIX-1359

### Describe how you validated your changes
- Parsed `.github/workflows/backport-pr.yml` with Python/PyYAML to verify YAML validity after the workflow edits.
- Reviewed the resulting workflow logic to confirm:
  - `Run cherry-pick script` can fail without terminating immediately (`continue-on-error: true`)
  - A PR comment is posted when `steps.cherry-pick.outcome == 'failure'`
  - The job still ends in failure after commenting via an explicit `exit 1` step
  - Existing success path for creating backport PRs remains unchanged.

### Additional Notes
The failure comment is intentionally actionable and includes the target branch, merge commit SHA, and a direct link to the workflow logs to speed up manual backporting.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/26a49399-2494-4361-8a23-6f353105fa93)

Comment @datadog to request changes