### PR TITLE
Avoid github login during SQG test

### DIFF
--- a/tasks/unit_tests/static_quality_gates_tests.py
+++ b/tasks/unit_tests/static_quality_gates_tests.py
@@ -725,6 +725,7 @@ class TestQualityGatesIntegration(unittest.TestCase):
     @patch("tasks.static_quality_gates.gates.GateMetricHandler.generate_metric_reports", new=MagicMock())
     @patch("tasks.quality_gates.get_ancestor", return_value="ancestor-sha")
     @patch("tasks.quality_gates.get_commit_sha", return_value="current-sha")
+    @patch("tasks.quality_gates.get_pr_for_branch", new=MagicMock(return_value=None))
     @patch("tasks.quality_gates.identify_gates_exceeding_pr_threshold")
     def test_per_pr_threshold_skipped_on_merge_queue(self, mock_identify, _mock_commit, _mock_ancestor, *_):
         """Per-PR threshold check is not applied on merge queue branches."""


### PR DESCRIPTION
### What does this PR do?

Patch a function that accesses github during static quality gates test to avoid spurious login attempts.

### Motivation

I started to work on some changes to Static Quality Gates, tried to run the test suite, and saw that it opened a browser window to ask me to log in. There doesn't seem to be a good reason to actually talk to GitHub for this test so it's better not to do it.

### Describe how you validated your changes

Passing tests.

### Additional Notes
