### PR TITLE
[PROF-14264] Make Standalone emit OTel semantically correct `profiler_version` and `profiler_name`

### DIFF
--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -59,7 +59,7 @@ func buildExporters(conf confMap, agent configManager) []any {
 		}
 		// Required headers set after additional headers to prevent overrides
 		headers["dd-api-key"] = key
-		headers["dd-evp-origin"] = version.ProfilerName
+		headers["dd-evp-origin"] = version.BundledProfilerName
 		headers["dd-evp-origin-version"] = version.ProfilerVersion
 		return confMap{
 			"profiles_endpoint": fmt.Sprintf(profilesEndpointFormat, site),
@@ -110,12 +110,12 @@ func buildProcessors(conf confMap) []any {
 	metadata := confMap{
 		"attributes": []any{
 			confMap{
-				"key":    "profiler_name",
-				"value":  version.ProfilerName,
+				"key":    version.DDProfilerNameKey,
+				"value":  version.BundledProfilerName,
 				"action": "upsert",
 			},
 			confMap{
-				"key":    "profiler_version",
+				"key":    version.DDProfilerVersionKey,
 				"value":  version.ProfilerVersion,
 				"action": "upsert",
 			},

--- a/comp/host-profiler/collector/impl/agentprovider/provider_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/provider_test.go
@@ -61,7 +61,7 @@ func createTestFactories(t *testing.T) otelcol.Factories {
 	t.Helper()
 
 	receivers, err := otelcol.MakeFactoryMap(
-		receiver.NewFactory(),
+		receiver.NewFactory(version.BundledProfilerName),
 		otlpreceiver.NewFactory(),
 		prometheusreceiver.NewFactory(),
 	)

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
@@ -5,7 +5,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
             x-datadog-profiling-metadata: workspace:peterg17
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
@@ -30,7 +30,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
             x-custom-routing: some-value
             x-datadog-profiling-metadata: workspace:peterg17,env:staging
@@ -29,7 +29,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: eu_key_1
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
@@ -27,7 +27,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -27,7 +27,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -28,7 +28,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -30,7 +30,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-disabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-disabled/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -27,7 +27,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-enabled/otel.yaml
@@ -5,7 +5,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -29,7 +29,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: additional_api_key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -11,7 +11,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: main_api_key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -35,7 +35,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-custom/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-custom/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -27,7 +27,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-disabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-disabled/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -18,7 +18,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/hpflare-custom-port/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/hpflare-custom-port/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -27,7 +27,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -11,7 +11,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: us3_api_key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
@@ -35,7 +35,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
@@ -27,7 +27,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: main_key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -11,7 +11,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: eu_key_1
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
@@ -35,7 +35,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: main_key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -11,7 +11,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: eu_key_1
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
@@ -19,7 +19,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: eu_key_2
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
@@ -27,7 +27,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: eu_key_3
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
@@ -51,7 +51,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -27,7 +27,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_key_123
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
@@ -27,7 +27,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test_api_key_456
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
@@ -27,7 +27,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: host-profiler-bundled
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -367,7 +367,7 @@ func (c *converterWithoutAgent) ensureOtlpHTTPExporterConfig(conf confMap, expor
 			if !ensureKeyStringValue(headers, fieldDDAPIKey) {
 				return fmt.Errorf("%s exporter missing required dd-api-key header", name)
 			}
-			if _, err := SetDefault(headers, fieldDDEVPOrigin, version.ProfilerName); err != nil {
+			if _, err := SetDefault(headers, fieldDDEVPOrigin, version.StandaloneProfilerName); err != nil {
 				return err
 			}
 			if _, err := SetDefault(headers, fieldDDEVPOriginVersion, version.ProfilerVersion); err != nil {

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -260,12 +260,12 @@ func addProfilerMetadataTags(conf confMap, profilesProcessors []any) ([]any, err
 	}
 
 	profilerNameElement := confMap{
-		"key":    "profiler_name",
-		"value":  version.ProfilerName,
+		"key":    version.OTelProfilerNameKey,
+		"value":  version.StandaloneProfilerName,
 		"action": "upsert",
 	}
 	profilerVersionElement := confMap{
-		"key":    "profiler_version",
+		"key":    version.OTelProfilerVersionKey,
 		"value":  version.ProfilerVersion,
 		"action": "upsert",
 	}

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -234,6 +234,7 @@ func ensureKeyStringValue(config confMap, key string) bool {
 
 // addProfilerMetadataTags always creates a dedicated resource/profiler-metadata processor
 // without searching for existing resource processors.
+// This function emits OTel semantic convention tags and must only be called from the standalone (no-agent) path.
 func addProfilerMetadataTags(conf confMap, profilesProcessors []any) ([]any, error) {
 	const resourceProcessorName = "resource/dd-profiler-internal-metadata"
 

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: "12345"
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -5,17 +5,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-existing-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-existing-ep/out.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://custom.metrics.example.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -21,10 +21,10 @@ processors:
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-infer-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-infer-ep/out.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
@@ -21,10 +21,10 @@ processors:
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-level-none/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-level-none/out.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
@@ -11,10 +11,10 @@ processors:
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-mixed/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/int-metrics-mixed/out.yaml
@@ -3,13 +3,13 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key-2
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
     otlphttp/with-ep:
         compression: zstd
         headers:
             dd-api-key: test-api-key-1
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
@@ -27,10 +27,10 @@ processors:
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -4,23 +4,23 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: "11111"
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
     otlphttp/staging:
         compression: zstd
         headers:
             dd-api-key: staging-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-profiling-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-profiling-recv/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-evp-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-evp-headers/out.yaml
@@ -10,10 +10,10 @@ processors:
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     batch:
@@ -16,10 +16,10 @@ processors:
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
@@ -4,7 +4,7 @@ exporters:
         endpoint: http://localhost:4318
         headers:
             dd-api-key: test-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 extensions:
     custom:
@@ -18,10 +18,10 @@ processors:
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -3,7 +3,7 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     batch:
@@ -12,10 +12,10 @@ processors:
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -3,17 +3,17 @@ exporters:
         compression: zstd
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: host-profiler
+            dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
     ddhostname/default: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
-              key: profiler_name
-              value: host-profiler
+              key: telemetry.distro.name
+              value: host-profiler-standalone
             - action: upsert
-              key: profiler_version
+              key: telemetry.distro.version
               value: 7.0.0-test
     resourcedetection/default:
         detectors:

--- a/comp/host-profiler/collector/impl/otel_col_factories.go
+++ b/comp/host-profiler/collector/impl/otel_col_factories.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/extensions/hpflareextension"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/processor/ddhostnameprocessor"
 	profilesreceiver "github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/receiver"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
 	ddprofilingextensionimpl "github.com/DataDog/datadog-agent/comp/otelcol/ddprofilingextension/impl"
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/processor/infraattributesprocessor"
 	traceagent "github.com/DataDog/datadog-agent/comp/trace/agent/def"
@@ -54,6 +55,7 @@ type ExtraFactories interface {
 	GetExtensions() []extension.Factory
 	GetLoggingOptions() []zap.Option
 	GetAgentConfig() config.Component
+	GetProfilerName() string
 }
 
 // extraFactoriesWithAgentCore is a struct that implements the ExtraFactories interface when the Agent Core is available.
@@ -133,6 +135,11 @@ func (e extraFactoriesWithAgentCore) GetConverters() []confmap.ConverterFactory 
 	return []confmap.ConverterFactory{}
 }
 
+// GetProfilerName returns the name of the profiler when the Agent Core is available.
+func (e extraFactoriesWithAgentCore) GetProfilerName() string {
+	return version.BundledProfilerName
+}
+
 // extraFactoriesWithoutAgentCore is a struct that implements the ExtraFactories interface when the Agent Core is not available.
 type extraFactoriesWithoutAgentCore struct{}
 
@@ -184,10 +191,15 @@ func (e extraFactoriesWithoutAgentCore) GetConverters() []confmap.ConverterFacto
 	}
 }
 
+// GetProfilerName returns the name of the profiler when the Agent Core is not available.
+func (e extraFactoriesWithoutAgentCore) GetProfilerName() string {
+	return version.StandaloneProfilerName
+}
+
 // createFactories creates a function that returns the factories for the collector.
 func createFactories(extraFactories ExtraFactories) func() (otelcol.Factories, error) {
 	return func() (otelcol.Factories, error) {
-		receiverFactories := []receiver.Factory{profilesreceiver.NewFactory(), otlpreceiver.NewFactory(), prometheusreceiver.NewFactory()}
+		receiverFactories := []receiver.Factory{profilesreceiver.NewFactory(extraFactories.GetProfilerName()), otlpreceiver.NewFactory(), prometheusreceiver.NewFactory()}
 		receiverFactories = append(receiverFactories, extraFactories.GetReceivers()...)
 		receivers, err := otelcol.MakeFactoryMap(receiverFactories...)
 		if err != nil {

--- a/comp/host-profiler/collector/impl/otel_col_factories_test.go
+++ b/comp/host-profiler/collector/impl/otel_col_factories_test.go
@@ -10,6 +10,7 @@ package collectorimpl
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
@@ -42,4 +43,14 @@ func TestExtraFactoriesWithoutAgentCore_GetReceivers(t *testing.T) {
 func TestExtraFactoriesWithAgentCore_GetReceivers(t *testing.T) {
 	extra := extraFactoriesWithAgentCore{}
 	assert.Nil(t, extra.GetReceivers(), "agent core mode should not add extra receivers")
+}
+
+func TestExtraFactoriesWithoutAgentCore_GetProfilerName(t *testing.T) {
+	extraFactories := NewExtraFactoriesWithoutAgentCore()
+	assert.Equal(t, version.StandaloneProfilerName, extraFactories.GetProfilerName())
+}
+
+func TestExtraFactoriesWithAgentCore_GetProfilerName(t *testing.T) {
+	extraFactories := extraFactoriesWithAgentCore{}
+	assert.Equal(t, version.BundledProfilerName, extraFactories.GetProfilerName())
 }

--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -83,7 +83,7 @@ func (c *Config) Validate() error {
 }
 
 // This is the default config for the profiles receiver
-func defaultConfig() component.Config {
+func defaultConfig(profilerName string) component.Config {
 	cfg := ebpfcollector.NewFactory().CreateDefaultConfig().(*ebpfconfig.Config)
 	cfg.Tracers = getDefaultTracersString()
 	// 60s batches more samples per report, improving compression and reducing upload bandwidth
@@ -92,7 +92,7 @@ func defaultConfig() component.Config {
 	// With 60s intervals, 20% would mean ~12s variation, so we reduce to 5% (~3s).
 	cfg.ReporterJitter = 0.05
 
-	symbolUploaderConfig := symboluploader.DefaultSymbolUploaderConfig()
+	symbolUploaderConfig := symboluploader.DefaultSymbolUploaderConfig(profilerName)
 	return Config{
 		EbpfCollectorConfig: cfg,
 		SymbolUploader:      symbolUploaderConfig,

--- a/comp/host-profiler/collector/impl/receiver/config_test.go
+++ b/comp/host-profiler/collector/impl/receiver/config_test.go
@@ -17,14 +17,16 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 )
 
+const profilerName = "host-profiler"
+
 func TestReporterInterval(t *testing.T) {
-	config := defaultConfig()
+	config := defaultConfig(profilerName)
 	cfg := config.(Config)
 	require.Equal(t, 60*time.Second, cfg.EbpfCollectorConfig.ReporterInterval)
 }
 
 func TestTracers(t *testing.T) {
-	config := defaultConfig()
+	config := defaultConfig(profilerName)
 	cfg := config.(Config)
 
 	require.Greater(t, len(cfg.EbpfCollectorConfig.Tracers), 0)
@@ -42,7 +44,7 @@ func TestTracers(t *testing.T) {
 }
 
 func TestDefaultEnvVars(t *testing.T) {
-	config := defaultConfig()
+	config := defaultConfig(profilerName)
 	cfg := config.(Config)
 	cfg.SymbolUploader.Enabled = false
 	require.Equal(t, "", cfg.EbpfCollectorConfig.IncludeEnvVars)
@@ -52,7 +54,7 @@ func TestDefaultEnvVars(t *testing.T) {
 }
 
 func TestSymbolUploader(t *testing.T) {
-	config := defaultConfig()
+	config := defaultConfig(profilerName)
 	cfg := config.(Config)
 	cfg.SymbolUploader.Enabled = false
 	require.NoError(t, cfg.Validate())
@@ -77,7 +79,7 @@ func TestFlatConfigParsingIsAccepted(t *testing.T) {
 		},
 	}
 
-	cfg := defaultConfig().(Config)
+	cfg := defaultConfig(profilerName).(Config)
 	err := confmap.NewFromStringMap(input).Unmarshal(&cfg)
 	require.NoError(t, err)
 
@@ -99,7 +101,7 @@ func TestNestedConfigIsRejected(t *testing.T) {
 		},
 	}
 
-	cfg := defaultConfig().(Config)
+	cfg := defaultConfig(profilerName).(Config)
 	err := confmap.NewFromStringMap(input).Unmarshal(&cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ebpf_collector")

--- a/comp/host-profiler/collector/impl/receiver/factory.go
+++ b/comp/host-profiler/collector/impl/receiver/factory.go
@@ -19,10 +19,10 @@ import (
 )
 
 // NewFactory creates a factory for the receiver.
-func NewFactory() receiver.Factory {
+func NewFactory(profilerName string) receiver.Factory {
 	return xreceiver.NewFactory(
 		component.MustNewType("profiling"),
-		defaultConfig,
+		func() component.Config { return defaultConfig(profilerName) },
 		xreceiver.WithProfiles(createProfilesReceiver, component.StabilityLevelAlpha))
 }
 

--- a/comp/host-profiler/symboluploader/config.go
+++ b/comp/host-profiler/symboluploader/config.go
@@ -53,7 +53,7 @@ type SymbolUploaderConfig struct {
 	Name string `mapstructure:"-"`
 }
 
-func DefaultSymbolUploaderConfig() SymbolUploaderConfig {
+func DefaultSymbolUploaderConfig(profilerName string) SymbolUploaderConfig {
 	return SymbolUploaderConfig{
 		SymbolUploaderOptions: SymbolUploaderOptions{
 			Enabled:              DefaultUploadSymbols,
@@ -63,7 +63,7 @@ func DefaultSymbolUploaderConfig() SymbolUploaderConfig {
 			SymbolQueryInterval:  DefaultSymbolQueryInterval,
 			DryRun:               DefaultUploadSymbolsDryRun,
 		},
-		Name:    version.ProfilerName,
+		Name:    profilerName,
 		Version: version.ProfilerVersion,
 	}
 }

--- a/comp/host-profiler/version/version.go
+++ b/comp/host-profiler/version/version.go
@@ -8,6 +8,18 @@ package version
 
 import "github.com/DataDog/datadog-agent/pkg/version"
 
-const ProfilerName = "host-profiler"
+// Datadog semantic conventions (bundled mode).
+const (
+	BundledProfilerName  = "host-profiler-bundled"
+	DDProfilerNameKey    = "profiler_name"
+	DDProfilerVersionKey = "profiler_version"
+)
+
+// OpenTelemetry semantic conventions (standalone mode).
+const (
+	StandaloneProfilerName = "host-profiler-standalone"
+	OTelProfilerNameKey    = "telemetry.distro.name"
+	OTelProfilerVersionKey = "telemetry.distro.version"
+)
 
 var ProfilerVersion = version.AgentVersion


### PR DESCRIPTION
### What does this PR do?

emit OTel semantic tags (`telemetry.*`) instead of dd semantics in standalone mode

### Motivation

As agreed, now that semantic conversion is in place, we only want to send standard OTel semantic tags in standalone mode.

### Describe how you validated your changes

Tested both modes locally.
## bundled mode
<img width="1574" height="1752" alt="image" src="https://github.com/user-attachments/assets/9f374557-0207-4743-9a04-e7c82160cd2d" />

## standalone mode
<img width="1116" height="1946" alt="image" src="https://github.com/user-attachments/assets/33a33c44-f56a-4b1d-a8ee-0b3fbe5107d5" />

### Additional Notes
