### PR TITLE
fix(collector): recover from check panics

### DIFF
--- a/pkg/collector/worker/worker.go
+++ b/pkg/collector/worker/worker.go
@@ -191,8 +191,18 @@ func (w *Worker) Run(ctx context.Context) {
 
 		utilizationTracker.Started()
 
-		// Run the check
-		checkErr := check.Run()
+		// Run the check, recovering from any panic so that a single
+		// misbehaving check cannot crash the entire agent process.
+		var checkErr error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					checkErr = fmt.Errorf("check panicked: %v", r)
+					log.Errorf("Recovered from panic in check %s: %v", check, r)
+				}
+			}()
+			checkErr = check.Run()
+		}()
 
 		utilizationTracker.Finished()
 

--- a/pkg/collector/worker/worker_test.go
+++ b/pkg/collector/worker/worker_test.go
@@ -44,6 +44,7 @@ type testCheck struct {
 	sync.Mutex
 	doErr       bool
 	doWarn      bool
+	doPanic     bool
 	id          string
 	longRunning bool
 	t           *testing.T
@@ -80,6 +81,10 @@ func (c *testCheck) Run() error {
 
 	c.Lock()
 	defer c.Unlock()
+
+	if c.doPanic {
+		panic("simulated third-party library panic")
+	}
 
 	if c.doErr {
 		return errors.New("myerror")
@@ -880,4 +885,70 @@ func TestWorkerWatchdogWarningLog(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWorkerRecoverFromCheckPanic(t *testing.T) {
+	mockConfig := configmock.New(t)
+	expvars.Reset()
+	mockConfig.SetWithoutSource("hostname", "myhost")
+
+	var wg sync.WaitGroup
+
+	checksTracker := tracker.NewRunningChecksTracker()
+	pendingChecksChan := make(chan check.Check, 10)
+	mockShouldAddStatsFunc := func(checkid.ID) bool { return true }
+
+	panicCheck := &testCheck{
+		doPanic:  true,
+		id:       "panicking_check:123",
+		t:        t,
+		runCount: atomic.NewUint64(0),
+	}
+	normalCheck := newCheck(t, "normal_check:456", false, nil)
+	errorCheck := newCheck(t, "error_check:789", true, nil)
+
+	// Schedule: panic, normal, panic again, error, normal
+	// The worker must survive the panics and run all checks.
+	pendingChecksChan <- panicCheck
+	pendingChecksChan <- normalCheck
+	pendingChecksChan <- panicCheck
+	pendingChecksChan <- errorCheck
+	pendingChecksChan <- normalCheck
+	close(pendingChecksChan)
+
+	worker, err := NewWorker(
+		aggregator.NewNoOpSenderManager(),
+		haagentmock.NewMockHaAgent(),
+		healthplatformmock.Mock(t),
+		100, 200,
+		pendingChecksChan,
+		checksTracker,
+		mockShouldAddStatsFunc,
+		0,
+	)
+	require.NoError(t, err)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		worker.Run(context.Background())
+	}()
+
+	wg.Wait()
+
+	// All checks ran despite the panics
+	assert.Equal(t, 2, panicCheck.RunCount(), "panicking check should have run twice")
+	assert.Equal(t, 2, normalCheck.RunCount(), "normal check should have run twice")
+	assert.Equal(t, 1, errorCheck.RunCount(), "error check should have run once")
+
+	// Panics count as errors
+	assertErrorCount(t, panicCheck, 2)
+	assertErrorCount(t, errorCheck, 1)
+	assertErrorCount(t, normalCheck, 0)
+
+	// Total: 5 runs, 3 errors (2 panics + 1 doErr)
+	assert.Equal(t, 5, int(expvars.GetRunsCount()))
+	assert.Equal(t, 3, int(expvars.GetErrorsCount()))
+
+	AssertAsyncWorkerCount(t, 0)
 }


### PR DESCRIPTION
### What does this PR do?

A panicking check can kill the entire agent process because Worker.Run had no recover.
This PR wraps `check.Run()` with defer/recover so panics are converted into check errors.
The agent logs the panic, marks the check as CRITICAL, and continues running other checks.

### Motivation

A check (or its 3rd party dependencies) that panic can cause the agent to crash.

### Describe how you validated your changes

Added a regression test.
I need to do a full build and deploy of the agent.

### Additional Notes

The `pkg/collector/corechecks/cluster/orchestrator/processors/processor.go` and `pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster.go` core check already have a recover. But no other ones, which leaves other checks to be able to crash the agent.
