### PR TITLE
Improve SQG GitHub auth errors

### DIFF
--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -517,7 +517,10 @@ class GithubAPI:
         if not running_in_ci():
             return Auth.Token(generate_local_github_token(Context()))
         if "GITHUB_TOKEN" in os.environ:
-            return Auth.Token(os.environ["GITHUB_TOKEN"])
+            token = os.environ["GITHUB_TOKEN"]
+            if not token:
+                raise RuntimeError("GITHUB_TOKEN is set but empty, dd-octo-sts may not be installed or failed to run")
+            return Auth.Token(token)
         if public_repo:
             return Auth.Login("user", "password")
 

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -272,7 +272,7 @@ def get_pr_for_branch(branch: str):
         prs = list(github.get_pr_for_branch(branch))
         return prs[0] if prs else None
     except Exception as e:
-        print(color_message(f"[WARN] Failed to get PR for branch {branch}: {e}", "orange"))
+        print(color_message(f"[WARN] Failed to get PR for branch {branch}: {type(e).__name__}: {e}", "orange"))
         return None
 
 


### PR DESCRIPTION
### What does this PR do?

Improve github auth error handling:
* Avoid displaying an empty error string (at the very least, include the error class name)
* Treat an empty token as a missing one

### Motivation

Avoid vague errors such as `[WARN] Failed to get PR for branch maxime/embed-schema: `

### Describe how you validated your changes

### Additional Notes
