### PR TITLE
[OTAGENT-863] register deprecated logs_config.experimental_auto_multi_line_detection key to suppress spurious warn log

### DIFF
--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1799,6 +1799,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.windows_open_file_timeout", 5)
 
 	// Auto multiline detection settings
+	config.BindEnvAndSetDefault("logs_config.experimental_auto_multi_line_detection", false) // deprecated alias, kept to suppress "unknown key" warnings
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection", false)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection_custom_samples", []map[string]interface{}{})
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.enable_json_detection", true)

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1799,8 +1799,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.windows_open_file_timeout", 5)
 
 	// Auto multiline detection settings
-	config.BindEnvAndSetDefault("logs_config.experimental_auto_multi_line_detection", false) // deprecated alias, kept to suppress "unknown key" warnings
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection", false)
+	config.BindEnvAndSetDefault("logs_config.experimental_auto_multi_line_detection", false) // deprecated alias for logs_config.auto_multi_line_detection
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection_custom_samples", []map[string]interface{}{})
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.enable_json_detection", true)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.enable_datetime_detection", true)


### PR DESCRIPTION
### What does this PR do?

Registers `logs_config.experimental_auto_multi_line_detection` as a known config key with a default of `false` in `common_settings.go`.

### Motivation

`AutoMultiLineStatus` unconditionally calls `coreConfig.GetBool("logs_config.experimental_auto_multi_line_detection")`. Both config backends (`nodetreemodel` and `viperconfig`) call `checkKnownKey` on every `GetBool` invocation, and emit a `WARN` when the key has no registered default or env binding. Since this deprecated key was never registered, the warning fires once per agent process for **all customers**, regardless of whether they ever used the experimental flag:

```
WARN | (comp/logs/agent/config/integration_config.go) | config key "logs_config.experimental_auto_multi_line_detection" is unknown
```

Registering the key with `BindEnvAndSetDefault(..., false)` makes it known to the config system — `checkKnownKey` no longer warns. The existing deprecation warning inside `AutoMultiLineStatus` still fires correctly if a user actually enables the flag.

### Describe how you validated your changes

- All 174 tests in `comp/logs/agent/config/` pass (`dda inv test --targets=./comp/logs/agent/config/`).

### Additional Notes

Needs backport to 7.76 per the Jira ticket.