### PR TITLE
Quality Gates: Adjust quality_gate_idle memory limit

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 171 MiB
+  memory_allotment: 176 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -38,7 +38,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher
-      upper_bound: "143 MiB"
+      upper_bound: "147 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
### What does this PR do?

Correct limit adjustment from yesterday

### Motivation

The heuristic we have used to set new limits (1% of the max observed + 1) starts to fall over as the magnitude of the max observed values decreases. Adjusting to a flat 5% buffer gives more room for variance.

### Additional Notes

In the future we need to do a better job of setting limits based on the observed variance of the agent. Quantile gates will help enable this.
