### PR TITLE
CI: switch to our linux image for SQG jobs

### DIFF
--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -14,7 +14,7 @@ static_quality_gates:
     - when: manual
       allow_failure: true
   extends: .dd_octo_sts
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   needs:
     - agent_deb-x64-a7


### PR DESCRIPTION
### What does this PR do?

Switch the SQG job to the "regular" linux build images

### Motivation

The job requires GitHub authentication, which requires dd-octo-sts, but that tool currently isn't installed in the docker_x64 image.

### Describe how you validated your changes

### Additional Notes
