### PR TITLE
[e2e] Add per-agent coverage required override

### DIFF
--- a/test/e2e-framework/testing/e2e/suite.go
+++ b/test/e2e-framework/testing/e2e/suite.go
@@ -807,6 +807,10 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 // If a test is explicitly restarting the agent the coverage should be saved first otherwise the counters are reset after restart.
 func (bs *BaseSuite[Env]) SaveCoverage(coverageDir string) error {
 	if coverageEnv, ok := any(bs.env).(common.Coverageable); ok {
+		// Apply coverage required override if set
+		if overrideable, ok := any(bs.env).(common.CoverageRequiredOverrideable); ok {
+			overrideable.SetCoverageRequiredOverride(bs.params.coverageRequired)
+		}
 		// Create coverage folder if it doesn't exist
 		rootTestName := strings.ToLower(strings.Split(bs.T().Name(), "/")[0])
 		coverageFolder := filepath.Join(coverageDir, rootTestName)

--- a/test/e2e-framework/testing/e2e/suite_params.go
+++ b/test/e2e-framework/testing/e2e/suite_params.go
@@ -24,6 +24,10 @@ type suiteParams struct {
 
 	disableCoverage bool
 
+	// coverageRequired holds per-agent overrides for the Required field of coverage targets.
+	// Keys are agent names (e.g. "datadog-agent", "trace-agent"). When nil, the defaults from the environment are used.
+	coverageRequired map[string]bool
+
 	provisioners provisioners.ProvisionerMap
 }
 
@@ -84,5 +88,14 @@ func WithPulumiProvisioner[Env any](runFunc provisioners.PulumiEnvRunFunc[Env], 
 func WithSkipCoverage() SuiteOption {
 	return func(options *suiteParams) {
 		options.disableCoverage = true
+	}
+}
+
+// WithCoverageRequired overrides the default Required field for the given coverage targets.
+// Each key must match a CoverageTargetSpec.AgentName (e.g. "datadog-agent", "trace-agent").
+// Targets not listed keep their environment default.
+func WithCoverageRequired(overrides map[string]bool) SuiteOption {
+	return func(options *suiteParams) {
+		options.coverageRequired = overrides
 	}
 }

--- a/test/e2e-framework/testing/environments/coverage.go
+++ b/test/e2e-framework/testing/environments/coverage.go
@@ -15,6 +15,30 @@ type CoverageTargetSpec struct {
 	Required        bool
 }
 
+// CoverageBase provides shared coverage override logic. Embed it in any environment
+// that implements Coverageable so the override setter and application come for free.
+type CoverageBase struct {
+	// requiredOverrides holds per-agent overrides keyed by AgentName.
+	// A nil map means "use defaults for everything".
+	requiredOverrides map[string]bool
+}
+
+// SetCoverageRequiredOverride records per-agent overrides for the Required field.
+// Each key must match a CoverageTargetSpec.AgentName. Passing a nil map clears all overrides.
+func (c *CoverageBase) SetCoverageRequiredOverride(overrides map[string]bool) {
+	c.requiredOverrides = overrides
+}
+
+// applyCoverageOverrides mutates targets in place, replacing Required for any
+// agent whose name appears in the override map.
+func (c *CoverageBase) applyCoverageOverrides(targets []CoverageTargetSpec) {
+	for i := range targets {
+		if required, ok := c.requiredOverrides[targets[i].AgentName]; ok {
+			targets[i].Required = required
+		}
+	}
+}
+
 func updateErrorOutput(target CoverageTargetSpec, outStr []string, errs []error, errorMessage string) ([]string, []error) {
 	outStr = append(outStr, fmt.Sprintf("[WARN] %s: %s", target.AgentName, errorMessage))
 	if target.Required {

--- a/test/e2e-framework/testing/environments/dockerhost.go
+++ b/test/e2e-framework/testing/environments/dockerhost.go
@@ -24,6 +24,7 @@ import (
 
 // DockerHost is an environment that contains a Docker VM, FakeIntake and Agent configured to talk to each other.
 type DockerHost struct {
+	CoverageBase
 	// Components
 	RemoteHost *components.RemoteHost
 	FakeIntake *components.FakeIntake
@@ -130,7 +131,7 @@ func (e *DockerHost) Coverage(outputDir string) (string, error) {
 
 // getAgentCoverageCommands returns the coverage commands for each agent component
 func (e *DockerHost) getAgentCoverageCommands() []CoverageTargetSpec {
-	return []CoverageTargetSpec{
+	targets := []CoverageTargetSpec{
 		{
 			AgentName:       "agent",
 			CoverageCommand: []string{"agent", "coverage", "generate"},
@@ -157,6 +158,8 @@ func (e *DockerHost) getAgentCoverageCommands() []CoverageTargetSpec {
 			Required:        false,
 		},
 	}
+	e.applyCoverageOverrides(targets)
+	return targets
 }
 
 func (e *DockerHost) generateAndDownloadCoverageForContainer(outputDir string) (string, error) {

--- a/test/e2e-framework/testing/environments/host.go
+++ b/test/e2e-framework/testing/environments/host.go
@@ -27,6 +27,7 @@ import (
 
 // Host is an environment that contains a Host, FakeIntake and Agent configured to talk to each other.
 type Host struct {
+	CoverageBase
 	RemoteHost *components.RemoteHost
 	FakeIntake *components.FakeIntake
 	Agent      *components.RemoteHostAgent
@@ -161,9 +162,10 @@ func generateAndDownloadAgentFlare(agent *components.RemoteHostAgent, host *comp
 }
 
 func (e *Host) getAgentCoverageCommands(family os.Family) ([]CoverageTargetSpec, error) {
+	var targets []CoverageTargetSpec
 	switch family {
 	case os.LinuxFamily:
-		return []CoverageTargetSpec{{
+		targets = []CoverageTargetSpec{{
 			AgentName:       "datadog-agent",
 			CoverageCommand: []string{"sudo", "datadog-agent", "coverage", "generate"},
 			Required:        true,
@@ -183,10 +185,10 @@ func (e *Host) getAgentCoverageCommands(family os.Family) ([]CoverageTargetSpec,
 			AgentName:       "system-probe",
 			CoverageCommand: []string{"sudo", "/opt/datadog-agent/embedded/bin/system-probe", "coverage", "generate"},
 			Required:        false,
-		}}, nil
+		}}
 	case os.WindowsFamily:
 		installPath := client.DefaultWindowsAgentInstallPath(e.RemoteHost.Host)
-		return []CoverageTargetSpec{{
+		targets = []CoverageTargetSpec{{
 			AgentName:       "datadog-agent",
 			CoverageCommand: []string{fmt.Sprintf(`& "%s\bin\agent.exe" "coverage" "generate"`, installPath)},
 			Required:        true,
@@ -206,9 +208,12 @@ func (e *Host) getAgentCoverageCommands(family os.Family) ([]CoverageTargetSpec,
 			AgentName:       "system-probe",
 			CoverageCommand: []string{fmt.Sprintf(`& "%s\bin\agent\system-probe.exe" "coverage" "generate"`, installPath)},
 			Required:        false,
-		}}, nil
+		}}
+	default:
+		return nil, fmt.Errorf("unsupported OS family: %v", family)
 	}
-	return nil, fmt.Errorf("unsupported OS family: %v", family)
+	e.applyCoverageOverrides(targets)
+	return targets, nil
 }
 
 // Coverage runs the coverage command for each agent and downloads the coverage folders to the output directory

--- a/test/e2e-framework/testing/environments/kubernetes.go
+++ b/test/e2e-framework/testing/environments/kubernetes.go
@@ -27,6 +27,7 @@ import (
 
 // Kubernetes is an environment that contains a Kubernetes cluster, the Agent and a FakeIntake.
 type Kubernetes struct {
+	CoverageBase
 	// Components
 	KubernetesCluster *components.KubernetesCluster
 	FakeIntake        *components.FakeIntake
@@ -188,8 +189,10 @@ const (
 
 // Should return the coverage commands for each pod and each container
 func (e *Kubernetes) getAgentCoverageCommands(podType podType) []CoverageTargetSpec {
-	if podType == podTypeWindows {
-		return []CoverageTargetSpec{
+	var targets []CoverageTargetSpec
+	switch podType {
+	case podTypeWindows:
+		targets = []CoverageTargetSpec{
 			{
 				AgentName:       "agent",
 				CoverageCommand: []string{"agent.exe", "coverage", "generate"},
@@ -221,47 +224,50 @@ func (e *Kubernetes) getAgentCoverageCommands(podType podType) []CoverageTargetS
 				Required:        false,
 			},
 		}
-	} else if podType == podTypeClusterAgent {
-		return []CoverageTargetSpec{
+	case podTypeClusterAgent:
+		targets = []CoverageTargetSpec{
 			{
 				AgentName:       "cluster-agent",
 				CoverageCommand: []string{"datadog-cluster-agent", "coverage", "generate"},
 				Required:        true,
 			},
 		}
+	default:
+		targets = []CoverageTargetSpec{
+			{
+				AgentName:       "agent",
+				CoverageCommand: []string{"agent", "coverage", "generate"},
+				Required:        true,
+			},
+			{
+				AgentName:       "trace-agent",
+				CoverageCommand: []string{"trace-agent", "coverage", "generate", "-c", "/etc/datadog-agent/datadog.yaml"},
+				Required:        false,
+			},
+			{
+				AgentName:       "process-agent",
+				CoverageCommand: []string{"process-agent", "coverage", "generate"},
+				Required:        false,
+			},
+			{
+				AgentName:       "security-agent",
+				CoverageCommand: []string{"security-agent", "coverage", "generate"},
+				Required:        false,
+			},
+			{
+				AgentName:       "system-probe",
+				CoverageCommand: []string{"system-probe", "coverage", "generate"},
+				Required:        false,
+			},
+			{
+				AgentName:       "otel-agent",
+				CoverageCommand: []string{"otel-agent", "coverage"},
+				Required:        false,
+			},
+		}
 	}
-	return []CoverageTargetSpec{
-		{
-			AgentName:       "agent",
-			CoverageCommand: []string{"agent", "coverage", "generate"},
-			Required:        true,
-		},
-		{
-			AgentName:       "trace-agent",
-			CoverageCommand: []string{"trace-agent", "coverage", "generate", "-c", "/etc/datadog-agent/datadog.yaml"},
-			Required:        false,
-		},
-		{
-			AgentName:       "process-agent",
-			CoverageCommand: []string{"process-agent", "coverage", "generate"},
-			Required:        false,
-		},
-		{
-			AgentName:       "security-agent",
-			CoverageCommand: []string{"security-agent", "coverage", "generate"},
-			Required:        false,
-		},
-		{
-			AgentName:       "system-probe",
-			CoverageCommand: []string{"system-probe", "coverage", "generate"},
-			Required:        false,
-		},
-		{
-			AgentName:       "otel-agent",
-			CoverageCommand: []string{"otel-agent", "coverage"},
-			Required:        false,
-		},
-	}
+	e.applyCoverageOverrides(targets)
+	return targets
 }
 
 // Coverage generates a coverage report for each pod and container

--- a/test/e2e-framework/testing/utils/common/types.go
+++ b/test/e2e-framework/testing/utils/common/types.go
@@ -29,3 +29,9 @@ type Diagnosable interface {
 type Coverageable interface {
 	Coverage(outputDir string) (string, error)
 }
+
+// CoverageRequiredOverrideable defines an optional interface for environments that support overriding
+// the default coverage required setting per agent. Each key in the map must match a CoverageTargetSpec.AgentName.
+type CoverageRequiredOverrideable interface {
+	SetCoverageRequiredOverride(overrides map[string]bool)
+}

--- a/test/new-e2e/tests/otel/otel-agent/dogtel_standalone_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/dogtel_standalone_test.go
@@ -88,6 +88,10 @@ func TestDogtelStandalone(t *testing.T) {
 	t.Parallel()
 	e2e.Run(t, &dogtelStandaloneTestSuite{},
 		e2e.WithProvisioner(dogtelStandaloneProvisioner()),
+		e2e.WithCoverageRequired(map[string]bool{
+			"agent":      false,
+			"otel-agent": true,
+		}),
 	)
 }
 


### PR DESCRIPTION
## Summary
- Add `CoverageBase` struct embedded in all coverageable environments (`Host`, `DockerHost`, `Kubernetes`) to provide shared per-agent coverage required override logic
- Add `WithCoverageRequired(map[string]bool)` suite option so individual tests can override which agent coverage targets are required
- Use it in `TestDogtelStandalone` to require only `otel-agent` coverage

## Test plan
- [ ] Verify `TestDogtelStandalone` runs with only `otel-agent` coverage required
- [ ] Verify other tests using coverage are unaffected (defaults preserved when no override is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)