### PR TITLE
secl/model: fix and expand Linux constants

### DIFF
--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -5879,7 +5879,9 @@ MMap flags are the supported flags for the mmap syscall.
 | `MAP_ANON` | all |
 | `MAP_ANONYMOUS` | all |
 | `MAP_DENYWRITE` | all |
+| `MAP_DROPPABLE` | all |
 | `MAP_EXECUTABLE` | all |
+| `MAP_FILE` | all |
 | `MAP_FIXED` | all |
 | `MAP_FIXED_NOREPLACE` | all |
 | `MAP_GROWSDOWN` | all |
@@ -5959,6 +5961,7 @@ Network Address Family constants are the supported network address families.
 | `AF_QIPCRTR` | all |
 | `AF_SMC` | all |
 | `AF_XDP` | all |
+| `AF_MCTP` | all |
 | `AF_MAX` | all |
 
 ### `Network Protocol Types` {#network-protocol-types}
@@ -6012,7 +6015,9 @@ Open flags are the supported flags for the open syscall.
 | `O_NOCTTY` | all |
 | `O_NOFOLLOW` | all |
 | `O_NONBLOCK` | all |
+| `O_PATH` | all |
 | `O_RSYNC` | all |
+| `O_TMPFILE` | all |
 
 ### `Pipe buffer flags` {#pipe-buffer-flags}
 Pipe buffer flags are the supported flags for a pipe buffer.
@@ -6062,6 +6067,8 @@ PrCtl Options are the supported options for the prctl event
 | `PR_SET_NO_NEW_PRIVS` | all |
 | `PR_GET_NO_NEW_PRIVS` | all |
 | `PR_PAC_RESET_KEYS` | all |
+| `PR_PAC_GET_ENABLED_KEYS` | all |
+| `PR_PAC_SET_ENABLED_KEYS` | all |
 | `PR_SET_PDEATHSIG` | all |
 | `PR_GET_PDEATHSIG` | all |
 | `PR_SET_PTRACER` | all |
@@ -6069,10 +6076,13 @@ PrCtl Options are the supported options for the prctl event
 | `PR_GET_SECCOMP` | all |
 | `PR_SET_SECUREBITS` | all |
 | `PR_GET_SECUREBITS` | all |
+| `PR_SCHED_CORE` | all |
 | `PR_GET_SPECULATION_CTRL` | all |
 | `PR_SET_SPECULATION_CTRL` | all |
 | `PR_SVE_SET_VL` | all |
 | `PR_SVE_GET_VL` | all |
+| `PR_SME_SET_VL` | all |
+| `PR_SME_GET_VL` | all |
 | `PR_SET_SYSCALL_USER_DISPATCH` | all |
 | `PR_SET_TAGGED_ADDR_CTRL` | all |
 | `PR_GET_TAGGED_ADDR_CTRL` | all |
@@ -6085,6 +6095,7 @@ PrCtl Options are the supported options for the prctl event
 | `PR_GET_TIMERSLACK` | all |
 | `PR_SET_TIMING` | all |
 | `PR_GET_TIMING` | all |
+| `PR_TIMER_CREATE_RESTORE_IDS` | all |
 | `PR_SET_TSC` | all |
 | `PR_GET_TSC` | all |
 | `PR_SET_UNALIGN` | all |
@@ -6092,6 +6103,16 @@ PrCtl Options are the supported options for the prctl event
 | `PR_GET_AUXV` | all |
 | `PR_SET_MDWE` | all |
 | `PR_GET_MDWE` | all |
+| `PR_SET_MEMORY_MERGE` | all |
+| `PR_GET_MEMORY_MERGE` | all |
+| `PR_SET_SHADOW_STACK_STATUS` | all |
+| `PR_GET_SHADOW_STACK_STATUS` | all |
+| `PR_LOCK_SHADOW_STACK_STATUS` | all |
+| `PR_FUTEX_HASH` | all |
+| `PR_PPC_GET_DEXCR` | all |
+| `PR_PPC_SET_DEXCR` | all |
+| `PR_RISCV_V_GET_CONTROL` | all |
+| `PR_RISCV_V_SET_CONTROL` | all |
 | `PR_RISCV_SET_ICACHE_FLUSH_CTX` | all |
 
 ### `Protection constants` {#protection-constants}
@@ -6124,6 +6145,8 @@ Ptrace constants are the supported ptrace commands for the ptrace syscall.
 | `PTRACE_ATTACH` | all |
 | `PTRACE_DETACH` | all |
 | `PTRACE_SYSCALL` | all |
+| `PTRACE_GETREGS` | all |
+| `PTRACE_SETREGS` | all |
 | `PTRACE_SETOPTIONS` | all |
 | `PTRACE_GETEVENTMSG` | all |
 | `PTRACE_GETSIGINFO` | all |
@@ -6139,6 +6162,10 @@ Ptrace constants are the supported ptrace commands for the ptrace syscall.
 | `PTRACE_SECCOMP_GET_FILTER` | all |
 | `PTRACE_SECCOMP_GET_METADATA` | all |
 | `PTRACE_GET_SYSCALL_INFO` | all |
+| `PTRACE_SET_SYSCALL_INFO` | all |
+| `PTRACE_GET_RSEQ_CONFIGURATION` | all |
+| `PTRACE_GET_SYSCALL_USER_DISPATCH_CONFIG` | all |
+| `PTRACE_SET_SYSCALL_USER_DISPATCH_CONFIG` | all |
 | `PTRACE_GETFPREGS` | amd64, arm |
 | `PTRACE_SETFPREGS` | amd64, arm |
 | `PTRACE_GETFPXREGS` | amd64 |

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -20350,7 +20350,15 @@
           "architecture": "all"
         },
         {
+          "name": "MAP_DROPPABLE",
+          "architecture": "all"
+        },
+        {
           "name": "MAP_EXECUTABLE",
+          "architecture": "all"
+        },
+        {
+          "name": "MAP_FILE",
           "architecture": "all"
         },
         {
@@ -20653,6 +20661,10 @@
           "architecture": "all"
         },
         {
+          "name": "AF_MCTP",
+          "architecture": "all"
+        },
+        {
           "name": "AF_MAX",
           "architecture": "all"
         }
@@ -20814,7 +20826,15 @@
           "architecture": "all"
         },
         {
+          "name": "O_PATH",
+          "architecture": "all"
+        },
+        {
           "name": "O_RSYNC",
+          "architecture": "all"
+        },
+        {
+          "name": "O_TMPFILE",
           "architecture": "all"
         }
       ]
@@ -20980,6 +21000,14 @@
           "architecture": "all"
         },
         {
+          "name": "PR_PAC_GET_ENABLED_KEYS",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_PAC_SET_ENABLED_KEYS",
+          "architecture": "all"
+        },
+        {
           "name": "PR_SET_PDEATHSIG",
           "architecture": "all"
         },
@@ -21008,6 +21036,10 @@
           "architecture": "all"
         },
         {
+          "name": "PR_SCHED_CORE",
+          "architecture": "all"
+        },
+        {
           "name": "PR_GET_SPECULATION_CTRL",
           "architecture": "all"
         },
@@ -21021,6 +21053,14 @@
         },
         {
           "name": "PR_SVE_GET_VL",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_SME_SET_VL",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_SME_GET_VL",
           "architecture": "all"
         },
         {
@@ -21072,6 +21112,10 @@
           "architecture": "all"
         },
         {
+          "name": "PR_TIMER_CREATE_RESTORE_IDS",
+          "architecture": "all"
+        },
+        {
           "name": "PR_SET_TSC",
           "architecture": "all"
         },
@@ -21097,6 +21141,46 @@
         },
         {
           "name": "PR_GET_MDWE",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_SET_MEMORY_MERGE",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_GET_MEMORY_MERGE",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_SET_SHADOW_STACK_STATUS",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_GET_SHADOW_STACK_STATUS",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_LOCK_SHADOW_STACK_STATUS",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_FUTEX_HASH",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_PPC_GET_DEXCR",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_PPC_SET_DEXCR",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_RISCV_V_GET_CONTROL",
+          "architecture": "all"
+        },
+        {
+          "name": "PR_RISCV_V_SET_CONTROL",
           "architecture": "all"
         },
         {
@@ -21194,6 +21278,14 @@
           "architecture": "all"
         },
         {
+          "name": "PTRACE_GETREGS",
+          "architecture": "all"
+        },
+        {
+          "name": "PTRACE_SETREGS",
+          "architecture": "all"
+        },
+        {
           "name": "PTRACE_SETOPTIONS",
           "architecture": "all"
         },
@@ -21251,6 +21343,22 @@
         },
         {
           "name": "PTRACE_GET_SYSCALL_INFO",
+          "architecture": "all"
+        },
+        {
+          "name": "PTRACE_SET_SYSCALL_INFO",
+          "architecture": "all"
+        },
+        {
+          "name": "PTRACE_GET_RSEQ_CONFIGURATION",
+          "architecture": "all"
+        },
+        {
+          "name": "PTRACE_GET_SYSCALL_USER_DISPATCH_CONFIG",
+          "architecture": "all"
+        },
+        {
+          "name": "PTRACE_SET_SYSCALL_USER_DISPATCH_CONFIG",
           "architecture": "all"
         },
         {

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -185,7 +185,9 @@ var (
 		"O_NOCTTY":   syscall.O_NOCTTY,
 		"O_NOFOLLOW": syscall.O_NOFOLLOW,
 		"O_NONBLOCK": syscall.O_NONBLOCK,
+		"O_PATH":     unix.O_PATH,
 		"O_RSYNC":    syscall.O_RSYNC,
+		"O_TMPFILE":  unix.O_TMPFILE,
 	}
 
 	// fileModeConstants contains the constants describing file permissions as well as the set-user-ID, set-group-ID, and sticky bits.
@@ -302,21 +304,27 @@ var (
 		"PTRACE_DETACH":     unix.PTRACE_DETACH,
 		"PTRACE_SYSCALL":    unix.PTRACE_SYSCALL,
 
-		"PTRACE_SETOPTIONS":           unix.PTRACE_SETOPTIONS,
-		"PTRACE_GETEVENTMSG":          unix.PTRACE_GETEVENTMSG,
-		"PTRACE_GETSIGINFO":           unix.PTRACE_GETSIGINFO,
-		"PTRACE_SETSIGINFO":           unix.PTRACE_SETSIGINFO,
-		"PTRACE_GETREGSET":            unix.PTRACE_GETREGSET,
-		"PTRACE_SETREGSET":            unix.PTRACE_SETREGSET,
-		"PTRACE_SEIZE":                unix.PTRACE_SEIZE,
-		"PTRACE_INTERRUPT":            unix.PTRACE_INTERRUPT,
-		"PTRACE_LISTEN":               unix.PTRACE_LISTEN,
-		"PTRACE_PEEKSIGINFO":          unix.PTRACE_PEEKSIGINFO,
-		"PTRACE_GETSIGMASK":           unix.PTRACE_GETSIGMASK,
-		"PTRACE_SETSIGMASK":           unix.PTRACE_SETSIGMASK,
-		"PTRACE_SECCOMP_GET_FILTER":   unix.PTRACE_SECCOMP_GET_FILTER,
-		"PTRACE_SECCOMP_GET_METADATA": unix.PTRACE_SECCOMP_GET_METADATA,
-		"PTRACE_GET_SYSCALL_INFO":     unix.PTRACE_GET_SYSCALL_INFO,
+		"PTRACE_GETREGS":                          unix.PTRACE_GETREGS,
+		"PTRACE_SETREGS":                          unix.PTRACE_SETREGS,
+		"PTRACE_SETOPTIONS":                       unix.PTRACE_SETOPTIONS,
+		"PTRACE_GETEVENTMSG":                      unix.PTRACE_GETEVENTMSG,
+		"PTRACE_GETSIGINFO":                       unix.PTRACE_GETSIGINFO,
+		"PTRACE_SETSIGINFO":                       unix.PTRACE_SETSIGINFO,
+		"PTRACE_GETREGSET":                        unix.PTRACE_GETREGSET,
+		"PTRACE_SETREGSET":                        unix.PTRACE_SETREGSET,
+		"PTRACE_SEIZE":                            unix.PTRACE_SEIZE,
+		"PTRACE_INTERRUPT":                        unix.PTRACE_INTERRUPT,
+		"PTRACE_LISTEN":                           unix.PTRACE_LISTEN,
+		"PTRACE_PEEKSIGINFO":                      unix.PTRACE_PEEKSIGINFO,
+		"PTRACE_GETSIGMASK":                       unix.PTRACE_GETSIGMASK,
+		"PTRACE_SETSIGMASK":                       unix.PTRACE_SETSIGMASK,
+		"PTRACE_SECCOMP_GET_FILTER":               unix.PTRACE_SECCOMP_GET_FILTER,
+		"PTRACE_SECCOMP_GET_METADATA":             unix.PTRACE_SECCOMP_GET_METADATA,
+		"PTRACE_GET_SYSCALL_INFO":                 unix.PTRACE_GET_SYSCALL_INFO,
+		"PTRACE_SET_SYSCALL_INFO":                 unix.PTRACE_SET_SYSCALL_INFO,
+		"PTRACE_GET_RSEQ_CONFIGURATION":           unix.PTRACE_GET_RSEQ_CONFIGURATION,
+		"PTRACE_GET_SYSCALL_USER_DISPATCH_CONFIG": unix.PTRACE_GET_SYSCALL_USER_DISPATCH_CONFIG,
+		"PTRACE_SET_SYSCALL_USER_DISPATCH_CONFIG": unix.PTRACE_SET_SYSCALL_USER_DISPATCH_CONFIG,
 	}
 
 	// protConstants are the supported protections for the mmap syscall
@@ -339,7 +347,9 @@ var (
 		"MAP_ANON":            unix.MAP_ANON,
 		"MAP_ANONYMOUS":       unix.MAP_ANONYMOUS,       /* don't use a file */
 		"MAP_DENYWRITE":       unix.MAP_DENYWRITE,       /* ETXTBSY */
+		"MAP_DROPPABLE":       unix.MAP_DROPPABLE,       /* pages can be dropped under memory pressure */
 		"MAP_EXECUTABLE":      unix.MAP_EXECUTABLE,      /* mark it as an executable */
+		"MAP_FILE":            unix.MAP_FILE,            /* compatibility flag, mapped to 0 */
 		"MAP_FIXED":           unix.MAP_FIXED,           /* Interpret addr exactly */
 		"MAP_FIXED_NOREPLACE": unix.MAP_FIXED_NOREPLACE, /* MAP_FIXED which doesn't unmap underlying mapping */
 		"MAP_GROWSDOWN":       unix.MAP_GROWSDOWN,       /* stack-like segment */
@@ -461,6 +471,7 @@ var (
 		"AF_QIPCRTR":    unix.AF_QIPCRTR,
 		"AF_SMC":        unix.AF_SMC,
 		"AF_XDP":        unix.AF_XDP,
+		"AF_MCTP":       unix.AF_MCTP,
 		"AF_MAX":        unix.AF_MAX,
 	}
 
@@ -1166,6 +1177,8 @@ var (
 		"PR_SET_NO_NEW_PRIVS":           unix.PR_SET_NO_NEW_PRIVS,
 		"PR_GET_NO_NEW_PRIVS":           unix.PR_GET_NO_NEW_PRIVS,
 		"PR_PAC_RESET_KEYS":             unix.PR_PAC_RESET_KEYS,
+		"PR_PAC_GET_ENABLED_KEYS":       unix.PR_PAC_GET_ENABLED_KEYS,
+		"PR_PAC_SET_ENABLED_KEYS":       unix.PR_PAC_SET_ENABLED_KEYS,
 		"PR_SET_PDEATHSIG":              unix.PR_SET_PDEATHSIG,
 		"PR_GET_PDEATHSIG":              unix.PR_GET_PDEATHSIG,
 		"PR_SET_PTRACER":                unix.PR_SET_PTRACER,
@@ -1173,10 +1186,13 @@ var (
 		"PR_GET_SECCOMP":                unix.PR_GET_SECCOMP,
 		"PR_SET_SECUREBITS":             unix.PR_SET_SECUREBITS,
 		"PR_GET_SECUREBITS":             unix.PR_GET_SECUREBITS,
+		"PR_SCHED_CORE":                 unix.PR_SCHED_CORE,
 		"PR_GET_SPECULATION_CTRL":       unix.PR_GET_SPECULATION_CTRL,
 		"PR_SET_SPECULATION_CTRL":       unix.PR_SET_SPECULATION_CTRL,
 		"PR_SVE_SET_VL":                 unix.PR_SVE_SET_VL,
 		"PR_SVE_GET_VL":                 unix.PR_SVE_GET_VL,
+		"PR_SME_SET_VL":                 unix.PR_SME_SET_VL,
+		"PR_SME_GET_VL":                 unix.PR_SME_GET_VL,
 		"PR_SET_SYSCALL_USER_DISPATCH":  unix.PR_SET_SYSCALL_USER_DISPATCH,
 		"PR_SET_TAGGED_ADDR_CTRL":       unix.PR_SET_TAGGED_ADDR_CTRL,
 		"PR_GET_TAGGED_ADDR_CTRL":       unix.PR_GET_TAGGED_ADDR_CTRL,
@@ -1189,6 +1205,7 @@ var (
 		"PR_GET_TIMERSLACK":             unix.PR_GET_TIMERSLACK,
 		"PR_SET_TIMING":                 unix.PR_SET_TIMING,
 		"PR_GET_TIMING":                 unix.PR_GET_TIMING,
+		"PR_TIMER_CREATE_RESTORE_IDS":   unix.PR_TIMER_CREATE_RESTORE_IDS,
 		"PR_SET_TSC":                    unix.PR_SET_TSC,
 		"PR_GET_TSC":                    unix.PR_GET_TSC,
 		"PR_SET_UNALIGN":                unix.PR_SET_UNALIGN,
@@ -1196,6 +1213,16 @@ var (
 		"PR_GET_AUXV":                   unix.PR_GET_AUXV,
 		"PR_SET_MDWE":                   unix.PR_SET_MDWE,
 		"PR_GET_MDWE":                   unix.PR_GET_MDWE,
+		"PR_SET_MEMORY_MERGE":           unix.PR_SET_MEMORY_MERGE,
+		"PR_GET_MEMORY_MERGE":           unix.PR_GET_MEMORY_MERGE,
+		"PR_SET_SHADOW_STACK_STATUS":    unix.PR_SET_SHADOW_STACK_STATUS,
+		"PR_GET_SHADOW_STACK_STATUS":    unix.PR_GET_SHADOW_STACK_STATUS,
+		"PR_LOCK_SHADOW_STACK_STATUS":   unix.PR_LOCK_SHADOW_STACK_STATUS,
+		"PR_FUTEX_HASH":                 unix.PR_FUTEX_HASH,
+		"PR_PPC_GET_DEXCR":              unix.PR_PPC_GET_DEXCR,
+		"PR_PPC_SET_DEXCR":              unix.PR_PPC_SET_DEXCR,
+		"PR_RISCV_V_GET_CONTROL":        unix.PR_RISCV_V_GET_CONTROL,
+		"PR_RISCV_V_SET_CONTROL":        unix.PR_RISCV_V_SET_CONTROL,
 		"PR_RISCV_SET_ICACHE_FLUSH_CTX": unix.PR_RISCV_SET_ICACHE_FLUSH_CTX,
 	}
 )

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -62,7 +62,7 @@ var (
 		"EHOSTDOWN":       -int(syscall.EHOSTDOWN),
 		"EHOSTUNREACH":    -int(syscall.EHOSTUNREACH),
 		"EIDRM":           -int(syscall.EIDRM),
-		"EILSEQ":          -int(syscall.EIDRM),
+		"EILSEQ":          -int(syscall.EILSEQ),
 		"EINPROGRESS":     -int(syscall.EINPROGRESS),
 		"EINTR":           -int(syscall.EINTR),
 		"EINVAL":          -int(syscall.EINVAL),

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -1136,7 +1136,7 @@ var (
 	// PrCtlOptionConstants is the list of available options for prctl events
 	// generate_constants:PrCtl Options,PrCtl Options are the supported options for the prctl event
 	PrCtlOptionConstants = map[string]int{
-		"PR_CAP_AMBIENT":                unix.PR_CAPBSET_READ,
+		"PR_CAP_AMBIENT":                unix.PR_CAP_AMBIENT,
 		"PR_CAPBSET_READ":               unix.PR_CAPBSET_READ,
 		"PR_CAPBSET_DROP":               unix.PR_CAPBSET_DROP,
 		"PR_SET_CHILD_SUBREAPER":        unix.PR_SET_CHILD_SUBREAPER,


### PR DESCRIPTION
### What does this PR do?

Fixes two bugs in the SECL constant maps and backfills missing Linux constants in `pkg/security/secl/model/consts_linux.go` so SECL rules can match on them.

### Motivation

The `ptraceConstants` map was missing common commands — including `PTRACE_SETREGS` / `PTRACE_GETREGS` — which meant rules referencing those operations could never fire. Several other constant maps (prctl options, open flags, mmap flags, address families) had also fallen behind the current `golang.org/x/sys/unix` package and the Linux kernel UAPI.

On top of that, two copy-paste bugs caused constants to resolve to the wrong kernel value:
- `PR_CAP_AMBIENT` was mapped to `unix.PR_CAPBSET_READ` (0x17) instead of `unix.PR_CAP_AMBIENT` (0x2f), so a rule intending to match ambient-capability prctls matched capability bounding-set reads.
- `EILSEQ` was mapped to `syscall.EIDRM` instead of `syscall.EILSEQ`, so a rule intending to match illegal byte sequence errors matched "identifier removed" errors.

The fix is split into three commits:
1. Fix the `PR_CAP_AMBIENT` misassignment.
2. Add the missing ptrace / prctl / open / mmap / address-family constants.
3. Fix the `EILSEQ` misassignment.

### Describe how you validated your changes

- `dda inv test --targets=./pkg/security/secl/model/...` — all tests pass
- `dda inv linter.go --targets=./pkg/security/secl/model/...` — clean
- Audited for duplicate keys and duplicate values within each map to confirm no other copy-paste bugs remain.

### Additional Notes

New constants only exist when `golang.org/x/sys/unix` exposes them at the common-linux level, so they compile across all supported Linux architectures.