### PR TITLE
pkg/dyninst: fix duplicate @return keys at multi-return line probes

### DIFF
--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -791,7 +791,11 @@ func analyzeAllProbes(
 				}
 			}
 
-			// Pre-scan: collect return variables and compute display names.
+			// Pre-scan: collect return variables and compute display names for
+			// return events. @return is a return-point concept, so these are
+			// only used when the probe has a Return event; at line probes,
+			// named returns are treated as locals and unnamed returns are
+			// filtered out (see the switch below).
 			var returnVars []*ir.Variable
 			if haveReturn {
 				for _, v := range inst.Subprogram.Variables {
@@ -828,6 +832,16 @@ func analyzeAllProbes(
 				case len(inst.Events) == 1 &&
 					inst.Events[0].Kind == ir.EventKindLine:
 					// The line-probe case.
+					//
+					// Return-role vars are either filtered out (unnamed,
+					// e.g. ~r0) or treated as plain locals (named). The
+					// function hasn't returned yet, so they aren't "return
+					// values" here; unnamed slots have no user-facing value
+					// and named returns are just pre-declared locals.
+					if v.Role == ir.VariableRoleReturn &&
+						strings.HasPrefix(v.Name, "~") {
+						continue
+					}
 					ips := inst.Events[0].InjectionPoints
 					if !variableIsAvailable(ips, v) {
 						continue
@@ -847,9 +861,12 @@ func analyzeAllProbes(
 				// Capture expression probes only capture explicitly listed
 				// expressions (handled below), not all variables.
 				if isSnapshot && !isCaptureExpression {
-					// Compute the display name for this expression.
+					// Compute the display name for this expression. The
+					// @return wrapping is only for return events; at line
+					// probes named returns keep their original name (see
+					// switch above).
 					name := v.Name
-					if v.Role == ir.VariableRoleReturn {
+					if exprKind == ir.RootExpressionKindReturn {
 						if returnDisplayNames == nil {
 							name = "@return"
 						} else {
@@ -902,8 +919,10 @@ func analyzeAllProbes(
 				delete(segmentRefs, v.Name)
 			}
 
-			// Handle @return references in template segments.
-			if segs, ok := segmentRefs["@return"]; ok && len(returnVars) > 0 {
+			// Handle @return references in template segments. @return is
+			// a return-point concept and only resolves at probes with a
+			// Return event.
+			if segs, ok := segmentRefs["@return"]; ok && haveReturn {
 				for _, seg := range segs {
 					rv, rewritten, errMsg := resolveReturnExpr(
 						seg.segment.JSON, returnVars, returnDisplayNames,
@@ -941,7 +960,7 @@ func analyzeAllProbes(
 				}
 				// Handle @return references in capture expressions.
 				var rootVar *ir.Variable
-				if rootVarName == "@return" && len(returnVars) > 0 {
+				if rootVarName == "@return" && haveReturn {
 					rootVar, parsedExpr, _ = resolveReturnExpr(
 						parsedExpr, returnVars, returnDisplayNames,
 					)
@@ -1047,7 +1066,7 @@ func analyzeAllProbes(
 					}
 				}
 				var rootVar *ir.Variable
-				if rootVarName == "@return" && len(returnVars) > 0 {
+				if rootVarName == "@return" && haveReturn {
 					var errMsg string
 					rootVar, condExpr, errMsg = resolveReturnExpr(
 						condExpr, returnVars, returnDisplayNames,

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -9,15 +9,15 @@ Probes:
       segments: [stackC]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 144}
+        - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1398 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xd0c6aa", Frameless: false}]
+              Type: 1399 EventRootType Probe[main.stackC]
+              InjectionPoints: [{PC: "0xd0c9aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1399 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xd0c6e5", Frameless: false}]
+              Type: 1400 EventRootType Probe[main.stackC]Return
+              InjectionPoints: [{PC: "0xd0c9e5", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -80,15 +80,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 124}
+        - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1369 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xd0b0ce", Frameless: false}]
+              Type: 1370 EventRootType Probe[main.testArrayArgAndReturn]
+              InjectionPoints: [{PC: "0xd0b3ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1370 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0b182", Frameless: false}]
+              Type: 1371 EventRootType Probe[main.testArrayArgAndReturn]Return
+              InjectionPoints: [{PC: "0xd0b482", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -338,15 +338,15 @@ Probes:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1417 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xd0cae0", Frameless: true}]
+              Type: 1418 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0xd0cde0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1418 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xd0cb02", Frameless: true}]
+              Type: 1419 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0xd0ce02", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1478 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1479 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xd0666e"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1479 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1480 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xd0666e"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 185, index: 0, name: x}
+                      Variable: {subprogram: 186, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -433,10 +433,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1480 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1481 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xd0666e"
                   Frameless: false
@@ -515,16 +515,16 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 158}
+        - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1425 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xd0cc00", Frameless: true}]
+              Type: 1426 EventRootType Probe[main.testTenStrings]
+              InjectionPoints: [{PC: "0xd0cf00", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 158, index: 0, name: x}
+                      Variable: {subprogram: 159, index: 0, name: x}
                       Offset: 144
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -789,11 +789,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 133}
+        - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1386 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xd0c1c0", Frameless: true}]
+              Type: 1387 EventRootType Probe[main.testEmptySlice]
+              InjectionPoints: [{PC: "0xd0c4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -816,11 +816,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 136}
+        - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1389 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xd0c220", Frameless: true}]
+              Type: 1390 EventRootType Probe[main.testEmptySliceOfStructs]
+              InjectionPoints: [{PC: "0xd0c520", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -844,11 +844,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 152}
+        - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1412 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xd0c7e0", Frameless: true}]
+              Type: 1413 EventRootType Probe[main.testEmptyString]
+              InjectionPoints: [{PC: "0xd0cae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -866,11 +866,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 159}
+        - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1426 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xd0cc60", Frameless: true}]
+              Type: 1427 EventRootType Probe[main.testEmptyStruct]
+              InjectionPoints: [{PC: "0xd0cf60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -887,11 +887,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 160}
+        - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1427 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xd0cc80", Frameless: true}]
+              Type: 1428 EventRootType Probe[main.testEmptyStructPointer]
+              InjectionPoints: [{PC: "0xd0cf80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1100,15 +1100,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1464 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xd0f880", Frameless: true}]
+              Type: 1465 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0xd0fb80", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1465 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd0f887", Frameless: true}]
+              Type: 1466 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xd0fb87", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1118,15 +1118,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1466 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xd0f8a4", Frameless: false}]
+              Type: 1467 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0xd0fba4", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1467 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xd0f8f1", Frameless: false}]
+              Type: 1468 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0xd0fbf1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1145,15 +1145,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1460 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xd0f7ea", Frameless: false}]
+              Type: 1461 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0xd0faea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1461 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xd0f7f9", Frameless: false}]
+              Type: 1462 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0xd0faf9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1163,15 +1163,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1462 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xd0f82a", Frameless: false}]
+              Type: 1463 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0xd0fb2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1463 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xd0f842", Frameless: false}]
+              Type: 1464 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0xd0fb42", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1190,18 +1190,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1468 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xd0f900", Frameless: true}]
+              Type: 1469 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0xd0fc00", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1469 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1470 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xd0f920"
+                - PC: "0xd0fc20"
                   Frameless: true
-                - PC: "0xd0f923"
+                - PC: "0xd0fc23"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1212,18 +1212,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1470 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xd0f94a", Frameless: false}]
+              Type: 1471 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0xd0fc4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1471 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1472 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xd0f9ab"
+                - PC: "0xd0fcab"
                   Frameless: false
-                - PC: "0xd0f9b3"
+                - PC: "0xd0fcb3"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1246,11 +1246,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Line
-              Type: 1472 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xd0f905", Frameless: true}]
+              Type: 1473 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0xd0fc05", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1258,11 +1258,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Line
-              Type: 1473 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xd0f95f", Frameless: false}]
+              Type: 1474 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0xd0fc5f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1279,15 +1279,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1448 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xd0f4a0", Frameless: true}]
+              Type: 1449 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0xd0f7a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1449 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xd0f4b0", Frameless: true}]
+              Type: 1450 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0xd0f7b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1297,15 +1297,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1450 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xd0f540", Frameless: true}]
+              Type: 1451 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0xd0f840", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1451 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xd0f548", Frameless: true}]
+              Type: 1452 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0xd0f848", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1325,15 +1325,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 166}
           events:
             - Kind: Entry
-              Type: 1436 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xd0f02e", Frameless: false}]
+              Type: 1437 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0xd0f32e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1437 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd0f114", Frameless: false}]
+              Type: 1438 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xd0f414", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1343,14 +1343,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1438 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1439 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x51ebce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1439 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1440 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x51ecbc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1371,15 +1371,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 167}
           events:
             - Kind: Entry
-              Type: 1440 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd0f16a", Frameless: false}]
+              Type: 1441 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xd0f46a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1441 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd0f179", Frameless: false}]
+              Type: 1442 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xd0f479", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1398,15 +1398,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1474 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xd0fa00", Frameless: true}]
+              Type: 1475 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0xd0fd00", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1475 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xd0fa06", Frameless: true}]
+              Type: 1476 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0xd0fd06", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1416,15 +1416,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1476 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xd0fa8a", Frameless: false}]
+              Type: 1477 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0xd0fd8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1477 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xd0faad", Frameless: false}]
+              Type: 1478 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0xd0fdad", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1443,15 +1443,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 163}
+        - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1432 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xd0ef80", Frameless: true}]
+              Type: 1433 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0xd0f280", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1433 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd0ef83", Frameless: true}]
+              Type: 1434 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xd0f283", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1461,15 +1461,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 164}
+        - subprogram: {subprogram: 165}
           events:
             - Kind: Entry
-              Type: 1434 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xd0efa0", Frameless: true}]
+              Type: 1435 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0xd0f2a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1435 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd0efab", Frameless: true}]
+              Type: 1436 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xd0f2ab", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1488,15 +1488,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1452 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xd0f600", Frameless: true}]
+              Type: 1453 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0xd0f900", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1453 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xd0f607", Frameless: true}]
+              Type: 1454 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0xd0f907", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1506,15 +1506,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1454 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xd0f6aa", Frameless: false}]
+              Type: 1455 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0xd0f9aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1455 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xd0f6d6", Frameless: false}]
+              Type: 1456 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0xd0f9d6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1533,33 +1533,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
-          events:
-            - Kind: Entry
-              Type: 1442 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xd0f440", Frameless: true}]
-              Condition: null
-            - Kind: Return
-              Type: 1443 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd0f443", Frameless: true}]
-              Condition: null
-          probeTemplate:
-            TemplateString: p={p}
-            Segments:
-                - p=
-                - JSON: {Ref: p}
-                  DSL: p
-                  EventKind: Entry
-                  EventExpressionIndex: 0
         - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1444 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xd0f460", Frameless: true}]
+              Type: 1443 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xd0f740", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1445 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xd0f463", Frameless: true}]
+              Type: 1444 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xd0f743", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1572,12 +1554,30 @@ Probes:
         - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1446 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xd0f480", Frameless: true}]
+              Type: 1445 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0xd0f760", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1447 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xd0f483", Frameless: true}]
+              Type: 1446 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0xd0f763", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: p={p}
+            Segments:
+                - p=
+                - JSON: {Ref: p}
+                  DSL: p
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+        - subprogram: {subprogram: 170}
+          events:
+            - Kind: Entry
+              Type: 1447 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0xd0f780", Frameless: true}]
+              Condition: null
+            - Kind: Return
+              Type: 1448 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0xd0f783", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1596,15 +1596,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1456 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xd0f7a0", Frameless: true}]
+              Type: 1457 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0xd0faa0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1457 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xd0f7a7", Frameless: true}]
+              Type: 1458 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0xd0faa7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1614,15 +1614,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1458 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xd0f7c0", Frameless: true}]
+              Type: 1459 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xd0fac0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1459 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd0f7ce", Frameless: true}]
+              Type: 1460 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xd0face", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1641,15 +1641,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 161}
+        - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1428 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xd0ef40", Frameless: true}]
+              Type: 1429 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0xd0f240", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1429 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xd0ef43", Frameless: true}]
+              Type: 1430 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xd0f243", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1659,15 +1659,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 162}
+        - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1430 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xd0ef60", Frameless: true}]
+              Type: 1431 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0xd0f260", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1431 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xd0ef6b", Frameless: true}]
+              Type: 1432 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xd0f26b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1774,10 +1774,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1484 EventRootType Probe[main.testInlinedBBB]
+              Type: 1485 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0xd06906", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1814,10 +1814,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1485 EventRootType Probe[main.testInlinedBCA]
+              Type: 1486 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0xd06a13", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1835,10 +1835,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1486 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1487 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0xd06a13", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1853,10 +1853,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1487 EventRootType Probe[main.testInlinedBCB]
+              Type: 1488 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0xd06ac6", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1874,10 +1874,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Line
-              Type: 1488 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1489 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0xd06ac6", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1892,10 +1892,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1494 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1495 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x51e6d2"
                   Frameless: true
@@ -1915,10 +1915,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1481 EventRootType Probe[main.testInlinedPrint]
+              Type: 1482 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0xd0666a"
                   Frameless: false
@@ -1932,7 +1932,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1482 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1483 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0xd066aa", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1954,10 +1954,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1483 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1484 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xd0666e"
                   Frameless: false
@@ -1986,10 +1986,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1489 EventRootType Probe[main.testInlinedSq]
+              Type: 1490 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0xd06b21", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2011,10 +2011,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Line
-              Type: 1490 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1491 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0xd06b21", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2034,10 +2034,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1491 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1492 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0xd06b65"
                   Frameless: false
@@ -2191,15 +2191,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 123}
+        - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1367 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xd0af4e", Frameless: false}]
+              Type: 1368 EventRootType Probe[main.testLargeArgAndReturn]
+              InjectionPoints: [{PC: "0xd0b24e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1368 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0b093", Frameless: false}]
+              Type: 1369 EventRootType Probe[main.testLargeArgAndReturn]Return
+              InjectionPoints: [{PC: "0xd0b393", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2329,15 +2329,15 @@ Probes:
           dsl: i
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 126}
+        - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1373 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xd0b3f3", Frameless: false}]
+              Type: 1374 EventRootType Probe[main.testManyArgsArrayReturn]
+              InjectionPoints: [{PC: "0xd0b6f3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1374 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xd0b602", Frameless: false}]
+              Type: 1375 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              InjectionPoints: [{PC: "0xd0b902", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2841,11 +2841,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1409 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xd0c7a0", Frameless: true}]
+              Type: 1410 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0xd0caa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2864,11 +2864,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1410 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xd0c7a0", Frameless: true}]
+              Type: 1411 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0xd0caa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2911,15 +2911,15 @@ Probes:
           dsl: s
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 127}
+        - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1375 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xd0b693", Frameless: false}]
+              Type: 1376 EventRootType Probe[main.testMixedArgsStackReturn]
+              InjectionPoints: [{PC: "0xd0b993", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1376 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xd0b8cb", Frameless: false}]
+              Type: 1377 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              InjectionPoints: [{PC: "0xd0bbcb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2981,15 +2981,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 129}
+        - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1379 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xd0ba0e", Frameless: false}]
+              Type: 1380 EventRootType Probe[main.testMultipleArrayArgs]
+              InjectionPoints: [{PC: "0xd0bd0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1380 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xd0bad6", Frameless: false}]
+              Type: 1381 EventRootType Probe[main.testMultipleArrayArgs]Return
+              InjectionPoints: [{PC: "0xd0bdd6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3016,15 +3016,15 @@ Probes:
           dsl: s2
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 125}
+        - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1371 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xd0b1ae", Frameless: false}]
+              Type: 1372 EventRootType Probe[main.testMultipleLargeArgs]
+              InjectionPoints: [{PC: "0xd0b4ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1372 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xd0b3ca", Frameless: false}]
+              Type: 1373 EventRootType Probe[main.testMultipleLargeArgs]Return
+              InjectionPoints: [{PC: "0xd0b6ca", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3271,11 +3271,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1421 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0cbe0", Frameless: true}]
+              Type: 1422 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xd0cee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3296,11 +3296,11 @@ Probes:
           dsl: x.nested.anotherString
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1422 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0cbe0", Frameless: true}]
+              Type: 1423 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xd0cee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3327,11 +3327,11 @@ Probes:
           dsl: x.notAMember
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1423 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0cbe0", Frameless: true}]
+              Type: 1424 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xd0cee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3352,11 +3352,11 @@ Probes:
           dsl: x.nested
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1424 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xd0cbe0", Frameless: true}]
+              Type: 1425 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xd0cee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3406,11 +3406,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 140}
+        - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1393 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xd0c2a0", Frameless: true}]
+              Type: 1394 EventRootType Probe[main.testNilSlice]
+              InjectionPoints: [{PC: "0xd0c5a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3433,11 +3433,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 137}
+        - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1390 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xd0c240", Frameless: true}]
+              Type: 1391 EventRootType Probe[main.testNilSliceOfStructs]
+              InjectionPoints: [{PC: "0xd0c540", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3468,11 +3468,11 @@ Probes:
           dsl: x
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 139}
+        - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1392 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xd0c280", Frameless: true}]
+              Type: 1393 EventRootType Probe[main.testNilSliceWithOtherParams]
+              InjectionPoints: [{PC: "0xd0c580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3500,11 +3500,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 149}
+        - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1408 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xd0c780", Frameless: true}]
+              Type: 1409 EventRootType Probe[main.testOneStringInStructPointer]
+              InjectionPoints: [{PC: "0xd0ca80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3941,15 +3941,15 @@ Probes:
       segments: [testReturnsArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 112}
+        - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1345 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xd0a9ea", Frameless: false}]
+              Type: 1346 EventRootType Probe[main.testReturnsArray]
+              InjectionPoints: [{PC: "0xd0acea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1346 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xd0aa4d", Frameless: false}]
+              Type: 1347 EventRootType Probe[main.testReturnsArray]Return
+              InjectionPoints: [{PC: "0xd0ad4d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3962,15 +3962,15 @@ Probes:
       segments: [testReturnsArrayOne]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 113}
+        - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1347 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xd0aa6a", Frameless: false}]
+              Type: 1348 EventRootType Probe[main.testReturnsArrayOne]
+              InjectionPoints: [{PC: "0xd0ad6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1348 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xd0aaab", Frameless: false}]
+              Type: 1349 EventRootType Probe[main.testReturnsArrayOne]Return
+              InjectionPoints: [{PC: "0xd0adab", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3983,15 +3983,15 @@ Probes:
       segments: [testReturnsArrayZero]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 114}
+        - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1349 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xd0aaca", Frameless: false}]
+              Type: 1350 EventRootType Probe[main.testReturnsArrayZero]
+              InjectionPoints: [{PC: "0xd0adca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1350 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xd0ab06", Frameless: false}]
+              Type: 1351 EventRootType Probe[main.testReturnsArrayZero]Return
+              InjectionPoints: [{PC: "0xd0ae06", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4004,15 +4004,15 @@ Probes:
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 116}
+        - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1353 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xd0abae", Frameless: false}]
+              Type: 1354 EventRootType Probe[main.testReturnsBacktrackInt]
+              InjectionPoints: [{PC: "0xd0aeae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1354 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xd0ac2a", Frameless: false}]
+              Type: 1355 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              InjectionPoints: [{PC: "0xd0af2a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4025,15 +4025,15 @@ Probes:
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 122}
+        - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1365 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xd0aeea", Frameless: false}]
+              Type: 1366 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              InjectionPoints: [{PC: "0xd0b1ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1366 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xd0af30", Frameless: false}]
+              Type: 1367 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              InjectionPoints: [{PC: "0xd0b230", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4046,15 +4046,15 @@ Probes:
       segments: [testReturnsComplex]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 110}
+        - subprogram: {subprogram: 111}
           events:
             - Kind: Entry
-              Type: 1341 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xd0a8aa", Frameless: false}]
+              Type: 1342 EventRootType Probe[main.testReturnsComplex]
+              InjectionPoints: [{PC: "0xd0abaa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1342 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xd0a906", Frameless: false}]
+              Type: 1343 EventRootType Probe[main.testReturnsComplex]Return
+              InjectionPoints: [{PC: "0xd0ac06", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4202,15 +4202,15 @@ Probes:
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 111}
+        - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1343 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xd0a92e", Frameless: false}]
+              Type: 1344 EventRootType Probe[main.testReturnsLargeStruct]
+              InjectionPoints: [{PC: "0xd0ac2e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1344 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xd0a9b3", Frameless: false}]
+              Type: 1345 EventRootType Probe[main.testReturnsLargeStruct]Return
+              InjectionPoints: [{PC: "0xd0acb3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4223,15 +4223,15 @@ Probes:
       segments: [testReturnsManyFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 109}
+        - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1339 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xd0a7ae", Frameless: false}]
+              Type: 1340 EventRootType Probe[main.testReturnsManyFloats]
+              InjectionPoints: [{PC: "0xd0aaae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1340 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xd0a885", Frameless: false}]
+              Type: 1341 EventRootType Probe[main.testReturnsManyFloats]Return
+              InjectionPoints: [{PC: "0xd0ab85", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4244,15 +4244,15 @@ Probes:
       segments: [testReturnsMixed]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 118}
+        - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1357 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xd0ad0a", Frameless: false}]
+              Type: 1358 EventRootType Probe[main.testReturnsMixed]
+              InjectionPoints: [{PC: "0xd0b00a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1358 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xd0ad6c", Frameless: false}]
+              Type: 1359 EventRootType Probe[main.testReturnsMixed]Return
+              InjectionPoints: [{PC: "0xd0b06c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4265,15 +4265,15 @@ Probes:
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 115}
+        - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1351 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xd0ab2a", Frameless: false}]
+              Type: 1352 EventRootType Probe[main.testReturnsMixedStruct]
+              InjectionPoints: [{PC: "0xd0ae2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1352 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xd0ab78", Frameless: false}]
+              Type: 1353 EventRootType Probe[main.testReturnsMixedStruct]Return
+              InjectionPoints: [{PC: "0xd0ae78", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4286,19 +4286,43 @@ Probes:
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 121}
+        - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1363 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xd0ae6a", Frameless: false}]
+              Type: 1364 EventRootType Probe[main.testReturnsMultipleFloats]
+              InjectionPoints: [{PC: "0xd0b16a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1364 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xd0aeb6", Frameless: false}]
+              Type: 1365 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              InjectionPoints: [{PC: "0xd0b1b6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
             Segments: [testReturnsMultipleFloats]
+    - id: testReturnsNamedDeferLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testReturnsNamedDeferLine
+        sourceFile: returns.go
+        lines: ["121"]
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 108}
+          events:
+            - Kind: Line
+              Type: 1337 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              InjectionPoints: [{PC: "0xd0a82f", Frameless: false}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{i}'
+            Segments:
+                - JSON: {Ref: i}
+                  DSL: i
+                  EventKind: Line
+                  EventExpressionIndex: 0
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -4307,15 +4331,15 @@ Probes:
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 120}
+        - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1361 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xd0ae0a", Frameless: false}]
+              Type: 1362 EventRootType Probe[main.testReturnsOnlyFloat]
+              InjectionPoints: [{PC: "0xd0b10a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1362 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xd0ae4e", Frameless: false}]
+              Type: 1363 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              InjectionPoints: [{PC: "0xd0b14e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4328,15 +4352,15 @@ Probes:
       segments: [testReturnsPrimitives]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 108}
+        - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1337 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xd0a72a", Frameless: false}]
+              Type: 1338 EventRootType Probe[main.testReturnsPrimitives]
+              InjectionPoints: [{PC: "0xd0aa2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1338 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xd0a791", Frameless: false}]
+              Type: 1339 EventRootType Probe[main.testReturnsPrimitives]Return
+              InjectionPoints: [{PC: "0xd0aa91", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4349,15 +4373,15 @@ Probes:
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 119}
+        - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1359 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xd0ad8a", Frameless: false}]
+              Type: 1360 EventRootType Probe[main.testReturnsStructWithArray]
+              InjectionPoints: [{PC: "0xd0b08a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1360 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xd0aded", Frameless: false}]
+              Type: 1361 EventRootType Probe[main.testReturnsStructWithArray]Return
+              InjectionPoints: [{PC: "0xd0b0ed", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4370,15 +4394,15 @@ Probes:
       segments: [testReturnsWideStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 117}
+        - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1355 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xd0ac4e", Frameless: false}]
+              Type: 1356 EventRootType Probe[main.testReturnsWideStruct]
+              InjectionPoints: [{PC: "0xd0af4e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1356 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xd0acd4", Frameless: false}]
+              Type: 1357 EventRootType Probe[main.testReturnsWideStruct]Return
+              InjectionPoints: [{PC: "0xd0afd4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4706,11 +4730,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 145}
+        - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1400 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xd0c700", Frameless: true}]
+              Type: 1401 EventRootType Probe[main.testSingleString]
+              InjectionPoints: [{PC: "0xd0ca00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4838,11 +4862,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 142}
+        - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1396 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xd0c2e0", Frameless: true}]
+              Type: 1397 EventRootType Probe[main.testSliceEmptyStructs]
+              InjectionPoints: [{PC: "0xd0c5e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4860,11 +4884,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 134}
+        - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1387 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xd0c1e0", Frameless: true}]
+              Type: 1388 EventRootType Probe[main.testSliceOfSlices]
+              InjectionPoints: [{PC: "0xd0c4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4928,15 +4952,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 128}
+        - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1377 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xd0b96a", Frameless: false}]
+              Type: 1378 EventRootType Probe[main.testStackArgRegReturns]
+              InjectionPoints: [{PC: "0xd0bc6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1378 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xd0b9dc", Frameless: false}]
+              Type: 1379 EventRootType Probe[main.testStackArgRegReturns]Return
+              InjectionPoints: [{PC: "0xd0bcdc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4998,11 +5022,11 @@ Probes:
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 138}
+        - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1391 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xd0c260", Frameless: true}]
+              Type: 1392 EventRootType Probe[main.testStringSlice]
+              InjectionPoints: [{PC: "0xd0c560", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5064,15 +5088,15 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1419 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xd0cae0", Frameless: true}]
+              Type: 1420 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0xd0cde0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1420 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xd0cb02", Frameless: true}]
+              Type: 1421 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0xd0ce02", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5095,11 +5119,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 135}
+        - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1388 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xd0c200", Frameless: true}]
+              Type: 1389 EventRootType Probe[main.testStructSlice]
+              InjectionPoints: [{PC: "0xd0c500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5143,15 +5167,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 130}
+        - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1381 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xd0bb0e", Frameless: false}]
+              Type: 1382 EventRootType Probe[main.testStructWithArrayArg]
+              InjectionPoints: [{PC: "0xd0be0e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1382 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xd0bbba", Frameless: false}]
+              Type: 1383 EventRootType Probe[main.testStructWithArrayArg]Return
+              InjectionPoints: [{PC: "0xd0beba", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5169,15 +5193,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 155}
+        - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1415 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xd0c9a0", Frameless: true}]
+              Type: 1416 EventRootType Probe[main.testStructWithCyclicMaps]
+              InjectionPoints: [{PC: "0xd0cca0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1416 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xd0c9be", Frameless: true}]
+              Type: 1417 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              InjectionPoints: [{PC: "0xd0ccbe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5194,11 +5218,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 154}
+        - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1414 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xd0c980", Frameless: true}]
+              Type: 1415 EventRootType Probe[main.testStructWithCyclicSlices]
+              InjectionPoints: [{PC: "0xd0cc80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5253,11 +5277,11 @@ Probes:
           dsl: cs
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 143}
+        - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1397 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xd0c300", Frameless: true}]
+              Type: 1398 EventRootType Probe[main.testSubslices]
+              InjectionPoints: [{PC: "0xd0c600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5293,11 +5317,11 @@ Probes:
           dsl: c
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 153}
+        - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1413 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xd0c800", Frameless: true}]
+              Type: 1414 EventRootType Probe[main.testSubstrings]
+              InjectionPoints: [{PC: "0xd0cb00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5411,11 +5435,11 @@ Probes:
           dsl: z
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 146}
+        - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1401 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xd0c720", Frameless: true}]
+              Type: 1402 EventRootType Probe[main.testThreeStrings]
+              InjectionPoints: [{PC: "0xd0ca20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5443,15 +5467,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1402 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xd0c740", Frameless: true}]
+              Type: 1403 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0xd0ca40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1403 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xd0c75e", Frameless: true}]
+              Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0xd0ca5e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5477,15 +5501,15 @@ Probes:
           dsl: t.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xd0c740", Frameless: true}]
+              Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0xd0ca40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xd0c75e", Frameless: true}]
+              Type: 1406 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0xd0ca5e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5513,11 +5537,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1406 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xd0c760", Frameless: true}]
+              Type: 1407 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0xd0ca60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5543,11 +5567,11 @@ Probes:
           dsl: a.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1407 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xd0c760", Frameless: true}]
+              Type: 1408 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0xd0ca60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5729,11 +5753,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 132}
+        - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1385 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xd0c1a0", Frameless: true}]
+              Type: 1386 EventRootType Probe[main.testUintSlice]
+              InjectionPoints: [{PC: "0xd0c4a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5751,11 +5775,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 151}
+        - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1411 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xd0c7c0", Frameless: true}]
+              Type: 1412 EventRootType Probe[main.testUnitializedString]
+              InjectionPoints: [{PC: "0xd0cac0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5817,11 +5841,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1394 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xd0c2c0", Frameless: true}]
+              Type: 1395 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0xd0c5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5839,11 +5863,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1395 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xd0c2c0", Frameless: true}]
+              Type: 1396 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0xd0c5c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5861,18 +5885,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1492 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1493 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0xd06d4a"
                   Frameless: false
-                - PC: "0xd0fba3"
+                - PC: "0xd0fea3"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1493 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1494 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0xd06d90", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5891,15 +5915,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 131}
+        - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1383 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xd0bbee", Frameless: false}]
+              Type: 1384 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              InjectionPoints: [{PC: "0xd0beee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1384 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xd0bc6c", Frameless: false}]
+              Type: 1385 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              InjectionPoints: [{PC: "0xd0bf6c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -8114,802 +8138,831 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 108
+      Name: main.testReturnsNamedDeferLine
+      OutOfLinePCRanges: [0xd0a720..0xd0a92f]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0a720..0xd0a7a6
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd0a7a6..0xd0a92f
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd0a757..0xd0a92f
+              Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
+          Role: Return
+          DictIndex: -1
+        - Name: b
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd0a75d..0xd0a92f
+              Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xd0a720..0xd0a79e]
+      OutOfLinePCRanges: [0xd0aa20..0xd0aa9e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd0a720..0xd0a791
+            - Range: 0xd0aa20..0xd0aa91
               Pieces: []
-            - Range: 0xd0a791..0xd0a792
+            - Range: 0xd0aa91..0xd0aa92
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0a792..0xd0a79e
+            - Range: 0xd0aa92..0xd0aa9e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 97 BaseType int16
           Locations:
-            - Range: 0xd0a720..0xd0a791
+            - Range: 0xd0aa20..0xd0aa91
               Pieces: []
-            - Range: 0xd0a791..0xd0a792
+            - Range: 0xd0aa91..0xd0aa92
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0a792..0xd0a79e
+            - Range: 0xd0aa92..0xd0aa9e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd0a720..0xd0a791
+            - Range: 0xd0aa20..0xd0aa91
               Pieces: []
-            - Range: 0xd0a791..0xd0a792
+            - Range: 0xd0aa91..0xd0aa92
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0a792..0xd0a79e
+            - Range: 0xd0aa92..0xd0aa9e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xd0a720..0xd0a791
+            - Range: 0xd0aa20..0xd0aa91
               Pieces: []
-            - Range: 0xd0a791..0xd0a792
+            - Range: 0xd0aa91..0xd0aa92
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0a792..0xd0a79e
+            - Range: 0xd0aa92..0xd0aa9e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd0a720..0xd0a791
+            - Range: 0xd0aa20..0xd0aa91
               Pieces: []
-            - Range: 0xd0a791..0xd0a792
+            - Range: 0xd0aa91..0xd0aa92
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0a792..0xd0a79e
+            - Range: 0xd0aa92..0xd0aa9e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xd0a720..0xd0a791
+            - Range: 0xd0aa20..0xd0aa91
               Pieces: []
-            - Range: 0xd0a791..0xd0a792
+            - Range: 0xd0aa91..0xd0aa92
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0a792..0xd0a79e
+            - Range: 0xd0aa92..0xd0aa9e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xd0a720..0xd0a791
+            - Range: 0xd0aa20..0xd0aa91
               Pieces: []
-            - Range: 0xd0a791..0xd0a792
+            - Range: 0xd0aa91..0xd0aa92
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0a792..0xd0a79e
+            - Range: 0xd0aa92..0xd0aa9e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xd0a720..0xd0a791
+            - Range: 0xd0aa20..0xd0aa91
               Pieces: []
-            - Range: 0xd0a791..0xd0a792
+            - Range: 0xd0aa91..0xd0aa92
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0a792..0xd0a79e
+            - Range: 0xd0aa92..0xd0aa9e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xd0a7a0..0xd0a895]
+      OutOfLinePCRanges: [0xd0aaa0..0xd0ab95]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0a7a0..0xd0a895, Pieces: []}]
+          Locations: [{Range: 0xd0aaa0..0xd0ab95, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd0a7a0..0xd0a885
+            - Range: 0xd0aaa0..0xd0ab85
               Pieces: []
-            - Range: 0xd0a885..0xd0a886
+            - Range: 0xd0ab85..0xd0ab86
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd0a886..0xd0a895
+            - Range: 0xd0ab86..0xd0ab95
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd0a7a0..0xd0a885
+            - Range: 0xd0aaa0..0xd0ab85
               Pieces: []
-            - Range: 0xd0a885..0xd0a886
+            - Range: 0xd0ab85..0xd0ab86
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0a886..0xd0a895
+            - Range: 0xd0ab86..0xd0ab95
               Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 110
-      Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xd0a8a0..0xd0a913]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 89 BaseType complex64
-          Locations: [{Range: 0xd0a8a0..0xd0a913, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 90 BaseType complex128
-          Locations: [{Range: 0xd0a8a0..0xd0a913, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0xd0aba0..0xd0ac13]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 89 BaseType complex64
+          Locations: [{Range: 0xd0aba0..0xd0ac13, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 90 BaseType complex128
+          Locations: [{Range: 0xd0aba0..0xd0ac13, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xd0a920..0xd0a9c5]
+      OutOfLinePCRanges: [0xd0ac20..0xd0acc5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0a920..0xd0a9b3
+            - Range: 0xd0ac20..0xd0acb3
               Pieces: []
-            - Range: 0xd0a9b3..0xd0a9b4
+            - Range: 0xd0acb3..0xd0acb4
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xd0a9b4..0xd0a9c5
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 112
-      Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xd0a9e0..0xd0aa5a]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 246 ArrayType [3]int
-          Locations:
-            - Range: 0xd0a9e0..0xd0aa4d
-              Pieces: []
-            - Range: 0xd0aa4d..0xd0aa4e
-              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd0aa4e..0xd0aa5a
+            - Range: 0xd0acb4..0xd0acc5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
-      Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xd0aa60..0xd0aab8]
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0xd0ace0..0xd0ad5a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 247 ArrayType [1]int
+          Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd0aa60..0xd0aaab
+            - Range: 0xd0ace0..0xd0ad4d
               Pieces: []
-            - Range: 0xd0aaab..0xd0aaac
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0aaac..0xd0aab8
+            - Range: 0xd0ad4d..0xd0ad4e
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xd0ad4e..0xd0ad5a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
-      Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xd0aac0..0xd0ab13]
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0xd0ad60..0xd0adb8]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 248 ArrayType [0]int
+          Type: 247 ArrayType [1]int
           Locations:
-            - Range: 0xd0aac0..0xd0ab06
+            - Range: 0xd0ad60..0xd0adab
               Pieces: []
-            - Range: 0xd0ab06..0xd0ab07
-              Pieces: []
-            - Range: 0xd0ab07..0xd0ab13
+            - Range: 0xd0adab..0xd0adac
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd0adac..0xd0adb8
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
-      Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xd0ab20..0xd0ab87]
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0xd0adc0..0xd0ae13]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 249 StructureType main.mixedStruct
-          Locations: [{Range: 0xd0ab20..0xd0ab87, Pieces: []}]
+          Type: 248 ArrayType [0]int
+          Locations:
+            - Range: 0xd0adc0..0xd0ae06
+              Pieces: []
+            - Range: 0xd0ae06..0xd0ae07
+              Pieces: []
+            - Range: 0xd0ae07..0xd0ae13
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0xd0ae20..0xd0ae87]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 249 StructureType main.mixedStruct
+          Locations: [{Range: 0xd0ae20..0xd0ae87, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xd0aba0..0xd0ac3a]
+      OutOfLinePCRanges: [0xd0aea0..0xd0af3a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aba0..0xd0ac2a
+            - Range: 0xd0aea0..0xd0af2a
               Pieces: []
-            - Range: 0xd0ac2a..0xd0ac2b
+            - Range: 0xd0af2a..0xd0af2b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ac2b..0xd0ac3a
+            - Range: 0xd0af2b..0xd0af3a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aba0..0xd0ac2a
+            - Range: 0xd0aea0..0xd0af2a
               Pieces: []
-            - Range: 0xd0ac2a..0xd0ac2b
+            - Range: 0xd0af2a..0xd0af2b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0ac2b..0xd0ac3a
+            - Range: 0xd0af2b..0xd0af3a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aba0..0xd0ac2a
+            - Range: 0xd0aea0..0xd0af2a
               Pieces: []
-            - Range: 0xd0ac2a..0xd0ac2b
+            - Range: 0xd0af2a..0xd0af2b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0ac2b..0xd0ac3a
+            - Range: 0xd0af2b..0xd0af3a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aba0..0xd0ac2a
+            - Range: 0xd0aea0..0xd0af2a
               Pieces: []
-            - Range: 0xd0ac2a..0xd0ac2b
+            - Range: 0xd0af2a..0xd0af2b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0ac2b..0xd0ac3a
+            - Range: 0xd0af2b..0xd0af3a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aba0..0xd0ac2a
+            - Range: 0xd0aea0..0xd0af2a
               Pieces: []
-            - Range: 0xd0ac2a..0xd0ac2b
+            - Range: 0xd0af2a..0xd0af2b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0ac2b..0xd0ac3a
+            - Range: 0xd0af2b..0xd0af3a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aba0..0xd0ac2a
+            - Range: 0xd0aea0..0xd0af2a
               Pieces: []
-            - Range: 0xd0ac2a..0xd0ac2b
+            - Range: 0xd0af2a..0xd0af2b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0ac2b..0xd0ac3a
+            - Range: 0xd0af2b..0xd0af3a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aba0..0xd0ac2a
+            - Range: 0xd0aea0..0xd0af2a
               Pieces: []
-            - Range: 0xd0ac2a..0xd0ac2b
+            - Range: 0xd0af2a..0xd0af2b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0ac2b..0xd0ac3a
+            - Range: 0xd0af2b..0xd0af3a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0aba0..0xd0ac2a
+            - Range: 0xd0aea0..0xd0af2a
               Pieces: []
-            - Range: 0xd0ac2a..0xd0ac2b
+            - Range: 0xd0af2a..0xd0af2b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0ac2b..0xd0ac3a
+            - Range: 0xd0af2b..0xd0af3a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0aba0..0xd0ac2a
+            - Range: 0xd0aea0..0xd0af2a
               Pieces: []
-            - Range: 0xd0ac2a..0xd0ac2b
+            - Range: 0xd0af2a..0xd0af2b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd0ac2b..0xd0ac3a
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 117
-      Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xd0ac40..0xd0ace5]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 250 StructureType main.wideStruct
-          Locations:
-            - Range: 0xd0ac40..0xd0acd4
-              Pieces: []
-            - Range: 0xd0acd4..0xd0acd5
-              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xd0acd5..0xd0ace5
+            - Range: 0xd0af2b..0xd0af3a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
-      Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xd0ad00..0xd0ad79]
+      Name: main.testReturnsWideStruct
+      OutOfLinePCRanges: [0xd0af40..0xd0afe5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 9 BaseType int
+          Type: 250 StructureType main.wideStruct
           Locations:
-            - Range: 0xd0ad00..0xd0ad6c
+            - Range: 0xd0af40..0xd0afd4
               Pieces: []
-            - Range: 0xd0ad6c..0xd0ad6d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0ad6d..0xd0ad79
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 17 BaseType float64
-          Locations: [{Range: 0xd0ad00..0xd0ad79, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0ad00..0xd0ad6c
-              Pieces: []
-            - Range: 0xd0ad6c..0xd0ad6d
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0ad6d..0xd0ad79
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 17 BaseType float64
-          Locations: [{Range: 0xd0ad00..0xd0ad79, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd0ad00..0xd0ad6c
-              Pieces: []
-            - Range: 0xd0ad6c..0xd0ad6d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0ad6d..0xd0ad79
+            - Range: 0xd0afd4..0xd0afd5
+              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
+            - Range: 0xd0afd5..0xd0afe5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
-      Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xd0ad80..0xd0adfa]
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0xd0b000..0xd0b079]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 251 StructureType main.structWithArray
+          Type: 9 BaseType int
           Locations:
-            - Range: 0xd0ad80..0xd0aded
+            - Range: 0xd0b000..0xd0b06c
               Pieces: []
-            - Range: 0xd0aded..0xd0adee
-              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd0adee..0xd0adfa
+            - Range: 0xd0b06c..0xd0b06d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd0b06d..0xd0b079
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd0b000..0xd0b079, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0b000..0xd0b06c
+              Pieces: []
+            - Range: 0xd0b06c..0xd0b06d
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd0b06d..0xd0b079
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd0b000..0xd0b079, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd0b000..0xd0b06c
+              Pieces: []
+            - Range: 0xd0b06c..0xd0b06d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xd0b06d..0xd0b079
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
-      Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xd0ae00..0xd0ae5b]
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0xd0b080..0xd0b0fa]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 17 BaseType float64
-          Locations: [{Range: 0xd0ae00..0xd0ae5b, Pieces: []}]
+          Type: 251 StructureType main.structWithArray
+          Locations:
+            - Range: 0xd0b080..0xd0b0ed
+              Pieces: []
+            - Range: 0xd0b0ed..0xd0b0ee
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xd0b0ee..0xd0b0fa
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
-      Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xd0ae60..0xd0aec7]
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0xd0b100..0xd0b15b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 16 BaseType float32
-          Locations: [{Range: 0xd0ae60..0xd0aec7, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd0ae60..0xd0aec7, Pieces: []}]
+          Locations: [{Range: 0xd0b100..0xd0b15b, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0xd0b160..0xd0b1c7]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 16 BaseType float32
+          Locations: [{Range: 0xd0b160..0xd0b1c7, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd0b160..0xd0b1c7, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xd0aee0..0xd0af3d]
+      OutOfLinePCRanges: [0xd0b1e0..0xd0b23d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd0aee0..0xd0af30
+            - Range: 0xd0b1e0..0xd0b230
               Pieces: []
-            - Range: 0xd0af30..0xd0af31
+            - Range: 0xd0b230..0xd0b231
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0af31..0xd0af3d
+            - Range: 0xd0b231..0xd0b23d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xd0aee0..0xd0af30
+            - Range: 0xd0b1e0..0xd0b230
               Pieces: []
-            - Range: 0xd0af30..0xd0af31
+            - Range: 0xd0b230..0xd0b231
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0af31..0xd0af3d
+            - Range: 0xd0b231..0xd0b23d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 123
+    - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xd0af40..0xd0b0a5]
+      OutOfLinePCRanges: [0xd0b240..0xd0b3a5]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0af40..0xd0b0a5
+            - Range: 0xd0b240..0xd0b3a5
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0af40..0xd0b093
+            - Range: 0xd0b240..0xd0b393
               Pieces: []
-            - Range: 0xd0b093..0xd0b094
+            - Range: 0xd0b393..0xd0b394
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xd0b094..0xd0b0a5
+            - Range: 0xd0b394..0xd0b3a5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 124
+    - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xd0b0c0..0xd0b192]
+      OutOfLinePCRanges: [0xd0b3c0..0xd0b492]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd0b0c0..0xd0b192
+            - Range: 0xd0b3c0..0xd0b492
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd0b0c0..0xd0b182
+            - Range: 0xd0b3c0..0xd0b482
               Pieces: []
-            - Range: 0xd0b182..0xd0b183
+            - Range: 0xd0b482..0xd0b483
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd0b183..0xd0b192
+            - Range: 0xd0b483..0xd0b492
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xd0b1a0..0xd0b3da]
+      OutOfLinePCRanges: [0xd0b4a0..0xd0b6da]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0b1a0..0xd0b3da
+            - Range: 0xd0b4a0..0xd0b6da
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0b1a0..0xd0b3da
+            - Range: 0xd0b4a0..0xd0b6da
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0b1a0..0xd0b3ca
+            - Range: 0xd0b4a0..0xd0b6ca
               Pieces: []
-            - Range: 0xd0b3ca..0xd0b3cb
+            - Range: 0xd0b6ca..0xd0b6cb
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xd0b3cb..0xd0b3da
+            - Range: 0xd0b6cb..0xd0b6da
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 126
+    - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xd0b3e0..0xd0b66f]
+      OutOfLinePCRanges: [0xd0b6e0..0xd0b96f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b3e0..0xd0b490
+            - Range: 0xd0b6e0..0xd0b790
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0b490..0xd0b66f
+            - Range: 0xd0b790..0xd0b96f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b3e0..0xd0b490
+            - Range: 0xd0b6e0..0xd0b790
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0b490..0xd0b66f
+            - Range: 0xd0b790..0xd0b96f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b3e0..0xd0b490
+            - Range: 0xd0b6e0..0xd0b790
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0b490..0xd0b66f
+            - Range: 0xd0b790..0xd0b96f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b3e0..0xd0b450
+            - Range: 0xd0b6e0..0xd0b750
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0b450..0xd0b66f
+            - Range: 0xd0b750..0xd0b96f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b3e0..0xd0b490
+            - Range: 0xd0b6e0..0xd0b790
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0b490..0xd0b66f
+            - Range: 0xd0b790..0xd0b96f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b3e0..0xd0b490
+            - Range: 0xd0b6e0..0xd0b790
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0b490..0xd0b66f
+            - Range: 0xd0b790..0xd0b96f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b3e0..0xd0b490
+            - Range: 0xd0b6e0..0xd0b790
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0b490..0xd0b66f
+            - Range: 0xd0b790..0xd0b96f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b3e0..0xd0b490
+            - Range: 0xd0b6e0..0xd0b790
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0b490..0xd0b66f
+            - Range: 0xd0b790..0xd0b96f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b3e0..0xd0b490
+            - Range: 0xd0b6e0..0xd0b790
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xd0b490..0xd0b66f
+            - Range: 0xd0b790..0xd0b96f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd0b3e0..0xd0b602
+            - Range: 0xd0b6e0..0xd0b902
               Pieces: []
-            - Range: 0xd0b602..0xd0b603
+            - Range: 0xd0b902..0xd0b903
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd0b603..0xd0b66f
+            - Range: 0xd0b903..0xd0b96f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 127
+    - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xd0b680..0xd0b94c]
+      OutOfLinePCRanges: [0xd0b980..0xd0bc4c]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b680..0xd0b72b
+            - Range: 0xd0b980..0xd0ba2b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0b72b..0xd0b94c
+            - Range: 0xd0ba2b..0xd0bc4c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b680..0xd0b72b
+            - Range: 0xd0b980..0xd0ba2b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0b72b..0xd0b94c
+            - Range: 0xd0ba2b..0xd0bc4c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b680..0xd0b72b
+            - Range: 0xd0b980..0xd0ba2b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0b72b..0xd0b94c
+            - Range: 0xd0ba2b..0xd0bc4c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b680..0xd0b6e2
+            - Range: 0xd0b980..0xd0b9e2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd0b6e2..0xd0b94c
+            - Range: 0xd0b9e2..0xd0bc4c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b680..0xd0b72b
+            - Range: 0xd0b980..0xd0ba2b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0b72b..0xd0b94c
+            - Range: 0xd0ba2b..0xd0bc4c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b680..0xd0b72b
+            - Range: 0xd0b980..0xd0ba2b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0b72b..0xd0b94c
+            - Range: 0xd0ba2b..0xd0bc4c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b680..0xd0b72b
+            - Range: 0xd0b980..0xd0ba2b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0b72b..0xd0b94c
+            - Range: 0xd0ba2b..0xd0bc4c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b680..0xd0b72b
+            - Range: 0xd0b980..0xd0ba2b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0b72b..0xd0b94c
+            - Range: 0xd0ba2b..0xd0bc4c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0b680..0xd0b94c
+            - Range: 0xd0b980..0xd0bc4c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8920,219 +8973,200 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd0b680..0xd0b8cb
+            - Range: 0xd0b980..0xd0bbcb
               Pieces: []
-            - Range: 0xd0b8cb..0xd0b8cc
+            - Range: 0xd0bbcb..0xd0bbcc
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xd0b8cc..0xd0b94c
+            - Range: 0xd0bbcc..0xd0bc4c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 128
+    - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xd0b960..0xd0b9ec]
+      OutOfLinePCRanges: [0xd0bc60..0xd0bcec]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0xd0b960..0xd0b9ec
+            - Range: 0xd0bc60..0xd0bcec
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b960..0xd0b9dc
+            - Range: 0xd0bc60..0xd0bcdc
               Pieces: []
-            - Range: 0xd0b9dc..0xd0b9dd
+            - Range: 0xd0bcdc..0xd0bcdd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0b9dd..0xd0b9ec
+            - Range: 0xd0bcdd..0xd0bcec
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b960..0xd0b9dc
+            - Range: 0xd0bc60..0xd0bcdc
               Pieces: []
-            - Range: 0xd0b9dc..0xd0b9dd
+            - Range: 0xd0bcdc..0xd0bcdd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0b9dd..0xd0b9ec
+            - Range: 0xd0bcdd..0xd0bcec
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0b960..0xd0b9dc
+            - Range: 0xd0bc60..0xd0bcdc
               Pieces: []
-            - Range: 0xd0b9dc..0xd0b9dd
+            - Range: 0xd0bcdc..0xd0bcdd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0b9dd..0xd0b9ec
+            - Range: 0xd0bcdd..0xd0bcec
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 129
+    - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xd0ba00..0xd0baea]
+      OutOfLinePCRanges: [0xd0bd00..0xd0bdea]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd0ba00..0xd0baea
+            - Range: 0xd0bd00..0xd0bdea
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd0ba00..0xd0baea
+            - Range: 0xd0bd00..0xd0bdea
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0ba00..0xd0bad6
+            - Range: 0xd0bd00..0xd0bdd6
               Pieces: []
-            - Range: 0xd0bad6..0xd0bad7
+            - Range: 0xd0bdd6..0xd0bdd7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bad7..0xd0baea
+            - Range: 0xd0bdd7..0xd0bdea
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd0ba00..0xd0bad6
+            - Range: 0xd0bd00..0xd0bdd6
               Pieces: []
-            - Range: 0xd0bad6..0xd0bad7
+            - Range: 0xd0bdd6..0xd0bdd7
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xd0bad7..0xd0baea
+            - Range: 0xd0bdd7..0xd0bdea
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 130
+    - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xd0bb00..0xd0bbcb]
+      OutOfLinePCRanges: [0xd0be00..0xd0becb]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0bb00..0xd0bbcb
+            - Range: 0xd0be00..0xd0becb
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0bb00..0xd0bbba
+            - Range: 0xd0be00..0xd0beba
               Pieces: []
-            - Range: 0xd0bbba..0xd0bbbb
+            - Range: 0xd0beba..0xd0bebb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bbbb..0xd0bbcb
+            - Range: 0xd0bebb..0xd0becb
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0xd0bb00..0xd0bbba
+            - Range: 0xd0be00..0xd0beba
               Pieces: []
-            - Range: 0xd0bbba..0xd0bbbb
+            - Range: 0xd0beba..0xd0bebb
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd0bbbb..0xd0bbcb
+            - Range: 0xd0bebb..0xd0becb
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0bb86..0xd0bbcb
+            - Range: 0xd0be86..0xd0becb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
-    - ID: 131
+    - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xd0bbe0..0xd0bc86]
+      OutOfLinePCRanges: [0xd0bee0..0xd0bf86]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 248 ArrayType [0]int
-          Locations: [{Range: 0xd0bbe0..0xd0bc86, Pieces: []}]
+          Locations: [{Range: 0xd0bee0..0xd0bf86, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0bbe0..0xd0bc25
+            - Range: 0xd0bee0..0xd0bf25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bc25..0xd0bc47
+            - Range: 0xd0bf25..0xd0bf47
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd0bc47..0xd0bc62
+            - Range: 0xd0bf47..0xd0bf62
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd0bc62..0xd0bc86
+            - Range: 0xd0bf62..0xd0bf86
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0bbe0..0xd0bc6c
+            - Range: 0xd0bee0..0xd0bf6c
               Pieces: []
-            - Range: 0xd0bc6c..0xd0bc6d
+            - Range: 0xd0bf6c..0xd0bf6d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0bc6d..0xd0bc86
+            - Range: 0xd0bf6d..0xd0bf86
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0xd0bbe0..0xd0bc6c
+            - Range: 0xd0bee0..0xd0bf6c
               Pieces: []
-            - Range: 0xd0bc6c..0xd0bc6d
+            - Range: 0xd0bf6c..0xd0bf6d
               Pieces: []
-            - Range: 0xd0bc6d..0xd0bc86
+            - Range: 0xd0bf6d..0xd0bf86
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 132
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd0c1a0..0xd0c1a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd0c1a0..0xd0c1a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
     - ID: 133
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd0c1c0..0xd0c1c1]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xd0c4a0..0xd0c4a1]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0c1c0..0xd0c1c1
+            - Range: 0xd0c4a0..0xd0c4a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9144,14 +9178,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 134
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd0c1e0..0xd0c1e1]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xd0c4c0..0xd0c4c1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 253 GoSliceHeaderType [][]uint
+          Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0c1e0..0xd0c1e1
+            - Range: 0xd0c4c0..0xd0c4c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9163,14 +9197,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 135
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd0c200..0xd0c201]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xd0c4e0..0xd0c4e1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 253 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xd0c200..0xd0c201
+            - Range: 0xd0c4e0..0xd0c4e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9178,25 +9212,18 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0c200..0xd0c201
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 136
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd0c220..0xd0c221]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xd0c500..0xd0c501]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd0c220..0xd0c221
+            - Range: 0xd0c500..0xd0c501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9209,20 +9236,20 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0c220..0xd0c221
+            - Range: 0xd0c500..0xd0c501
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xd0c240..0xd0c241]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xd0c520..0xd0c521]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd0c240..0xd0c241
+            - Range: 0xd0c520..0xd0c521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9235,20 +9262,46 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0c240..0xd0c241
+            - Range: 0xd0c520..0xd0c521
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xd0c540..0xd0c541]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd0c540..0xd0c541
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0c540..0xd0c541
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xd0c260..0xd0c261]
+      OutOfLinePCRanges: [0xd0c560..0xd0c561]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 258 GoSliceHeaderType []string
           Locations:
-            - Range: 0xd0c260..0xd0c261
+            - Range: 0xd0c560..0xd0c561
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9259,22 +9312,22 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 139
+    - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xd0c280..0xd0c281]
+      OutOfLinePCRanges: [0xd0c580..0xd0c581]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd0c280..0xd0c281
+            - Range: 0xd0c580..0xd0c581
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 259 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xd0c280..0xd0c281
+            - Range: 0xd0c580..0xd0c581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9287,39 +9340,20 @@ Subprograms:
         - Name: x
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd0c280..0xd0c281
+            - Range: 0xd0c580..0xd0c581
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
+    - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd0c2a0..0xd0c2a1]
+      OutOfLinePCRanges: [0xd0c5a0..0xd0c5a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xd0c2a0..0xd0c2a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xd0c2c0..0xd0c2c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd0c2c0..0xd0c2c1
+            - Range: 0xd0c5a0..0xd0c5a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9331,14 +9365,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 142
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xd0c2e0..0xd0c2e1]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xd0c5c0..0xd0c5c1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 261 GoSliceHeaderType []struct {}
+          Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0c2e0..0xd0c2e1
+            - Range: 0xd0c5c0..0xd0c5c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9350,14 +9384,33 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xd0c5e0..0xd0c5e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 261 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xd0c5e0..0xd0c5e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xd0c300..0xd0c301]
+      OutOfLinePCRanges: [0xd0c600..0xd0c601]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0c300..0xd0c301
+            - Range: 0xd0c600..0xd0c601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9370,7 +9423,7 @@ Subprograms:
         - Name: bs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0c300..0xd0c301
+            - Range: 0xd0c600..0xd0c601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9383,7 +9436,7 @@ Subprograms:
         - Name: cs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0c300..0xd0c301
+            - Range: 0xd0c600..0xd0c601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9394,36 +9447,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
+    - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0xd0c6a0..0xd0c6f2]
+      OutOfLinePCRanges: [0xd0c9a0..0xd0c9f2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c6a0..0xd0c6e5
+            - Range: 0xd0c9a0..0xd0c9e5
               Pieces: []
-            - Range: 0xd0c6e5..0xd0c6e6
+            - Range: 0xd0c9e5..0xd0c9e6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0c6e6..0xd0c6f2
+            - Range: 0xd0c9e6..0xd0c9f2
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 145
+    - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd0c700..0xd0c701]
+      OutOfLinePCRanges: [0xd0ca00..0xd0ca01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c700..0xd0c701
+            - Range: 0xd0ca00..0xd0ca01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9432,15 +9485,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd0c720..0xd0c721]
+      OutOfLinePCRanges: [0xd0ca20..0xd0ca21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c720..0xd0c721
+            - Range: 0xd0ca20..0xd0ca21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9451,7 +9504,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c720..0xd0c721
+            - Range: 0xd0ca20..0xd0ca21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9462,7 +9515,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c720..0xd0c721
+            - Range: 0xd0ca20..0xd0ca21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9471,15 +9524,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 147
+    - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd0c740..0xd0c75f]
+      OutOfLinePCRanges: [0xd0ca40..0xd0ca5f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 263 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd0c740..0xd0c75f
+            - Range: 0xd0ca40..0xd0ca5f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9496,58 +9549,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 148
+    - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd0c760..0xd0c761]
+      OutOfLinePCRanges: [0xd0ca60..0xd0ca61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd0c760..0xd0c761
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd0c780..0xd0c781]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 265 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0xd0c780..0xd0c781
+            - Range: 0xd0ca60..0xd0ca61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd0c7a0..0xd0c7a1]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0xd0ca80..0xd0ca81]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
+        - Name: a
+          Type: 265 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd0c7a0..0xd0c7a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd0ca80..0xd0ca81
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd0c7c0..0xd0c7c1]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xd0caa0..0xd0caa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c7c0..0xd0c7c1
+            - Range: 0xd0caa0..0xd0caa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9557,14 +9593,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 152
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd0c7e0..0xd0c7e1]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xd0cac0..0xd0cac1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c7e0..0xd0c7e1
+            - Range: 0xd0cac0..0xd0cac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9574,14 +9610,31 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 153
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xd0cae0..0xd0cae1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd0cae0..0xd0cae1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xd0c800..0xd0c801]
+      OutOfLinePCRanges: [0xd0cb00..0xd0cb01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c800..0xd0c801
+            - Range: 0xd0cb00..0xd0cb01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9592,7 +9645,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c800..0xd0c801
+            - Range: 0xd0cb00..0xd0cb01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9603,7 +9656,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0c800..0xd0c801
+            - Range: 0xd0cb00..0xd0cb01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9612,28 +9665,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
+    - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xd0c980..0xd0c981]
+      OutOfLinePCRanges: [0xd0cc80..0xd0cc81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xd0c980..0xd0c981
+            - Range: 0xd0cc80..0xd0cc81
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
+    - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xd0c9a0..0xd0c9bf]
+      OutOfLinePCRanges: [0xd0cca0..0xd0ccbf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xd0c9a0..0xd0c9bf
+            - Range: 0xd0cca0..0xd0ccbf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9650,15 +9703,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
+    - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd0cae0..0xd0cb03]
+      OutOfLinePCRanges: [0xd0cde0..0xd0ce03]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0xd0cae0..0xd0cb03
+            - Range: 0xd0cde0..0xd0ce03
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9677,151 +9730,151 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 157
+    - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xd0cbe0..0xd0cbe1]
+      OutOfLinePCRanges: [0xd0cee0..0xd0cee1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 312 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xd0cbe0..0xd0cbe1
+            - Range: 0xd0cee0..0xd0cee1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 158
+    - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xd0cc00..0xd0cc01]
+      OutOfLinePCRanges: [0xd0cf00..0xd0cf01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.tenStrings
           Locations:
-            - Range: 0xd0cc00..0xd0cc01
+            - Range: 0xd0cf00..0xd0cf01
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 159
+    - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd0cc60..0xd0cc61]
+      OutOfLinePCRanges: [0xd0cf60..0xd0cf61]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 315 StructureType main.emptyStruct
-          Locations: [{Range: 0xd0cc60..0xd0cc61, Pieces: []}]
+          Locations: [{Range: 0xd0cf60..0xd0cf61, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 160
+    - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd0cc80..0xd0cc81]
+      OutOfLinePCRanges: [0xd0cf80..0xd0cf81]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 316 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xd0cc80..0xd0cc81
+            - Range: 0xd0cf80..0xd0cf81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 161
+    - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xd0ef40..0xd0ef44]
+      OutOfLinePCRanges: [0xd0f240..0xd0f244]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0ef40..0xd0ef44
+            - Range: 0xd0f240..0xd0f244
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd0ef40..0xd0ef43
+            - Range: 0xd0f240..0xd0f243
               Pieces: []
-            - Range: 0xd0ef43..0xd0ef44
+            - Range: 0xd0f243..0xd0f244
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 162
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xd0ef60..0xd0ef6c]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 319 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0xd0ef60..0xd0ef6b
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0ef6b..0xd0ef6c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xd0ef60..0xd0ef6b
-              Pieces: []
-            - Range: 0xd0ef6b..0xd0ef6c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0xd0f260..0xd0f26c]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 319 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xd0f260..0xd0f26b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xd0f26b..0xd0f26c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xd0f260..0xd0f26b
+              Pieces: []
+            - Range: 0xd0f26b..0xd0f26c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xd0ef80..0xd0ef84]
+      OutOfLinePCRanges: [0xd0f280..0xd0f284]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd0ef80..0xd0ef84
+            - Range: 0xd0f280..0xd0f284
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0ef80..0xd0ef83
+            - Range: 0xd0f280..0xd0f283
               Pieces: []
-            - Range: 0xd0ef83..0xd0ef84
+            - Range: 0xd0f283..0xd0f284
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 164
+    - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xd0efa0..0xd0efac]
+      OutOfLinePCRanges: [0xd0f2a0..0xd0f2ac]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd0efa0..0xd0efab
+            - Range: 0xd0f2a0..0xd0f2ab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0efab..0xd0efac
+            - Range: 0xd0f2ab..0xd0f2ac
               Pieces:
                 - Size: 8
                   Op: null
@@ -9832,9 +9885,9 @@ Subprograms:
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0efa0..0xd0efab
+            - Range: 0xd0f2a0..0xd0f2ab
               Pieces: []
-            - Range: 0xd0efab..0xd0efac
+            - Range: 0xd0f2ab..0xd0f2ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9843,15 +9896,15 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xd0f020..0xd0f156]
+      OutOfLinePCRanges: [0xd0f320..0xd0f456]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd0f020..0xd0f053
+            - Range: 0xd0f320..0xd0f353
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9859,7 +9912,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0f053..0xd0f05b
+            - Range: 0xd0f353..0xd0f35b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9867,7 +9920,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xd0f05b..0xd0f156
+            - Range: 0xd0f35b..0xd0f456
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9880,18 +9933,18 @@ Subprograms:
         - Name: pred
           Type: 323 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xd0f020..0xd0f05b
+            - Range: 0xd0f320..0xd0f35b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0f05b..0xd0f156
+            - Range: 0xd0f35b..0xd0f456
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd0f020..0xd0f114
+            - Range: 0xd0f320..0xd0f414
               Pieces: []
-            - Range: 0xd0f114..0xd0f115
+            - Range: 0xd0f414..0xd0f415
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9899,14 +9952,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0f115..0xd0f156
+            - Range: 0xd0f415..0xd0f456
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd0f05b..0xd0f079
+            - Range: 0xd0f35b..0xd0f379
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9914,7 +9967,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd0f079..0xd0f081
+            - Range: 0xd0f379..0xd0f381
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9922,7 +9975,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd0f081..0xd0f089
+            - Range: 0xd0f381..0xd0f389
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9930,7 +9983,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd0f089..0xd0f089
+            - Range: 0xd0f389..0xd0f389
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9938,7 +9991,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd0f089..0xd0f0b3
+            - Range: 0xd0f389..0xd0f3b3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -9946,7 +9999,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0f0b3..0xd0f10b
+            - Range: 0xd0f3b3..0xd0f40b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9954,7 +10007,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xd0f10b..0xd0f156
+            - Range: 0xd0f40b..0xd0f456
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -9967,132 +10020,132 @@ Subprograms:
         - Name: item
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f0a6..0xd0f0b3
+            - Range: 0xd0f3a6..0xd0f3b3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0f0b3..0xd0f10b
+            - Range: 0xd0f3b3..0xd0f40b
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 166
+    - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd0f160..0xd0f1a4]
+      OutOfLinePCRanges: [0xd0f460..0xd0f4a4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xd0f160..0xd0f179
+            - Range: 0xd0f460..0xd0f479
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 324 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xd0f160..0xd0f179
+            - Range: 0xd0f460..0xd0f479
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xd0f160..0xd0f179
+            - Range: 0xd0f460..0xd0f479
               Pieces: []
-            - Range: 0xd0f179..0xd0f17a
+            - Range: 0xd0f479..0xd0f47a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0f17a..0xd0f1a4
+            - Range: 0xd0f47a..0xd0f4a4
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 167
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xd0f440..0xd0f444]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 322 PointerType *go.shape.int
-          Locations:
-            - Range: 0xd0f440..0xd0f444
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 322 PointerType *go.shape.int
-          Locations:
-            - Range: 0xd0f440..0xd0f443
-              Pieces: []
-            - Range: 0xd0f443..0xd0f444
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 168
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xd0f460..0xd0f464]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0xd0f740..0xd0f744]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 325 PointerType *go.shape.struct { Name string }
+          Type: 322 PointerType *go.shape.int
           Locations:
-            - Range: 0xd0f460..0xd0f464
+            - Range: 0xd0f740..0xd0f744
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 325 PointerType *go.shape.struct { Name string }
+          Type: 322 PointerType *go.shape.int
           Locations:
-            - Range: 0xd0f460..0xd0f463
+            - Range: 0xd0f740..0xd0f743
               Pieces: []
-            - Range: 0xd0f463..0xd0f464
+            - Range: 0xd0f743..0xd0f744
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0xd0f760..0xd0f764]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 325 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0xd0f760..0xd0f764
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 325 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0xd0f760..0xd0f763
+              Pieces: []
+            - Range: 0xd0f763..0xd0f764
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xd0f480..0xd0f484]
+      OutOfLinePCRanges: [0xd0f780..0xd0f784]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 327 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xd0f480..0xd0f484
+            - Range: 0xd0f780..0xd0f784
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 327 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xd0f480..0xd0f483
+            - Range: 0xd0f780..0xd0f783
               Pieces: []
-            - Range: 0xd0f483..0xd0f484
+            - Range: 0xd0f783..0xd0f784
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
+    - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xd0f4a0..0xd0f4b1]
+      OutOfLinePCRanges: [0xd0f7a0..0xd0f7b1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xd0f4a0..0xd0f4b1
+            - Range: 0xd0f7a0..0xd0f7b1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f4a0..0xd0f4b0
+            - Range: 0xd0f7a0..0xd0f7b0
               Pieces: []
-            - Range: 0xd0f4b0..0xd0f4b1
+            - Range: 0xd0f7b0..0xd0f7b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10101,71 +10154,71 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 171
+    - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xd0f540..0xd0f549]
+      OutOfLinePCRanges: [0xd0f840..0xd0f849]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 331 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xd0f540..0xd0f549
+            - Range: 0xd0f840..0xd0f849
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f540..0xd0f548
+            - Range: 0xd0f840..0xd0f848
               Pieces: []
-            - Range: 0xd0f548..0xd0f549
+            - Range: 0xd0f848..0xd0f849
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
+    - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xd0f600..0xd0f608]
+      OutOfLinePCRanges: [0xd0f900..0xd0f908]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xd0f600..0xd0f608
+            - Range: 0xd0f900..0xd0f908
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f600..0xd0f608
+            - Range: 0xd0f900..0xd0f908
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0xd0f600..0xd0f608
+            - Range: 0xd0f900..0xd0f908
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 173
+    - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xd0f6a0..0xd0f711]
+      OutOfLinePCRanges: [0xd0f9a0..0xd0fa11]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xd0f6a0..0xd0f711
+            - Range: 0xd0f9a0..0xd0fa11
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f6a0..0xd0f711
+            - Range: 0xd0f9a0..0xd0fa11
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10176,20 +10229,20 @@ Subprograms:
         - Name: v
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f6a0..0xd0f711
+            - Range: 0xd0f9a0..0xd0fa11
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 174
+    - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xd0f7a0..0xd0f7a8]
+      OutOfLinePCRanges: [0xd0faa0..0xd0faa8]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f7a0..0xd0f7a8
+            - Range: 0xd0faa0..0xd0faa8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10200,25 +10253,25 @@ Subprograms:
         - Name: b
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0xd0f7a0..0xd0f7a8
+            - Range: 0xd0faa0..0xd0faa8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0xd0f7a0..0xd0f7a7
+            - Range: 0xd0faa0..0xd0faa7
               Pieces: []
-            - Range: 0xd0f7a7..0xd0f7a8
+            - Range: 0xd0faa7..0xd0faa8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f7a0..0xd0f7a7
+            - Range: 0xd0faa0..0xd0faa7
               Pieces: []
-            - Range: 0xd0f7a7..0xd0f7a8
+            - Range: 0xd0faa7..0xd0faa8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10227,28 +10280,28 @@ Subprograms:
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 175
+    - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xd0f7c0..0xd0f7cf]
+      OutOfLinePCRanges: [0xd0fac0..0xd0facf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f7c0..0xd0f7ce
+            - Range: 0xd0fac0..0xd0face
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f7c0..0xd0f7cb
+            - Range: 0xd0fac0..0xd0facb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0f7cb..0xd0f7cf
+            - Range: 0xd0facb..0xd0facf
               Pieces:
                 - Size: 8
                   Op: null
@@ -10259,9 +10312,9 @@ Subprograms:
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f7c0..0xd0f7ce
+            - Range: 0xd0fac0..0xd0face
               Pieces: []
-            - Range: 0xd0f7ce..0xd0f7cf
+            - Range: 0xd0face..0xd0facf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10272,56 +10325,56 @@ Subprograms:
         - Name: ~r1
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f7c0..0xd0f7ce
+            - Range: 0xd0fac0..0xd0face
               Pieces: []
-            - Range: 0xd0f7ce..0xd0f7cf
+            - Range: 0xd0face..0xd0facf
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 176
+    - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xd0f7e0..0xd0f81a]
+      OutOfLinePCRanges: [0xd0fae0..0xd0fb1a]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 337 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xd0f7e0..0xd0f7f9
+            - Range: 0xd0fae0..0xd0faf9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0f7e0..0xd0f7f9
+            - Range: 0xd0fae0..0xd0faf9
               Pieces: []
-            - Range: 0xd0f7f9..0xd0f7fa
+            - Range: 0xd0faf9..0xd0fafa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0f7fa..0xd0f81a
+            - Range: 0xd0fafa..0xd0fb1a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 177
+    - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xd0f820..0xd0f86d]
+      OutOfLinePCRanges: [0xd0fb20..0xd0fb6d]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 338 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xd0f820..0xd0f83f
+            - Range: 0xd0fb20..0xd0fb3f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xd0f83f..0xd0f842
+            - Range: 0xd0fb3f..0xd0fb42
               Pieces:
                 - Size: 8
                   Op: null
@@ -10332,37 +10385,37 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0f820..0xd0f842
+            - Range: 0xd0fb20..0xd0fb42
               Pieces: []
-            - Range: 0xd0f842..0xd0f843
+            - Range: 0xd0fb42..0xd0fb43
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0f843..0xd0f86d
+            - Range: 0xd0fb43..0xd0fb6d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 178
+    - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xd0f880..0xd0f888]
+      OutOfLinePCRanges: [0xd0fb80..0xd0fb88]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 339 PointerType *go.shape.string
           Locations:
-            - Range: 0xd0f880..0xd0f887
+            - Range: 0xd0fb80..0xd0fb87
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f880..0xd0f887
+            - Range: 0xd0fb80..0xd0fb87
               Pieces: []
-            - Range: 0xd0f887..0xd0f888
+            - Range: 0xd0fb87..0xd0fb88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10371,24 +10424,24 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 179
+    - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xd0f8a0..0xd0f8f7]
+      OutOfLinePCRanges: [0xd0fba0..0xd0fbf7]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 340 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd0f8a0..0xd0f8dd
+            - Range: 0xd0fba0..0xd0fbdd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 341 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xd0f8a0..0xd0f8f1
+            - Range: 0xd0fba0..0xd0fbf1
               Pieces: []
-            - Range: 0xd0f8f1..0xd0f8f2
+            - Range: 0xd0fbf1..0xd0fbf2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10402,20 +10455,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd0f8f2..0xd0f8f7
+            - Range: 0xd0fbf2..0xd0fbf7
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 180
+    - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xd0f900..0xd0f924]
+      OutOfLinePCRanges: [0xd0fc00..0xd0fc24]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xd0f900..0xd0f924
+            - Range: 0xd0fc00..0xd0fc24
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10428,33 +10481,33 @@ Subprograms:
         - Name: needle
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0f900..0xd0f924
+            - Range: 0xd0fc00..0xd0fc24
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd0f900..0xd0f920
+            - Range: 0xd0fc00..0xd0fc20
               Pieces: []
-            - Range: 0xd0f920..0xd0f921
+            - Range: 0xd0fc20..0xd0fc21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0f921..0xd0f923
+            - Range: 0xd0fc21..0xd0fc23
               Pieces: []
-            - Range: 0xd0f923..0xd0f924
+            - Range: 0xd0fc23..0xd0fc24
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xd0f940..0xd0f9ff]
+      OutOfLinePCRanges: [0xd0fc40..0xd0fcff]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 342 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xd0f940..0xd0f95d
+            - Range: 0xd0fc40..0xd0fc5d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10462,7 +10515,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd0f95d..0xd0f95f
+            - Range: 0xd0fc5d..0xd0fc5f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10475,13 +10528,13 @@ Subprograms:
         - Name: needle
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f940..0xd0f98c
+            - Range: 0xd0fc40..0xd0fc8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xd0f98c..0xd0f9ff
+            - Range: 0xd0fc8c..0xd0fcff
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10492,28 +10545,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd0f940..0xd0f9ab
+            - Range: 0xd0fc40..0xd0fcab
               Pieces: []
-            - Range: 0xd0f9ab..0xd0f9ac
+            - Range: 0xd0fcab..0xd0fcac
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0f9ac..0xd0f9b3
+            - Range: 0xd0fcac..0xd0fcb3
               Pieces: []
-            - Range: 0xd0f9b3..0xd0f9b4
+            - Range: 0xd0fcb3..0xd0fcb4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0f9b4..0xd0f9ff
+            - Range: 0xd0fcb4..0xd0fcff
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0f96f..0xd0f981
+            - Range: 0xd0fc6f..0xd0fc81
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xd0f981..0xd0f98c
+            - Range: 0xd0fc81..0xd0fc8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10522,56 +10575,56 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 182
+    - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xd0fa00..0xd0fa07]
+      OutOfLinePCRanges: [0xd0fd00..0xd0fd07]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 343 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xd0fa00..0xd0fa06
+            - Range: 0xd0fd00..0xd0fd06
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0xd0fa00..0xd0fa07
+            - Range: 0xd0fd00..0xd0fd07
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd0fa00..0xd0fa06
+            - Range: 0xd0fd00..0xd0fd06
               Pieces: []
-            - Range: 0xd0fa06..0xd0fa07
+            - Range: 0xd0fd06..0xd0fd07
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
-    - ID: 183
+    - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xd0fa80..0xd0faec]
+      OutOfLinePCRanges: [0xd0fd80..0xd0fdec]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xd0fa80..0xd0faa0
+            - Range: 0xd0fd80..0xd0fda0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0faa0..0xd0faa8
+            - Range: 0xd0fda0..0xd0fda8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0faa8..0xd0faad
+            - Range: 0xd0fda8..0xd0fdad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10582,7 +10635,7 @@ Subprograms:
         - Name: value
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xd0fa80..0xd0faad
+            - Range: 0xd0fd80..0xd0fdad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10593,16 +10646,16 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd0fa80..0xd0faad
+            - Range: 0xd0fd80..0xd0fdad
               Pieces: []
-            - Range: 0xd0faad..0xd0faae
+            - Range: 0xd0fdad..0xd0fdae
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0faae..0xd0faec
+            - Range: 0xd0fdae..0xd0fdec
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 184
+    - ID: 185
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x51ebc0..0x51ed05]
       InlinePCRanges: []
@@ -10733,7 +10786,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 185
+    - ID: 186
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xd06660..0xd066c2]
       InlinePCRanges:
@@ -10764,7 +10817,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 186
+    - ID: 187
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10772,7 +10825,7 @@ Subprograms:
           RootRanges: [0xd068a0..0xd06965]
       Variables: []
       DictRegister: null
-    - ID: 187
+    - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10780,7 +10833,7 @@ Subprograms:
           RootRanges: [0xd06a00..0xd06b0e]
       Variables: []
       DictRegister: null
-    - ID: 188
+    - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10788,7 +10841,7 @@ Subprograms:
           RootRanges: [0xd06a00..0xd06b0e]
       Variables: []
       DictRegister: null
-    - ID: 189
+    - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10803,7 +10856,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 191
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10822,12 +10875,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 191
+    - ID: 192
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xd06d40..0xd06db1]
       InlinePCRanges:
-        - Ranges: [0xd0fba3..0xd0fbe5]
-          RootRanges: [0xd0fb80..0xd0fc16]
+        - Ranges: [0xd0fea3..0xd0fee5]
+          RootRanges: [0xd0fe80..0xd0ff16]
       Variables:
         - Name: b
           Type: 349 StructureType main.firstBehavior
@@ -10862,7 +10915,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 192
+    - ID: 193
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -13896,7 +13949,7 @@ Types:
       GoKind: 22
       Pointee: 715 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1438
+      ID: 1439
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -13915,7 +13968,7 @@ Types:
             Type: 345 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -13926,7 +13979,7 @@ Types:
             Type: 345 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -13937,12 +13990,12 @@ Types:
             Type: 348 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: pred}
+                  Variable: {subprogram: 185, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1439
+      ID: 1440
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -13955,12 +14008,12 @@ Types:
             Type: 345 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 185, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1436
+      ID: 1437
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -13979,7 +14032,7 @@ Types:
             Type: 321 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -13990,7 +14043,7 @@ Types:
             Type: 321 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14001,12 +14054,12 @@ Types:
             Type: 323 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: pred}
+                  Variable: {subprogram: 166, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1437
+      ID: 1438
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14019,15 +14072,15 @@ Types:
             Type: 321 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 2, name: ~r0}
+                  Variable: {subprogram: 166, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1440
+      ID: 1441
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14046,7 +14099,7 @@ Types:
             Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14057,7 +14110,7 @@ Types:
             Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14068,12 +14121,12 @@ Types:
             Type: 324 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: f}
+                  Variable: {subprogram: 167, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1441
+      ID: 1442
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14086,12 +14139,12 @@ Types:
             Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 2, name: ~r0}
+                  Variable: {subprogram: 167, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1452
+      ID: 1453
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14113,7 +14166,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14124,7 +14177,7 @@ Types:
             Type: 332 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: x}
+                  Variable: {subprogram: 173, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14135,7 +14188,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14146,15 +14199,15 @@ Types:
             Type: 334 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 2, name: v}
+                  Variable: {subprogram: 173, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1453
+      ID: 1454
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1454
+      ID: 1455
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14176,7 +14229,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14187,7 +14240,7 @@ Types:
             Type: 335 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: x}
+                  Variable: {subprogram: 174, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14198,7 +14251,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14209,15 +14262,15 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 2, name: v}
+                  Variable: {subprogram: 174, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1455
+      ID: 1456
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1492
+      ID: 1493
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14229,12 +14282,12 @@ Types:
             Type: 349 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 0, name: b}
+                  Variable: {subprogram: 192, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1493
+      ID: 1494
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14246,12 +14299,12 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 1, name: ~r0}
+                  Variable: {subprogram: 192, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1468
+      ID: 1469
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14270,7 +14323,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14281,7 +14334,7 @@ Types:
             Type: 321 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14292,14 +14345,14 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1472
+      ID: 1473
       Name: Probe[main.genericContains[go.shape.int]]Line
-      ByteSize: 50
+      ByteSize: 49
       ExprStatusArraySize: 1
       DictEntries:
         - DictIndex: 0
@@ -14316,7 +14369,7 @@ Types:
             Type: 321 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14327,23 +14380,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
-        - Name: '@return'
-          Offset: 49
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1469
+      ID: 1470
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14355,12 +14397,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1470
+      ID: 1471
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14379,7 +14421,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14390,7 +14432,7 @@ Types:
             Type: 342 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: haystack}
+                  Variable: {subprogram: 182, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14401,14 +14443,14 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1473
+      ID: 1474
       Name: Probe[main.genericContains[go.shape.string]]Line
-      ByteSize: 26
+      ByteSize: 25
       ExprStatusArraySize: 1
       DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
       Expressions:
@@ -14419,23 +14461,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
-        - Name: '@return'
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1471
+      ID: 1472
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14447,12 +14478,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1464
+      ID: 1465
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14465,7 +14496,7 @@ Types:
             Type: 339 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14476,12 +14507,12 @@ Types:
             Type: 339 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1465
+      ID: 1466
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14494,12 +14525,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Variable: {subprogram: 179, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1466
+      ID: 1467
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14512,7 +14543,7 @@ Types:
             Type: 340 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14523,12 +14554,12 @@ Types:
             Type: 340 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1467
+      ID: 1468
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14541,12 +14572,12 @@ Types:
             Type: 341 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: ~r0}
+                  Variable: {subprogram: 180, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1460
+      ID: 1461
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14559,7 +14590,7 @@ Types:
             Type: 337 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14570,59 +14601,13 @@ Types:
             Type: 337 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1461
-      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: '@return'
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1462
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
-      Expressions:
-        - Name: val
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 338 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-        - Name: val
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 338 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-    - __kind: EventRootType
-      ID: 1463
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -14638,7 +14623,53 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1463
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
+      Expressions:
+        - Name: val
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 338 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+        - Name: val
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 338 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+    - __kind: EventRootType
+      ID: 1464
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1443
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14651,7 +14682,7 @@ Types:
             Type: 322 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14662,12 +14693,12 @@ Types:
             Type: 322 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1443
+      ID: 1444
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14680,12 +14711,12 @@ Types:
             Type: 322 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1445
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14698,7 +14729,7 @@ Types:
             Type: 325 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14709,12 +14740,12 @@ Types:
             Type: 325 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1445
+      ID: 1446
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14727,12 +14758,12 @@ Types:
             Type: 325 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1446
+      ID: 1447
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14745,7 +14776,7 @@ Types:
             Type: 327 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14756,12 +14787,12 @@ Types:
             Type: 327 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1447
+      ID: 1448
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14774,12 +14805,12 @@ Types:
             Type: 327 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1458
+      ID: 1459
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -14798,7 +14829,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14809,7 +14840,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14820,12 +14851,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: b}
+                  Variable: {subprogram: 176, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1459
+      ID: 1460
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14844,7 +14875,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 2, name: ~r0}
+                  Variable: {subprogram: 176, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14855,12 +14886,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 3, name: ~r1}
+                  Variable: {subprogram: 176, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1456
+      ID: 1457
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14879,7 +14910,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -14890,7 +14921,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -14901,12 +14932,12 @@ Types:
             Type: 334 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: b}
+                  Variable: {subprogram: 175, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1457
+      ID: 1458
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -14925,7 +14956,7 @@ Types:
             Type: 334 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 2, name: ~r0}
+                  Variable: {subprogram: 175, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
@@ -14936,12 +14967,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 3, name: ~r1}
+                  Variable: {subprogram: 175, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1450
+      ID: 1451
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -14954,7 +14985,7 @@ Types:
             Type: 331 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
@@ -14965,12 +14996,12 @@ Types:
             Type: 331 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1451
+      ID: 1452
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14983,12 +15014,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 172, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1448
+      ID: 1449
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15001,7 +15032,7 @@ Types:
             Type: 329 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
@@ -15012,12 +15043,12 @@ Types:
             Type: 329 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1449
+      ID: 1450
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15030,12 +15061,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1432
+      ID: 1433
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15048,7 +15079,7 @@ Types:
             Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15059,12 +15090,12 @@ Types:
             Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1433
+      ID: 1434
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15077,12 +15108,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1434
+      ID: 1435
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15095,7 +15126,7 @@ Types:
             Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15106,12 +15137,12 @@ Types:
             Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1435
+      ID: 1436
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15124,15 +15155,15 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1398
+      ID: 1399
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1399
+      ID: 1400
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15144,7 +15175,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: ~r0}
+                  Variable: {subprogram: 145, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -15239,7 +15270,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1369
+      ID: 1370
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15251,7 +15282,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -15262,12 +15293,12 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1370
+      ID: 1371
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15279,7 +15310,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -15981,7 +16012,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1389
+      ID: 1390
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -15993,7 +16024,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16004,7 +16035,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16015,7 +16046,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16026,12 +16057,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1386
+      ID: 1387
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16043,7 +16074,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16054,12 +16085,12 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1412
+      ID: 1413
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16071,7 +16102,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -16082,12 +16113,12 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1427
+      ID: 1428
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16099,7 +16130,7 @@ Types:
             Type: 316 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16110,12 +16141,12 @@ Types:
             Type: 316 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1426
+      ID: 1427
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16127,7 +16158,7 @@ Types:
             Type: 315 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -16138,18 +16169,18 @@ Types:
             Type: 315 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
       ID: 1208
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 58
-      ExprStatusArraySize: 2
+      ByteSize: 49
+      ExprStatusArraySize: 1
       Expressions:
         - Name: x
-          Offset: 2
+          Offset: 1
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -16160,7 +16191,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 10
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 18 GoInterfaceType error
@@ -16170,19 +16201,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: '@return'
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
         - Name: x
-          Offset: 34
+          Offset: 25
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -16193,7 +16213,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 42
+          Offset: 33
           Kind: local
           Expression:
             Type: 18 GoInterfaceType error
@@ -16324,7 +16344,7 @@ Types:
     - __kind: EventRootType
       ID: 1236
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 89
+      ByteSize: 81
       ExprStatusArraySize: 1
       Expressions:
         - Name: a
@@ -16348,17 +16368,6 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-          DictIndex: -1
-        - Name: '@return'
-          Offset: 81
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1235
@@ -16485,7 +16494,7 @@ Types:
       ID: 1229
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1484
+      ID: 1485
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1226
@@ -16541,16 +16550,16 @@ Types:
       ID: 1227
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1485
+      ID: 1486
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1230
@@ -16559,7 +16568,7 @@ Types:
       ID: 1231
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1481
+      ID: 1482
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16571,7 +16580,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16582,24 +16591,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1478
-      Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x_val
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16616,12 +16608,29 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1480
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 186, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1481
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16633,7 +16642,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16644,12 +16653,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1483
+      ID: 1484
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16661,7 +16670,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16672,15 +16681,15 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1482
+      ID: 1483
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16692,7 +16701,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16703,12 +16712,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16720,7 +16729,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16731,12 +16740,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -16748,7 +16757,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -16759,7 +16768,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -16932,7 +16941,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -16944,7 +16953,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -16955,12 +16964,12 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -16972,7 +16981,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: ~r0}
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17064,7 +17073,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1373
+      ID: 1374
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -17076,7 +17085,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17087,7 +17096,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17098,7 +17107,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17109,7 +17118,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17120,7 +17129,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17131,7 +17140,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17142,7 +17151,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17153,7 +17162,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17164,7 +17173,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17175,7 +17184,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17186,7 +17195,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17197,7 +17206,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17208,7 +17217,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17219,7 +17228,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17230,7 +17239,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17241,7 +17250,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17252,7 +17261,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17263,12 +17272,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17280,7 +17289,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 9, name: ~r0}
+                  Variable: {subprogram: 127, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -17845,34 +17854,6 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1409
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1410
       Name: Probe[main.testMassiveString]
       ByteSize: 33
@@ -17885,7 +17866,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -17896,12 +17877,40 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1375
+      ID: 1411
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1376
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -17913,7 +17922,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17924,7 +17933,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17935,7 +17944,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17946,7 +17955,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17957,7 +17966,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17968,7 +17977,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17979,7 +17988,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17990,7 +17999,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18001,7 +18010,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18012,7 +18021,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18023,7 +18032,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18034,7 +18043,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18045,7 +18054,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18056,7 +18065,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18067,7 +18076,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18078,7 +18087,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18089,7 +18098,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18100,12 +18109,12 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18117,12 +18126,12 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 9, name: ~r0}
+                  Variable: {subprogram: 128, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1379
+      ID: 1380
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18134,7 +18143,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18145,7 +18154,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -18156,7 +18165,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18167,12 +18176,12 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1380
+      ID: 1381
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -18184,7 +18193,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18195,12 +18204,12 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1371
+      ID: 1372
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -18212,7 +18221,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18223,7 +18232,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18234,7 +18243,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18245,12 +18254,12 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18262,7 +18271,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18915,7 +18924,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1421
+      ID: 1422
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18927,7 +18936,7 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18938,12 +18947,12 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1423
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -18955,7 +18964,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -18966,10 +18975,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1423
+      ID: 1424
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1424
+      ID: 1425
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -18981,7 +18990,7 @@ Types:
             Type: 116 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19042,7 +19051,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1390
+      ID: 1391
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -19054,7 +19063,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19065,7 +19074,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19076,7 +19085,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19087,12 +19096,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1392
+      ID: 1393
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -19104,7 +19113,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19115,7 +19124,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19126,7 +19135,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19137,7 +19146,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19148,7 +19157,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19159,12 +19168,12 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1393
+      ID: 1394
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -19176,7 +19185,7 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19187,12 +19196,12 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1408
+      ID: 1409
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19204,7 +19213,7 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19215,7 +19224,7 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19427,10 +19436,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1347
+      ID: 1348
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1348
+      ID: 1349
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -19442,15 +19451,15 @@ Types:
             Type: 247 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1349
+      ID: 1350
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1350
+      ID: 1351
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -19462,15 +19471,15 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1345
+      ID: 1346
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1346
+      ID: 1347
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19482,15 +19491,15 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1353
+      ID: 1354
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1354
+      ID: 1355
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -19502,7 +19511,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19513,7 +19522,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19524,7 +19533,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19535,7 +19544,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19546,7 +19555,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19557,7 +19566,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 5, name: ~r5}
+                  Variable: {subprogram: 117, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19568,7 +19577,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 6, name: ~r6}
+                  Variable: {subprogram: 117, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19579,7 +19588,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 7, name: ~r7}
+                  Variable: {subprogram: 117, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19590,15 +19599,15 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 8, name: ~r8}
+                  Variable: {subprogram: 117, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -19610,7 +19619,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: ~r0}
+                  Variable: {subprogram: 123, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19621,15 +19630,15 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r1}
+                  Variable: {subprogram: 123, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1341
+      ID: 1342
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1342
+      ID: 1343
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19641,7 +19650,7 @@ Types:
             Type: 89 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19652,7 +19661,7 @@ Types:
             Type: 90 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: ~r1}
+                  Variable: {subprogram: 111, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -20115,10 +20124,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1343
+      ID: 1344
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1344
+      ID: 1345
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -20130,15 +20139,15 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1339
+      ID: 1340
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1340
+      ID: 1341
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -20150,7 +20159,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20161,7 +20170,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: ~r1}
+                  Variable: {subprogram: 110, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20172,7 +20181,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 2, name: ~r2}
+                  Variable: {subprogram: 110, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20183,7 +20192,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 3, name: ~r3}
+                  Variable: {subprogram: 110, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20194,7 +20203,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 4, name: ~r4}
+                  Variable: {subprogram: 110, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20205,7 +20214,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 5, name: ~r5}
+                  Variable: {subprogram: 110, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20216,7 +20225,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 6, name: ~r6}
+                  Variable: {subprogram: 110, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20227,7 +20236,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 7, name: ~r7}
+                  Variable: {subprogram: 110, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20238,7 +20247,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 8, name: ~r8}
+                  Variable: {subprogram: 110, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20249,7 +20258,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 9, name: ~r9}
+                  Variable: {subprogram: 110, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20260,7 +20269,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 10, name: ~r10}
+                  Variable: {subprogram: 110, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20271,7 +20280,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 11, name: ~r11}
+                  Variable: {subprogram: 110, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20282,7 +20291,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 12, name: ~r12}
+                  Variable: {subprogram: 110, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20293,7 +20302,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 13, name: ~r13}
+                  Variable: {subprogram: 110, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20304,7 +20313,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 14, name: ~r14}
+                  Variable: {subprogram: 110, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20315,7 +20324,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 110, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20326,15 +20335,15 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 110, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1351
+      ID: 1352
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1352
+      ID: 1353
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20346,15 +20355,15 @@ Types:
             Type: 249 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1357
+      ID: 1358
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1358
+      ID: 1359
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20366,7 +20375,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20377,7 +20386,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20388,7 +20397,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 2, name: ~r2}
+                  Variable: {subprogram: 119, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20399,7 +20408,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 3, name: ~r3}
+                  Variable: {subprogram: 119, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20410,15 +20419,15 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 4, name: ~r4}
+                  Variable: {subprogram: 119, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1363
+      ID: 1364
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -20430,7 +20439,7 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: ~r0}
+                  Variable: {subprogram: 122, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20441,15 +20450,65 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r1}
+                  Variable: {subprogram: 122, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1361
-      Name: Probe[main.testReturnsOnlyFloat]
+      ID: 1337
+      Name: Probe[main.testReturnsNamedDeferLine]Line
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: a
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 1362
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1363
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20461,15 +20520,15 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1337
+      ID: 1338
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1338
+      ID: 1339
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -20481,7 +20540,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20492,7 +20551,7 @@ Types:
             Type: 97 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -20503,7 +20562,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: ~r2}
+                  Variable: {subprogram: 109, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20514,7 +20573,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 3, name: ~r3}
+                  Variable: {subprogram: 109, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20525,7 +20584,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 4, name: ~r4}
+                  Variable: {subprogram: 109, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20536,7 +20595,7 @@ Types:
             Type: 7 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 5, name: ~r5}
+                  Variable: {subprogram: 109, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -20547,7 +20606,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 6, name: ~r6}
+                  Variable: {subprogram: 109, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20558,15 +20617,15 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 7, name: ~r7}
+                  Variable: {subprogram: 109, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1359
+      ID: 1360
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1360
+      ID: 1361
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20578,15 +20637,15 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1355
+      ID: 1356
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1356
+      ID: 1357
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -20598,7 +20657,7 @@ Types:
             Type: 250 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
           DictIndex: -1
@@ -20883,7 +20942,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1400
+      ID: 1401
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -20895,7 +20954,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -20906,7 +20965,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21051,7 +21110,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1396
+      ID: 1397
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21063,7 +21122,7 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21074,12 +21133,12 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1387
+      ID: 1388
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21091,7 +21150,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21102,7 +21161,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21356,7 +21415,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1377
+      ID: 1378
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -21368,7 +21427,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -21379,12 +21438,12 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1378
+      ID: 1379
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21396,7 +21455,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21407,7 +21466,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21418,7 +21477,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r2}
+                  Variable: {subprogram: 129, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21479,7 +21538,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1391
+      ID: 1392
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21491,7 +21550,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21502,7 +21561,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21563,7 +21622,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1388
+      ID: 1389
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -21575,7 +21634,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21586,7 +21645,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21597,7 +21656,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21608,7 +21667,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21641,7 +21700,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1381
+      ID: 1382
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21653,7 +21712,7 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21664,12 +21723,12 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1382
+      ID: 1383
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21681,7 +21740,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 1, name: ~r0}
+                  Variable: {subprogram: 131, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21692,12 +21751,12 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 2, name: ~r1}
+                  Variable: {subprogram: 131, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1415
+      ID: 1416
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -21709,7 +21768,7 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -21720,15 +21779,15 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1416
+      ID: 1417
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1414
+      ID: 1415
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -21740,7 +21799,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -21751,7 +21810,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -21784,7 +21843,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1417
+      ID: 1418
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -21796,12 +21855,12 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1419
+      ID: 1420
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -21813,7 +21872,7 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
@@ -21824,18 +21883,18 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1418
+      ID: 1419
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1420
+      ID: 1421
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1397
+      ID: 1398
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -21847,7 +21906,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21858,7 +21917,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21869,7 +21928,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21880,7 +21939,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21891,7 +21950,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21902,12 +21961,12 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1413
+      ID: 1414
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -21919,7 +21978,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21930,7 +21989,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21941,7 +22000,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21952,7 +22011,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21963,7 +22022,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21974,12 +22033,12 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1425
+      ID: 1426
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -21991,12 +22050,12 @@ Types:
             Type: 314 StructureType main.tenStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 160
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1406
+      ID: 1407
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22008,7 +22067,7 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22019,12 +22078,12 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1407
+      ID: 1408
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22036,7 +22095,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22050,7 +22109,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22064,7 +22123,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22072,7 +22131,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1402
+      ID: 1403
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22084,7 +22143,7 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22095,12 +22154,12 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1404
+      ID: 1405
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22112,7 +22171,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22123,7 +22182,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
           DictIndex: -1
@@ -22134,18 +22193,18 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1403
+      ID: 1404
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1405
+      ID: 1406
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1401
+      ID: 1402
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22157,7 +22216,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22168,7 +22227,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22179,7 +22238,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22190,7 +22249,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22201,7 +22260,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22212,7 +22271,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22413,7 +22472,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1385
+      ID: 1386
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22425,7 +22484,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22436,12 +22495,12 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1411
+      ID: 1412
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22453,7 +22512,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22464,7 +22523,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22525,34 +22584,6 @@ Types:
                   ByteSize: 800
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1394
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1395
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -22565,7 +22596,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22576,12 +22607,40 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1383
+      ID: 1396
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1384
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22593,7 +22652,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -22604,7 +22663,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22615,7 +22674,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -22626,12 +22685,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1384
+      ID: 1385
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22643,7 +22702,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 2, name: ~r0}
+                  Variable: {subprogram: 132, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22654,12 +22713,12 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 3, name: ~r1}
+                  Variable: {subprogram: 132, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1474
+      ID: 1475
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -22678,7 +22737,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -22689,7 +22748,7 @@ Types:
             Type: 343 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: x}
+                  Variable: {subprogram: 183, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -22700,12 +22759,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1475
+      ID: 1476
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -22717,12 +22776,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 2, name: ~r0}
+                  Variable: {subprogram: 183, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1476
+      ID: 1477
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -22741,7 +22800,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -22752,7 +22811,7 @@ Types:
             Type: 344 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: x}
+                  Variable: {subprogram: 184, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -22763,12 +22822,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1477
+      ID: 1478
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -22780,12 +22839,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 2, name: ~r0}
+                  Variable: {subprogram: 184, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1428
+      ID: 1429
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22798,7 +22857,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -22809,12 +22868,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1429
+      ID: 1430
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22827,12 +22886,12 @@ Types:
             Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 1, name: ~r0}
+                  Variable: {subprogram: 162, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1430
+      ID: 1431
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -22845,7 +22904,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -22856,12 +22915,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1431
+      ID: 1432
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22874,7 +22933,7 @@ Types:
             Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 1, name: ~r0}
+                  Variable: {subprogram: 163, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -30271,7 +30330,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 956384
       GoKind: 5
-MaxTypeID: 1494
+MaxTypeID: 1495
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -9,15 +9,15 @@ Probes:
       segments: [stackC]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 144}
+        - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1573 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xcddaea", Frameless: false}]
+              Type: 1574 EventRootType Probe[main.stackC]
+              InjectionPoints: [{PC: "0xcdddea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1574 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xcddb25", Frameless: false}]
+              Type: 1575 EventRootType Probe[main.stackC]Return
+              InjectionPoints: [{PC: "0xcdde25", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -80,15 +80,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 124}
+        - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1544 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xcdc50e", Frameless: false}]
+              Type: 1545 EventRootType Probe[main.testArrayArgAndReturn]
+              InjectionPoints: [{PC: "0xcdc80e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1545 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcdc5c2", Frameless: false}]
+              Type: 1546 EventRootType Probe[main.testArrayArgAndReturn]Return
+              InjectionPoints: [{PC: "0xcdc8c2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -338,15 +338,15 @@ Probes:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcddf20", Frameless: true}]
+              Type: 1593 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0xcde220", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1593 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xcddf42", Frameless: true}]
+              Type: 1594 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0xcde242", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1653 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1654 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcd798e"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1654 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1655 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcd798e"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 185, index: 0, name: x}
+                      Variable: {subprogram: 186, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -433,10 +433,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1655 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1656 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcd798e"
                   Frameless: false
@@ -515,16 +515,16 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 158}
+        - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xcde040", Frameless: true}]
+              Type: 1601 EventRootType Probe[main.testTenStrings]
+              InjectionPoints: [{PC: "0xcde340", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 158, index: 0, name: x}
+                      Variable: {subprogram: 159, index: 0, name: x}
                       Offset: 144
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -789,11 +789,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 133}
+        - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1561 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xcdd600", Frameless: true}]
+              Type: 1562 EventRootType Probe[main.testEmptySlice]
+              InjectionPoints: [{PC: "0xcdd900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -816,11 +816,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 136}
+        - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1564 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xcdd660", Frameless: true}]
+              Type: 1565 EventRootType Probe[main.testEmptySliceOfStructs]
+              InjectionPoints: [{PC: "0xcdd960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -844,11 +844,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 152}
+        - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xcddc20", Frameless: true}]
+              Type: 1588 EventRootType Probe[main.testEmptyString]
+              InjectionPoints: [{PC: "0xcddf20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -866,11 +866,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 159}
+        - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xcde0a0", Frameless: true}]
+              Type: 1602 EventRootType Probe[main.testEmptyStruct]
+              InjectionPoints: [{PC: "0xcde3a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -887,11 +887,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 160}
+        - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xcde0c0", Frameless: true}]
+              Type: 1603 EventRootType Probe[main.testEmptyStructPointer]
+              InjectionPoints: [{PC: "0xcde3c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1100,15 +1100,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1639 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xce0cc0", Frameless: true}]
+              Type: 1640 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0xce0fc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1640 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce0cc7", Frameless: true}]
+              Type: 1641 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce0fc7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1118,15 +1118,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1641 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xce0ce4", Frameless: false}]
+              Type: 1642 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0xce0fe4", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1642 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xce0d31", Frameless: false}]
+              Type: 1643 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0xce1031", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1145,15 +1145,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1635 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xce0c2a", Frameless: false}]
+              Type: 1636 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0xce0f2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1636 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xce0c39", Frameless: false}]
+              Type: 1637 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0xce0f39", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1163,15 +1163,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1637 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xce0c6a", Frameless: false}]
+              Type: 1638 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0xce0f6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1638 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xce0c82", Frameless: false}]
+              Type: 1639 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0xce0f82", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1190,18 +1190,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1643 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xce0d40", Frameless: true}]
+              Type: 1644 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0xce1040", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1644 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1645 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xce0d60"
+                - PC: "0xce1060"
                   Frameless: true
-                - PC: "0xce0d63"
+                - PC: "0xce1063"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1212,18 +1212,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1645 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xce0d8a", Frameless: false}]
+              Type: 1646 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0xce108a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1646 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1647 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xce0deb"
+                - PC: "0xce10eb"
                   Frameless: false
-                - PC: "0xce0df3"
+                - PC: "0xce10f3"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1246,11 +1246,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Line
-              Type: 1647 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xce0d45", Frameless: true}]
+              Type: 1648 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0xce1045", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1258,11 +1258,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Line
-              Type: 1648 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xce0d9f", Frameless: false}]
+              Type: 1649 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0xce109f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1279,15 +1279,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1623 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xce08e0", Frameless: true}]
+              Type: 1624 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0xce0be0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1624 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xce08f0", Frameless: true}]
+              Type: 1625 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0xce0bf0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1297,15 +1297,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1625 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xce0980", Frameless: true}]
+              Type: 1626 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0xce0c80", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1626 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xce0988", Frameless: true}]
+              Type: 1627 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0xce0c88", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1325,15 +1325,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 166}
           events:
             - Kind: Entry
-              Type: 1611 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce046e", Frameless: false}]
+              Type: 1612 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0xce076e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1612 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce0554", Frameless: false}]
+              Type: 1613 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce0854", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1343,14 +1343,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1613 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1614 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x5235ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1614 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1615 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x52369c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1371,15 +1371,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 167}
           events:
             - Kind: Entry
-              Type: 1615 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce05aa", Frameless: false}]
+              Type: 1616 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xce08aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1616 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce05b9", Frameless: false}]
+              Type: 1617 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce08b9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1398,15 +1398,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1649 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xce0e40", Frameless: true}]
+              Type: 1650 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0xce1140", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1650 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xce0e46", Frameless: true}]
+              Type: 1651 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0xce1146", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1416,15 +1416,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1651 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xce0eca", Frameless: false}]
+              Type: 1652 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0xce11ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1652 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xce0eed", Frameless: false}]
+              Type: 1653 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0xce11ed", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1443,15 +1443,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 163}
+        - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1607 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce03c0", Frameless: true}]
+              Type: 1608 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1608 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce03c3", Frameless: true}]
+              Type: 1609 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce06c3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1461,15 +1461,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 164}
+        - subprogram: {subprogram: 165}
           events:
             - Kind: Entry
-              Type: 1609 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce03e0", Frameless: true}]
+              Type: 1610 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0xce06e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1610 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce03eb", Frameless: true}]
+              Type: 1611 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce06eb", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1488,15 +1488,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1627 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xce0a40", Frameless: true}]
+              Type: 1628 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0xce0d40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1628 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xce0a47", Frameless: true}]
+              Type: 1629 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0xce0d47", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1506,15 +1506,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1629 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xce0aea", Frameless: false}]
+              Type: 1630 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0xce0dea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1630 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xce0b16", Frameless: false}]
+              Type: 1631 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0xce0e16", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1533,33 +1533,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
-          events:
-            - Kind: Entry
-              Type: 1617 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xce0880", Frameless: true}]
-              Condition: null
-            - Kind: Return
-              Type: 1618 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce0883", Frameless: true}]
-              Condition: null
-          probeTemplate:
-            TemplateString: p={p}
-            Segments:
-                - p=
-                - JSON: {Ref: p}
-                  DSL: p
-                  EventKind: Entry
-                  EventExpressionIndex: 0
         - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1619 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xce08a0", Frameless: true}]
+              Type: 1618 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xce0b80", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1620 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xce08a3", Frameless: true}]
+              Type: 1619 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce0b83", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1572,12 +1554,30 @@ Probes:
         - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1621 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xce08c0", Frameless: true}]
+              Type: 1620 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0xce0ba0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1622 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xce08c3", Frameless: true}]
+              Type: 1621 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0xce0ba3", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: p={p}
+            Segments:
+                - p=
+                - JSON: {Ref: p}
+                  DSL: p
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+        - subprogram: {subprogram: 170}
+          events:
+            - Kind: Entry
+              Type: 1622 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0xce0bc0", Frameless: true}]
+              Condition: null
+            - Kind: Return
+              Type: 1623 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0xce0bc3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1596,15 +1596,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1631 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xce0be0", Frameless: true}]
+              Type: 1632 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0xce0ee0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1632 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xce0be7", Frameless: true}]
+              Type: 1633 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0xce0ee7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1614,15 +1614,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1633 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce0c00", Frameless: true}]
+              Type: 1634 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xce0f00", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1634 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce0c0e", Frameless: true}]
+              Type: 1635 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce0f0e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1641,15 +1641,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 161}
+        - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1603 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce0380", Frameless: true}]
+              Type: 1604 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0xce0680", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1604 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce0383", Frameless: true}]
+              Type: 1605 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce0683", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1659,15 +1659,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 162}
+        - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1605 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce03a0", Frameless: true}]
+              Type: 1606 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0xce06a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1606 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce03ab", Frameless: true}]
+              Type: 1607 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce06ab", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1774,10 +1774,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1659 EventRootType Probe[main.testInlinedBBB]
+              Type: 1660 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0xcd7c26", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1814,10 +1814,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1660 EventRootType Probe[main.testInlinedBCA]
+              Type: 1661 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0xcd7d33", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1835,10 +1835,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1661 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1662 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0xcd7d33", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1853,10 +1853,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1662 EventRootType Probe[main.testInlinedBCB]
+              Type: 1663 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0xcd7de6", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1874,10 +1874,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Line
-              Type: 1663 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1664 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0xcd7de6", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1892,10 +1892,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1669 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1670 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x5230a1"
                   Frameless: true
@@ -1915,10 +1915,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1656 EventRootType Probe[main.testInlinedPrint]
+              Type: 1657 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0xcd798a"
                   Frameless: false
@@ -1932,7 +1932,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1657 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1658 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0xcd79ca", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1954,10 +1954,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1658 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1659 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcd798e"
                   Frameless: false
@@ -1986,10 +1986,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1664 EventRootType Probe[main.testInlinedSq]
+              Type: 1665 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0xcd7e41", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2011,10 +2011,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Line
-              Type: 1665 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1666 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0xcd7e41", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2034,10 +2034,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1666 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1667 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0xcd7e85"
                   Frameless: false
@@ -2191,15 +2191,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 123}
+        - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1542 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xcdc36e", Frameless: false}]
+              Type: 1543 EventRootType Probe[main.testLargeArgAndReturn]
+              InjectionPoints: [{PC: "0xcdc66e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1543 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcdc4d3", Frameless: false}]
+              Type: 1544 EventRootType Probe[main.testLargeArgAndReturn]Return
+              InjectionPoints: [{PC: "0xcdc7d3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2329,15 +2329,15 @@ Probes:
           dsl: i
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 126}
+        - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1548 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xcdc833", Frameless: false}]
+              Type: 1549 EventRootType Probe[main.testManyArgsArrayReturn]
+              InjectionPoints: [{PC: "0xcdcb33", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1549 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xcdca42", Frameless: false}]
+              Type: 1550 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              InjectionPoints: [{PC: "0xcdcd42", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2841,11 +2841,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcddbe0", Frameless: true}]
+              Type: 1585 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0xcddee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2864,11 +2864,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcddbe0", Frameless: true}]
+              Type: 1586 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0xcddee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2911,15 +2911,15 @@ Probes:
           dsl: s
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 127}
+        - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1550 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xcdcad3", Frameless: false}]
+              Type: 1551 EventRootType Probe[main.testMixedArgsStackReturn]
+              InjectionPoints: [{PC: "0xcdcdd3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1551 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xcdcd0b", Frameless: false}]
+              Type: 1552 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              InjectionPoints: [{PC: "0xcdd00b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2981,15 +2981,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 129}
+        - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1554 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xcdce4e", Frameless: false}]
+              Type: 1555 EventRootType Probe[main.testMultipleArrayArgs]
+              InjectionPoints: [{PC: "0xcdd14e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1555 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xcdcf1e", Frameless: false}]
+              Type: 1556 EventRootType Probe[main.testMultipleArrayArgs]Return
+              InjectionPoints: [{PC: "0xcdd21e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3016,15 +3016,15 @@ Probes:
           dsl: s2
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 125}
+        - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1546 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xcdc5ee", Frameless: false}]
+              Type: 1547 EventRootType Probe[main.testMultipleLargeArgs]
+              InjectionPoints: [{PC: "0xcdc8ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1547 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xcdc80a", Frameless: false}]
+              Type: 1548 EventRootType Probe[main.testMultipleLargeArgs]Return
+              InjectionPoints: [{PC: "0xcdcb0a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3271,11 +3271,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcde020", Frameless: true}]
+              Type: 1597 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xcde320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3296,11 +3296,11 @@ Probes:
           dsl: x.nested.anotherString
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcde020", Frameless: true}]
+              Type: 1598 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xcde320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3327,11 +3327,11 @@ Probes:
           dsl: x.notAMember
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcde020", Frameless: true}]
+              Type: 1599 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xcde320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3352,11 +3352,11 @@ Probes:
           dsl: x.nested
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1599 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xcde020", Frameless: true}]
+              Type: 1600 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xcde320", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3406,11 +3406,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 140}
+        - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1568 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xcdd6e0", Frameless: true}]
+              Type: 1569 EventRootType Probe[main.testNilSlice]
+              InjectionPoints: [{PC: "0xcdd9e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3433,11 +3433,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 137}
+        - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1565 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xcdd680", Frameless: true}]
+              Type: 1566 EventRootType Probe[main.testNilSliceOfStructs]
+              InjectionPoints: [{PC: "0xcdd980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3468,11 +3468,11 @@ Probes:
           dsl: x
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 139}
+        - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1567 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xcdd6c0", Frameless: true}]
+              Type: 1568 EventRootType Probe[main.testNilSliceWithOtherParams]
+              InjectionPoints: [{PC: "0xcdd9c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3500,11 +3500,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 149}
+        - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xcddbc0", Frameless: true}]
+              Type: 1584 EventRootType Probe[main.testOneStringInStructPointer]
+              InjectionPoints: [{PC: "0xcddec0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3941,15 +3941,15 @@ Probes:
       segments: [testReturnsArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 112}
+        - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1520 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xcdbe0a", Frameless: false}]
+              Type: 1521 EventRootType Probe[main.testReturnsArray]
+              InjectionPoints: [{PC: "0xcdc10a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1521 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xcdbe6d", Frameless: false}]
+              Type: 1522 EventRootType Probe[main.testReturnsArray]Return
+              InjectionPoints: [{PC: "0xcdc16d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3962,15 +3962,15 @@ Probes:
       segments: [testReturnsArrayOne]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 113}
+        - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1522 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xcdbe8a", Frameless: false}]
+              Type: 1523 EventRootType Probe[main.testReturnsArrayOne]
+              InjectionPoints: [{PC: "0xcdc18a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1523 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xcdbecb", Frameless: false}]
+              Type: 1524 EventRootType Probe[main.testReturnsArrayOne]Return
+              InjectionPoints: [{PC: "0xcdc1cb", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3983,15 +3983,15 @@ Probes:
       segments: [testReturnsArrayZero]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 114}
+        - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1524 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xcdbeea", Frameless: false}]
+              Type: 1525 EventRootType Probe[main.testReturnsArrayZero]
+              InjectionPoints: [{PC: "0xcdc1ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1525 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xcdbf26", Frameless: false}]
+              Type: 1526 EventRootType Probe[main.testReturnsArrayZero]Return
+              InjectionPoints: [{PC: "0xcdc226", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4004,15 +4004,15 @@ Probes:
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 116}
+        - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1528 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xcdbfce", Frameless: false}]
+              Type: 1529 EventRootType Probe[main.testReturnsBacktrackInt]
+              InjectionPoints: [{PC: "0xcdc2ce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1529 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xcdc04a", Frameless: false}]
+              Type: 1530 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              InjectionPoints: [{PC: "0xcdc34a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4025,15 +4025,15 @@ Probes:
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 122}
+        - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1540 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xcdc30a", Frameless: false}]
+              Type: 1541 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              InjectionPoints: [{PC: "0xcdc60a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1541 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xcdc350", Frameless: false}]
+              Type: 1542 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              InjectionPoints: [{PC: "0xcdc650", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4046,15 +4046,15 @@ Probes:
       segments: [testReturnsComplex]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 110}
+        - subprogram: {subprogram: 111}
           events:
             - Kind: Entry
-              Type: 1516 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xcdbcca", Frameless: false}]
+              Type: 1517 EventRootType Probe[main.testReturnsComplex]
+              InjectionPoints: [{PC: "0xcdbfca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1517 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xcdbd26", Frameless: false}]
+              Type: 1518 EventRootType Probe[main.testReturnsComplex]Return
+              InjectionPoints: [{PC: "0xcdc026", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4202,15 +4202,15 @@ Probes:
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 111}
+        - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1518 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xcdbd4e", Frameless: false}]
+              Type: 1519 EventRootType Probe[main.testReturnsLargeStruct]
+              InjectionPoints: [{PC: "0xcdc04e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1519 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xcdbdd3", Frameless: false}]
+              Type: 1520 EventRootType Probe[main.testReturnsLargeStruct]Return
+              InjectionPoints: [{PC: "0xcdc0d3", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4223,15 +4223,15 @@ Probes:
       segments: [testReturnsManyFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 109}
+        - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1514 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xcdbbce", Frameless: false}]
+              Type: 1515 EventRootType Probe[main.testReturnsManyFloats]
+              InjectionPoints: [{PC: "0xcdbece", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1515 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xcdbca7", Frameless: false}]
+              Type: 1516 EventRootType Probe[main.testReturnsManyFloats]Return
+              InjectionPoints: [{PC: "0xcdbfa7", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4244,15 +4244,15 @@ Probes:
       segments: [testReturnsMixed]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 118}
+        - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1532 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xcdc12a", Frameless: false}]
+              Type: 1533 EventRootType Probe[main.testReturnsMixed]
+              InjectionPoints: [{PC: "0xcdc42a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1533 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xcdc18c", Frameless: false}]
+              Type: 1534 EventRootType Probe[main.testReturnsMixed]Return
+              InjectionPoints: [{PC: "0xcdc48c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4265,15 +4265,15 @@ Probes:
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 115}
+        - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1526 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xcdbf4a", Frameless: false}]
+              Type: 1527 EventRootType Probe[main.testReturnsMixedStruct]
+              InjectionPoints: [{PC: "0xcdc24a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1527 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xcdbf98", Frameless: false}]
+              Type: 1528 EventRootType Probe[main.testReturnsMixedStruct]Return
+              InjectionPoints: [{PC: "0xcdc298", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4286,19 +4286,43 @@ Probes:
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 121}
+        - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1538 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xcdc28a", Frameless: false}]
+              Type: 1539 EventRootType Probe[main.testReturnsMultipleFloats]
+              InjectionPoints: [{PC: "0xcdc58a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1539 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xcdc2d6", Frameless: false}]
+              Type: 1540 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              InjectionPoints: [{PC: "0xcdc5d6", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
             Segments: [testReturnsMultipleFloats]
+    - id: testReturnsNamedDeferLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testReturnsNamedDeferLine
+        sourceFile: returns.go
+        lines: ["121"]
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 108}
+          events:
+            - Kind: Line
+              Type: 1512 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              InjectionPoints: [{PC: "0xcdbc4f", Frameless: false}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{i}'
+            Segments:
+                - JSON: {Ref: i}
+                  DSL: i
+                  EventKind: Line
+                  EventExpressionIndex: 0
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -4307,15 +4331,15 @@ Probes:
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 120}
+        - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1536 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xcdc22a", Frameless: false}]
+              Type: 1537 EventRootType Probe[main.testReturnsOnlyFloat]
+              InjectionPoints: [{PC: "0xcdc52a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1537 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xcdc26e", Frameless: false}]
+              Type: 1538 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              InjectionPoints: [{PC: "0xcdc56e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4328,15 +4352,15 @@ Probes:
       segments: [testReturnsPrimitives]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 108}
+        - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1512 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xcdbb4a", Frameless: false}]
+              Type: 1513 EventRootType Probe[main.testReturnsPrimitives]
+              InjectionPoints: [{PC: "0xcdbe4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1513 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xcdbbb1", Frameless: false}]
+              Type: 1514 EventRootType Probe[main.testReturnsPrimitives]Return
+              InjectionPoints: [{PC: "0xcdbeb1", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4349,15 +4373,15 @@ Probes:
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 119}
+        - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1534 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xcdc1aa", Frameless: false}]
+              Type: 1535 EventRootType Probe[main.testReturnsStructWithArray]
+              InjectionPoints: [{PC: "0xcdc4aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1535 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xcdc20d", Frameless: false}]
+              Type: 1536 EventRootType Probe[main.testReturnsStructWithArray]Return
+              InjectionPoints: [{PC: "0xcdc50d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4370,15 +4394,15 @@ Probes:
       segments: [testReturnsWideStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 117}
+        - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1530 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xcdc06e", Frameless: false}]
+              Type: 1531 EventRootType Probe[main.testReturnsWideStruct]
+              InjectionPoints: [{PC: "0xcdc36e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1531 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xcdc0f4", Frameless: false}]
+              Type: 1532 EventRootType Probe[main.testReturnsWideStruct]Return
+              InjectionPoints: [{PC: "0xcdc3f4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4706,11 +4730,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 145}
+        - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1575 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xcddb40", Frameless: true}]
+              Type: 1576 EventRootType Probe[main.testSingleString]
+              InjectionPoints: [{PC: "0xcdde40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4838,11 +4862,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 142}
+        - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1571 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xcdd720", Frameless: true}]
+              Type: 1572 EventRootType Probe[main.testSliceEmptyStructs]
+              InjectionPoints: [{PC: "0xcdda20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4860,11 +4884,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 134}
+        - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1562 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xcdd620", Frameless: true}]
+              Type: 1563 EventRootType Probe[main.testSliceOfSlices]
+              InjectionPoints: [{PC: "0xcdd920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4928,15 +4952,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 128}
+        - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1552 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xcdcdaa", Frameless: false}]
+              Type: 1553 EventRootType Probe[main.testStackArgRegReturns]
+              InjectionPoints: [{PC: "0xcdd0aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1553 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xcdce1c", Frameless: false}]
+              Type: 1554 EventRootType Probe[main.testStackArgRegReturns]Return
+              InjectionPoints: [{PC: "0xcdd11c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4998,11 +5022,11 @@ Probes:
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 138}
+        - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1566 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xcdd6a0", Frameless: true}]
+              Type: 1567 EventRootType Probe[main.testStringSlice]
+              InjectionPoints: [{PC: "0xcdd9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5064,15 +5088,15 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcddf20", Frameless: true}]
+              Type: 1595 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0xcde220", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1595 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xcddf42", Frameless: true}]
+              Type: 1596 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0xcde242", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5095,11 +5119,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 135}
+        - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1563 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xcdd640", Frameless: true}]
+              Type: 1564 EventRootType Probe[main.testStructSlice]
+              InjectionPoints: [{PC: "0xcdd940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5143,15 +5167,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 130}
+        - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1556 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xcdcf4e", Frameless: false}]
+              Type: 1557 EventRootType Probe[main.testStructWithArrayArg]
+              InjectionPoints: [{PC: "0xcdd24e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1557 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xcdcffa", Frameless: false}]
+              Type: 1558 EventRootType Probe[main.testStructWithArrayArg]Return
+              InjectionPoints: [{PC: "0xcdd2fa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5169,15 +5193,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 155}
+        - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xcddde0", Frameless: true}]
+              Type: 1591 EventRootType Probe[main.testStructWithCyclicMaps]
+              InjectionPoints: [{PC: "0xcde0e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1591 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xcdddfe", Frameless: true}]
+              Type: 1592 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              InjectionPoints: [{PC: "0xcde0fe", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5194,11 +5218,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 154}
+        - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xcdddc0", Frameless: true}]
+              Type: 1590 EventRootType Probe[main.testStructWithCyclicSlices]
+              InjectionPoints: [{PC: "0xcde0c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5253,11 +5277,11 @@ Probes:
           dsl: cs
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 143}
+        - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1572 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xcdd740", Frameless: true}]
+              Type: 1573 EventRootType Probe[main.testSubslices]
+              InjectionPoints: [{PC: "0xcdda40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5293,11 +5317,11 @@ Probes:
           dsl: c
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 153}
+        - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1588 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xcddc40", Frameless: true}]
+              Type: 1589 EventRootType Probe[main.testSubstrings]
+              InjectionPoints: [{PC: "0xcddf40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5411,11 +5435,11 @@ Probes:
           dsl: z
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 146}
+        - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1576 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xcddb60", Frameless: true}]
+              Type: 1577 EventRootType Probe[main.testThreeStrings]
+              InjectionPoints: [{PC: "0xcdde60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5443,15 +5467,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcddb80", Frameless: true}]
+              Type: 1578 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0xcdde80", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1578 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xcddb9e", Frameless: true}]
+              Type: 1579 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0xcdde9e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5477,15 +5501,15 @@ Probes:
           dsl: t.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcddb80", Frameless: true}]
+              Type: 1580 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0xcdde80", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1580 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xcddb9e", Frameless: true}]
+              Type: 1581 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0xcdde9e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5513,11 +5537,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcddba0", Frameless: true}]
+              Type: 1582 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0xcddea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5543,11 +5567,11 @@ Probes:
           dsl: a.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcddba0", Frameless: true}]
+              Type: 1583 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0xcddea0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5729,11 +5753,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 132}
+        - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1560 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xcdd5e0", Frameless: true}]
+              Type: 1561 EventRootType Probe[main.testUintSlice]
+              InjectionPoints: [{PC: "0xcdd8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5751,11 +5775,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 151}
+        - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xcddc00", Frameless: true}]
+              Type: 1587 EventRootType Probe[main.testUnitializedString]
+              InjectionPoints: [{PC: "0xcddf00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5817,11 +5841,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1569 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcdd700", Frameless: true}]
+              Type: 1570 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0xcdda00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5839,11 +5863,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1570 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcdd700", Frameless: true}]
+              Type: 1571 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0xcdda00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5861,18 +5885,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1667 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1668 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0xcd806a"
                   Frameless: false
-                - PC: "0xce0fe3"
+                - PC: "0xce12e3"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1668 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1669 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0xcd80b0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5891,15 +5915,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 131}
+        - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1558 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xcdd02e", Frameless: false}]
+              Type: 1559 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              InjectionPoints: [{PC: "0xcdd32e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1559 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcdd0ac", Frameless: false}]
+              Type: 1560 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              InjectionPoints: [{PC: "0xcdd3ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -8114,802 +8138,831 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 108
+      Name: main.testReturnsNamedDeferLine
+      OutOfLinePCRanges: [0xcdbb40..0xcdbd4f]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdbb40..0xcdbbc6
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdbbc6..0xcdbd4f
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdbb77..0xcdbd4f
+              Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
+          Role: Return
+          DictIndex: -1
+        - Name: b
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdbb7d..0xcdbd4f
+              Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcdbb40..0xcdbbbe]
+      OutOfLinePCRanges: [0xcdbe40..0xcdbebe]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcdbb40..0xcdbbb1
+            - Range: 0xcdbe40..0xcdbeb1
               Pieces: []
-            - Range: 0xcdbbb1..0xcdbbb2
+            - Range: 0xcdbeb1..0xcdbeb2
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdbbb2..0xcdbbbe
+            - Range: 0xcdbeb2..0xcdbebe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 102 BaseType int16
           Locations:
-            - Range: 0xcdbb40..0xcdbbb1
+            - Range: 0xcdbe40..0xcdbeb1
               Pieces: []
-            - Range: 0xcdbbb1..0xcdbbb2
+            - Range: 0xcdbeb1..0xcdbeb2
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdbbb2..0xcdbbbe
+            - Range: 0xcdbeb2..0xcdbebe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcdbb40..0xcdbbb1
+            - Range: 0xcdbe40..0xcdbeb1
               Pieces: []
-            - Range: 0xcdbbb1..0xcdbbb2
+            - Range: 0xcdbeb1..0xcdbeb2
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdbbb2..0xcdbbbe
+            - Range: 0xcdbeb2..0xcdbebe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xcdbb40..0xcdbbb1
+            - Range: 0xcdbe40..0xcdbeb1
               Pieces: []
-            - Range: 0xcdbbb1..0xcdbbb2
+            - Range: 0xcdbeb1..0xcdbeb2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdbbb2..0xcdbbbe
+            - Range: 0xcdbeb2..0xcdbebe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdbb40..0xcdbbb1
+            - Range: 0xcdbe40..0xcdbeb1
               Pieces: []
-            - Range: 0xcdbbb1..0xcdbbb2
+            - Range: 0xcdbeb1..0xcdbeb2
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdbbb2..0xcdbbbe
+            - Range: 0xcdbeb2..0xcdbebe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcdbb40..0xcdbbb1
+            - Range: 0xcdbe40..0xcdbeb1
               Pieces: []
-            - Range: 0xcdbbb1..0xcdbbb2
+            - Range: 0xcdbeb1..0xcdbeb2
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdbbb2..0xcdbbbe
+            - Range: 0xcdbeb2..0xcdbebe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcdbb40..0xcdbbb1
+            - Range: 0xcdbe40..0xcdbeb1
               Pieces: []
-            - Range: 0xcdbbb1..0xcdbbb2
+            - Range: 0xcdbeb1..0xcdbeb2
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdbbb2..0xcdbbbe
+            - Range: 0xcdbeb2..0xcdbebe
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcdbb40..0xcdbbb1
+            - Range: 0xcdbe40..0xcdbeb1
               Pieces: []
-            - Range: 0xcdbbb1..0xcdbbb2
+            - Range: 0xcdbeb1..0xcdbeb2
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdbbb2..0xcdbbbe
+            - Range: 0xcdbeb2..0xcdbebe
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcdbbc0..0xcdbcb7]
+      OutOfLinePCRanges: [0xcdbec0..0xcdbfb7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdbbc0..0xcdbcb7, Pieces: []}]
+          Locations: [{Range: 0xcdbec0..0xcdbfb7, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcdbbc0..0xcdbca7
+            - Range: 0xcdbec0..0xcdbfa7
               Pieces: []
-            - Range: 0xcdbca7..0xcdbca8
+            - Range: 0xcdbfa7..0xcdbfa8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcdbca8..0xcdbcb7
+            - Range: 0xcdbfa8..0xcdbfb7
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcdbbc0..0xcdbca7
+            - Range: 0xcdbec0..0xcdbfa7
               Pieces: []
-            - Range: 0xcdbca7..0xcdbca8
+            - Range: 0xcdbfa7..0xcdbfa8
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdbca8..0xcdbcb7
+            - Range: 0xcdbfa8..0xcdbfb7
               Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 110
-      Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcdbcc0..0xcdbd33]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 94 BaseType complex64
-          Locations: [{Range: 0xcdbcc0..0xcdbd33, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 95 BaseType complex128
-          Locations: [{Range: 0xcdbcc0..0xcdbd33, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0xcdbfc0..0xcdc033]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 94 BaseType complex64
+          Locations: [{Range: 0xcdbfc0..0xcdc033, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 95 BaseType complex128
+          Locations: [{Range: 0xcdbfc0..0xcdc033, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcdbd40..0xcdbde5]
+      OutOfLinePCRanges: [0xcdc040..0xcdc0e5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdbd40..0xcdbdd3
+            - Range: 0xcdc040..0xcdc0d3
               Pieces: []
-            - Range: 0xcdbdd3..0xcdbdd4
+            - Range: 0xcdc0d3..0xcdc0d4
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcdbdd4..0xcdbde5
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 112
-      Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcdbe00..0xcdbe7a]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 249 ArrayType [3]int
-          Locations:
-            - Range: 0xcdbe00..0xcdbe6d
-              Pieces: []
-            - Range: 0xcdbe6d..0xcdbe6e
-              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcdbe6e..0xcdbe7a
+            - Range: 0xcdc0d4..0xcdc0e5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
-      Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcdbe80..0xcdbed8]
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0xcdc100..0xcdc17a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 250 ArrayType [1]int
+          Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcdbe80..0xcdbecb
+            - Range: 0xcdc100..0xcdc16d
               Pieces: []
-            - Range: 0xcdbecb..0xcdbecc
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdbecc..0xcdbed8
+            - Range: 0xcdc16d..0xcdc16e
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xcdc16e..0xcdc17a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
-      Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcdbee0..0xcdbf33]
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0xcdc180..0xcdc1d8]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 251 ArrayType [0]int
+          Type: 250 ArrayType [1]int
           Locations:
-            - Range: 0xcdbee0..0xcdbf26
+            - Range: 0xcdc180..0xcdc1cb
               Pieces: []
-            - Range: 0xcdbf26..0xcdbf27
-              Pieces: []
-            - Range: 0xcdbf27..0xcdbf33
+            - Range: 0xcdc1cb..0xcdc1cc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdc1cc..0xcdc1d8
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
-      Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcdbf40..0xcdbfa7]
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0xcdc1e0..0xcdc233]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 252 StructureType main.mixedStruct
-          Locations: [{Range: 0xcdbf40..0xcdbfa7, Pieces: []}]
+          Type: 251 ArrayType [0]int
+          Locations:
+            - Range: 0xcdc1e0..0xcdc226
+              Pieces: []
+            - Range: 0xcdc226..0xcdc227
+              Pieces: []
+            - Range: 0xcdc227..0xcdc233
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0xcdc240..0xcdc2a7]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 252 StructureType main.mixedStruct
+          Locations: [{Range: 0xcdc240..0xcdc2a7, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcdbfc0..0xcdc05a]
+      OutOfLinePCRanges: [0xcdc2c0..0xcdc35a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdbfc0..0xcdc04a
+            - Range: 0xcdc2c0..0xcdc34a
               Pieces: []
-            - Range: 0xcdc04a..0xcdc04b
+            - Range: 0xcdc34a..0xcdc34b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc04b..0xcdc05a
+            - Range: 0xcdc34b..0xcdc35a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdbfc0..0xcdc04a
+            - Range: 0xcdc2c0..0xcdc34a
               Pieces: []
-            - Range: 0xcdc04a..0xcdc04b
+            - Range: 0xcdc34a..0xcdc34b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdc04b..0xcdc05a
+            - Range: 0xcdc34b..0xcdc35a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdbfc0..0xcdc04a
+            - Range: 0xcdc2c0..0xcdc34a
               Pieces: []
-            - Range: 0xcdc04a..0xcdc04b
+            - Range: 0xcdc34a..0xcdc34b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdc04b..0xcdc05a
+            - Range: 0xcdc34b..0xcdc35a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdbfc0..0xcdc04a
+            - Range: 0xcdc2c0..0xcdc34a
               Pieces: []
-            - Range: 0xcdc04a..0xcdc04b
+            - Range: 0xcdc34a..0xcdc34b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdc04b..0xcdc05a
+            - Range: 0xcdc34b..0xcdc35a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdbfc0..0xcdc04a
+            - Range: 0xcdc2c0..0xcdc34a
               Pieces: []
-            - Range: 0xcdc04a..0xcdc04b
+            - Range: 0xcdc34a..0xcdc34b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdc04b..0xcdc05a
+            - Range: 0xcdc34b..0xcdc35a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdbfc0..0xcdc04a
+            - Range: 0xcdc2c0..0xcdc34a
               Pieces: []
-            - Range: 0xcdc04a..0xcdc04b
+            - Range: 0xcdc34a..0xcdc34b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdc04b..0xcdc05a
+            - Range: 0xcdc34b..0xcdc35a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdbfc0..0xcdc04a
+            - Range: 0xcdc2c0..0xcdc34a
               Pieces: []
-            - Range: 0xcdc04a..0xcdc04b
+            - Range: 0xcdc34a..0xcdc34b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdc04b..0xcdc05a
+            - Range: 0xcdc34b..0xcdc35a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdbfc0..0xcdc04a
+            - Range: 0xcdc2c0..0xcdc34a
               Pieces: []
-            - Range: 0xcdc04a..0xcdc04b
+            - Range: 0xcdc34a..0xcdc34b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdc04b..0xcdc05a
+            - Range: 0xcdc34b..0xcdc35a
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdbfc0..0xcdc04a
+            - Range: 0xcdc2c0..0xcdc34a
               Pieces: []
-            - Range: 0xcdc04a..0xcdc04b
+            - Range: 0xcdc34a..0xcdc34b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcdc04b..0xcdc05a
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 117
-      Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xcdc060..0xcdc105]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 253 StructureType main.wideStruct
-          Locations:
-            - Range: 0xcdc060..0xcdc0f4
-              Pieces: []
-            - Range: 0xcdc0f4..0xcdc0f5
-              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xcdc0f5..0xcdc105
+            - Range: 0xcdc34b..0xcdc35a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
-      Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xcdc120..0xcdc199]
+      Name: main.testReturnsWideStruct
+      OutOfLinePCRanges: [0xcdc360..0xcdc405]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 7 BaseType int
+          Type: 253 StructureType main.wideStruct
           Locations:
-            - Range: 0xcdc120..0xcdc18c
+            - Range: 0xcdc360..0xcdc3f4
               Pieces: []
-            - Range: 0xcdc18c..0xcdc18d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc18d..0xcdc199
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 18 BaseType float64
-          Locations: [{Range: 0xcdc120..0xcdc199, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdc120..0xcdc18c
-              Pieces: []
-            - Range: 0xcdc18c..0xcdc18d
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdc18d..0xcdc199
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 18 BaseType float64
-          Locations: [{Range: 0xcdc120..0xcdc199, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdc120..0xcdc18c
-              Pieces: []
-            - Range: 0xcdc18c..0xcdc18d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcdc18d..0xcdc199
+            - Range: 0xcdc3f4..0xcdc3f5
+              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
+            - Range: 0xcdc3f5..0xcdc405
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
-      Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcdc1a0..0xcdc21a]
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0xcdc420..0xcdc499]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 254 StructureType main.structWithArray
+          Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc1a0..0xcdc20d
+            - Range: 0xcdc420..0xcdc48c
               Pieces: []
-            - Range: 0xcdc20d..0xcdc20e
-              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcdc20e..0xcdc21a
+            - Range: 0xcdc48c..0xcdc48d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdc48d..0xcdc499
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcdc420..0xcdc499, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdc420..0xcdc48c
+              Pieces: []
+            - Range: 0xcdc48c..0xcdc48d
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcdc48d..0xcdc499
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcdc420..0xcdc499, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdc420..0xcdc48c
+              Pieces: []
+            - Range: 0xcdc48c..0xcdc48d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcdc48d..0xcdc499
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
-      Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcdc220..0xcdc27b]
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0xcdc4a0..0xcdc51a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 18 BaseType float64
-          Locations: [{Range: 0xcdc220..0xcdc27b, Pieces: []}]
+          Type: 254 StructureType main.structWithArray
+          Locations:
+            - Range: 0xcdc4a0..0xcdc50d
+              Pieces: []
+            - Range: 0xcdc50d..0xcdc50e
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xcdc50e..0xcdc51a
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
-      Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xcdc280..0xcdc2e7]
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0xcdc520..0xcdc57b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 17 BaseType float32
-          Locations: [{Range: 0xcdc280..0xcdc2e7, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcdc280..0xcdc2e7, Pieces: []}]
+          Locations: [{Range: 0xcdc520..0xcdc57b, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0xcdc580..0xcdc5e7]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 17 BaseType float32
+          Locations: [{Range: 0xcdc580..0xcdc5e7, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcdc580..0xcdc5e7, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcdc300..0xcdc35d]
+      OutOfLinePCRanges: [0xcdc600..0xcdc65d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdc300..0xcdc350
+            - Range: 0xcdc600..0xcdc650
               Pieces: []
-            - Range: 0xcdc350..0xcdc351
+            - Range: 0xcdc650..0xcdc651
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc351..0xcdc35d
+            - Range: 0xcdc651..0xcdc65d
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xcdc300..0xcdc350
+            - Range: 0xcdc600..0xcdc650
               Pieces: []
-            - Range: 0xcdc350..0xcdc351
+            - Range: 0xcdc650..0xcdc651
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdc351..0xcdc35d
+            - Range: 0xcdc651..0xcdc65d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 123
+    - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcdc360..0xcdc4e5]
+      OutOfLinePCRanges: [0xcdc660..0xcdc7e5]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdc360..0xcdc4e5
+            - Range: 0xcdc660..0xcdc7e5
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdc360..0xcdc4d3
+            - Range: 0xcdc660..0xcdc7d3
               Pieces: []
-            - Range: 0xcdc4d3..0xcdc4d4
+            - Range: 0xcdc7d3..0xcdc7d4
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcdc4d4..0xcdc4e5
+            - Range: 0xcdc7d4..0xcdc7e5
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 124
+    - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcdc500..0xcdc5d2]
+      OutOfLinePCRanges: [0xcdc800..0xcdc8d2]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcdc500..0xcdc5d2
+            - Range: 0xcdc800..0xcdc8d2
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcdc500..0xcdc5c2
+            - Range: 0xcdc800..0xcdc8c2
               Pieces: []
-            - Range: 0xcdc5c2..0xcdc5c3
+            - Range: 0xcdc8c2..0xcdc8c3
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdc5c3..0xcdc5d2
+            - Range: 0xcdc8c3..0xcdc8d2
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xcdc5e0..0xcdc81a]
+      OutOfLinePCRanges: [0xcdc8e0..0xcdcb1a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdc5e0..0xcdc81a
+            - Range: 0xcdc8e0..0xcdcb1a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdc5e0..0xcdc81a
+            - Range: 0xcdc8e0..0xcdcb1a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdc5e0..0xcdc80a
+            - Range: 0xcdc8e0..0xcdcb0a
               Pieces: []
-            - Range: 0xcdc80a..0xcdc80b
+            - Range: 0xcdcb0a..0xcdcb0b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xcdc80b..0xcdc81a
+            - Range: 0xcdcb0b..0xcdcb1a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 126
+    - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xcdc820..0xcdcaaf]
+      OutOfLinePCRanges: [0xcdcb20..0xcdcdaf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc820..0xcdc8d0
+            - Range: 0xcdcb20..0xcdcbd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdc8d0..0xcdcaaf
+            - Range: 0xcdcbd0..0xcdcdaf
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc820..0xcdc8d0
+            - Range: 0xcdcb20..0xcdcbd0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdc8d0..0xcdcaaf
+            - Range: 0xcdcbd0..0xcdcdaf
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc820..0xcdc8ba
+            - Range: 0xcdcb20..0xcdcbba
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdc8ba..0xcdcaaf
+            - Range: 0xcdcbba..0xcdcdaf
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc820..0xcdc890
+            - Range: 0xcdcb20..0xcdcb90
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdc890..0xcdcaaf
+            - Range: 0xcdcb90..0xcdcdaf
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc820..0xcdc8d0
+            - Range: 0xcdcb20..0xcdcbd0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdc8d0..0xcdcaaf
+            - Range: 0xcdcbd0..0xcdcdaf
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc820..0xcdc8d0
+            - Range: 0xcdcb20..0xcdcbd0
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdc8d0..0xcdcaaf
+            - Range: 0xcdcbd0..0xcdcdaf
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc820..0xcdc8d0
+            - Range: 0xcdcb20..0xcdcbd0
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdc8d0..0xcdcaaf
+            - Range: 0xcdcbd0..0xcdcdaf
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc820..0xcdc8d0
+            - Range: 0xcdcb20..0xcdcbd0
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdc8d0..0xcdcaaf
+            - Range: 0xcdcbd0..0xcdcdaf
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdc820..0xcdc8d0
+            - Range: 0xcdcb20..0xcdcbd0
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xcdc8d0..0xcdcaaf
+            - Range: 0xcdcbd0..0xcdcdaf
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcdc820..0xcdca42
+            - Range: 0xcdcb20..0xcdcd42
               Pieces: []
-            - Range: 0xcdca42..0xcdca43
+            - Range: 0xcdcd42..0xcdcd43
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcdca43..0xcdcaaf
+            - Range: 0xcdcd43..0xcdcdaf
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 127
+    - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xcdcac0..0xcdcd8c]
+      OutOfLinePCRanges: [0xcdcdc0..0xcdd08c]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcac0..0xcdcb6b
+            - Range: 0xcdcdc0..0xcdce6b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdcb6b..0xcdcd8c
+            - Range: 0xcdce6b..0xcdd08c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcac0..0xcdcb6b
+            - Range: 0xcdcdc0..0xcdce6b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdcb6b..0xcdcd8c
+            - Range: 0xcdce6b..0xcdd08c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcac0..0xcdcb55
+            - Range: 0xcdcdc0..0xcdce55
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdcb55..0xcdcd8c
+            - Range: 0xcdce55..0xcdd08c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcac0..0xcdcb22
+            - Range: 0xcdcdc0..0xcdce22
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdcb22..0xcdcd8c
+            - Range: 0xcdce22..0xcdd08c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcac0..0xcdcb6b
+            - Range: 0xcdcdc0..0xcdce6b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdcb6b..0xcdcd8c
+            - Range: 0xcdce6b..0xcdd08c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcac0..0xcdcb6b
+            - Range: 0xcdcdc0..0xcdce6b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdcb6b..0xcdcd8c
+            - Range: 0xcdce6b..0xcdd08c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcac0..0xcdcb6b
+            - Range: 0xcdcdc0..0xcdce6b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdcb6b..0xcdcd8c
+            - Range: 0xcdce6b..0xcdd08c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcac0..0xcdcb6b
+            - Range: 0xcdcdc0..0xcdce6b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdcb6b..0xcdcd8c
+            - Range: 0xcdce6b..0xcdd08c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdcac0..0xcdcd8c
+            - Range: 0xcdcdc0..0xcdd08c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8920,219 +8973,200 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdcac0..0xcdcd0b
+            - Range: 0xcdcdc0..0xcdd00b
               Pieces: []
-            - Range: 0xcdcd0b..0xcdcd0c
+            - Range: 0xcdd00b..0xcdd00c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xcdcd0c..0xcdcd8c
+            - Range: 0xcdd00c..0xcdd08c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 128
+    - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcdcda0..0xcdce2c]
+      OutOfLinePCRanges: [0xcdd0a0..0xcdd12c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0xcdcda0..0xcdce2c
+            - Range: 0xcdd0a0..0xcdd12c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcda0..0xcdce1c
+            - Range: 0xcdd0a0..0xcdd11c
               Pieces: []
-            - Range: 0xcdce1c..0xcdce1d
+            - Range: 0xcdd11c..0xcdd11d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdce1d..0xcdce2c
+            - Range: 0xcdd11d..0xcdd12c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcda0..0xcdce1c
+            - Range: 0xcdd0a0..0xcdd11c
               Pieces: []
-            - Range: 0xcdce1c..0xcdce1d
+            - Range: 0xcdd11c..0xcdd11d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdce1d..0xcdce2c
+            - Range: 0xcdd11d..0xcdd12c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcda0..0xcdce1c
+            - Range: 0xcdd0a0..0xcdd11c
               Pieces: []
-            - Range: 0xcdce1c..0xcdce1d
+            - Range: 0xcdd11c..0xcdd11d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdce1d..0xcdce2c
+            - Range: 0xcdd11d..0xcdd12c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 129
+    - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcdce40..0xcdcf2e]
+      OutOfLinePCRanges: [0xcdd140..0xcdd22e]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcdce40..0xcdcf2e
+            - Range: 0xcdd140..0xcdd22e
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcdce40..0xcdcf2e
+            - Range: 0xcdd140..0xcdd22e
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdce40..0xcdcf1e
+            - Range: 0xcdd140..0xcdd21e
               Pieces: []
-            - Range: 0xcdcf1e..0xcdcf1f
+            - Range: 0xcdd21e..0xcdd21f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdcf1f..0xcdcf2e
+            - Range: 0xcdd21f..0xcdd22e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcdce40..0xcdcf1e
+            - Range: 0xcdd140..0xcdd21e
               Pieces: []
-            - Range: 0xcdcf1e..0xcdcf1f
+            - Range: 0xcdd21e..0xcdd21f
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcdcf1f..0xcdcf2e
+            - Range: 0xcdd21f..0xcdd22e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 130
+    - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcdcf40..0xcdd00b]
+      OutOfLinePCRanges: [0xcdd240..0xcdd30b]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdcf40..0xcdd00b
+            - Range: 0xcdd240..0xcdd30b
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcf40..0xcdcffa
+            - Range: 0xcdd240..0xcdd2fa
               Pieces: []
-            - Range: 0xcdcffa..0xcdcffb
+            - Range: 0xcdd2fa..0xcdd2fb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdcffb..0xcdd00b
+            - Range: 0xcdd2fb..0xcdd30b
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdcf40..0xcdcffa
+            - Range: 0xcdd240..0xcdd2fa
               Pieces: []
-            - Range: 0xcdcffa..0xcdcffb
+            - Range: 0xcdd2fa..0xcdd2fb
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdcffb..0xcdd00b
+            - Range: 0xcdd2fb..0xcdd30b
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdcfc6..0xcdd00b
+            - Range: 0xcdd2c6..0xcdd30b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
-    - ID: 131
+    - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcdd020..0xcdd0c6]
+      OutOfLinePCRanges: [0xcdd320..0xcdd3c6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 ArrayType [0]int
-          Locations: [{Range: 0xcdd020..0xcdd0c6, Pieces: []}]
+          Locations: [{Range: 0xcdd320..0xcdd3c6, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd020..0xcdd065
+            - Range: 0xcdd320..0xcdd365
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd065..0xcdd087
+            - Range: 0xcdd365..0xcdd387
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcdd087..0xcdd09a
+            - Range: 0xcdd387..0xcdd39a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcdd09a..0xcdd0c6
+            - Range: 0xcdd39a..0xcdd3c6
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd020..0xcdd0ac
+            - Range: 0xcdd320..0xcdd3ac
               Pieces: []
-            - Range: 0xcdd0ac..0xcdd0ad
+            - Range: 0xcdd3ac..0xcdd3ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd0ad..0xcdd0c6
+            - Range: 0xcdd3ad..0xcdd3c6
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0xcdd020..0xcdd0ac
+            - Range: 0xcdd320..0xcdd3ac
               Pieces: []
-            - Range: 0xcdd0ac..0xcdd0ad
+            - Range: 0xcdd3ac..0xcdd3ad
               Pieces: []
-            - Range: 0xcdd0ad..0xcdd0c6
+            - Range: 0xcdd3ad..0xcdd3c6
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 132
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdd5e0..0xcdd5e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdd5e0..0xcdd5e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
     - ID: 133
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcdd600..0xcdd601]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcdd8e0..0xcdd8e1]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdd600..0xcdd601
+            - Range: 0xcdd8e0..0xcdd8e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9144,14 +9178,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 134
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcdd620..0xcdd621]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcdd900..0xcdd901]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 256 GoSliceHeaderType [][]uint
+          Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdd620..0xcdd621
+            - Range: 0xcdd900..0xcdd901
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9163,14 +9197,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 135
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcdd640..0xcdd641]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcdd920..0xcdd921]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 256 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xcdd640..0xcdd641
+            - Range: 0xcdd920..0xcdd921
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9178,25 +9212,18 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdd640..0xcdd641
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 136
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcdd660..0xcdd661]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcdd940..0xcdd941]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcdd660..0xcdd661
+            - Range: 0xcdd940..0xcdd941
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9209,20 +9236,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd660..0xcdd661
+            - Range: 0xcdd940..0xcdd941
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcdd680..0xcdd681]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcdd960..0xcdd961]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcdd680..0xcdd681
+            - Range: 0xcdd960..0xcdd961
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9235,20 +9262,46 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd680..0xcdd681
+            - Range: 0xcdd960..0xcdd961
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcdd980..0xcdd981]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdd980..0xcdd981
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd980..0xcdd981
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcdd6a0..0xcdd6a1]
+      OutOfLinePCRanges: [0xcdd9a0..0xcdd9a1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 261 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcdd6a0..0xcdd6a1
+            - Range: 0xcdd9a0..0xcdd9a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9259,22 +9312,22 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 139
+    - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcdd6c0..0xcdd6c1]
+      OutOfLinePCRanges: [0xcdd9c0..0xcdd9c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcdd6c0..0xcdd6c1
+            - Range: 0xcdd9c0..0xcdd9c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 262 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcdd6c0..0xcdd6c1
+            - Range: 0xcdd9c0..0xcdd9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9287,39 +9340,20 @@ Subprograms:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcdd6c0..0xcdd6c1
+            - Range: 0xcdd9c0..0xcdd9c1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
+    - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdd6e0..0xcdd6e1]
+      OutOfLinePCRanges: [0xcdd9e0..0xcdd9e1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcdd6e0..0xcdd6e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcdd700..0xcdd701]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdd700..0xcdd701
+            - Range: 0xcdd9e0..0xcdd9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9331,14 +9365,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 142
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xcdd720..0xcdd721]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcdda00..0xcdda01]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 264 GoSliceHeaderType []struct {}
+          Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdd720..0xcdd721
+            - Range: 0xcdda00..0xcdda01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9350,14 +9384,33 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xcdda20..0xcdda21]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 264 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xcdda20..0xcdda21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xcdd740..0xcdd741]
+      OutOfLinePCRanges: [0xcdda40..0xcdda41]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdd740..0xcdd741
+            - Range: 0xcdda40..0xcdda41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9370,7 +9423,7 @@ Subprograms:
         - Name: bs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdd740..0xcdd741
+            - Range: 0xcdda40..0xcdda41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9383,7 +9436,7 @@ Subprograms:
         - Name: cs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdd740..0xcdd741
+            - Range: 0xcdda40..0xcdda41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9394,36 +9447,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
+    - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0xcddae0..0xcddb32]
+      OutOfLinePCRanges: [0xcddde0..0xcdde32]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddae0..0xcddb25
+            - Range: 0xcddde0..0xcdde25
               Pieces: []
-            - Range: 0xcddb25..0xcddb26
+            - Range: 0xcdde25..0xcdde26
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb26..0xcddb32
+            - Range: 0xcdde26..0xcdde32
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 145
+    - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcddb40..0xcddb41]
+      OutOfLinePCRanges: [0xcdde40..0xcdde41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddb40..0xcddb41
+            - Range: 0xcdde40..0xcdde41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9432,15 +9485,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcddb60..0xcddb61]
+      OutOfLinePCRanges: [0xcdde60..0xcdde61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddb60..0xcddb61
+            - Range: 0xcdde60..0xcdde61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9451,7 +9504,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddb60..0xcddb61
+            - Range: 0xcdde60..0xcdde61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9462,7 +9515,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddb60..0xcddb61
+            - Range: 0xcdde60..0xcdde61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9471,15 +9524,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 147
+    - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcddb80..0xcddb9f]
+      OutOfLinePCRanges: [0xcdde80..0xcdde9f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcddb80..0xcddb9f
+            - Range: 0xcdde80..0xcdde9f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9496,58 +9549,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 148
+    - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcddba0..0xcddba1]
+      OutOfLinePCRanges: [0xcddea0..0xcddea1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcddba0..0xcddba1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcddbc0..0xcddbc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 268 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0xcddbc0..0xcddbc1
+            - Range: 0xcddea0..0xcddea1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcddbe0..0xcddbe1]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0xcddec0..0xcddec1]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 268 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcddbe0..0xcddbe1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddec0..0xcddec1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcddc00..0xcddc01]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xcddee0..0xcddee1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddc00..0xcddc01
+            - Range: 0xcddee0..0xcddee1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9557,14 +9593,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 152
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcddc20..0xcddc21]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xcddf00..0xcddf01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddc20..0xcddc21
+            - Range: 0xcddf00..0xcddf01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9574,14 +9610,31 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 153
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcddf20..0xcddf21]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcddf20..0xcddf21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xcddc40..0xcddc41]
+      OutOfLinePCRanges: [0xcddf40..0xcddf41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddc40..0xcddc41
+            - Range: 0xcddf40..0xcddf41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9592,7 +9645,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddc40..0xcddc41
+            - Range: 0xcddf40..0xcddf41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9603,7 +9656,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcddc40..0xcddc41
+            - Range: 0xcddf40..0xcddf41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9612,28 +9665,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
+    - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcdddc0..0xcdddc1]
+      OutOfLinePCRanges: [0xcde0c0..0xcde0c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcdddc0..0xcdddc1
+            - Range: 0xcde0c0..0xcde0c1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
+    - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcddde0..0xcdddff]
+      OutOfLinePCRanges: [0xcde0e0..0xcde0ff]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 283 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcddde0..0xcdddff
+            - Range: 0xcde0e0..0xcde0ff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9650,15 +9703,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
+    - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcddf20..0xcddf43]
+      OutOfLinePCRanges: [0xcde220..0xcde243]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.aStruct
           Locations:
-            - Range: 0xcddf20..0xcddf43
+            - Range: 0xcde220..0xcde243
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9677,151 +9730,151 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 157
+    - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xcde020..0xcde021]
+      OutOfLinePCRanges: [0xcde320..0xcde321]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xcde020..0xcde021
+            - Range: 0xcde320..0xcde321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 158
+    - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xcde040..0xcde041]
+      OutOfLinePCRanges: [0xcde340..0xcde341]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 StructureType main.tenStrings
           Locations:
-            - Range: 0xcde040..0xcde041
+            - Range: 0xcde340..0xcde341
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 159
+    - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcde0a0..0xcde0a1]
+      OutOfLinePCRanges: [0xcde3a0..0xcde3a1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 318 StructureType main.emptyStruct
-          Locations: [{Range: 0xcde0a0..0xcde0a1, Pieces: []}]
+          Locations: [{Range: 0xcde3a0..0xcde3a1, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 160
+    - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcde0c0..0xcde0c1]
+      OutOfLinePCRanges: [0xcde3c0..0xcde3c1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcde0c0..0xcde0c1
+            - Range: 0xcde3c0..0xcde3c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 161
+    - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce0380..0xce0384]
+      OutOfLinePCRanges: [0xce0680..0xce0684]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0380..0xce0384
+            - Range: 0xce0680..0xce0684
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce0380..0xce0383
+            - Range: 0xce0680..0xce0683
               Pieces: []
-            - Range: 0xce0383..0xce0384
+            - Range: 0xce0683..0xce0684
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 162
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce03a0..0xce03ac]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 322 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0xce03a0..0xce03ab
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce03ab..0xce03ac
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xce03a0..0xce03ab
-              Pieces: []
-            - Range: 0xce03ab..0xce03ac
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0xce06a0..0xce06ac]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 322 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xce06a0..0xce06ab
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xce06ab..0xce06ac
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xce06a0..0xce06ab
+              Pieces: []
+            - Range: 0xce06ab..0xce06ac
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce03c0..0xce03c4]
+      OutOfLinePCRanges: [0xce06c0..0xce06c4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce03c0..0xce03c4
+            - Range: 0xce06c0..0xce06c4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce03c0..0xce03c3
+            - Range: 0xce06c0..0xce06c3
               Pieces: []
-            - Range: 0xce03c3..0xce03c4
+            - Range: 0xce06c3..0xce06c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 164
+    - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce03e0..0xce03ec]
+      OutOfLinePCRanges: [0xce06e0..0xce06ec]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce03e0..0xce03eb
+            - Range: 0xce06e0..0xce06eb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce03eb..0xce03ec
+            - Range: 0xce06eb..0xce06ec
               Pieces:
                 - Size: 8
                   Op: null
@@ -9832,9 +9885,9 @@ Subprograms:
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce03e0..0xce03eb
+            - Range: 0xce06e0..0xce06eb
               Pieces: []
-            - Range: 0xce03eb..0xce03ec
+            - Range: 0xce06eb..0xce06ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9843,15 +9896,15 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce0460..0xce0596]
+      OutOfLinePCRanges: [0xce0760..0xce0896]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce0460..0xce0493
+            - Range: 0xce0760..0xce0793
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9859,7 +9912,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce0493..0xce049b
+            - Range: 0xce0793..0xce079b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9867,7 +9920,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce049b..0xce0596
+            - Range: 0xce079b..0xce0896
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9880,18 +9933,18 @@ Subprograms:
         - Name: pred
           Type: 326 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce0460..0xce049b
+            - Range: 0xce0760..0xce079b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce049b..0xce0596
+            - Range: 0xce079b..0xce0896
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce0460..0xce0554
+            - Range: 0xce0760..0xce0854
               Pieces: []
-            - Range: 0xce0554..0xce0555
+            - Range: 0xce0854..0xce0855
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9899,14 +9952,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce0555..0xce0596
+            - Range: 0xce0855..0xce0896
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce049b..0xce04b9
+            - Range: 0xce079b..0xce07b9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9914,7 +9967,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce04b9..0xce04c1
+            - Range: 0xce07b9..0xce07c1
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9922,7 +9975,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce04c1..0xce04c9
+            - Range: 0xce07c1..0xce07c9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9930,7 +9983,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce04c9..0xce04c9
+            - Range: 0xce07c9..0xce07c9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9938,7 +9991,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce04c9..0xce04f3
+            - Range: 0xce07c9..0xce07f3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -9946,7 +9999,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce04f3..0xce054b
+            - Range: 0xce07f3..0xce084b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9954,7 +10007,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce054b..0xce0596
+            - Range: 0xce084b..0xce0896
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -9967,132 +10020,132 @@ Subprograms:
         - Name: item
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce04e6..0xce04f3
+            - Range: 0xce07e6..0xce07f3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce04f3..0xce054b
+            - Range: 0xce07f3..0xce084b
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 166
+    - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce05a0..0xce05e4]
+      OutOfLinePCRanges: [0xce08a0..0xce08e4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce05a0..0xce05b9
+            - Range: 0xce08a0..0xce08b9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 327 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce05a0..0xce05b9
+            - Range: 0xce08a0..0xce08b9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce05a0..0xce05b9
+            - Range: 0xce08a0..0xce08b9
               Pieces: []
-            - Range: 0xce05b9..0xce05ba
+            - Range: 0xce08b9..0xce08ba
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce05ba..0xce05e4
+            - Range: 0xce08ba..0xce08e4
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 167
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xce0880..0xce0884]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 325 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce0880..0xce0884
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 325 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce0880..0xce0883
-              Pieces: []
-            - Range: 0xce0883..0xce0884
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 168
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xce08a0..0xce08a4]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0xce0b80..0xce0b84]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 328 PointerType *go.shape.struct { Name string }
+          Type: 325 PointerType *go.shape.int
           Locations:
-            - Range: 0xce08a0..0xce08a4
+            - Range: 0xce0b80..0xce0b84
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 PointerType *go.shape.struct { Name string }
+          Type: 325 PointerType *go.shape.int
           Locations:
-            - Range: 0xce08a0..0xce08a3
+            - Range: 0xce0b80..0xce0b83
               Pieces: []
-            - Range: 0xce08a3..0xce08a4
+            - Range: 0xce0b83..0xce0b84
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0xce0ba0..0xce0ba4]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 328 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0xce0ba0..0xce0ba4
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 328 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0xce0ba0..0xce0ba3
+              Pieces: []
+            - Range: 0xce0ba3..0xce0ba4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xce08c0..0xce08c4]
+      OutOfLinePCRanges: [0xce0bc0..0xce0bc4]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 330 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce08c0..0xce08c4
+            - Range: 0xce0bc0..0xce0bc4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce08c0..0xce08c3
+            - Range: 0xce0bc0..0xce0bc3
               Pieces: []
-            - Range: 0xce08c3..0xce08c4
+            - Range: 0xce0bc3..0xce0bc4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
+    - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xce08e0..0xce08f1]
+      OutOfLinePCRanges: [0xce0be0..0xce0bf1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xce08e0..0xce08f1
+            - Range: 0xce0be0..0xce0bf1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce08e0..0xce08f0
+            - Range: 0xce0be0..0xce0bf0
               Pieces: []
-            - Range: 0xce08f0..0xce08f1
+            - Range: 0xce0bf0..0xce0bf1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10101,71 +10154,71 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 171
+    - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xce0980..0xce0989]
+      OutOfLinePCRanges: [0xce0c80..0xce0c89]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xce0980..0xce0989
+            - Range: 0xce0c80..0xce0c89
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0980..0xce0988
+            - Range: 0xce0c80..0xce0c88
               Pieces: []
-            - Range: 0xce0988..0xce0989
+            - Range: 0xce0c88..0xce0c89
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
+    - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xce0a40..0xce0a48]
+      OutOfLinePCRanges: [0xce0d40..0xce0d48]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xce0a40..0xce0a48
+            - Range: 0xce0d40..0xce0d48
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0a40..0xce0a48
+            - Range: 0xce0d40..0xce0d48
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0xce0a40..0xce0a48
+            - Range: 0xce0d40..0xce0d48
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 173
+    - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xce0ae0..0xce0b51]
+      OutOfLinePCRanges: [0xce0de0..0xce0e51]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xce0ae0..0xce0b51
+            - Range: 0xce0de0..0xce0e51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0ae0..0xce0b51
+            - Range: 0xce0de0..0xce0e51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10176,20 +10229,20 @@ Subprograms:
         - Name: v
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0ae0..0xce0b51
+            - Range: 0xce0de0..0xce0e51
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 174
+    - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xce0be0..0xce0be8]
+      OutOfLinePCRanges: [0xce0ee0..0xce0ee8]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0be0..0xce0be8
+            - Range: 0xce0ee0..0xce0ee8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10200,25 +10253,25 @@ Subprograms:
         - Name: b
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0xce0be0..0xce0be8
+            - Range: 0xce0ee0..0xce0ee8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0xce0be0..0xce0be7
+            - Range: 0xce0ee0..0xce0ee7
               Pieces: []
-            - Range: 0xce0be7..0xce0be8
+            - Range: 0xce0ee7..0xce0ee8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0be0..0xce0be7
+            - Range: 0xce0ee0..0xce0ee7
               Pieces: []
-            - Range: 0xce0be7..0xce0be8
+            - Range: 0xce0ee7..0xce0ee8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10227,28 +10280,28 @@ Subprograms:
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 175
+    - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce0c00..0xce0c0f]
+      OutOfLinePCRanges: [0xce0f00..0xce0f0f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0c00..0xce0c0e
+            - Range: 0xce0f00..0xce0f0e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0c00..0xce0c0b
+            - Range: 0xce0f00..0xce0f0b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce0c0b..0xce0c0f
+            - Range: 0xce0f0b..0xce0f0f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10259,9 +10312,9 @@ Subprograms:
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0c00..0xce0c0e
+            - Range: 0xce0f00..0xce0f0e
               Pieces: []
-            - Range: 0xce0c0e..0xce0c0f
+            - Range: 0xce0f0e..0xce0f0f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10272,56 +10325,56 @@ Subprograms:
         - Name: ~r1
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0c00..0xce0c0e
+            - Range: 0xce0f00..0xce0f0e
               Pieces: []
-            - Range: 0xce0c0e..0xce0c0f
+            - Range: 0xce0f0e..0xce0f0f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 176
+    - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xce0c20..0xce0c5a]
+      OutOfLinePCRanges: [0xce0f20..0xce0f5a]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 340 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xce0c20..0xce0c39
+            - Range: 0xce0f20..0xce0f39
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0c20..0xce0c39
+            - Range: 0xce0f20..0xce0f39
               Pieces: []
-            - Range: 0xce0c39..0xce0c3a
+            - Range: 0xce0f39..0xce0f3a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0c3a..0xce0c5a
+            - Range: 0xce0f3a..0xce0f5a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 177
+    - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xce0c60..0xce0cad]
+      OutOfLinePCRanges: [0xce0f60..0xce0fad]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 341 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xce0c60..0xce0c7f
+            - Range: 0xce0f60..0xce0f7f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce0c7f..0xce0c82
+            - Range: 0xce0f7f..0xce0f82
               Pieces:
                 - Size: 8
                   Op: null
@@ -10332,37 +10385,37 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0c60..0xce0c82
+            - Range: 0xce0f60..0xce0f82
               Pieces: []
-            - Range: 0xce0c82..0xce0c83
+            - Range: 0xce0f82..0xce0f83
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0c83..0xce0cad
+            - Range: 0xce0f83..0xce0fad
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 178
+    - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xce0cc0..0xce0cc8]
+      OutOfLinePCRanges: [0xce0fc0..0xce0fc8]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 342 PointerType *go.shape.string
           Locations:
-            - Range: 0xce0cc0..0xce0cc7
+            - Range: 0xce0fc0..0xce0fc7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0cc0..0xce0cc7
+            - Range: 0xce0fc0..0xce0fc7
               Pieces: []
-            - Range: 0xce0cc7..0xce0cc8
+            - Range: 0xce0fc7..0xce0fc8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10371,24 +10424,24 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 179
+    - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xce0ce0..0xce0d37]
+      OutOfLinePCRanges: [0xce0fe0..0xce1037]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce0ce0..0xce0d1d
+            - Range: 0xce0fe0..0xce101d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 344 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce0ce0..0xce0d31
+            - Range: 0xce0fe0..0xce1031
               Pieces: []
-            - Range: 0xce0d31..0xce0d32
+            - Range: 0xce1031..0xce1032
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10402,20 +10455,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce0d32..0xce0d37
+            - Range: 0xce1032..0xce1037
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 180
+    - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xce0d40..0xce0d64]
+      OutOfLinePCRanges: [0xce1040..0xce1064]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce0d40..0xce0d64
+            - Range: 0xce1040..0xce1064
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10428,33 +10481,33 @@ Subprograms:
         - Name: needle
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0d40..0xce0d64
+            - Range: 0xce1040..0xce1064
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce0d40..0xce0d60
+            - Range: 0xce1040..0xce1060
               Pieces: []
-            - Range: 0xce0d60..0xce0d61
+            - Range: 0xce1060..0xce1061
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0d61..0xce0d63
+            - Range: 0xce1061..0xce1063
               Pieces: []
-            - Range: 0xce0d63..0xce0d64
+            - Range: 0xce1063..0xce1064
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xce0d80..0xce0e3f]
+      OutOfLinePCRanges: [0xce1080..0xce113f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 345 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xce0d80..0xce0d9d
+            - Range: 0xce1080..0xce109d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10462,7 +10515,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce0d9d..0xce0d9f
+            - Range: 0xce109d..0xce109f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10475,13 +10528,13 @@ Subprograms:
         - Name: needle
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0d80..0xce0dcc
+            - Range: 0xce1080..0xce10cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce0dcc..0xce0e3f
+            - Range: 0xce10cc..0xce113f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10492,28 +10545,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce0d80..0xce0deb
+            - Range: 0xce1080..0xce10eb
               Pieces: []
-            - Range: 0xce0deb..0xce0dec
+            - Range: 0xce10eb..0xce10ec
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0dec..0xce0df3
+            - Range: 0xce10ec..0xce10f3
               Pieces: []
-            - Range: 0xce0df3..0xce0df4
+            - Range: 0xce10f3..0xce10f4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0df4..0xce0e3f
+            - Range: 0xce10f4..0xce113f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0daf..0xce0dc1
+            - Range: 0xce10af..0xce10c1
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xce0dc1..0xce0dcc
+            - Range: 0xce10c1..0xce10cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10522,56 +10575,56 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 182
+    - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xce0e40..0xce0e47]
+      OutOfLinePCRanges: [0xce1140..0xce1147]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xce0e40..0xce0e46
+            - Range: 0xce1140..0xce1146
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0xce0e40..0xce0e47
+            - Range: 0xce1140..0xce1147
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce0e40..0xce0e46
+            - Range: 0xce1140..0xce1146
               Pieces: []
-            - Range: 0xce0e46..0xce0e47
+            - Range: 0xce1146..0xce1147
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
-    - ID: 183
+    - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xce0ec0..0xce0f2c]
+      OutOfLinePCRanges: [0xce11c0..0xce122c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xce0ec0..0xce0ee0
+            - Range: 0xce11c0..0xce11e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0ee0..0xce0ee8
+            - Range: 0xce11e0..0xce11e8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0ee8..0xce0eed
+            - Range: 0xce11e8..0xce11ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10582,7 +10635,7 @@ Subprograms:
         - Name: value
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce0ec0..0xce0eed
+            - Range: 0xce11c0..0xce11ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10593,16 +10646,16 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce0ec0..0xce0eed
+            - Range: 0xce11c0..0xce11ed
               Pieces: []
-            - Range: 0xce0eed..0xce0eee
+            - Range: 0xce11ed..0xce11ee
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0eee..0xce0f2c
+            - Range: 0xce11ee..0xce122c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 184
+    - ID: 185
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x5235a0..0x5236e5]
       InlinePCRanges: []
@@ -10733,7 +10786,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 185
+    - ID: 186
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd7980..0xcd79e2]
       InlinePCRanges:
@@ -10764,7 +10817,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 186
+    - ID: 187
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10772,7 +10825,7 @@ Subprograms:
           RootRanges: [0xcd7bc0..0xcd7c85]
       Variables: []
       DictRegister: null
-    - ID: 187
+    - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10780,7 +10833,7 @@ Subprograms:
           RootRanges: [0xcd7d20..0xcd7e2e]
       Variables: []
       DictRegister: null
-    - ID: 188
+    - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10788,7 +10841,7 @@ Subprograms:
           RootRanges: [0xcd7d20..0xcd7e2e]
       Variables: []
       DictRegister: null
-    - ID: 189
+    - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10803,7 +10856,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 191
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10822,12 +10875,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 191
+    - ID: 192
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xcd8060..0xcd80d1]
       InlinePCRanges:
-        - Ranges: [0xce0fe3..0xce1025]
-          RootRanges: [0xce0fc0..0xce1056]
+        - Ranges: [0xce12e3..0xce1325]
+          RootRanges: [0xce12c0..0xce1356]
       Variables:
         - Name: b
           Type: 352 StructureType main.firstBehavior
@@ -10862,7 +10915,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 192
+    - ID: 193
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -14201,7 +14254,7 @@ Types:
       GoKind: 22
       Pointee: 852 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14220,7 +14273,7 @@ Types:
             Type: 348 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14231,7 +14284,7 @@ Types:
             Type: 348 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14242,12 +14295,12 @@ Types:
             Type: 351 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: pred}
+                  Variable: {subprogram: 185, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14260,12 +14313,12 @@ Types:
             Type: 348 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 185, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14284,7 +14337,7 @@ Types:
             Type: 324 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14295,7 +14348,7 @@ Types:
             Type: 324 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14306,12 +14359,12 @@ Types:
             Type: 326 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: pred}
+                  Variable: {subprogram: 166, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14324,15 +14377,15 @@ Types:
             Type: 324 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 2, name: ~r0}
+                  Variable: {subprogram: 166, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1669
+      ID: 1670
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14351,7 +14404,7 @@ Types:
             Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14362,7 +14415,7 @@ Types:
             Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14373,12 +14426,12 @@ Types:
             Type: 327 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: f}
+                  Variable: {subprogram: 167, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14391,12 +14444,12 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 2, name: ~r0}
+                  Variable: {subprogram: 167, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14418,7 +14471,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14429,7 +14482,7 @@ Types:
             Type: 335 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: x}
+                  Variable: {subprogram: 173, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14440,7 +14493,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14451,15 +14504,15 @@ Types:
             Type: 337 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 2, name: v}
+                  Variable: {subprogram: 173, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1629
+      ID: 1630
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14481,7 +14534,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14492,7 +14545,7 @@ Types:
             Type: 338 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: x}
+                  Variable: {subprogram: 174, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14503,7 +14556,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14514,15 +14567,15 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 2, name: v}
+                  Variable: {subprogram: 174, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1630
+      ID: 1631
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1667
+      ID: 1668
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14534,12 +14587,12 @@ Types:
             Type: 352 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 0, name: b}
+                  Variable: {subprogram: 192, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1668
+      ID: 1669
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14551,12 +14604,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 1, name: ~r0}
+                  Variable: {subprogram: 192, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1643
+      ID: 1644
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14575,7 +14628,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14586,7 +14639,7 @@ Types:
             Type: 324 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14597,14 +14650,14 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1647
+      ID: 1648
       Name: Probe[main.genericContains[go.shape.int]]Line
-      ByteSize: 50
+      ByteSize: 49
       ExprStatusArraySize: 1
       DictEntries:
         - DictIndex: 0
@@ -14621,7 +14674,7 @@ Types:
             Type: 324 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14632,23 +14685,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
-        - Name: '@return'
-          Offset: 49
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1644
+      ID: 1645
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14660,12 +14702,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1645
+      ID: 1646
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14684,7 +14726,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14695,7 +14737,7 @@ Types:
             Type: 345 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: haystack}
+                  Variable: {subprogram: 182, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14706,14 +14748,14 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1648
+      ID: 1649
       Name: Probe[main.genericContains[go.shape.string]]Line
-      ByteSize: 26
+      ByteSize: 25
       ExprStatusArraySize: 1
       DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
       Expressions:
@@ -14724,23 +14766,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
-        - Name: '@return'
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14752,12 +14783,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14770,7 +14801,7 @@ Types:
             Type: 342 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14781,12 +14812,12 @@ Types:
             Type: 342 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1640
+      ID: 1641
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14799,12 +14830,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Variable: {subprogram: 179, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14817,7 +14848,7 @@ Types:
             Type: 343 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14828,12 +14859,12 @@ Types:
             Type: 343 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1642
+      ID: 1643
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14846,12 +14877,12 @@ Types:
             Type: 344 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: ~r0}
+                  Variable: {subprogram: 180, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1635
+      ID: 1636
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14864,7 +14895,7 @@ Types:
             Type: 340 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14875,59 +14906,13 @@ Types:
             Type: 340 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1636
-      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: '@return'
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1637
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
-      Expressions:
-        - Name: val
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 341 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-        - Name: val
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 341 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-    - __kind: EventRootType
-      ID: 1638
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -14943,7 +14928,53 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1638
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
+      Expressions:
+        - Name: val
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 341 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+        - Name: val
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 341 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+    - __kind: EventRootType
+      ID: 1639
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1618
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14956,7 +14987,7 @@ Types:
             Type: 325 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14967,12 +14998,12 @@ Types:
             Type: 325 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14985,12 +15016,12 @@ Types:
             Type: 325 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1619
+      ID: 1620
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15003,7 +15034,7 @@ Types:
             Type: 328 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15014,12 +15045,12 @@ Types:
             Type: 328 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15032,12 +15063,12 @@ Types:
             Type: 328 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1621
+      ID: 1622
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15050,7 +15081,7 @@ Types:
             Type: 330 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15061,12 +15092,12 @@ Types:
             Type: 330 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15079,12 +15110,12 @@ Types:
             Type: 330 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1633
+      ID: 1634
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15103,7 +15134,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15114,7 +15145,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15125,12 +15156,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: b}
+                  Variable: {subprogram: 176, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1634
+      ID: 1635
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15149,7 +15180,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 2, name: ~r0}
+                  Variable: {subprogram: 176, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -15160,12 +15191,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 3, name: ~r1}
+                  Variable: {subprogram: 176, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1631
+      ID: 1632
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15184,7 +15215,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15195,7 +15226,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15206,12 +15237,12 @@ Types:
             Type: 337 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: b}
+                  Variable: {subprogram: 175, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1632
+      ID: 1633
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15230,7 +15261,7 @@ Types:
             Type: 337 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 2, name: ~r0}
+                  Variable: {subprogram: 175, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
@@ -15241,12 +15272,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 3, name: ~r1}
+                  Variable: {subprogram: 175, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1625
+      ID: 1626
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15259,7 +15290,7 @@ Types:
             Type: 334 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
@@ -15270,12 +15301,12 @@ Types:
             Type: 334 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1626
+      ID: 1627
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15288,12 +15319,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 172, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1623
+      ID: 1624
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15306,7 +15337,7 @@ Types:
             Type: 332 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
@@ -15317,12 +15348,12 @@ Types:
             Type: 332 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1624
+      ID: 1625
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15335,12 +15366,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15353,7 +15384,7 @@ Types:
             Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15364,12 +15395,12 @@ Types:
             Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15382,12 +15413,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15400,7 +15431,7 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15411,12 +15442,12 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15429,15 +15460,15 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15449,7 +15480,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: ~r0}
+                  Variable: {subprogram: 145, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -15544,7 +15575,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15556,7 +15587,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -15567,12 +15598,12 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15584,7 +15615,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16286,7 +16317,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16298,7 +16329,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16309,7 +16340,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16320,7 +16351,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16331,12 +16362,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16348,7 +16379,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16359,12 +16390,12 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1588
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16376,7 +16407,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -16387,12 +16418,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1602
+      ID: 1603
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16404,7 +16435,7 @@ Types:
             Type: 319 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16415,12 +16446,12 @@ Types:
             Type: 319 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1602
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16432,7 +16463,7 @@ Types:
             Type: 318 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -16443,18 +16474,18 @@ Types:
             Type: 318 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
       ID: 1383
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 58
-      ExprStatusArraySize: 2
+      ByteSize: 49
+      ExprStatusArraySize: 1
       Expressions:
         - Name: x
-          Offset: 2
+          Offset: 1
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -16465,7 +16496,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 10
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 13 GoInterfaceType error
@@ -16475,19 +16506,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: '@return'
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
         - Name: x
-          Offset: 34
+          Offset: 25
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16498,7 +16518,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 42
+          Offset: 33
           Kind: local
           Expression:
             Type: 13 GoInterfaceType error
@@ -16629,7 +16649,7 @@ Types:
     - __kind: EventRootType
       ID: 1411
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 89
+      ByteSize: 81
       ExprStatusArraySize: 1
       Expressions:
         - Name: a
@@ -16653,17 +16673,6 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-          DictIndex: -1
-        - Name: '@return'
-          Offset: 81
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1410
@@ -16790,7 +16799,7 @@ Types:
       ID: 1404
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1659
+      ID: 1660
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1401
@@ -16846,16 +16855,16 @@ Types:
       ID: 1402
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1661
+      ID: 1662
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1405
@@ -16864,7 +16873,7 @@ Types:
       ID: 1406
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1656
+      ID: 1657
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16876,7 +16885,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16887,24 +16896,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1653
-      Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x_val
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16921,12 +16913,29 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1655
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 186, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1656
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16938,7 +16947,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16949,12 +16958,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16966,7 +16975,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16977,15 +16986,15 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1657
+      ID: 1658
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16997,7 +17006,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17008,12 +17017,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17025,7 +17034,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17036,12 +17045,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17053,7 +17062,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17064,7 +17073,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17237,7 +17246,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -17249,7 +17258,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17260,12 +17269,12 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17277,7 +17286,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: ~r0}
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17369,7 +17378,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -17381,7 +17390,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17392,7 +17401,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17403,7 +17412,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17414,7 +17423,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17425,7 +17434,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17436,7 +17445,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17447,7 +17456,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17458,7 +17467,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17469,7 +17478,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17480,7 +17489,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17491,7 +17500,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17502,7 +17511,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17513,7 +17522,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17524,7 +17533,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17535,7 +17544,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17546,7 +17555,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17557,7 +17566,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17568,12 +17577,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17585,7 +17594,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 9, name: ~r0}
+                  Variable: {subprogram: 127, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18150,34 +18159,6 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1585
       Name: Probe[main.testMassiveString]
       ByteSize: 33
@@ -18190,7 +18171,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18201,12 +18182,40 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1550
+      ID: 1586
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1551
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -18218,7 +18227,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18229,7 +18238,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18240,7 +18249,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18251,7 +18260,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18262,7 +18271,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18273,7 +18282,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18284,7 +18293,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18295,7 +18304,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18306,7 +18315,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18317,7 +18326,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18328,7 +18337,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18339,7 +18348,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18350,7 +18359,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18361,7 +18370,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18372,7 +18381,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18383,7 +18392,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18394,7 +18403,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18405,12 +18414,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18422,12 +18431,12 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 9, name: ~r0}
+                  Variable: {subprogram: 128, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18439,7 +18448,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18450,7 +18459,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -18461,7 +18470,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18472,12 +18481,12 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -18489,7 +18498,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18500,12 +18509,12 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -18517,7 +18526,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18528,7 +18537,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18539,7 +18548,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18550,12 +18559,12 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18567,7 +18576,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -19220,7 +19229,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1597
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19232,7 +19241,7 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19243,12 +19252,12 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19260,7 +19269,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19271,10 +19280,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1599
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19286,7 +19295,7 @@ Types:
             Type: 121 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19347,7 +19356,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -19359,7 +19368,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19370,7 +19379,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19381,7 +19390,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19392,12 +19401,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -19409,7 +19418,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19420,7 +19429,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19431,7 +19440,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19442,7 +19451,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19453,7 +19462,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19464,12 +19473,12 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -19481,7 +19490,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19492,12 +19501,12 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19509,7 +19518,7 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19520,7 +19529,7 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19732,10 +19741,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -19747,15 +19756,15 @@ Types:
             Type: 250 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -19767,15 +19776,15 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19787,15 +19796,15 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -19807,7 +19816,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19818,7 +19827,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19829,7 +19838,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19840,7 +19849,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19851,7 +19860,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19862,7 +19871,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 5, name: ~r5}
+                  Variable: {subprogram: 117, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19873,7 +19882,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 6, name: ~r6}
+                  Variable: {subprogram: 117, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19884,7 +19893,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 7, name: ~r7}
+                  Variable: {subprogram: 117, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19895,15 +19904,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 8, name: ~r8}
+                  Variable: {subprogram: 117, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -19915,7 +19924,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: ~r0}
+                  Variable: {subprogram: 123, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19926,15 +19935,15 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r1}
+                  Variable: {subprogram: 123, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19946,7 +19955,7 @@ Types:
             Type: 94 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19957,7 +19966,7 @@ Types:
             Type: 95 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: ~r1}
+                  Variable: {subprogram: 111, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -20420,10 +20429,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -20435,15 +20444,15 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -20455,7 +20464,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20466,7 +20475,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: ~r1}
+                  Variable: {subprogram: 110, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20477,7 +20486,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 2, name: ~r2}
+                  Variable: {subprogram: 110, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20488,7 +20497,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 3, name: ~r3}
+                  Variable: {subprogram: 110, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20499,7 +20508,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 4, name: ~r4}
+                  Variable: {subprogram: 110, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20510,7 +20519,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 5, name: ~r5}
+                  Variable: {subprogram: 110, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20521,7 +20530,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 6, name: ~r6}
+                  Variable: {subprogram: 110, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20532,7 +20541,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 7, name: ~r7}
+                  Variable: {subprogram: 110, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20543,7 +20552,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 8, name: ~r8}
+                  Variable: {subprogram: 110, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20554,7 +20563,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 9, name: ~r9}
+                  Variable: {subprogram: 110, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20565,7 +20574,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 10, name: ~r10}
+                  Variable: {subprogram: 110, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20576,7 +20585,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 11, name: ~r11}
+                  Variable: {subprogram: 110, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20587,7 +20596,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 12, name: ~r12}
+                  Variable: {subprogram: 110, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20598,7 +20607,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 13, name: ~r13}
+                  Variable: {subprogram: 110, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20609,7 +20618,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 14, name: ~r14}
+                  Variable: {subprogram: 110, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20620,7 +20629,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 110, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20631,15 +20640,15 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 110, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20651,15 +20660,15 @@ Types:
             Type: 252 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20671,7 +20680,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20682,7 +20691,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20693,7 +20702,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 2, name: ~r2}
+                  Variable: {subprogram: 119, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20704,7 +20713,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 3, name: ~r3}
+                  Variable: {subprogram: 119, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20715,15 +20724,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 4, name: ~r4}
+                  Variable: {subprogram: 119, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -20735,7 +20744,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: ~r0}
+                  Variable: {subprogram: 122, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20746,15 +20755,65 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r1}
+                  Variable: {subprogram: 122, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1536
-      Name: Probe[main.testReturnsOnlyFloat]
+      ID: 1512
+      Name: Probe[main.testReturnsNamedDeferLine]Line
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: a
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 1537
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1538
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20766,15 +20825,15 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -20786,7 +20845,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20797,7 +20856,7 @@ Types:
             Type: 102 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -20808,7 +20867,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: ~r2}
+                  Variable: {subprogram: 109, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20819,7 +20878,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 3, name: ~r3}
+                  Variable: {subprogram: 109, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20830,7 +20889,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 4, name: ~r4}
+                  Variable: {subprogram: 109, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20841,7 +20900,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 5, name: ~r5}
+                  Variable: {subprogram: 109, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -20852,7 +20911,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 6, name: ~r6}
+                  Variable: {subprogram: 109, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20863,15 +20922,15 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 7, name: ~r7}
+                  Variable: {subprogram: 109, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20883,15 +20942,15 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -20903,7 +20962,7 @@ Types:
             Type: 253 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
           DictIndex: -1
@@ -21188,7 +21247,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21200,7 +21259,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21211,7 +21270,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21356,7 +21415,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21368,7 +21427,7 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21379,12 +21438,12 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21396,7 +21455,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21407,7 +21466,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21661,7 +21720,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -21673,7 +21732,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -21684,12 +21743,12 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21701,7 +21760,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21712,7 +21771,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21723,7 +21782,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r2}
+                  Variable: {subprogram: 129, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21784,7 +21843,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21796,7 +21855,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21807,7 +21866,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21868,7 +21927,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -21880,7 +21939,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21891,7 +21950,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21902,7 +21961,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21913,7 +21972,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21946,7 +22005,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21958,7 +22017,7 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21969,12 +22028,12 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21986,7 +22045,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 1, name: ~r0}
+                  Variable: {subprogram: 131, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21997,12 +22056,12 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 2, name: ~r1}
+                  Variable: {subprogram: 131, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1591
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22014,7 +22073,7 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22025,15 +22084,15 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1589
+      ID: 1590
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -22045,7 +22104,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22056,7 +22115,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22089,7 +22148,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22101,12 +22160,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -22118,7 +22177,7 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
@@ -22129,18 +22188,18 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -22152,7 +22211,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22163,7 +22222,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22174,7 +22233,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22185,7 +22244,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22196,7 +22255,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22207,12 +22266,12 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
+      ID: 1589
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22224,7 +22283,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22235,7 +22294,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22246,7 +22305,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22257,7 +22316,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22268,7 +22327,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22279,12 +22338,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1601
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -22296,12 +22355,12 @@ Types:
             Type: 317 StructureType main.tenStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 160
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22313,7 +22372,7 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22324,12 +22383,12 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22341,7 +22400,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22355,7 +22414,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22369,7 +22428,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22377,7 +22436,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1578
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22389,7 +22448,7 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22400,12 +22459,12 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22417,7 +22476,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22428,7 +22487,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
           DictIndex: -1
@@ -22439,18 +22498,18 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22462,7 +22521,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22473,7 +22532,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22484,7 +22543,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22495,7 +22554,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22506,7 +22565,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22517,7 +22576,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22718,7 +22777,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22730,7 +22789,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22741,12 +22800,12 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22758,7 +22817,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22769,7 +22828,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22830,34 +22889,6 @@ Types:
                   ByteSize: 800
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1569
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1570
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -22870,7 +22901,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22881,12 +22912,40 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1558
+      ID: 1571
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1559
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22898,7 +22957,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -22909,7 +22968,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22920,7 +22979,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -22931,12 +22990,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22948,7 +23007,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 2, name: ~r0}
+                  Variable: {subprogram: 132, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22959,12 +23018,12 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 3, name: ~r1}
+                  Variable: {subprogram: 132, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1649
+      ID: 1650
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -22983,7 +23042,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -22994,7 +23053,7 @@ Types:
             Type: 346 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: x}
+                  Variable: {subprogram: 183, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23005,12 +23064,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1650
+      ID: 1651
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23022,12 +23081,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 2, name: ~r0}
+                  Variable: {subprogram: 183, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1651
+      ID: 1652
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23046,7 +23105,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -23057,7 +23116,7 @@ Types:
             Type: 347 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: x}
+                  Variable: {subprogram: 184, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23068,12 +23127,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1652
+      ID: 1653
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23085,12 +23144,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 2, name: ~r0}
+                  Variable: {subprogram: 184, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1604
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23103,7 +23162,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23114,12 +23173,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1604
+      ID: 1605
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23132,12 +23191,12 @@ Types:
             Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 1, name: ~r0}
+                  Variable: {subprogram: 162, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23150,7 +23209,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23161,12 +23220,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23179,7 +23238,7 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 1, name: ~r0}
+                  Variable: {subprogram: 163, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -32030,7 +32089,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994592
       GoKind: 5
-MaxTypeID: 1669
+MaxTypeID: 1670
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -9,15 +9,15 @@ Probes:
       segments: [stackC]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 144}
+        - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xce222a", Frameless: false}]
+              Type: 1593 EventRootType Probe[main.stackC]
+              InjectionPoints: [{PC: "0xce252a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1593 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xce2265", Frameless: false}]
+              Type: 1594 EventRootType Probe[main.stackC]Return
+              InjectionPoints: [{PC: "0xce2565", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -80,15 +80,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 124}
+        - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1563 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xce0c6e", Frameless: false}]
+              Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]
+              InjectionPoints: [{PC: "0xce0f6e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce0d22", Frameless: false}]
+              Type: 1565 EventRootType Probe[main.testArrayArgAndReturn]Return
+              InjectionPoints: [{PC: "0xce1022", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -338,15 +338,15 @@ Probes:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1611 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce2660", Frameless: true}]
+              Type: 1612 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0xce2960", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1612 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce2682", Frameless: true}]
+              Type: 1613 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0xce2982", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1672 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcdc18e"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1674 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcdc18e"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 185, index: 0, name: x}
+                      Variable: {subprogram: 186, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -433,10 +433,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1674 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1675 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcdc18e"
                   Frameless: false
@@ -515,16 +515,16 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 158}
+        - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1619 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xce2780", Frameless: true}]
+              Type: 1620 EventRootType Probe[main.testTenStrings]
+              InjectionPoints: [{PC: "0xce2a80", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 158, index: 0, name: x}
+                      Variable: {subprogram: 159, index: 0, name: x}
                       Offset: 144
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -789,11 +789,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 133}
+        - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xce1d40", Frameless: true}]
+              Type: 1581 EventRootType Probe[main.testEmptySlice]
+              InjectionPoints: [{PC: "0xce2040", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -816,11 +816,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 136}
+        - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xce1da0", Frameless: true}]
+              Type: 1584 EventRootType Probe[main.testEmptySliceOfStructs]
+              InjectionPoints: [{PC: "0xce20a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -844,11 +844,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 152}
+        - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1606 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xce2360", Frameless: true}]
+              Type: 1607 EventRootType Probe[main.testEmptyString]
+              InjectionPoints: [{PC: "0xce2660", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -866,11 +866,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 159}
+        - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1620 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xce27e0", Frameless: true}]
+              Type: 1621 EventRootType Probe[main.testEmptyStruct]
+              InjectionPoints: [{PC: "0xce2ae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -887,11 +887,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 160}
+        - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1621 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xce2800", Frameless: true}]
+              Type: 1622 EventRootType Probe[main.testEmptyStructPointer]
+              InjectionPoints: [{PC: "0xce2b00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1100,15 +1100,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1658 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xce5300", Frameless: true}]
+              Type: 1659 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0xce5600", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1659 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce5307", Frameless: true}]
+              Type: 1660 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce5607", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1118,15 +1118,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1660 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xce5324", Frameless: false}]
+              Type: 1661 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0xce5624", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1661 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xce5371", Frameless: false}]
+              Type: 1662 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0xce5671", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1145,15 +1145,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1654 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xce526a", Frameless: false}]
+              Type: 1655 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0xce556a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1655 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xce5279", Frameless: false}]
+              Type: 1656 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0xce5579", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1163,15 +1163,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1656 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xce52aa", Frameless: false}]
+              Type: 1657 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0xce55aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1657 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xce52c2", Frameless: false}]
+              Type: 1658 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0xce55c2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1190,18 +1190,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1662 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xce5380", Frameless: true}]
+              Type: 1663 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0xce5680", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1663 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1664 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xce53a0"
+                - PC: "0xce56a0"
                   Frameless: true
-                - PC: "0xce53a3"
+                - PC: "0xce56a3"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1212,18 +1212,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1664 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xce53ca", Frameless: false}]
+              Type: 1665 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0xce56ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1665 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1666 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xce542b"
+                - PC: "0xce572b"
                   Frameless: false
-                - PC: "0xce5433"
+                - PC: "0xce5733"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1246,11 +1246,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Line
-              Type: 1666 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xce5385", Frameless: true}]
+              Type: 1667 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0xce5685", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1258,11 +1258,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Line
-              Type: 1667 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xce53df", Frameless: false}]
+              Type: 1668 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0xce56df", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1279,15 +1279,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1642 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xce4f20", Frameless: true}]
+              Type: 1643 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0xce5220", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1643 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xce4f30", Frameless: true}]
+              Type: 1644 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0xce5230", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1297,15 +1297,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1644 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xce4fc0", Frameless: true}]
+              Type: 1645 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0xce52c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1645 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xce4fc8", Frameless: true}]
+              Type: 1646 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0xce52c8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1325,15 +1325,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 166}
           events:
             - Kind: Entry
-              Type: 1630 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xce4aae", Frameless: false}]
+              Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0xce4dae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce4b94", Frameless: false}]
+              Type: 1632 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce4e94", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1343,14 +1343,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1632 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1633 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x52c3ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1633 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1634 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x52c49c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1371,15 +1371,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 167}
           events:
             - Kind: Entry
-              Type: 1634 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce4bea", Frameless: false}]
+              Type: 1635 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xce4eea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1635 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce4bf9", Frameless: false}]
+              Type: 1636 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce4ef9", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1398,15 +1398,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1668 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xce5480", Frameless: true}]
+              Type: 1669 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0xce5780", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1669 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xce5486", Frameless: true}]
+              Type: 1670 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0xce5786", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1416,15 +1416,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1670 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xce550a", Frameless: false}]
+              Type: 1671 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0xce580a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1671 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xce552d", Frameless: false}]
+              Type: 1672 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0xce582d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1443,15 +1443,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 163}
+        - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1626 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xce4a00", Frameless: true}]
+              Type: 1627 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0xce4d00", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1627 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce4a03", Frameless: true}]
+              Type: 1628 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce4d03", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1461,15 +1461,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 164}
+        - subprogram: {subprogram: 165}
           events:
             - Kind: Entry
-              Type: 1628 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xce4a20", Frameless: true}]
+              Type: 1629 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0xce4d20", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1629 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce4a2b", Frameless: true}]
+              Type: 1630 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce4d2b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1488,15 +1488,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1646 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xce5080", Frameless: true}]
+              Type: 1647 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0xce5380", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1647 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xce5087", Frameless: true}]
+              Type: 1648 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0xce5387", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1506,15 +1506,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1648 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xce512a", Frameless: false}]
+              Type: 1649 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0xce542a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1649 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xce5153", Frameless: false}]
+              Type: 1650 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0xce5453", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1533,33 +1533,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
-          events:
-            - Kind: Entry
-              Type: 1636 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xce4ec0", Frameless: true}]
-              Condition: null
-            - Kind: Return
-              Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce4ec3", Frameless: true}]
-              Condition: null
-          probeTemplate:
-            TemplateString: p={p}
-            Segments:
-                - p=
-                - JSON: {Ref: p}
-                  DSL: p
-                  EventKind: Entry
-                  EventExpressionIndex: 0
         - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1638 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xce4ee0", Frameless: true}]
+              Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xce51c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1639 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xce4ee3", Frameless: true}]
+              Type: 1638 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce51c3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1572,12 +1554,30 @@ Probes:
         - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1640 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xce4f00", Frameless: true}]
+              Type: 1639 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0xce51e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1641 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xce4f03", Frameless: true}]
+              Type: 1640 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0xce51e3", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: p={p}
+            Segments:
+                - p=
+                - JSON: {Ref: p}
+                  DSL: p
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+        - subprogram: {subprogram: 170}
+          events:
+            - Kind: Entry
+              Type: 1641 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0xce5200", Frameless: true}]
+              Condition: null
+            - Kind: Return
+              Type: 1642 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0xce5203", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1596,15 +1596,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1650 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xce5220", Frameless: true}]
+              Type: 1651 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0xce5520", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1651 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xce5227", Frameless: true}]
+              Type: 1652 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0xce5527", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1614,15 +1614,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1652 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xce5240", Frameless: true}]
+              Type: 1653 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xce5540", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1653 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce524e", Frameless: true}]
+              Type: 1654 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce554e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1641,15 +1641,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 161}
+        - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1622 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xce49c0", Frameless: true}]
+              Type: 1623 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0xce4cc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1623 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xce49c3", Frameless: true}]
+              Type: 1624 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xce4cc3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1659,15 +1659,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 162}
+        - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1624 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xce49e0", Frameless: true}]
+              Type: 1625 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0xce4ce0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1625 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xce49eb", Frameless: true}]
+              Type: 1626 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xce4ceb", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1774,10 +1774,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1678 EventRootType Probe[main.testInlinedBBB]
+              Type: 1679 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0xcdc426", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1814,10 +1814,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1679 EventRootType Probe[main.testInlinedBCA]
+              Type: 1680 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0xcdc533", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1835,10 +1835,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1680 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1681 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0xcdc533", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1853,10 +1853,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1681 EventRootType Probe[main.testInlinedBCB]
+              Type: 1682 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0xcdc5db", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1874,10 +1874,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Line
-              Type: 1682 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1683 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0xcdc5db", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1892,10 +1892,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1688 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1689 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x52bec1"
                   Frameless: true
@@ -1915,10 +1915,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1675 EventRootType Probe[main.testInlinedPrint]
+              Type: 1676 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0xcdc18a"
                   Frameless: false
@@ -1932,7 +1932,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1676 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1677 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0xcdc1ca", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1954,10 +1954,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1677 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1678 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xcdc18e"
                   Frameless: false
@@ -1986,10 +1986,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1683 EventRootType Probe[main.testInlinedSq]
+              Type: 1684 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0xcdc641", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2011,10 +2011,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Line
-              Type: 1684 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1685 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0xcdc641", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2034,10 +2034,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1685 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1686 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0xcdc685"
                   Frameless: false
@@ -2191,15 +2191,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 123}
+        - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1561 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xce0ace", Frameless: false}]
+              Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]
+              InjectionPoints: [{PC: "0xce0dce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce0c33", Frameless: false}]
+              Type: 1563 EventRootType Probe[main.testLargeArgAndReturn]Return
+              InjectionPoints: [{PC: "0xce0f33", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2329,15 +2329,15 @@ Probes:
           dsl: i
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 126}
+        - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1567 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xce0f93", Frameless: false}]
+              Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]
+              InjectionPoints: [{PC: "0xce1293", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xce11a2", Frameless: false}]
+              Type: 1569 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              InjectionPoints: [{PC: "0xce14a2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2841,11 +2841,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1603 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce2320", Frameless: true}]
+              Type: 1604 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0xce2620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2864,11 +2864,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xce2320", Frameless: true}]
+              Type: 1605 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0xce2620", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2911,15 +2911,15 @@ Probes:
           dsl: s
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 127}
+        - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1569 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xce1233", Frameless: false}]
+              Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]
+              InjectionPoints: [{PC: "0xce1533", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xce146b", Frameless: false}]
+              Type: 1571 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              InjectionPoints: [{PC: "0xce176b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2981,15 +2981,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 129}
+        - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1573 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xce15ae", Frameless: false}]
+              Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]
+              InjectionPoints: [{PC: "0xce18ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xce167f", Frameless: false}]
+              Type: 1575 EventRootType Probe[main.testMultipleArrayArgs]Return
+              InjectionPoints: [{PC: "0xce197f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3016,15 +3016,15 @@ Probes:
           dsl: s2
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 125}
+        - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1565 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xce0d4e", Frameless: false}]
+              Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]
+              InjectionPoints: [{PC: "0xce104e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xce0f6a", Frameless: false}]
+              Type: 1567 EventRootType Probe[main.testMultipleLargeArgs]Return
+              InjectionPoints: [{PC: "0xce126a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3271,11 +3271,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1615 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce2760", Frameless: true}]
+              Type: 1616 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xce2a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3296,11 +3296,11 @@ Probes:
           dsl: x.nested.anotherString
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1616 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce2760", Frameless: true}]
+              Type: 1617 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xce2a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3327,11 +3327,11 @@ Probes:
           dsl: x.notAMember
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1617 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce2760", Frameless: true}]
+              Type: 1618 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xce2a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3352,11 +3352,11 @@ Probes:
           dsl: x.nested
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1618 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xce2760", Frameless: true}]
+              Type: 1619 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xce2a60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3406,11 +3406,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 140}
+        - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xce1e20", Frameless: true}]
+              Type: 1588 EventRootType Probe[main.testNilSlice]
+              InjectionPoints: [{PC: "0xce2120", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3433,11 +3433,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 137}
+        - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xce1dc0", Frameless: true}]
+              Type: 1585 EventRootType Probe[main.testNilSliceOfStructs]
+              InjectionPoints: [{PC: "0xce20c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3468,11 +3468,11 @@ Probes:
           dsl: x
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 139}
+        - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xce1e00", Frameless: true}]
+              Type: 1587 EventRootType Probe[main.testNilSliceWithOtherParams]
+              InjectionPoints: [{PC: "0xce2100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3500,11 +3500,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 149}
+        - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xce2300", Frameless: true}]
+              Type: 1603 EventRootType Probe[main.testOneStringInStructPointer]
+              InjectionPoints: [{PC: "0xce2600", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3941,15 +3941,15 @@ Probes:
       segments: [testReturnsArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 112}
+        - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1539 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xce056a", Frameless: false}]
+              Type: 1540 EventRootType Probe[main.testReturnsArray]
+              InjectionPoints: [{PC: "0xce086a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1540 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xce05cd", Frameless: false}]
+              Type: 1541 EventRootType Probe[main.testReturnsArray]Return
+              InjectionPoints: [{PC: "0xce08cd", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3962,15 +3962,15 @@ Probes:
       segments: [testReturnsArrayOne]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 113}
+        - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1541 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xce05ea", Frameless: false}]
+              Type: 1542 EventRootType Probe[main.testReturnsArrayOne]
+              InjectionPoints: [{PC: "0xce08ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1542 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xce062b", Frameless: false}]
+              Type: 1543 EventRootType Probe[main.testReturnsArrayOne]Return
+              InjectionPoints: [{PC: "0xce092b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3983,15 +3983,15 @@ Probes:
       segments: [testReturnsArrayZero]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 114}
+        - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1543 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xce064a", Frameless: false}]
+              Type: 1544 EventRootType Probe[main.testReturnsArrayZero]
+              InjectionPoints: [{PC: "0xce094a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1544 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xce0686", Frameless: false}]
+              Type: 1545 EventRootType Probe[main.testReturnsArrayZero]Return
+              InjectionPoints: [{PC: "0xce0986", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4004,15 +4004,15 @@ Probes:
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 116}
+        - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1547 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xce072e", Frameless: false}]
+              Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]
+              InjectionPoints: [{PC: "0xce0a2e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xce07aa", Frameless: false}]
+              Type: 1549 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              InjectionPoints: [{PC: "0xce0aaa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4025,15 +4025,15 @@ Probes:
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 122}
+        - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1559 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xce0a6a", Frameless: false}]
+              Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              InjectionPoints: [{PC: "0xce0d6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xce0ab0", Frameless: false}]
+              Type: 1561 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              InjectionPoints: [{PC: "0xce0db0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4046,15 +4046,15 @@ Probes:
       segments: [testReturnsComplex]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 110}
+        - subprogram: {subprogram: 111}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xce042a", Frameless: false}]
+              Type: 1536 EventRootType Probe[main.testReturnsComplex]
+              InjectionPoints: [{PC: "0xce072a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1536 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xce0486", Frameless: false}]
+              Type: 1537 EventRootType Probe[main.testReturnsComplex]Return
+              InjectionPoints: [{PC: "0xce0786", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4202,15 +4202,15 @@ Probes:
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 111}
+        - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xce04ae", Frameless: false}]
+              Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]
+              InjectionPoints: [{PC: "0xce07ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xce0533", Frameless: false}]
+              Type: 1539 EventRootType Probe[main.testReturnsLargeStruct]Return
+              InjectionPoints: [{PC: "0xce0833", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4223,15 +4223,15 @@ Probes:
       segments: [testReturnsManyFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 109}
+        - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xce032e", Frameless: false}]
+              Type: 1534 EventRootType Probe[main.testReturnsManyFloats]
+              InjectionPoints: [{PC: "0xce062e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1534 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xce0407", Frameless: false}]
+              Type: 1535 EventRootType Probe[main.testReturnsManyFloats]Return
+              InjectionPoints: [{PC: "0xce0707", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4244,15 +4244,15 @@ Probes:
       segments: [testReturnsMixed]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 118}
+        - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1551 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xce088a", Frameless: false}]
+              Type: 1552 EventRootType Probe[main.testReturnsMixed]
+              InjectionPoints: [{PC: "0xce0b8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1552 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xce08ec", Frameless: false}]
+              Type: 1553 EventRootType Probe[main.testReturnsMixed]Return
+              InjectionPoints: [{PC: "0xce0bec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4265,15 +4265,15 @@ Probes:
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 115}
+        - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1545 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xce06aa", Frameless: false}]
+              Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]
+              InjectionPoints: [{PC: "0xce09aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xce06f8", Frameless: false}]
+              Type: 1547 EventRootType Probe[main.testReturnsMixedStruct]Return
+              InjectionPoints: [{PC: "0xce09f8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4286,19 +4286,43 @@ Probes:
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 121}
+        - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1557 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xce09ea", Frameless: false}]
+              Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]
+              InjectionPoints: [{PC: "0xce0cea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xce0a36", Frameless: false}]
+              Type: 1559 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              InjectionPoints: [{PC: "0xce0d36", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
             Segments: [testReturnsMultipleFloats]
+    - id: testReturnsNamedDeferLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testReturnsNamedDeferLine
+        sourceFile: returns.go
+        lines: ["121"]
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 108}
+          events:
+            - Kind: Line
+              Type: 1531 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              InjectionPoints: [{PC: "0xce03af", Frameless: false}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{i}'
+            Segments:
+                - JSON: {Ref: i}
+                  DSL: i
+                  EventKind: Line
+                  EventExpressionIndex: 0
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -4307,15 +4331,15 @@ Probes:
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 120}
+        - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1555 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xce098a", Frameless: false}]
+              Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]
+              InjectionPoints: [{PC: "0xce0c8a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xce09ce", Frameless: false}]
+              Type: 1557 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              InjectionPoints: [{PC: "0xce0cce", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4328,15 +4352,15 @@ Probes:
       segments: [testReturnsPrimitives]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 108}
+        - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1531 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xce02aa", Frameless: false}]
+              Type: 1532 EventRootType Probe[main.testReturnsPrimitives]
+              InjectionPoints: [{PC: "0xce05aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1532 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xce0311", Frameless: false}]
+              Type: 1533 EventRootType Probe[main.testReturnsPrimitives]Return
+              InjectionPoints: [{PC: "0xce0611", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4349,15 +4373,15 @@ Probes:
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 119}
+        - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1553 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xce090a", Frameless: false}]
+              Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]
+              InjectionPoints: [{PC: "0xce0c0a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xce096d", Frameless: false}]
+              Type: 1555 EventRootType Probe[main.testReturnsStructWithArray]Return
+              InjectionPoints: [{PC: "0xce0c6d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4370,15 +4394,15 @@ Probes:
       segments: [testReturnsWideStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 117}
+        - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1549 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xce07ce", Frameless: false}]
+              Type: 1550 EventRootType Probe[main.testReturnsWideStruct]
+              InjectionPoints: [{PC: "0xce0ace", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1550 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xce0854", Frameless: false}]
+              Type: 1551 EventRootType Probe[main.testReturnsWideStruct]Return
+              InjectionPoints: [{PC: "0xce0b54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4706,11 +4730,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 145}
+        - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xce2280", Frameless: true}]
+              Type: 1595 EventRootType Probe[main.testSingleString]
+              InjectionPoints: [{PC: "0xce2580", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4838,11 +4862,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 142}
+        - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xce1e60", Frameless: true}]
+              Type: 1591 EventRootType Probe[main.testSliceEmptyStructs]
+              InjectionPoints: [{PC: "0xce2160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4860,11 +4884,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 134}
+        - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xce1d60", Frameless: true}]
+              Type: 1582 EventRootType Probe[main.testSliceOfSlices]
+              InjectionPoints: [{PC: "0xce2060", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4928,15 +4952,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 128}
+        - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1571 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xce150a", Frameless: false}]
+              Type: 1572 EventRootType Probe[main.testStackArgRegReturns]
+              InjectionPoints: [{PC: "0xce180a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1572 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xce157c", Frameless: false}]
+              Type: 1573 EventRootType Probe[main.testStackArgRegReturns]Return
+              InjectionPoints: [{PC: "0xce187c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4998,11 +5022,11 @@ Probes:
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 138}
+        - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xce1de0", Frameless: true}]
+              Type: 1586 EventRootType Probe[main.testStringSlice]
+              InjectionPoints: [{PC: "0xce20e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5064,15 +5088,15 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1613 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xce2660", Frameless: true}]
+              Type: 1614 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0xce2960", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1614 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0xce2682", Frameless: true}]
+              Type: 1615 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0xce2982", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5095,11 +5119,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 135}
+        - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xce1d80", Frameless: true}]
+              Type: 1583 EventRootType Probe[main.testStructSlice]
+              InjectionPoints: [{PC: "0xce2080", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5143,15 +5167,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 130}
+        - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1575 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xce16ae", Frameless: false}]
+              Type: 1576 EventRootType Probe[main.testStructWithArrayArg]
+              InjectionPoints: [{PC: "0xce19ae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1576 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xce175c", Frameless: false}]
+              Type: 1577 EventRootType Probe[main.testStructWithArrayArg]Return
+              InjectionPoints: [{PC: "0xce1a5c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5169,15 +5193,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 155}
+        - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1609 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xce2520", Frameless: true}]
+              Type: 1610 EventRootType Probe[main.testStructWithCyclicMaps]
+              InjectionPoints: [{PC: "0xce2820", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1610 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0xce253e", Frameless: true}]
+              Type: 1611 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              InjectionPoints: [{PC: "0xce283e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5194,11 +5218,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 154}
+        - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1608 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xce2500", Frameless: true}]
+              Type: 1609 EventRootType Probe[main.testStructWithCyclicSlices]
+              InjectionPoints: [{PC: "0xce2800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5253,11 +5277,11 @@ Probes:
           dsl: cs
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 143}
+        - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xce1e80", Frameless: true}]
+              Type: 1592 EventRootType Probe[main.testSubslices]
+              InjectionPoints: [{PC: "0xce2180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5293,11 +5317,11 @@ Probes:
           dsl: c
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 153}
+        - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1607 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xce2380", Frameless: true}]
+              Type: 1608 EventRootType Probe[main.testSubstrings]
+              InjectionPoints: [{PC: "0xce2680", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5411,11 +5435,11 @@ Probes:
           dsl: z
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 146}
+        - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xce22a0", Frameless: true}]
+              Type: 1596 EventRootType Probe[main.testThreeStrings]
+              InjectionPoints: [{PC: "0xce25a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5443,15 +5467,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce22c0", Frameless: true}]
+              Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0xce25c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce22de", Frameless: true}]
+              Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0xce25de", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5477,15 +5501,15 @@ Probes:
           dsl: t.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xce22c0", Frameless: true}]
+              Type: 1599 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0xce25c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1599 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0xce22de", Frameless: true}]
+              Type: 1600 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0xce25de", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5513,11 +5537,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce22e0", Frameless: true}]
+              Type: 1601 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0xce25e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5543,11 +5567,11 @@ Probes:
           dsl: a.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xce22e0", Frameless: true}]
+              Type: 1602 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0xce25e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5729,11 +5753,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 132}
+        - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xce1d20", Frameless: true}]
+              Type: 1580 EventRootType Probe[main.testUintSlice]
+              InjectionPoints: [{PC: "0xce2020", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5751,11 +5775,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 151}
+        - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1605 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xce2340", Frameless: true}]
+              Type: 1606 EventRootType Probe[main.testUnitializedString]
+              InjectionPoints: [{PC: "0xce2640", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5817,11 +5841,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1588 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce1e40", Frameless: true}]
+              Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0xce2140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5839,11 +5863,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xce1e40", Frameless: true}]
+              Type: 1590 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0xce2140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5861,18 +5885,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1686 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1687 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0xcdc86a"
                   Frameless: false
-                - PC: "0xce5623"
+                - PC: "0xce5923"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1687 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1688 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0xcdc8a5", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5891,15 +5915,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 131}
+        - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xce178e", Frameless: false}]
+              Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              InjectionPoints: [{PC: "0xce1a8e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xce180c", Frameless: false}]
+              Type: 1579 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              InjectionPoints: [{PC: "0xce1b0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -8110,802 +8134,831 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 108
+      Name: main.testReturnsNamedDeferLine
+      OutOfLinePCRanges: [0xce02a0..0xce04af]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xce02a0..0xce0326
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xce0326..0xce04af
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xce02d7..0xce04af
+              Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
+          Role: Return
+          DictIndex: -1
+        - Name: b
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xce02dd..0xce04af
+              Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xce02a0..0xce031e]
+      OutOfLinePCRanges: [0xce05a0..0xce061e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xce02a0..0xce0311
+            - Range: 0xce05a0..0xce0611
               Pieces: []
-            - Range: 0xce0311..0xce0312
+            - Range: 0xce0611..0xce0612
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0312..0xce031e
+            - Range: 0xce0612..0xce061e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 104 BaseType int16
           Locations:
-            - Range: 0xce02a0..0xce0311
+            - Range: 0xce05a0..0xce0611
               Pieces: []
-            - Range: 0xce0311..0xce0312
+            - Range: 0xce0611..0xce0612
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce0312..0xce031e
+            - Range: 0xce0612..0xce061e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xce02a0..0xce0311
+            - Range: 0xce05a0..0xce0611
               Pieces: []
-            - Range: 0xce0311..0xce0312
+            - Range: 0xce0611..0xce0612
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce0312..0xce031e
+            - Range: 0xce0612..0xce061e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xce02a0..0xce0311
+            - Range: 0xce05a0..0xce0611
               Pieces: []
-            - Range: 0xce0311..0xce0312
+            - Range: 0xce0611..0xce0612
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce0312..0xce031e
+            - Range: 0xce0612..0xce061e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xce02a0..0xce0311
+            - Range: 0xce05a0..0xce0611
               Pieces: []
-            - Range: 0xce0311..0xce0312
+            - Range: 0xce0611..0xce0612
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce0312..0xce031e
+            - Range: 0xce0612..0xce061e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xce02a0..0xce0311
+            - Range: 0xce05a0..0xce0611
               Pieces: []
-            - Range: 0xce0311..0xce0312
+            - Range: 0xce0611..0xce0612
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce0312..0xce031e
+            - Range: 0xce0612..0xce061e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xce02a0..0xce0311
+            - Range: 0xce05a0..0xce0611
               Pieces: []
-            - Range: 0xce0311..0xce0312
+            - Range: 0xce0611..0xce0612
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce0312..0xce031e
+            - Range: 0xce0612..0xce061e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xce02a0..0xce0311
+            - Range: 0xce05a0..0xce0611
               Pieces: []
-            - Range: 0xce0311..0xce0312
+            - Range: 0xce0611..0xce0612
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce0312..0xce031e
+            - Range: 0xce0612..0xce061e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xce0320..0xce0417]
+      OutOfLinePCRanges: [0xce0620..0xce0717]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce0320..0xce0417, Pieces: []}]
+          Locations: [{Range: 0xce0620..0xce0717, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xce0320..0xce0407
+            - Range: 0xce0620..0xce0707
               Pieces: []
-            - Range: 0xce0407..0xce0408
+            - Range: 0xce0707..0xce0708
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce0408..0xce0417
+            - Range: 0xce0708..0xce0717
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xce0320..0xce0407
+            - Range: 0xce0620..0xce0707
               Pieces: []
-            - Range: 0xce0407..0xce0408
+            - Range: 0xce0707..0xce0708
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xce0408..0xce0417
+            - Range: 0xce0708..0xce0717
               Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 110
-      Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xce0420..0xce0493]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 96 BaseType complex64
-          Locations: [{Range: 0xce0420..0xce0493, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 97 BaseType complex128
-          Locations: [{Range: 0xce0420..0xce0493, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0xce0720..0xce0793]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 96 BaseType complex64
+          Locations: [{Range: 0xce0720..0xce0793, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 97 BaseType complex128
+          Locations: [{Range: 0xce0720..0xce0793, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xce04a0..0xce0545]
+      OutOfLinePCRanges: [0xce07a0..0xce0845]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce04a0..0xce0533
+            - Range: 0xce07a0..0xce0833
               Pieces: []
-            - Range: 0xce0533..0xce0534
+            - Range: 0xce0833..0xce0834
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xce0534..0xce0545
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 112
-      Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xce0560..0xce05da]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 251 ArrayType [3]int
-          Locations:
-            - Range: 0xce0560..0xce05cd
-              Pieces: []
-            - Range: 0xce05cd..0xce05ce
-              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce05ce..0xce05da
+            - Range: 0xce0834..0xce0845
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
-      Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xce05e0..0xce0638]
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0xce0860..0xce08da]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 252 ArrayType [1]int
+          Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xce05e0..0xce062b
+            - Range: 0xce0860..0xce08cd
               Pieces: []
-            - Range: 0xce062b..0xce062c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce062c..0xce0638
+            - Range: 0xce08cd..0xce08ce
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xce08ce..0xce08da
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
-      Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xce0640..0xce0693]
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0xce08e0..0xce0938]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 253 ArrayType [0]int
+          Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0xce0640..0xce0686
+            - Range: 0xce08e0..0xce092b
               Pieces: []
-            - Range: 0xce0686..0xce0687
-              Pieces: []
-            - Range: 0xce0687..0xce0693
+            - Range: 0xce092b..0xce092c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xce092c..0xce0938
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
-      Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xce06a0..0xce0707]
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0xce0940..0xce0993]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0xce06a0..0xce0707, Pieces: []}]
+          Type: 253 ArrayType [0]int
+          Locations:
+            - Range: 0xce0940..0xce0986
+              Pieces: []
+            - Range: 0xce0986..0xce0987
+              Pieces: []
+            - Range: 0xce0987..0xce0993
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0xce09a0..0xce0a07]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 254 StructureType main.mixedStruct
+          Locations: [{Range: 0xce09a0..0xce0a07, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xce0720..0xce07ba]
+      OutOfLinePCRanges: [0xce0a20..0xce0aba]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0720..0xce07aa
+            - Range: 0xce0a20..0xce0aaa
               Pieces: []
-            - Range: 0xce07aa..0xce07ab
+            - Range: 0xce0aaa..0xce0aab
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce07ab..0xce07ba
+            - Range: 0xce0aab..0xce0aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0720..0xce07aa
+            - Range: 0xce0a20..0xce0aaa
               Pieces: []
-            - Range: 0xce07aa..0xce07ab
+            - Range: 0xce0aaa..0xce0aab
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce07ab..0xce07ba
+            - Range: 0xce0aab..0xce0aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0720..0xce07aa
+            - Range: 0xce0a20..0xce0aaa
               Pieces: []
-            - Range: 0xce07aa..0xce07ab
+            - Range: 0xce0aaa..0xce0aab
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce07ab..0xce07ba
+            - Range: 0xce0aab..0xce0aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0720..0xce07aa
+            - Range: 0xce0a20..0xce0aaa
               Pieces: []
-            - Range: 0xce07aa..0xce07ab
+            - Range: 0xce0aaa..0xce0aab
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce07ab..0xce07ba
+            - Range: 0xce0aab..0xce0aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0720..0xce07aa
+            - Range: 0xce0a20..0xce0aaa
               Pieces: []
-            - Range: 0xce07aa..0xce07ab
+            - Range: 0xce0aaa..0xce0aab
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce07ab..0xce07ba
+            - Range: 0xce0aab..0xce0aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0720..0xce07aa
+            - Range: 0xce0a20..0xce0aaa
               Pieces: []
-            - Range: 0xce07aa..0xce07ab
+            - Range: 0xce0aaa..0xce0aab
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce07ab..0xce07ba
+            - Range: 0xce0aab..0xce0aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0720..0xce07aa
+            - Range: 0xce0a20..0xce0aaa
               Pieces: []
-            - Range: 0xce07aa..0xce07ab
+            - Range: 0xce0aaa..0xce0aab
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce07ab..0xce07ba
+            - Range: 0xce0aab..0xce0aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0720..0xce07aa
+            - Range: 0xce0a20..0xce0aaa
               Pieces: []
-            - Range: 0xce07aa..0xce07ab
+            - Range: 0xce0aaa..0xce0aab
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce07ab..0xce07ba
+            - Range: 0xce0aab..0xce0aba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0720..0xce07aa
+            - Range: 0xce0a20..0xce0aaa
               Pieces: []
-            - Range: 0xce07aa..0xce07ab
+            - Range: 0xce0aaa..0xce0aab
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce07ab..0xce07ba
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 117
-      Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xce07c0..0xce0865]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 255 StructureType main.wideStruct
-          Locations:
-            - Range: 0xce07c0..0xce0854
-              Pieces: []
-            - Range: 0xce0854..0xce0855
-              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xce0855..0xce0865
+            - Range: 0xce0aab..0xce0aba
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
-      Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xce0880..0xce08f9]
+      Name: main.testReturnsWideStruct
+      OutOfLinePCRanges: [0xce0ac0..0xce0b65]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 7 BaseType int
+          Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0xce0880..0xce08ec
+            - Range: 0xce0ac0..0xce0b54
               Pieces: []
-            - Range: 0xce08ec..0xce08ed
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce08ed..0xce08f9
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 15 BaseType float64
-          Locations: [{Range: 0xce0880..0xce08f9, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xce0880..0xce08ec
-              Pieces: []
-            - Range: 0xce08ec..0xce08ed
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce08ed..0xce08f9
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 15 BaseType float64
-          Locations: [{Range: 0xce0880..0xce08f9, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xce0880..0xce08ec
-              Pieces: []
-            - Range: 0xce08ec..0xce08ed
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce08ed..0xce08f9
+            - Range: 0xce0b54..0xce0b55
+              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
+            - Range: 0xce0b55..0xce0b65
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
-      Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xce0900..0xce097a]
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0xce0b80..0xce0bf9]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 256 StructureType main.structWithArray
+          Type: 7 BaseType int
           Locations:
-            - Range: 0xce0900..0xce096d
+            - Range: 0xce0b80..0xce0bec
               Pieces: []
-            - Range: 0xce096d..0xce096e
-              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xce096e..0xce097a
+            - Range: 0xce0bec..0xce0bed
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xce0bed..0xce0bf9
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xce0b80..0xce0bf9, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xce0b80..0xce0bec
+              Pieces: []
+            - Range: 0xce0bec..0xce0bed
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xce0bed..0xce0bf9
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xce0b80..0xce0bf9, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xce0b80..0xce0bec
+              Pieces: []
+            - Range: 0xce0bec..0xce0bed
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xce0bed..0xce0bf9
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
-      Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xce0980..0xce09db]
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0xce0c00..0xce0c7a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 15 BaseType float64
-          Locations: [{Range: 0xce0980..0xce09db, Pieces: []}]
+          Type: 256 StructureType main.structWithArray
+          Locations:
+            - Range: 0xce0c00..0xce0c6d
+              Pieces: []
+            - Range: 0xce0c6d..0xce0c6e
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xce0c6e..0xce0c7a
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
-      Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xce09e0..0xce0a47]
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0xce0c80..0xce0cdb]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 18 BaseType float32
-          Locations: [{Range: 0xce09e0..0xce0a47, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xce09e0..0xce0a47, Pieces: []}]
+          Locations: [{Range: 0xce0c80..0xce0cdb, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0xce0ce0..0xce0d47]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 18 BaseType float32
+          Locations: [{Range: 0xce0ce0..0xce0d47, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xce0ce0..0xce0d47, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xce0a60..0xce0abd]
+      OutOfLinePCRanges: [0xce0d60..0xce0dbd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce0a60..0xce0ab0
+            - Range: 0xce0d60..0xce0db0
               Pieces: []
-            - Range: 0xce0ab0..0xce0ab1
+            - Range: 0xce0db0..0xce0db1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce0ab1..0xce0abd
+            - Range: 0xce0db1..0xce0dbd
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xce0a60..0xce0ab0
+            - Range: 0xce0d60..0xce0db0
               Pieces: []
-            - Range: 0xce0ab0..0xce0ab1
+            - Range: 0xce0db0..0xce0db1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce0ab1..0xce0abd
+            - Range: 0xce0db1..0xce0dbd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 123
+    - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xce0ac0..0xce0c45]
+      OutOfLinePCRanges: [0xce0dc0..0xce0f45]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce0ac0..0xce0c45
+            - Range: 0xce0dc0..0xce0f45
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce0ac0..0xce0c33
+            - Range: 0xce0dc0..0xce0f33
               Pieces: []
-            - Range: 0xce0c33..0xce0c34
+            - Range: 0xce0f33..0xce0f34
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xce0c34..0xce0c45
+            - Range: 0xce0f34..0xce0f45
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 124
+    - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xce0c60..0xce0d32]
+      OutOfLinePCRanges: [0xce0f60..0xce1032]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xce0c60..0xce0d32
+            - Range: 0xce0f60..0xce1032
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xce0c60..0xce0d22
+            - Range: 0xce0f60..0xce1022
               Pieces: []
-            - Range: 0xce0d22..0xce0d23
+            - Range: 0xce1022..0xce1023
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce0d23..0xce0d32
+            - Range: 0xce1023..0xce1032
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xce0d40..0xce0f7a]
+      OutOfLinePCRanges: [0xce1040..0xce127a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce0d40..0xce0f7a
+            - Range: 0xce1040..0xce127a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce0d40..0xce0f7a
+            - Range: 0xce1040..0xce127a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce0d40..0xce0f6a
+            - Range: 0xce1040..0xce126a
               Pieces: []
-            - Range: 0xce0f6a..0xce0f6b
+            - Range: 0xce126a..0xce126b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xce0f6b..0xce0f7a
+            - Range: 0xce126b..0xce127a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 126
+    - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xce0f80..0xce120f]
+      OutOfLinePCRanges: [0xce1280..0xce150f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0f80..0xce1030
+            - Range: 0xce1280..0xce1330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1030..0xce120f
+            - Range: 0xce1330..0xce150f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0f80..0xce1030
+            - Range: 0xce1280..0xce1330
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce1030..0xce120f
+            - Range: 0xce1330..0xce150f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0f80..0xce101a
+            - Range: 0xce1280..0xce131a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce101a..0xce120f
+            - Range: 0xce131a..0xce150f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0f80..0xce0ff0
+            - Range: 0xce1280..0xce12f0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce0ff0..0xce120f
+            - Range: 0xce12f0..0xce150f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0f80..0xce1030
+            - Range: 0xce1280..0xce1330
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce1030..0xce120f
+            - Range: 0xce1330..0xce150f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0f80..0xce1030
+            - Range: 0xce1280..0xce1330
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce1030..0xce120f
+            - Range: 0xce1330..0xce150f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0f80..0xce1030
+            - Range: 0xce1280..0xce1330
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce1030..0xce120f
+            - Range: 0xce1330..0xce150f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0f80..0xce1030
+            - Range: 0xce1280..0xce1330
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce1030..0xce120f
+            - Range: 0xce1330..0xce150f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce0f80..0xce1030
+            - Range: 0xce1280..0xce1330
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xce1030..0xce120f
+            - Range: 0xce1330..0xce150f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xce0f80..0xce11a2
+            - Range: 0xce1280..0xce14a2
               Pieces: []
-            - Range: 0xce11a2..0xce11a3
+            - Range: 0xce14a2..0xce14a3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xce11a3..0xce120f
+            - Range: 0xce14a3..0xce150f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 127
+    - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xce1220..0xce14ec]
+      OutOfLinePCRanges: [0xce1520..0xce17ec]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1220..0xce12cb
+            - Range: 0xce1520..0xce15cb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce12cb..0xce14ec
+            - Range: 0xce15cb..0xce17ec
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1220..0xce12cb
+            - Range: 0xce1520..0xce15cb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce12cb..0xce14ec
+            - Range: 0xce15cb..0xce17ec
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1220..0xce12b5
+            - Range: 0xce1520..0xce15b5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce12b5..0xce14ec
+            - Range: 0xce15b5..0xce17ec
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1220..0xce1282
+            - Range: 0xce1520..0xce1582
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xce1282..0xce14ec
+            - Range: 0xce1582..0xce17ec
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1220..0xce12cb
+            - Range: 0xce1520..0xce15cb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce12cb..0xce14ec
+            - Range: 0xce15cb..0xce17ec
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1220..0xce12cb
+            - Range: 0xce1520..0xce15cb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xce12cb..0xce14ec
+            - Range: 0xce15cb..0xce17ec
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1220..0xce12cb
+            - Range: 0xce1520..0xce15cb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xce12cb..0xce14ec
+            - Range: 0xce15cb..0xce17ec
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1220..0xce12cb
+            - Range: 0xce1520..0xce15cb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xce12cb..0xce14ec
+            - Range: 0xce15cb..0xce17ec
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce1220..0xce14ec
+            - Range: 0xce1520..0xce17ec
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8916,219 +8969,200 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xce1220..0xce146b
+            - Range: 0xce1520..0xce176b
               Pieces: []
-            - Range: 0xce146b..0xce146c
+            - Range: 0xce176b..0xce176c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xce146c..0xce14ec
+            - Range: 0xce176c..0xce17ec
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 128
+    - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xce1500..0xce158c]
+      OutOfLinePCRanges: [0xce1800..0xce188c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xce1500..0xce158c
+            - Range: 0xce1800..0xce188c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1500..0xce157c
+            - Range: 0xce1800..0xce187c
               Pieces: []
-            - Range: 0xce157c..0xce157d
+            - Range: 0xce187c..0xce187d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce157d..0xce158c
+            - Range: 0xce187d..0xce188c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1500..0xce157c
+            - Range: 0xce1800..0xce187c
               Pieces: []
-            - Range: 0xce157c..0xce157d
+            - Range: 0xce187c..0xce187d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xce157d..0xce158c
+            - Range: 0xce187d..0xce188c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1500..0xce157c
+            - Range: 0xce1800..0xce187c
               Pieces: []
-            - Range: 0xce157c..0xce157d
+            - Range: 0xce187c..0xce187d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce157d..0xce158c
+            - Range: 0xce187d..0xce188c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 129
+    - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xce15a0..0xce168f]
+      OutOfLinePCRanges: [0xce18a0..0xce198f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xce15a0..0xce168f
+            - Range: 0xce18a0..0xce198f
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xce15a0..0xce168f
+            - Range: 0xce18a0..0xce198f
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce15a0..0xce167f
+            - Range: 0xce18a0..0xce197f
               Pieces: []
-            - Range: 0xce167f..0xce1680
+            - Range: 0xce197f..0xce1980
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce1680..0xce168f
+            - Range: 0xce1980..0xce198f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xce15a0..0xce167f
+            - Range: 0xce18a0..0xce197f
               Pieces: []
-            - Range: 0xce167f..0xce1680
+            - Range: 0xce197f..0xce1980
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xce1680..0xce168f
+            - Range: 0xce1980..0xce198f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 130
+    - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xce16a0..0xce176c]
+      OutOfLinePCRanges: [0xce19a0..0xce1a6c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xce16a0..0xce176c
+            - Range: 0xce19a0..0xce1a6c
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce16a0..0xce175c
+            - Range: 0xce19a0..0xce1a5c
               Pieces: []
-            - Range: 0xce175c..0xce175d
+            - Range: 0xce1a5c..0xce1a5d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce175d..0xce176c
+            - Range: 0xce1a5d..0xce1a6c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xce16a0..0xce175c
+            - Range: 0xce19a0..0xce1a5c
               Pieces: []
-            - Range: 0xce175c..0xce175d
+            - Range: 0xce1a5c..0xce1a5d
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xce175d..0xce176c
+            - Range: 0xce1a5d..0xce1a6c
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1726..0xce176c
+            - Range: 0xce1a26..0xce1a6c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
-    - ID: 131
+    - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xce1780..0xce1826]
+      OutOfLinePCRanges: [0xce1a80..0xce1b26]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0xce1780..0xce1826, Pieces: []}]
+          Locations: [{Range: 0xce1a80..0xce1b26, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1780..0xce17c5
+            - Range: 0xce1a80..0xce1ac5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce17c5..0xce17e7
+            - Range: 0xce1ac5..0xce1ae7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xce17e7..0xce17fa
+            - Range: 0xce1ae7..0xce1afa
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xce17fa..0xce1826
+            - Range: 0xce1afa..0xce1b26
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1780..0xce180c
+            - Range: 0xce1a80..0xce1b0c
               Pieces: []
-            - Range: 0xce180c..0xce180d
+            - Range: 0xce1b0c..0xce1b0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce180d..0xce1826
+            - Range: 0xce1b0d..0xce1b26
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0xce1780..0xce180c
+            - Range: 0xce1a80..0xce1b0c
               Pieces: []
-            - Range: 0xce180c..0xce180d
+            - Range: 0xce1b0c..0xce1b0d
               Pieces: []
-            - Range: 0xce180d..0xce1826
+            - Range: 0xce1b0d..0xce1b26
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 132
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xce1d20..0xce1d21]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xce1d20..0xce1d21
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
     - ID: 133
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xce1d40..0xce1d41]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xce2020..0xce2021]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce1d40..0xce1d41
+            - Range: 0xce2020..0xce2021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9140,14 +9174,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 134
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xce1d60..0xce1d61]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xce2040..0xce2041]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 258 GoSliceHeaderType [][]uint
+          Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce1d60..0xce1d61
+            - Range: 0xce2040..0xce2041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9159,14 +9193,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 135
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xce1d80..0xce1d81]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xce2060..0xce2061]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xce1d80..0xce1d81
+            - Range: 0xce2060..0xce2061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9174,25 +9208,18 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xce1d80..0xce1d81
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 136
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xce1da0..0xce1da1]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xce2080..0xce2081]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xce1da0..0xce1da1
+            - Range: 0xce2080..0xce2081
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9205,20 +9232,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1da0..0xce1da1
+            - Range: 0xce2080..0xce2081
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xce1dc0..0xce1dc1]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xce20a0..0xce20a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xce1dc0..0xce1dc1
+            - Range: 0xce20a0..0xce20a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9231,20 +9258,46 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce1dc0..0xce1dc1
+            - Range: 0xce20a0..0xce20a1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xce20c0..0xce20c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xce20c0..0xce20c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xce20c0..0xce20c1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xce1de0..0xce1de1]
+      OutOfLinePCRanges: [0xce20e0..0xce20e1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 263 GoSliceHeaderType []string
           Locations:
-            - Range: 0xce1de0..0xce1de1
+            - Range: 0xce20e0..0xce20e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9255,22 +9308,22 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 139
+    - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xce1e00..0xce1e01]
+      OutOfLinePCRanges: [0xce2100..0xce2101]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xce1e00..0xce1e01
+            - Range: 0xce2100..0xce2101
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 264 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xce1e00..0xce1e01
+            - Range: 0xce2100..0xce2101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9283,39 +9336,20 @@ Subprograms:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xce1e00..0xce1e01
+            - Range: 0xce2100..0xce2101
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
+    - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xce1e20..0xce1e21]
+      OutOfLinePCRanges: [0xce2120..0xce2121]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xce1e20..0xce1e21
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xce1e40..0xce1e41]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xce1e40..0xce1e41
+            - Range: 0xce2120..0xce2121
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9327,14 +9361,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 142
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xce1e60..0xce1e61]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xce2140..0xce2141]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 266 GoSliceHeaderType []struct {}
+          Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce1e60..0xce1e61
+            - Range: 0xce2140..0xce2141
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9346,14 +9380,33 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xce2160..0xce2161]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xce2160..0xce2161
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xce1e80..0xce1e81]
+      OutOfLinePCRanges: [0xce2180..0xce2181]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce1e80..0xce1e81
+            - Range: 0xce2180..0xce2181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9366,7 +9419,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce1e80..0xce1e81
+            - Range: 0xce2180..0xce2181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9379,7 +9432,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xce1e80..0xce1e81
+            - Range: 0xce2180..0xce2181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9390,36 +9443,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
+    - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0xce2220..0xce2272]
+      OutOfLinePCRanges: [0xce2520..0xce2572]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2220..0xce2265
+            - Range: 0xce2520..0xce2565
               Pieces: []
-            - Range: 0xce2265..0xce2266
+            - Range: 0xce2565..0xce2566
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce2266..0xce2272
+            - Range: 0xce2566..0xce2572
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 145
+    - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xce2280..0xce2281]
+      OutOfLinePCRanges: [0xce2580..0xce2581]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2280..0xce2281
+            - Range: 0xce2580..0xce2581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9428,15 +9481,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xce22a0..0xce22a1]
+      OutOfLinePCRanges: [0xce25a0..0xce25a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce22a0..0xce22a1
+            - Range: 0xce25a0..0xce25a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9447,7 +9500,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce22a0..0xce22a1
+            - Range: 0xce25a0..0xce25a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9458,7 +9511,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce22a0..0xce22a1
+            - Range: 0xce25a0..0xce25a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9467,15 +9520,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 147
+    - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xce22c0..0xce22df]
+      OutOfLinePCRanges: [0xce25c0..0xce25df]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xce22c0..0xce22df
+            - Range: 0xce25c0..0xce25df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9492,58 +9545,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 148
+    - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xce22e0..0xce22e1]
+      OutOfLinePCRanges: [0xce25e0..0xce25e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 269 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xce22e0..0xce22e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xce2300..0xce2301]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 270 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0xce2300..0xce2301
+            - Range: 0xce25e0..0xce25e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xce2320..0xce2321]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0xce2600..0xce2601]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 270 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xce2320..0xce2321
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xce2600..0xce2601
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xce2340..0xce2341]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xce2620..0xce2621]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2340..0xce2341
+            - Range: 0xce2620..0xce2621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9553,14 +9589,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 152
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xce2360..0xce2361]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xce2640..0xce2641]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2360..0xce2361
+            - Range: 0xce2640..0xce2641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9570,14 +9606,31 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 153
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xce2660..0xce2661]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xce2660..0xce2661
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xce2380..0xce2381]
+      OutOfLinePCRanges: [0xce2680..0xce2681]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2380..0xce2381
+            - Range: 0xce2680..0xce2681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9588,7 +9641,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2380..0xce2381
+            - Range: 0xce2680..0xce2681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9599,7 +9652,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce2380..0xce2381
+            - Range: 0xce2680..0xce2681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9608,28 +9661,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
+    - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xce2500..0xce2501]
+      OutOfLinePCRanges: [0xce2800..0xce2801]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xce2500..0xce2501
+            - Range: 0xce2800..0xce2801
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
+    - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xce2520..0xce253f]
+      OutOfLinePCRanges: [0xce2820..0xce283f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 285 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xce2520..0xce253f
+            - Range: 0xce2820..0xce283f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9646,15 +9699,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
+    - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0xce2660..0xce2683]
+      OutOfLinePCRanges: [0xce2960..0xce2983]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 StructureType main.aStruct
           Locations:
-            - Range: 0xce2660..0xce2683
+            - Range: 0xce2960..0xce2983
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9673,151 +9726,151 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 157
+    - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xce2760..0xce2761]
+      OutOfLinePCRanges: [0xce2a60..0xce2a61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xce2760..0xce2761
+            - Range: 0xce2a60..0xce2a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 158
+    - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xce2780..0xce2781]
+      OutOfLinePCRanges: [0xce2a80..0xce2a81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 319 StructureType main.tenStrings
           Locations:
-            - Range: 0xce2780..0xce2781
+            - Range: 0xce2a80..0xce2a81
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 159
+    - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xce27e0..0xce27e1]
+      OutOfLinePCRanges: [0xce2ae0..0xce2ae1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 StructureType main.emptyStruct
-          Locations: [{Range: 0xce27e0..0xce27e1, Pieces: []}]
+          Locations: [{Range: 0xce2ae0..0xce2ae1, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 160
+    - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xce2800..0xce2801]
+      OutOfLinePCRanges: [0xce2b00..0xce2b01]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 321 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xce2800..0xce2801
+            - Range: 0xce2b00..0xce2b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 161
+    - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xce49c0..0xce49c4]
+      OutOfLinePCRanges: [0xce4cc0..0xce4cc4]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce49c0..0xce49c4
+            - Range: 0xce4cc0..0xce4cc4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce49c0..0xce49c3
+            - Range: 0xce4cc0..0xce4cc3
               Pieces: []
-            - Range: 0xce49c3..0xce49c4
+            - Range: 0xce4cc3..0xce4cc4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 162
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xce49e0..0xce49ec]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 324 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0xce49e0..0xce49eb
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce49eb..0xce49ec
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xce49e0..0xce49eb
-              Pieces: []
-            - Range: 0xce49eb..0xce49ec
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0xce4ce0..0xce4cec]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 324 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xce4ce0..0xce4ceb
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xce4ceb..0xce4cec
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xce4ce0..0xce4ceb
+              Pieces: []
+            - Range: 0xce4ceb..0xce4cec
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xce4a00..0xce4a04]
+      OutOfLinePCRanges: [0xce4d00..0xce4d04]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce4a00..0xce4a04
+            - Range: 0xce4d00..0xce4d04
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce4a00..0xce4a03
+            - Range: 0xce4d00..0xce4d03
               Pieces: []
-            - Range: 0xce4a03..0xce4a04
+            - Range: 0xce4d03..0xce4d04
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 164
+    - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xce4a20..0xce4a2c]
+      OutOfLinePCRanges: [0xce4d20..0xce4d2c]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce4a20..0xce4a2b
+            - Range: 0xce4d20..0xce4d2b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce4a2b..0xce4a2c
+            - Range: 0xce4d2b..0xce4d2c
               Pieces:
                 - Size: 8
                   Op: null
@@ -9828,9 +9881,9 @@ Subprograms:
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce4a20..0xce4a2b
+            - Range: 0xce4d20..0xce4d2b
               Pieces: []
-            - Range: 0xce4a2b..0xce4a2c
+            - Range: 0xce4d2b..0xce4d2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9839,15 +9892,15 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xce4aa0..0xce4bd6]
+      OutOfLinePCRanges: [0xce4da0..0xce4ed6]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce4aa0..0xce4ad3
+            - Range: 0xce4da0..0xce4dd3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9855,7 +9908,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce4ad3..0xce4adb
+            - Range: 0xce4dd3..0xce4ddb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9863,7 +9916,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xce4adb..0xce4bd6
+            - Range: 0xce4ddb..0xce4ed6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9876,18 +9929,18 @@ Subprograms:
         - Name: pred
           Type: 328 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xce4aa0..0xce4adb
+            - Range: 0xce4da0..0xce4ddb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xce4adb..0xce4bd6
+            - Range: 0xce4ddb..0xce4ed6
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce4aa0..0xce4b94
+            - Range: 0xce4da0..0xce4e94
               Pieces: []
-            - Range: 0xce4b94..0xce4b95
+            - Range: 0xce4e94..0xce4e95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9895,14 +9948,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce4b95..0xce4bd6
+            - Range: 0xce4e95..0xce4ed6
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce4adb..0xce4af9
+            - Range: 0xce4ddb..0xce4df9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9910,7 +9963,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce4af9..0xce4b01
+            - Range: 0xce4df9..0xce4e01
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9918,7 +9971,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce4b01..0xce4b09
+            - Range: 0xce4e01..0xce4e09
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9926,7 +9979,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce4b09..0xce4b09
+            - Range: 0xce4e09..0xce4e09
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9934,7 +9987,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce4b09..0xce4b33
+            - Range: 0xce4e09..0xce4e33
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -9942,7 +9995,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce4b33..0xce4b8b
+            - Range: 0xce4e33..0xce4e8b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9950,7 +10003,7 @@ Subprograms:
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: -48}
-            - Range: 0xce4b8b..0xce4bd6
+            - Range: 0xce4e8b..0xce4ed6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
@@ -9963,132 +10016,132 @@ Subprograms:
         - Name: item
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce4b26..0xce4b33
+            - Range: 0xce4e26..0xce4e33
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce4b33..0xce4b8b
+            - Range: 0xce4e33..0xce4e8b
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 166
+    - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce4be0..0xce4c24]
+      OutOfLinePCRanges: [0xce4ee0..0xce4f24]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xce4be0..0xce4bf9
+            - Range: 0xce4ee0..0xce4ef9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 329 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xce4be0..0xce4bf9
+            - Range: 0xce4ee0..0xce4ef9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xce4be0..0xce4bf9
+            - Range: 0xce4ee0..0xce4ef9
               Pieces: []
-            - Range: 0xce4bf9..0xce4bfa
+            - Range: 0xce4ef9..0xce4efa
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce4bfa..0xce4c24
+            - Range: 0xce4efa..0xce4f24
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 167
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xce4ec0..0xce4ec4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 327 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce4ec0..0xce4ec4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 327 PointerType *go.shape.int
-          Locations:
-            - Range: 0xce4ec0..0xce4ec3
-              Pieces: []
-            - Range: 0xce4ec3..0xce4ec4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 168
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xce4ee0..0xce4ee4]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0xce51c0..0xce51c4]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 330 PointerType *go.shape.struct { Name string }
+          Type: 327 PointerType *go.shape.int
           Locations:
-            - Range: 0xce4ee0..0xce4ee4
+            - Range: 0xce51c0..0xce51c4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 330 PointerType *go.shape.struct { Name string }
+          Type: 327 PointerType *go.shape.int
           Locations:
-            - Range: 0xce4ee0..0xce4ee3
+            - Range: 0xce51c0..0xce51c3
               Pieces: []
-            - Range: 0xce4ee3..0xce4ee4
+            - Range: 0xce51c3..0xce51c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0xce51e0..0xce51e4]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 330 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0xce51e0..0xce51e4
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 330 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0xce51e0..0xce51e3
+              Pieces: []
+            - Range: 0xce51e3..0xce51e4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xce4f00..0xce4f04]
+      OutOfLinePCRanges: [0xce5200..0xce5204]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 332 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce4f00..0xce4f04
+            - Range: 0xce5200..0xce5204
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xce4f00..0xce4f03
+            - Range: 0xce5200..0xce5203
               Pieces: []
-            - Range: 0xce4f03..0xce4f04
+            - Range: 0xce5203..0xce5204
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
+    - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xce4f20..0xce4f31]
+      OutOfLinePCRanges: [0xce5220..0xce5231]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xce4f20..0xce4f31
+            - Range: 0xce5220..0xce5231
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce4f20..0xce4f30
+            - Range: 0xce5220..0xce5230
               Pieces: []
-            - Range: 0xce4f30..0xce4f31
+            - Range: 0xce5230..0xce5231
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10097,71 +10150,71 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 171
+    - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xce4fc0..0xce4fc9]
+      OutOfLinePCRanges: [0xce52c0..0xce52c9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xce4fc0..0xce4fc9
+            - Range: 0xce52c0..0xce52c9
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce4fc0..0xce4fc8
+            - Range: 0xce52c0..0xce52c8
               Pieces: []
-            - Range: 0xce4fc8..0xce4fc9
+            - Range: 0xce52c8..0xce52c9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
+    - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xce5080..0xce5088]
+      OutOfLinePCRanges: [0xce5380..0xce5388]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 337 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xce5080..0xce5088
+            - Range: 0xce5380..0xce5388
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5080..0xce5088
+            - Range: 0xce5380..0xce5388
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0xce5080..0xce5088
+            - Range: 0xce5380..0xce5388
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 173
+    - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xce5120..0xce518e]
+      OutOfLinePCRanges: [0xce5420..0xce548e]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xce5120..0xce518e
+            - Range: 0xce5420..0xce548e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5120..0xce518e
+            - Range: 0xce5420..0xce548e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10172,20 +10225,20 @@ Subprograms:
         - Name: v
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5120..0xce518e
+            - Range: 0xce5420..0xce548e
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 174
+    - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xce5220..0xce5228]
+      OutOfLinePCRanges: [0xce5520..0xce5528]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5220..0xce5228
+            - Range: 0xce5520..0xce5528
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10196,25 +10249,25 @@ Subprograms:
         - Name: b
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0xce5220..0xce5228
+            - Range: 0xce5520..0xce5528
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0xce5220..0xce5227
+            - Range: 0xce5520..0xce5527
               Pieces: []
-            - Range: 0xce5227..0xce5228
+            - Range: 0xce5527..0xce5528
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5220..0xce5227
+            - Range: 0xce5520..0xce5527
               Pieces: []
-            - Range: 0xce5227..0xce5228
+            - Range: 0xce5527..0xce5528
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10223,28 +10276,28 @@ Subprograms:
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 175
+    - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xce5240..0xce524f]
+      OutOfLinePCRanges: [0xce5540..0xce554f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5240..0xce524e
+            - Range: 0xce5540..0xce554e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5240..0xce524b
+            - Range: 0xce5540..0xce554b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce524b..0xce524f
+            - Range: 0xce554b..0xce554f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10255,9 +10308,9 @@ Subprograms:
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5240..0xce524e
+            - Range: 0xce5540..0xce554e
               Pieces: []
-            - Range: 0xce524e..0xce524f
+            - Range: 0xce554e..0xce554f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10268,56 +10321,56 @@ Subprograms:
         - Name: ~r1
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5240..0xce524e
+            - Range: 0xce5540..0xce554e
               Pieces: []
-            - Range: 0xce524e..0xce524f
+            - Range: 0xce554e..0xce554f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 176
+    - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xce5260..0xce529a]
+      OutOfLinePCRanges: [0xce5560..0xce559a]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 342 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xce5260..0xce5279
+            - Range: 0xce5560..0xce5579
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce5260..0xce5279
+            - Range: 0xce5560..0xce5579
               Pieces: []
-            - Range: 0xce5279..0xce527a
+            - Range: 0xce5579..0xce557a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce527a..0xce529a
+            - Range: 0xce557a..0xce559a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 177
+    - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xce52a0..0xce52ed]
+      OutOfLinePCRanges: [0xce55a0..0xce55ed]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 343 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xce52a0..0xce52bf
+            - Range: 0xce55a0..0xce55bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xce52bf..0xce52c2
+            - Range: 0xce55bf..0xce55c2
               Pieces:
                 - Size: 8
                   Op: null
@@ -10328,37 +10381,37 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce52a0..0xce52c2
+            - Range: 0xce55a0..0xce55c2
               Pieces: []
-            - Range: 0xce52c2..0xce52c3
+            - Range: 0xce55c2..0xce55c3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce52c3..0xce52ed
+            - Range: 0xce55c3..0xce55ed
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 178
+    - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xce5300..0xce5308]
+      OutOfLinePCRanges: [0xce5600..0xce5608]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 344 PointerType *go.shape.string
           Locations:
-            - Range: 0xce5300..0xce5307
+            - Range: 0xce5600..0xce5607
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5300..0xce5307
+            - Range: 0xce5600..0xce5607
               Pieces: []
-            - Range: 0xce5307..0xce5308
+            - Range: 0xce5607..0xce5608
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10367,24 +10420,24 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 179
+    - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xce5320..0xce5377]
+      OutOfLinePCRanges: [0xce5620..0xce5677]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 345 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce5320..0xce535d
+            - Range: 0xce5620..0xce565d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 346 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xce5320..0xce5371
+            - Range: 0xce5620..0xce5671
               Pieces: []
-            - Range: 0xce5371..0xce5372
+            - Range: 0xce5671..0xce5672
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10398,20 +10451,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce5372..0xce5377
+            - Range: 0xce5672..0xce5677
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 180
+    - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xce5380..0xce53a4]
+      OutOfLinePCRanges: [0xce5680..0xce56a4]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xce5380..0xce53a4
+            - Range: 0xce5680..0xce56a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10424,33 +10477,33 @@ Subprograms:
         - Name: needle
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5380..0xce53a4
+            - Range: 0xce5680..0xce56a4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce5380..0xce53a0
+            - Range: 0xce5680..0xce56a0
               Pieces: []
-            - Range: 0xce53a0..0xce53a1
+            - Range: 0xce56a0..0xce56a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce53a1..0xce53a3
+            - Range: 0xce56a1..0xce56a3
               Pieces: []
-            - Range: 0xce53a3..0xce53a4
+            - Range: 0xce56a3..0xce56a4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xce53c0..0xce547f]
+      OutOfLinePCRanges: [0xce56c0..0xce577f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 347 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xce53c0..0xce53dd
+            - Range: 0xce56c0..0xce56dd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10458,7 +10511,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce53dd..0xce53df
+            - Range: 0xce56dd..0xce56df
               Pieces:
                 - Size: 8
                   Op: null
@@ -10471,13 +10524,13 @@ Subprograms:
         - Name: needle
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce53c0..0xce540c
+            - Range: 0xce56c0..0xce570c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xce540c..0xce547f
+            - Range: 0xce570c..0xce577f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10488,28 +10541,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce53c0..0xce542b
+            - Range: 0xce56c0..0xce572b
               Pieces: []
-            - Range: 0xce542b..0xce542c
+            - Range: 0xce572b..0xce572c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce542c..0xce5433
+            - Range: 0xce572c..0xce5733
               Pieces: []
-            - Range: 0xce5433..0xce5434
+            - Range: 0xce5733..0xce5734
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce5434..0xce547f
+            - Range: 0xce5734..0xce577f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce53ef..0xce5401
+            - Range: 0xce56ef..0xce5701
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xce5401..0xce540c
+            - Range: 0xce5701..0xce570c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10518,56 +10571,56 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 182
+    - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xce5480..0xce5487]
+      OutOfLinePCRanges: [0xce5780..0xce5787]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xce5480..0xce5486
+            - Range: 0xce5780..0xce5786
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0xce5480..0xce5487
+            - Range: 0xce5780..0xce5787
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce5480..0xce5486
+            - Range: 0xce5780..0xce5786
               Pieces: []
-            - Range: 0xce5486..0xce5487
+            - Range: 0xce5786..0xce5787
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
-    - ID: 183
+    - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xce5500..0xce556c]
+      OutOfLinePCRanges: [0xce5800..0xce586c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 349 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xce5500..0xce5520
+            - Range: 0xce5800..0xce5820
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce5520..0xce5528
+            - Range: 0xce5820..0xce5828
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce5528..0xce552d
+            - Range: 0xce5828..0xce582d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10578,7 +10631,7 @@ Subprograms:
         - Name: value
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xce5500..0xce552d
+            - Range: 0xce5800..0xce582d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10589,16 +10642,16 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce5500..0xce552d
+            - Range: 0xce5800..0xce582d
               Pieces: []
-            - Range: 0xce552d..0xce552e
+            - Range: 0xce582d..0xce582e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce552e..0xce556c
+            - Range: 0xce582e..0xce586c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 184
+    - ID: 185
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x52c3a0..0x52c4e5]
       InlinePCRanges: []
@@ -10729,7 +10782,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 185
+    - ID: 186
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcdc180..0xcdc1e2]
       InlinePCRanges:
@@ -10760,7 +10813,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 186
+    - ID: 187
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10768,7 +10821,7 @@ Subprograms:
           RootRanges: [0xcdc3c0..0xcdc485]
       Variables: []
       DictRegister: null
-    - ID: 187
+    - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10776,7 +10829,7 @@ Subprograms:
           RootRanges: [0xcdc520..0xcdc625]
       Variables: []
       DictRegister: null
-    - ID: 188
+    - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10784,7 +10837,7 @@ Subprograms:
           RootRanges: [0xcdc520..0xcdc625]
       Variables: []
       DictRegister: null
-    - ID: 189
+    - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10799,7 +10852,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 191
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10818,12 +10871,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 191
+    - ID: 192
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xcdc860..0xcdc8c6]
       InlinePCRanges:
-        - Ranges: [0xce5623..0xce5651]
-          RootRanges: [0xce5600..0xce567f]
+        - Ranges: [0xce5923..0xce5951]
+          RootRanges: [0xce5900..0xce597f]
       Variables:
         - Name: b
           Type: 354 StructureType main.firstBehavior
@@ -10852,7 +10905,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 192
+    - ID: 193
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -14258,7 +14311,7 @@ Types:
       GoKind: 22
       Pointee: 865 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1632
+      ID: 1633
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14277,7 +14330,7 @@ Types:
             Type: 350 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14288,7 +14341,7 @@ Types:
             Type: 350 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14299,12 +14352,12 @@ Types:
             Type: 353 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: pred}
+                  Variable: {subprogram: 185, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1633
+      ID: 1634
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14317,12 +14370,12 @@ Types:
             Type: 350 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 185, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1630
+      ID: 1631
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14341,7 +14394,7 @@ Types:
             Type: 326 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14352,7 +14405,7 @@ Types:
             Type: 326 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14363,12 +14416,12 @@ Types:
             Type: 328 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: pred}
+                  Variable: {subprogram: 166, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1631
+      ID: 1632
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14381,15 +14434,15 @@ Types:
             Type: 326 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 2, name: ~r0}
+                  Variable: {subprogram: 166, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1688
+      ID: 1689
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1634
+      ID: 1635
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14408,7 +14461,7 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14419,7 +14472,7 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14430,12 +14483,12 @@ Types:
             Type: 329 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: f}
+                  Variable: {subprogram: 167, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1635
+      ID: 1636
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14448,12 +14501,12 @@ Types:
             Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 2, name: ~r0}
+                  Variable: {subprogram: 167, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14475,7 +14528,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14486,7 +14539,7 @@ Types:
             Type: 337 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: x}
+                  Variable: {subprogram: 173, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14497,7 +14550,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14508,15 +14561,15 @@ Types:
             Type: 339 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 2, name: v}
+                  Variable: {subprogram: 173, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1647
+      ID: 1648
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1648
+      ID: 1649
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14538,7 +14591,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14549,7 +14602,7 @@ Types:
             Type: 340 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: x}
+                  Variable: {subprogram: 174, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14560,7 +14613,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14571,15 +14624,15 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 2, name: v}
+                  Variable: {subprogram: 174, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1649
+      ID: 1650
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1686
+      ID: 1687
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14591,12 +14644,12 @@ Types:
             Type: 354 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 0, name: b}
+                  Variable: {subprogram: 192, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1687
+      ID: 1688
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14608,12 +14661,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 1, name: ~r0}
+                  Variable: {subprogram: 192, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14632,7 +14685,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14643,7 +14696,7 @@ Types:
             Type: 326 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14654,14 +14707,14 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.genericContains[go.shape.int]]Line
-      ByteSize: 50
+      ByteSize: 49
       ExprStatusArraySize: 1
       DictEntries:
         - DictIndex: 0
@@ -14678,7 +14731,7 @@ Types:
             Type: 326 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14689,23 +14742,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
-        - Name: '@return'
-          Offset: 49
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14717,12 +14759,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14741,7 +14783,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14752,7 +14794,7 @@ Types:
             Type: 347 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: haystack}
+                  Variable: {subprogram: 182, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14763,14 +14805,14 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1667
+      ID: 1668
       Name: Probe[main.genericContains[go.shape.string]]Line
-      ByteSize: 26
+      ByteSize: 25
       ExprStatusArraySize: 1
       DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
       Expressions:
@@ -14781,23 +14823,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
-        - Name: '@return'
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14809,12 +14840,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14827,7 +14858,7 @@ Types:
             Type: 344 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14838,12 +14869,12 @@ Types:
             Type: 344 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1659
+      ID: 1660
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14856,12 +14887,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Variable: {subprogram: 179, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14874,7 +14905,7 @@ Types:
             Type: 345 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14885,12 +14916,12 @@ Types:
             Type: 345 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1661
+      ID: 1662
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14903,12 +14934,12 @@ Types:
             Type: 346 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: ~r0}
+                  Variable: {subprogram: 180, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1654
+      ID: 1655
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14921,7 +14952,7 @@ Types:
             Type: 342 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14932,59 +14963,13 @@ Types:
             Type: 342 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1655
-      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: '@return'
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1656
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
-      Expressions:
-        - Name: val
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 343 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-        - Name: val
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 343 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-    - __kind: EventRootType
-      ID: 1657
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -15000,7 +14985,53 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1636
+      ID: 1657
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
+      Expressions:
+        - Name: val
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 343 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+        - Name: val
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 343 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+    - __kind: EventRootType
+      ID: 1658
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1637
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15013,7 +15044,7 @@ Types:
             Type: 327 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15024,12 +15055,12 @@ Types:
             Type: 327 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1637
+      ID: 1638
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15042,12 +15073,12 @@ Types:
             Type: 327 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1638
+      ID: 1639
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15060,7 +15091,7 @@ Types:
             Type: 330 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15071,12 +15102,12 @@ Types:
             Type: 330 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15089,12 +15120,12 @@ Types:
             Type: 330 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1640
+      ID: 1641
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15107,7 +15138,7 @@ Types:
             Type: 332 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15118,12 +15149,12 @@ Types:
             Type: 332 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15136,12 +15167,12 @@ Types:
             Type: 332 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1652
+      ID: 1653
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15160,7 +15191,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15171,7 +15202,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15182,12 +15213,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: b}
+                  Variable: {subprogram: 176, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1653
+      ID: 1654
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15206,7 +15237,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 2, name: ~r0}
+                  Variable: {subprogram: 176, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -15217,12 +15248,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 3, name: ~r1}
+                  Variable: {subprogram: 176, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1650
+      ID: 1651
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15241,7 +15272,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15252,7 +15283,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15263,12 +15294,12 @@ Types:
             Type: 339 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: b}
+                  Variable: {subprogram: 175, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1651
+      ID: 1652
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15287,7 +15318,7 @@ Types:
             Type: 339 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 2, name: ~r0}
+                  Variable: {subprogram: 175, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
@@ -15298,12 +15329,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 3, name: ~r1}
+                  Variable: {subprogram: 175, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1644
+      ID: 1645
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15316,7 +15347,7 @@ Types:
             Type: 336 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
@@ -15327,12 +15358,12 @@ Types:
             Type: 336 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1645
+      ID: 1646
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15345,12 +15376,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 172, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1642
+      ID: 1643
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15363,7 +15394,7 @@ Types:
             Type: 334 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
@@ -15374,12 +15405,12 @@ Types:
             Type: 334 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1643
+      ID: 1644
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15392,12 +15423,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1626
+      ID: 1627
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15410,7 +15441,7 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15421,12 +15452,12 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15439,12 +15470,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15457,7 +15488,7 @@ Types:
             Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15468,12 +15499,12 @@ Types:
             Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1629
+      ID: 1630
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15486,15 +15517,15 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15506,7 +15537,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: ~r0}
+                  Variable: {subprogram: 145, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -15601,7 +15632,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15613,7 +15644,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -15624,12 +15655,12 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15641,7 +15672,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16343,7 +16374,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16355,7 +16386,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16366,7 +16397,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16377,7 +16408,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16388,12 +16419,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16405,7 +16436,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16416,12 +16447,12 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16433,7 +16464,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -16444,12 +16475,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1621
+      ID: 1622
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16461,7 +16492,7 @@ Types:
             Type: 321 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16472,12 +16503,12 @@ Types:
             Type: 321 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16489,7 +16520,7 @@ Types:
             Type: 320 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -16500,18 +16531,18 @@ Types:
             Type: 320 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
       ID: 1402
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 58
-      ExprStatusArraySize: 2
+      ByteSize: 49
+      ExprStatusArraySize: 1
       Expressions:
         - Name: x
-          Offset: 2
+          Offset: 1
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -16522,7 +16553,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 10
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 13 GoInterfaceType error
@@ -16532,19 +16563,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: '@return'
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
         - Name: x
-          Offset: 34
+          Offset: 25
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16555,7 +16575,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 42
+          Offset: 33
           Kind: local
           Expression:
             Type: 13 GoInterfaceType error
@@ -16686,7 +16706,7 @@ Types:
     - __kind: EventRootType
       ID: 1430
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 89
+      ByteSize: 81
       ExprStatusArraySize: 1
       Expressions:
         - Name: a
@@ -16710,17 +16730,6 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-          DictIndex: -1
-        - Name: '@return'
-          Offset: 81
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1429
@@ -16847,7 +16856,7 @@ Types:
       ID: 1423
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1678
+      ID: 1679
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1420
@@ -16903,16 +16912,16 @@ Types:
       ID: 1421
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1679
+      ID: 1680
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1680
+      ID: 1681
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1681
+      ID: 1682
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1682
+      ID: 1683
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1424
@@ -16921,7 +16930,7 @@ Types:
       ID: 1425
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1675
+      ID: 1676
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16933,7 +16942,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16944,24 +16953,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1672
-      Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x_val
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16978,12 +16970,29 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1674
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 186, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1675
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16995,7 +17004,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17006,12 +17015,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1677
+      ID: 1678
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17023,7 +17032,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17034,15 +17043,15 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1676
+      ID: 1677
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1683
+      ID: 1684
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17054,7 +17063,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17065,12 +17074,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1684
+      ID: 1685
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17082,7 +17091,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17093,12 +17102,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1685
+      ID: 1686
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17110,7 +17119,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17121,7 +17130,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17294,7 +17303,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -17306,7 +17315,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17317,12 +17326,12 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17334,7 +17343,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: ~r0}
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17426,7 +17435,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -17438,7 +17447,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17449,7 +17458,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17460,7 +17469,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17471,7 +17480,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17482,7 +17491,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17493,7 +17502,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17504,7 +17513,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17515,7 +17524,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17526,7 +17535,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17537,7 +17546,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17548,7 +17557,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17559,7 +17568,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17570,7 +17579,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17581,7 +17590,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17592,7 +17601,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17603,7 +17612,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17614,7 +17623,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17625,12 +17634,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17642,7 +17651,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 9, name: ~r0}
+                  Variable: {subprogram: 127, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18207,34 +18216,6 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1604
       Name: Probe[main.testMassiveString]
       ByteSize: 33
@@ -18247,7 +18228,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18258,12 +18239,40 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1569
+      ID: 1605
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1570
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -18275,7 +18284,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18286,7 +18295,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18297,7 +18306,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18308,7 +18317,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18319,7 +18328,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18330,7 +18339,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18341,7 +18350,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18352,7 +18361,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18363,7 +18372,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18374,7 +18383,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18385,7 +18394,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18396,7 +18405,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18407,7 +18416,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18418,7 +18427,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18429,7 +18438,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18440,7 +18449,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18451,7 +18460,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18462,12 +18471,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18479,12 +18488,12 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 9, name: ~r0}
+                  Variable: {subprogram: 128, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18496,7 +18505,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18507,7 +18516,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -18518,7 +18527,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18529,12 +18538,12 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -18546,7 +18555,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18557,12 +18566,12 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -18574,7 +18583,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18585,7 +18594,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18596,7 +18605,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18607,12 +18616,12 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18624,7 +18633,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -19277,7 +19286,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19289,7 +19298,7 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19300,12 +19309,12 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19317,7 +19326,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19328,10 +19337,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1618
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19343,7 +19352,7 @@ Types:
             Type: 123 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19404,7 +19413,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1585
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -19416,7 +19425,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19427,7 +19436,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19438,7 +19447,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19449,12 +19458,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -19466,7 +19475,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19477,7 +19486,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19488,7 +19497,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19499,7 +19508,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19510,7 +19519,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19521,12 +19530,12 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1588
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -19538,7 +19547,7 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19549,12 +19558,12 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1602
+      ID: 1603
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19566,7 +19575,7 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19577,7 +19586,7 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19789,10 +19798,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -19804,15 +19813,15 @@ Types:
             Type: 252 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -19824,15 +19833,15 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19844,15 +19853,15 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -19864,7 +19873,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19875,7 +19884,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19886,7 +19895,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19897,7 +19906,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19908,7 +19917,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19919,7 +19928,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 5, name: ~r5}
+                  Variable: {subprogram: 117, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19930,7 +19939,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 6, name: ~r6}
+                  Variable: {subprogram: 117, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19941,7 +19950,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 7, name: ~r7}
+                  Variable: {subprogram: 117, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19952,15 +19961,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 8, name: ~r8}
+                  Variable: {subprogram: 117, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -19972,7 +19981,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: ~r0}
+                  Variable: {subprogram: 123, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19983,15 +19992,15 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r1}
+                  Variable: {subprogram: 123, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20003,7 +20012,7 @@ Types:
             Type: 96 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20014,7 +20023,7 @@ Types:
             Type: 97 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: ~r1}
+                  Variable: {subprogram: 111, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -20477,10 +20486,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -20492,15 +20501,15 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -20512,7 +20521,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20523,7 +20532,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: ~r1}
+                  Variable: {subprogram: 110, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20534,7 +20543,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 2, name: ~r2}
+                  Variable: {subprogram: 110, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20545,7 +20554,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 3, name: ~r3}
+                  Variable: {subprogram: 110, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20556,7 +20565,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 4, name: ~r4}
+                  Variable: {subprogram: 110, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20567,7 +20576,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 5, name: ~r5}
+                  Variable: {subprogram: 110, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20578,7 +20587,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 6, name: ~r6}
+                  Variable: {subprogram: 110, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20589,7 +20598,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 7, name: ~r7}
+                  Variable: {subprogram: 110, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20600,7 +20609,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 8, name: ~r8}
+                  Variable: {subprogram: 110, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20611,7 +20620,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 9, name: ~r9}
+                  Variable: {subprogram: 110, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20622,7 +20631,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 10, name: ~r10}
+                  Variable: {subprogram: 110, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20633,7 +20642,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 11, name: ~r11}
+                  Variable: {subprogram: 110, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20644,7 +20653,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 12, name: ~r12}
+                  Variable: {subprogram: 110, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20655,7 +20664,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 13, name: ~r13}
+                  Variable: {subprogram: 110, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20666,7 +20675,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 14, name: ~r14}
+                  Variable: {subprogram: 110, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20677,7 +20686,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 110, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20688,15 +20697,15 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 110, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20708,15 +20717,15 @@ Types:
             Type: 254 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20728,7 +20737,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20739,7 +20748,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20750,7 +20759,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 2, name: ~r2}
+                  Variable: {subprogram: 119, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20761,7 +20770,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 3, name: ~r3}
+                  Variable: {subprogram: 119, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20772,15 +20781,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 4, name: ~r4}
+                  Variable: {subprogram: 119, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -20792,7 +20801,7 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: ~r0}
+                  Variable: {subprogram: 122, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20803,15 +20812,65 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r1}
+                  Variable: {subprogram: 122, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
-      Name: Probe[main.testReturnsOnlyFloat]
+      ID: 1531
+      Name: Probe[main.testReturnsNamedDeferLine]Line
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: a
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 1556
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1557
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20823,15 +20882,15 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -20843,7 +20902,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20854,7 +20913,7 @@ Types:
             Type: 104 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -20865,7 +20924,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: ~r2}
+                  Variable: {subprogram: 109, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20876,7 +20935,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 3, name: ~r3}
+                  Variable: {subprogram: 109, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20887,7 +20946,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 4, name: ~r4}
+                  Variable: {subprogram: 109, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20898,7 +20957,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 5, name: ~r5}
+                  Variable: {subprogram: 109, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -20909,7 +20968,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 6, name: ~r6}
+                  Variable: {subprogram: 109, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20920,15 +20979,15 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 7, name: ~r7}
+                  Variable: {subprogram: 109, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20940,15 +20999,15 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -20960,7 +21019,7 @@ Types:
             Type: 255 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
           DictIndex: -1
@@ -21245,7 +21304,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21257,7 +21316,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21268,7 +21327,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21413,7 +21472,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1591
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21425,7 +21484,7 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21436,12 +21495,12 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21453,7 +21512,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21464,7 +21523,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21718,7 +21777,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -21730,7 +21789,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -21741,12 +21800,12 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21758,7 +21817,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21769,7 +21828,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21780,7 +21839,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r2}
+                  Variable: {subprogram: 129, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21841,7 +21900,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1586
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21853,7 +21912,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21864,7 +21923,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21925,7 +21984,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -21937,7 +21996,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21948,7 +22007,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21959,7 +22018,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21970,7 +22029,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22003,7 +22062,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22015,7 +22074,7 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22026,12 +22085,12 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22043,7 +22102,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 1, name: ~r0}
+                  Variable: {subprogram: 131, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22054,12 +22113,12 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 2, name: ~r1}
+                  Variable: {subprogram: 131, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22071,7 +22130,7 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22082,15 +22141,15 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -22102,7 +22161,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22113,7 +22172,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22146,7 +22205,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22158,12 +22217,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -22175,7 +22234,7 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
@@ -22186,18 +22245,18 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -22209,7 +22268,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22220,7 +22279,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22231,7 +22290,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22242,7 +22301,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22253,7 +22312,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22264,12 +22323,12 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22281,7 +22340,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22292,7 +22351,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22303,7 +22362,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22314,7 +22373,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22325,7 +22384,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22336,12 +22395,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1619
+      ID: 1620
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -22353,12 +22412,12 @@ Types:
             Type: 319 StructureType main.tenStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 160
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1601
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22370,7 +22429,7 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22381,12 +22440,12 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1602
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22398,7 +22457,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22412,7 +22471,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22426,7 +22485,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22434,7 +22493,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1597
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22446,7 +22505,7 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22457,12 +22516,12 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1599
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22474,7 +22533,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22485,7 +22544,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
           DictIndex: -1
@@ -22496,18 +22555,18 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22519,7 +22578,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22530,7 +22589,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22541,7 +22600,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22552,7 +22611,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22563,7 +22622,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22574,7 +22633,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22775,7 +22834,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22787,7 +22846,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22798,12 +22857,12 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22815,7 +22874,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22826,7 +22885,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22887,34 +22946,6 @@ Types:
                   ByteSize: 800
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1589
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -22927,7 +22958,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22938,12 +22969,40 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1590
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1578
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22955,7 +23014,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -22966,7 +23025,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22977,7 +23036,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -22988,12 +23047,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23005,7 +23064,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 2, name: ~r0}
+                  Variable: {subprogram: 132, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -23016,12 +23075,12 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 3, name: ~r1}
+                  Variable: {subprogram: 132, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1668
+      ID: 1669
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23040,7 +23099,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -23051,7 +23110,7 @@ Types:
             Type: 348 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: x}
+                  Variable: {subprogram: 183, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23062,12 +23121,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1669
+      ID: 1670
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23079,12 +23138,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 2, name: ~r0}
+                  Variable: {subprogram: 183, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1670
+      ID: 1671
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23103,7 +23162,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -23114,7 +23173,7 @@ Types:
             Type: 349 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: x}
+                  Variable: {subprogram: 184, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23125,12 +23184,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1671
+      ID: 1672
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23142,12 +23201,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 2, name: ~r0}
+                  Variable: {subprogram: 184, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23160,7 +23219,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23171,12 +23230,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1623
+      ID: 1624
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23189,12 +23248,12 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 1, name: ~r0}
+                  Variable: {subprogram: 162, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1624
+      ID: 1625
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23207,7 +23266,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23218,12 +23277,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1625
+      ID: 1626
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23236,7 +23295,7 @@ Types:
             Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 1, name: ~r0}
+                  Variable: {subprogram: 163, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -32247,7 +32306,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 999072
       GoKind: 5
-MaxTypeID: 1688
+MaxTypeID: 1689
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -9,15 +9,15 @@ Probes:
       segments: [stackC]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 144}
+        - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0xcee54a", Frameless: false}]
+              Type: 1593 EventRootType Probe[main.stackC]
+              InjectionPoints: [{PC: "0xcee86a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1593 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0xcee585", Frameless: false}]
+              Type: 1594 EventRootType Probe[main.stackC]Return
+              InjectionPoints: [{PC: "0xcee8a5", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -80,15 +80,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 124}
+        - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1563 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0xcecf6e", Frameless: false}]
+              Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]
+              InjectionPoints: [{PC: "0xced26e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0xced02a", Frameless: false}]
+              Type: 1565 EventRootType Probe[main.testArrayArgAndReturn]Return
+              InjectionPoints: [{PC: "0xced32a", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -334,11 +334,11 @@ Probes:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1608 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcee980", Frameless: true}]
+              Type: 1609 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0xceeca0", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -353,10 +353,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1667 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1668 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xce84ee"
                   Frameless: false
@@ -383,10 +383,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1668 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1669 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xce84ee"
                   Frameless: false
@@ -402,7 +402,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 185, index: 0, name: x}
+                      Variable: {subprogram: 186, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -425,10 +425,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1669 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1670 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xce84ee"
                   Frameless: false
@@ -507,16 +507,16 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 158}
+        - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1614 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0xceea60", Frameless: true}]
+              Type: 1615 EventRootType Probe[main.testTenStrings]
+              InjectionPoints: [{PC: "0xceed80", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 158, index: 0, name: x}
+                      Variable: {subprogram: 159, index: 0, name: x}
                       Offset: 144
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -781,11 +781,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 133}
+        - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0xcee0a0", Frameless: true}]
+              Type: 1581 EventRootType Probe[main.testEmptySlice]
+              InjectionPoints: [{PC: "0xcee3c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -808,11 +808,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 136}
+        - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0xcee100", Frameless: true}]
+              Type: 1584 EventRootType Probe[main.testEmptySliceOfStructs]
+              InjectionPoints: [{PC: "0xcee420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -836,11 +836,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 152}
+        - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0xcee680", Frameless: true}]
+              Type: 1605 EventRootType Probe[main.testEmptyString]
+              InjectionPoints: [{PC: "0xcee9a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -858,11 +858,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 159}
+        - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1615 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0xceeac0", Frameless: true}]
+              Type: 1616 EventRootType Probe[main.testEmptyStruct]
+              InjectionPoints: [{PC: "0xceede0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -879,11 +879,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 160}
+        - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1616 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0xceeae0", Frameless: true}]
+              Type: 1617 EventRootType Probe[main.testEmptyStructPointer]
+              InjectionPoints: [{PC: "0xceee00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1092,15 +1092,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1653 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf13e0", Frameless: true}]
+              Type: 1654 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0xcf1700", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1654 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf13e7", Frameless: true}]
+              Type: 1655 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xcf1707", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1110,15 +1110,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1655 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0xcf1404", Frameless: false}]
+              Type: 1656 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0xcf1724", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1656 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0xcf1455", Frameless: false}]
+              Type: 1657 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0xcf1775", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1137,15 +1137,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1649 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0xcf134a", Frameless: false}]
+              Type: 1650 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0xcf166a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1650 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0xcf1359", Frameless: false}]
+              Type: 1651 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0xcf1679", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1155,15 +1155,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1651 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0xcf138a", Frameless: false}]
+              Type: 1652 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0xcf16aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1652 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0xcf13a2", Frameless: false}]
+              Type: 1653 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0xcf16c2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1182,18 +1182,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1657 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf1460", Frameless: true}]
+              Type: 1658 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0xcf1780", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1658 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1659 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0xcf1480"
+                - PC: "0xcf17a0"
                   Frameless: true
-                - PC: "0xcf1483"
+                - PC: "0xcf17a3"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1204,18 +1204,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1659 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf14aa", Frameless: false}]
+              Type: 1660 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0xcf17ca", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1660 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1661 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0xcf150b"
+                - PC: "0xcf182b"
                   Frameless: false
-                - PC: "0xcf1513"
+                - PC: "0xcf1833"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1238,11 +1238,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Line
-              Type: 1661 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0xcf1465", Frameless: true}]
+              Type: 1662 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0xcf1785", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1250,11 +1250,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Line
-              Type: 1662 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0xcf14bf", Frameless: false}]
+              Type: 1663 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0xcf17df", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1271,15 +1271,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1637 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0xcf1000", Frameless: true}]
+              Type: 1638 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0xcf1320", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1638 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf1010", Frameless: true}]
+              Type: 1639 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0xcf1330", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1289,15 +1289,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1639 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0xcf10e0", Frameless: true}]
+              Type: 1640 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0xcf1400", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1640 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0xcf10e8", Frameless: true}]
+              Type: 1641 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0xcf1408", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1317,15 +1317,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 166}
           events:
             - Kind: Entry
-              Type: 1625 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf0b33", Frameless: false}]
+              Type: 1626 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0xcf0e53", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1626 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf0cba", Frameless: false}]
+              Type: 1627 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xcf0fda", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1335,14 +1335,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1627 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1628 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x53dfd3", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1628 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1629 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x53e15a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1363,15 +1363,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 167}
           events:
             - Kind: Entry
-              Type: 1629 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf0d2a", Frameless: false}]
+              Type: 1630 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xcf104a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1630 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf0d39", Frameless: false}]
+              Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xcf1059", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1390,15 +1390,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1663 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0xcf1560", Frameless: true}]
+              Type: 1664 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0xcf1880", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1664 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0xcf1566", Frameless: true}]
+              Type: 1665 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0xcf1886", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1408,15 +1408,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1665 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0xcf15ca", Frameless: false}]
+              Type: 1666 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0xcf18ea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1666 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0xcf15ed", Frameless: false}]
+              Type: 1667 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0xcf190d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1435,15 +1435,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 163}
+        - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1621 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf0a80", Frameless: true}]
+              Type: 1622 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0xcf0da0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1622 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf0a83", Frameless: true}]
+              Type: 1623 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xcf0da3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1453,15 +1453,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 164}
+        - subprogram: {subprogram: 165}
           events:
             - Kind: Entry
-              Type: 1623 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf0aa0", Frameless: true}]
+              Type: 1624 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0xcf0dc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1624 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf0aab", Frameless: true}]
+              Type: 1625 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xcf0dcb", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1480,15 +1480,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1641 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0xcf11a0", Frameless: true}]
+              Type: 1642 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0xcf14c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1642 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf11a7", Frameless: true}]
+              Type: 1643 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0xcf14c7", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1498,15 +1498,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1643 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0xcf122a", Frameless: false}]
+              Type: 1644 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0xcf154a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1644 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0xcf1253", Frameless: false}]
+              Type: 1645 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0xcf1573", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1525,33 +1525,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
-          events:
-            - Kind: Entry
-              Type: 1631 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf0fa0", Frameless: true}]
-              Condition: null
-            - Kind: Return
-              Type: 1632 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf0fa3", Frameless: true}]
-              Condition: null
-          probeTemplate:
-            TemplateString: p={p}
-            Segments:
-                - p=
-                - JSON: {Ref: p}
-                  DSL: p
-                  EventKind: Entry
-                  EventExpressionIndex: 0
         - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1633 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0xcf0fc0", Frameless: true}]
+              Type: 1632 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0xcf12c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1634 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0xcf0fc3", Frameless: true}]
+              Type: 1633 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xcf12c3", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1564,12 +1546,30 @@ Probes:
         - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1635 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0xcf0fe0", Frameless: true}]
+              Type: 1634 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0xcf12e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1636 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0xcf0fe3", Frameless: true}]
+              Type: 1635 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0xcf12e3", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: p={p}
+            Segments:
+                - p=
+                - JSON: {Ref: p}
+                  DSL: p
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+        - subprogram: {subprogram: 170}
+          events:
+            - Kind: Entry
+              Type: 1636 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0xcf1300", Frameless: true}]
+              Condition: null
+            - Kind: Return
+              Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0xcf1303", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1588,15 +1588,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1645 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0xcf1300", Frameless: true}]
+              Type: 1646 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0xcf1620", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1646 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0xcf1307", Frameless: true}]
+              Type: 1647 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0xcf1627", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1606,15 +1606,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1647 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0xcf1320", Frameless: true}]
+              Type: 1648 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0xcf1640", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1648 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf132e", Frameless: true}]
+              Type: 1649 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0xcf164e", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1633,15 +1633,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 161}
+        - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1617 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0xcf0a40", Frameless: true}]
+              Type: 1618 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0xcf0d60", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1618 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0xcf0a43", Frameless: true}]
+              Type: 1619 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0xcf0d63", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1651,15 +1651,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 162}
+        - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1619 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0xcf0a60", Frameless: true}]
+              Type: 1620 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0xcf0d80", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1620 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0xcf0a6b", Frameless: true}]
+              Type: 1621 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0xcf0d8b", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1766,10 +1766,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1673 EventRootType Probe[main.testInlinedBBB]
+              Type: 1674 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0xce8786", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1806,10 +1806,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1674 EventRootType Probe[main.testInlinedBCA]
+              Type: 1675 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0xce8893", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1827,10 +1827,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1675 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1676 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0xce8893", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1845,10 +1845,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1676 EventRootType Probe[main.testInlinedBCB]
+              Type: 1677 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0xce893b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1866,10 +1866,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Line
-              Type: 1677 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1678 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0xce893b", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1884,10 +1884,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1683 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1684 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x53dae1"
                   Frameless: true
@@ -1907,10 +1907,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1670 EventRootType Probe[main.testInlinedPrint]
+              Type: 1671 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0xce84ea"
                   Frameless: false
@@ -1924,7 +1924,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1671 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1672 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0xce852a", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1946,10 +1946,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1672 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0xce84ee"
                   Frameless: false
@@ -1978,10 +1978,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1678 EventRootType Probe[main.testInlinedSq]
+              Type: 1679 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0xce89a1", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2003,10 +2003,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Line
-              Type: 1679 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1680 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0xce89a1", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2026,10 +2026,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1680 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1681 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0xce89ed"
                   Frameless: false
@@ -2183,15 +2183,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 123}
+        - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1561 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0xcecdee", Frameless: false}]
+              Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]
+              InjectionPoints: [{PC: "0xced0ee", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcecf4d", Frameless: false}]
+              Type: 1563 EventRootType Probe[main.testLargeArgAndReturn]Return
+              InjectionPoints: [{PC: "0xced24d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2321,15 +2321,15 @@ Probes:
           dsl: i
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 126}
+        - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1567 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0xced293", Frameless: false}]
+              Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]
+              InjectionPoints: [{PC: "0xced593", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0xced4c2", Frameless: false}]
+              Type: 1569 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              InjectionPoints: [{PC: "0xced7c2", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2833,11 +2833,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcee640", Frameless: true}]
+              Type: 1602 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0xcee960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2856,11 +2856,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0xcee640", Frameless: true}]
+              Type: 1603 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0xcee960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2903,15 +2903,15 @@ Probes:
           dsl: s
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 127}
+        - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1569 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0xced553", Frameless: false}]
+              Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]
+              InjectionPoints: [{PC: "0xced853", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0xced782", Frameless: false}]
+              Type: 1571 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              InjectionPoints: [{PC: "0xceda82", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2973,15 +2973,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 129}
+        - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1573 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0xced8ce", Frameless: false}]
+              Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]
+              InjectionPoints: [{PC: "0xcedbce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0xced99d", Frameless: false}]
+              Type: 1575 EventRootType Probe[main.testMultipleArrayArgs]Return
+              InjectionPoints: [{PC: "0xcedc9d", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3008,15 +3008,15 @@ Probes:
           dsl: s2
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 125}
+        - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1565 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0xced04e", Frameless: false}]
+              Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]
+              InjectionPoints: [{PC: "0xced34e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0xced26b", Frameless: false}]
+              Type: 1567 EventRootType Probe[main.testMultipleLargeArgs]Return
+              InjectionPoints: [{PC: "0xced56b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3263,11 +3263,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1610 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xceea40", Frameless: true}]
+              Type: 1611 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xceed60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3288,11 +3288,11 @@ Probes:
           dsl: x.nested.anotherString
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1611 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xceea40", Frameless: true}]
+              Type: 1612 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xceed60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3319,11 +3319,11 @@ Probes:
           dsl: x.notAMember
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1612 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xceea40", Frameless: true}]
+              Type: 1613 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xceed60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3344,11 +3344,11 @@ Probes:
           dsl: x.nested
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1613 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0xceea40", Frameless: true}]
+              Type: 1614 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0xceed60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3398,11 +3398,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 140}
+        - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0xcee180", Frameless: true}]
+              Type: 1588 EventRootType Probe[main.testNilSlice]
+              InjectionPoints: [{PC: "0xcee4a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3425,11 +3425,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 137}
+        - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0xcee120", Frameless: true}]
+              Type: 1585 EventRootType Probe[main.testNilSliceOfStructs]
+              InjectionPoints: [{PC: "0xcee440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3460,11 +3460,11 @@ Probes:
           dsl: x
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 139}
+        - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0xcee160", Frameless: true}]
+              Type: 1587 EventRootType Probe[main.testNilSliceWithOtherParams]
+              InjectionPoints: [{PC: "0xcee480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3492,11 +3492,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 149}
+        - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0xcee620", Frameless: true}]
+              Type: 1601 EventRootType Probe[main.testOneStringInStructPointer]
+              InjectionPoints: [{PC: "0xcee940", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3933,15 +3933,15 @@ Probes:
       segments: [testReturnsArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 112}
+        - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1539 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0xcec86a", Frameless: false}]
+              Type: 1540 EventRootType Probe[main.testReturnsArray]
+              InjectionPoints: [{PC: "0xcecb6a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1540 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0xcec8cf", Frameless: false}]
+              Type: 1541 EventRootType Probe[main.testReturnsArray]Return
+              InjectionPoints: [{PC: "0xcecbcf", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3954,15 +3954,15 @@ Probes:
       segments: [testReturnsArrayOne]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 113}
+        - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1541 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0xcec8ea", Frameless: false}]
+              Type: 1542 EventRootType Probe[main.testReturnsArrayOne]
+              InjectionPoints: [{PC: "0xcecbea", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1542 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0xcec92b", Frameless: false}]
+              Type: 1543 EventRootType Probe[main.testReturnsArrayOne]Return
+              InjectionPoints: [{PC: "0xcecc2b", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3975,15 +3975,15 @@ Probes:
       segments: [testReturnsArrayZero]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 114}
+        - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1543 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0xcec94a", Frameless: false}]
+              Type: 1544 EventRootType Probe[main.testReturnsArrayZero]
+              InjectionPoints: [{PC: "0xcecc4a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1544 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0xcec986", Frameless: false}]
+              Type: 1545 EventRootType Probe[main.testReturnsArrayZero]Return
+              InjectionPoints: [{PC: "0xcecc86", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -3996,15 +3996,15 @@ Probes:
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 116}
+        - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1547 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0xceca2e", Frameless: false}]
+              Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]
+              InjectionPoints: [{PC: "0xcecd2e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0xcecaaa", Frameless: false}]
+              Type: 1549 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              InjectionPoints: [{PC: "0xcecdaa", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4017,15 +4017,15 @@ Probes:
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 122}
+        - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1559 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0xcecd8a", Frameless: false}]
+              Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              InjectionPoints: [{PC: "0xced08a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0xcecdd0", Frameless: false}]
+              Type: 1561 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              InjectionPoints: [{PC: "0xced0d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4038,15 +4038,15 @@ Probes:
       segments: [testReturnsComplex]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 110}
+        - subprogram: {subprogram: 111}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0xcec72a", Frameless: false}]
+              Type: 1536 EventRootType Probe[main.testReturnsComplex]
+              InjectionPoints: [{PC: "0xceca2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1536 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0xcec786", Frameless: false}]
+              Type: 1537 EventRootType Probe[main.testReturnsComplex]Return
+              InjectionPoints: [{PC: "0xceca86", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4194,15 +4194,15 @@ Probes:
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 111}
+        - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0xcec7ae", Frameless: false}]
+              Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]
+              InjectionPoints: [{PC: "0xcecaae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0xcec843", Frameless: false}]
+              Type: 1539 EventRootType Probe[main.testReturnsLargeStruct]Return
+              InjectionPoints: [{PC: "0xcecb43", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4215,15 +4215,15 @@ Probes:
       segments: [testReturnsManyFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 109}
+        - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0xcec62e", Frameless: false}]
+              Type: 1534 EventRootType Probe[main.testReturnsManyFloats]
+              InjectionPoints: [{PC: "0xcec92e", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1534 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0xcec707", Frameless: false}]
+              Type: 1535 EventRootType Probe[main.testReturnsManyFloats]Return
+              InjectionPoints: [{PC: "0xceca07", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4236,15 +4236,15 @@ Probes:
       segments: [testReturnsMixed]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 118}
+        - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1551 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0xcecbaa", Frameless: false}]
+              Type: 1552 EventRootType Probe[main.testReturnsMixed]
+              InjectionPoints: [{PC: "0xceceaa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1552 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0xcecc0c", Frameless: false}]
+              Type: 1553 EventRootType Probe[main.testReturnsMixed]Return
+              InjectionPoints: [{PC: "0xcecf0c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4257,15 +4257,15 @@ Probes:
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 115}
+        - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1545 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0xcec9aa", Frameless: false}]
+              Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]
+              InjectionPoints: [{PC: "0xceccaa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0xcec9f8", Frameless: false}]
+              Type: 1547 EventRootType Probe[main.testReturnsMixedStruct]Return
+              InjectionPoints: [{PC: "0xceccf8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4278,19 +4278,43 @@ Probes:
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 121}
+        - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1557 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0xcecd0a", Frameless: false}]
+              Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]
+              InjectionPoints: [{PC: "0xced00a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0xcecd56", Frameless: false}]
+              Type: 1559 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              InjectionPoints: [{PC: "0xced056", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
             Segments: [testReturnsMultipleFloats]
+    - id: testReturnsNamedDeferLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testReturnsNamedDeferLine
+        sourceFile: returns.go
+        lines: ["121"]
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 108}
+          events:
+            - Kind: Line
+              Type: 1531 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              InjectionPoints: [{PC: "0xcec6af", Frameless: false}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{i}'
+            Segments:
+                - JSON: {Ref: i}
+                  DSL: i
+                  EventKind: Line
+                  EventExpressionIndex: 0
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -4299,15 +4323,15 @@ Probes:
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 120}
+        - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1555 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0xceccaa", Frameless: false}]
+              Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]
+              InjectionPoints: [{PC: "0xcecfaa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0xceccee", Frameless: false}]
+              Type: 1557 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              InjectionPoints: [{PC: "0xcecfee", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4320,15 +4344,15 @@ Probes:
       segments: [testReturnsPrimitives]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 108}
+        - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1531 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0xcec5aa", Frameless: false}]
+              Type: 1532 EventRootType Probe[main.testReturnsPrimitives]
+              InjectionPoints: [{PC: "0xcec8aa", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1532 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0xcec611", Frameless: false}]
+              Type: 1533 EventRootType Probe[main.testReturnsPrimitives]Return
+              InjectionPoints: [{PC: "0xcec911", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4341,15 +4365,15 @@ Probes:
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 119}
+        - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1553 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0xcecc2a", Frameless: false}]
+              Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]
+              InjectionPoints: [{PC: "0xcecf2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0xcecc8f", Frameless: false}]
+              Type: 1555 EventRootType Probe[main.testReturnsStructWithArray]Return
+              InjectionPoints: [{PC: "0xcecf8f", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4362,15 +4386,15 @@ Probes:
       segments: [testReturnsWideStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 117}
+        - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1549 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0xcecace", Frameless: false}]
+              Type: 1550 EventRootType Probe[main.testReturnsWideStruct]
+              InjectionPoints: [{PC: "0xcecdce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1550 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0xcecb72", Frameless: false}]
+              Type: 1551 EventRootType Probe[main.testReturnsWideStruct]Return
+              InjectionPoints: [{PC: "0xcece72", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4698,11 +4722,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 145}
+        - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0xcee5a0", Frameless: true}]
+              Type: 1595 EventRootType Probe[main.testSingleString]
+              InjectionPoints: [{PC: "0xcee8c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4830,11 +4854,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 142}
+        - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0xcee1c0", Frameless: true}]
+              Type: 1591 EventRootType Probe[main.testSliceEmptyStructs]
+              InjectionPoints: [{PC: "0xcee4e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4852,11 +4876,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 134}
+        - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0xcee0c0", Frameless: true}]
+              Type: 1582 EventRootType Probe[main.testSliceOfSlices]
+              InjectionPoints: [{PC: "0xcee3e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4920,15 +4944,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 128}
+        - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1571 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0xced82a", Frameless: false}]
+              Type: 1572 EventRootType Probe[main.testStackArgRegReturns]
+              InjectionPoints: [{PC: "0xcedb2a", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1572 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0xced89e", Frameless: false}]
+              Type: 1573 EventRootType Probe[main.testStackArgRegReturns]Return
+              InjectionPoints: [{PC: "0xcedb9e", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4990,11 +5014,11 @@ Probes:
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 138}
+        - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0xcee140", Frameless: true}]
+              Type: 1586 EventRootType Probe[main.testStringSlice]
+              InjectionPoints: [{PC: "0xcee460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5056,11 +5080,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1609 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0xcee980", Frameless: true}]
+              Type: 1610 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0xceeca0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5083,11 +5107,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 135}
+        - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0xcee0e0", Frameless: true}]
+              Type: 1583 EventRootType Probe[main.testStructSlice]
+              InjectionPoints: [{PC: "0xcee400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5131,15 +5155,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 130}
+        - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1575 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0xced9ce", Frameless: false}]
+              Type: 1576 EventRootType Probe[main.testStructWithArrayArg]
+              InjectionPoints: [{PC: "0xcedcce", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1576 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0xceda84", Frameless: false}]
+              Type: 1577 EventRootType Probe[main.testStructWithArrayArg]Return
+              InjectionPoints: [{PC: "0xcedd84", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5157,11 +5181,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 155}
+        - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1607 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0xcee840", Frameless: true}]
+              Type: 1608 EventRootType Probe[main.testStructWithCyclicMaps]
+              InjectionPoints: [{PC: "0xceeb60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5178,11 +5202,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 154}
+        - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1606 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0xcee820", Frameless: true}]
+              Type: 1607 EventRootType Probe[main.testStructWithCyclicSlices]
+              InjectionPoints: [{PC: "0xceeb40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5237,11 +5261,11 @@ Probes:
           dsl: cs
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 143}
+        - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0xcee1e0", Frameless: true}]
+              Type: 1592 EventRootType Probe[main.testSubslices]
+              InjectionPoints: [{PC: "0xcee500", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5277,11 +5301,11 @@ Probes:
           dsl: c
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 153}
+        - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1605 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0xcee6a0", Frameless: true}]
+              Type: 1606 EventRootType Probe[main.testSubstrings]
+              InjectionPoints: [{PC: "0xcee9c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5395,11 +5419,11 @@ Probes:
           dsl: z
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 146}
+        - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0xcee5c0", Frameless: true}]
+              Type: 1596 EventRootType Probe[main.testThreeStrings]
+              InjectionPoints: [{PC: "0xcee8e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5427,11 +5451,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcee5e0", Frameless: true}]
+              Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0xcee900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5457,11 +5481,11 @@ Probes:
           dsl: t.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0xcee5e0", Frameless: true}]
+              Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0xcee900", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5489,11 +5513,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcee600", Frameless: true}]
+              Type: 1599 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0xcee920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5519,11 +5543,11 @@ Probes:
           dsl: a.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1599 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0xcee600", Frameless: true}]
+              Type: 1600 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0xcee920", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5705,11 +5729,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 132}
+        - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0xcee080", Frameless: true}]
+              Type: 1580 EventRootType Probe[main.testUintSlice]
+              InjectionPoints: [{PC: "0xcee3a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5727,11 +5751,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 151}
+        - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1603 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0xcee660", Frameless: true}]
+              Type: 1604 EventRootType Probe[main.testUnitializedString]
+              InjectionPoints: [{PC: "0xcee980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5793,11 +5817,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1588 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcee1a0", Frameless: true}]
+              Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0xcee4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5815,11 +5839,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0xcee1a0", Frameless: true}]
+              Type: 1590 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0xcee4c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5837,18 +5861,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1681 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1682 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0xce8bca"
                   Frameless: false
-                - PC: "0xcf16ba"
+                - PC: "0xcf19da"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1682 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1683 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0xce8c05", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5867,15 +5891,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 131}
+        - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0xcedaae", Frameless: false}]
+              Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              InjectionPoints: [{PC: "0xceddae", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0xcedb2c", Frameless: false}]
+              Type: 1579 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              InjectionPoints: [{PC: "0xcede2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -8088,802 +8112,831 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 108
+      Name: main.testReturnsNamedDeferLine
+      OutOfLinePCRanges: [0xcec5a0..0xcec7af]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcec5a0..0xcec626
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcec626..0xcec7af
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcec5d7..0xcec7af
+              Pieces: [{Size: 16, Op: {CfaOffset: -128}}]
+          Role: Return
+          DictIndex: -1
+        - Name: b
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcec5dd..0xcec7af
+              Pieces: [{Size: 16, Op: {CfaOffset: -144}}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcec5a0..0xcec61e]
+      OutOfLinePCRanges: [0xcec8a0..0xcec91e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 20 BaseType int8
           Locations:
-            - Range: 0xcec5a0..0xcec611
+            - Range: 0xcec8a0..0xcec911
               Pieces: []
-            - Range: 0xcec611..0xcec612
+            - Range: 0xcec911..0xcec912
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcec612..0xcec61e
+            - Range: 0xcec912..0xcec91e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 109 BaseType int16
           Locations:
-            - Range: 0xcec5a0..0xcec611
+            - Range: 0xcec8a0..0xcec911
               Pieces: []
-            - Range: 0xcec611..0xcec612
+            - Range: 0xcec911..0xcec912
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcec612..0xcec61e
+            - Range: 0xcec912..0xcec91e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcec5a0..0xcec611
+            - Range: 0xcec8a0..0xcec911
               Pieces: []
-            - Range: 0xcec611..0xcec612
+            - Range: 0xcec911..0xcec912
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcec612..0xcec61e
+            - Range: 0xcec912..0xcec91e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xcec5a0..0xcec611
+            - Range: 0xcec8a0..0xcec911
               Pieces: []
-            - Range: 0xcec611..0xcec612
+            - Range: 0xcec911..0xcec912
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcec612..0xcec61e
+            - Range: 0xcec912..0xcec91e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcec5a0..0xcec611
+            - Range: 0xcec8a0..0xcec911
               Pieces: []
-            - Range: 0xcec611..0xcec612
+            - Range: 0xcec911..0xcec912
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcec612..0xcec61e
+            - Range: 0xcec912..0xcec91e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcec5a0..0xcec611
+            - Range: 0xcec8a0..0xcec911
               Pieces: []
-            - Range: 0xcec611..0xcec612
+            - Range: 0xcec911..0xcec912
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcec612..0xcec61e
+            - Range: 0xcec912..0xcec91e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcec5a0..0xcec611
+            - Range: 0xcec8a0..0xcec911
               Pieces: []
-            - Range: 0xcec611..0xcec612
+            - Range: 0xcec911..0xcec912
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcec612..0xcec61e
+            - Range: 0xcec912..0xcec91e
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcec5a0..0xcec611
+            - Range: 0xcec8a0..0xcec911
               Pieces: []
-            - Range: 0xcec611..0xcec612
+            - Range: 0xcec911..0xcec912
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcec612..0xcec61e
+            - Range: 0xcec912..0xcec91e
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcec620..0xcec717]
+      OutOfLinePCRanges: [0xcec920..0xceca17]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r9
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r10
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r11
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r12
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r13
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r14
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcec620..0xcec717, Pieces: []}]
+          Locations: [{Range: 0xcec920..0xceca17, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: onlyOnAmd64_16
           Type: 13 BaseType float64
           Locations:
-            - Range: 0xcec620..0xcec707
+            - Range: 0xcec920..0xceca07
               Pieces: []
-            - Range: 0xcec707..0xcec708
+            - Range: 0xceca07..0xceca08
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcec708..0xcec717
+            - Range: 0xceca08..0xceca17
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: bothArmAndAmd64
           Type: 13 BaseType float64
           Locations:
-            - Range: 0xcec620..0xcec707
+            - Range: 0xcec920..0xceca07
               Pieces: []
-            - Range: 0xcec707..0xcec708
+            - Range: 0xceca07..0xceca08
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcec708..0xcec717
+            - Range: 0xceca08..0xceca17
               Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 110
-      Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcec720..0xcec793]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 102 BaseType complex64
-          Locations: [{Range: 0xcec720..0xcec793, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 18 BaseType complex128
-          Locations: [{Range: 0xcec720..0xcec793, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0xceca20..0xceca93]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 102 BaseType complex64
+          Locations: [{Range: 0xceca20..0xceca93, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 18 BaseType complex128
+          Locations: [{Range: 0xceca20..0xceca93, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcec7a0..0xcec853]
+      OutOfLinePCRanges: [0xcecaa0..0xcecb53]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xcec7a0..0xcec843
+            - Range: 0xcecaa0..0xcecb43
               Pieces: []
-            - Range: 0xcec843..0xcec844
+            - Range: 0xcecb43..0xcecb44
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcec844..0xcec853
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 112
-      Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcec860..0xcec8dc]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 257 ArrayType [3]int
-          Locations:
-            - Range: 0xcec860..0xcec8cf
-              Pieces: []
-            - Range: 0xcec8cf..0xcec8d0
-              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcec8d0..0xcec8dc
+            - Range: 0xcecb44..0xcecb53
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
-      Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcec8e0..0xcec938]
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0xcecb60..0xcecbdc]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 258 ArrayType [1]int
+          Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xcec8e0..0xcec92b
+            - Range: 0xcecb60..0xcecbcf
               Pieces: []
-            - Range: 0xcec92b..0xcec92c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcec92c..0xcec938
+            - Range: 0xcecbcf..0xcecbd0
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xcecbd0..0xcecbdc
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
-      Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcec940..0xcec993]
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0xcecbe0..0xcecc38]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 259 ArrayType [0]int
+          Type: 258 ArrayType [1]int
           Locations:
-            - Range: 0xcec940..0xcec986
+            - Range: 0xcecbe0..0xcecc2b
               Pieces: []
-            - Range: 0xcec986..0xcec987
-              Pieces: []
-            - Range: 0xcec987..0xcec993
+            - Range: 0xcecc2b..0xcecc2c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcecc2c..0xcecc38
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
-      Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcec9a0..0xceca07]
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0xcecc40..0xcecc93]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 260 StructureType main.mixedStruct
-          Locations: [{Range: 0xcec9a0..0xceca07, Pieces: []}]
+          Type: 259 ArrayType [0]int
+          Locations:
+            - Range: 0xcecc40..0xcecc86
+              Pieces: []
+            - Range: 0xcecc86..0xcecc87
+              Pieces: []
+            - Range: 0xcecc87..0xcecc93
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0xcecca0..0xcecd07]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 260 StructureType main.mixedStruct
+          Locations: [{Range: 0xcecca0..0xcecd07, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xceca20..0xcecaba]
+      OutOfLinePCRanges: [0xcecd20..0xcecdba]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceca20..0xcecaaa
+            - Range: 0xcecd20..0xcecdaa
               Pieces: []
-            - Range: 0xcecaaa..0xcecaab
+            - Range: 0xcecdaa..0xcecdab
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcecaab..0xcecaba
+            - Range: 0xcecdab..0xcecdba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceca20..0xcecaaa
+            - Range: 0xcecd20..0xcecdaa
               Pieces: []
-            - Range: 0xcecaaa..0xcecaab
+            - Range: 0xcecdaa..0xcecdab
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcecaab..0xcecaba
+            - Range: 0xcecdab..0xcecdba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceca20..0xcecaaa
+            - Range: 0xcecd20..0xcecdaa
               Pieces: []
-            - Range: 0xcecaaa..0xcecaab
+            - Range: 0xcecdaa..0xcecdab
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcecaab..0xcecaba
+            - Range: 0xcecdab..0xcecdba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceca20..0xcecaaa
+            - Range: 0xcecd20..0xcecdaa
               Pieces: []
-            - Range: 0xcecaaa..0xcecaab
+            - Range: 0xcecdaa..0xcecdab
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcecaab..0xcecaba
+            - Range: 0xcecdab..0xcecdba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceca20..0xcecaaa
+            - Range: 0xcecd20..0xcecdaa
               Pieces: []
-            - Range: 0xcecaaa..0xcecaab
+            - Range: 0xcecdaa..0xcecdab
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcecaab..0xcecaba
+            - Range: 0xcecdab..0xcecdba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceca20..0xcecaaa
+            - Range: 0xcecd20..0xcecdaa
               Pieces: []
-            - Range: 0xcecaaa..0xcecaab
+            - Range: 0xcecdaa..0xcecdab
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcecaab..0xcecaba
+            - Range: 0xcecdab..0xcecdba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceca20..0xcecaaa
+            - Range: 0xcecd20..0xcecdaa
               Pieces: []
-            - Range: 0xcecaaa..0xcecaab
+            - Range: 0xcecdaa..0xcecdab
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcecaab..0xcecaba
+            - Range: 0xcecdab..0xcecdba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceca20..0xcecaaa
+            - Range: 0xcecd20..0xcecdaa
               Pieces: []
-            - Range: 0xcecaaa..0xcecaab
+            - Range: 0xcecdaa..0xcecdab
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcecaab..0xcecaba
+            - Range: 0xcecdab..0xcecdba
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xceca20..0xcecaaa
+            - Range: 0xcecd20..0xcecdaa
               Pieces: []
-            - Range: 0xcecaaa..0xcecaab
+            - Range: 0xcecdaa..0xcecdab
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcecaab..0xcecaba
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 117
-      Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xcecac0..0xcecb85]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 261 StructureType main.wideStruct
-          Locations:
-            - Range: 0xcecac0..0xcecb72
-              Pieces: []
-            - Range: 0xcecb72..0xcecb73
-              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xcecb73..0xcecb85
+            - Range: 0xcecdab..0xcecdba
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 118
-      Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xcecba0..0xcecc19]
+      Name: main.testReturnsWideStruct
+      OutOfLinePCRanges: [0xcecdc0..0xcece85]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 7 BaseType int
+          Type: 261 StructureType main.wideStruct
           Locations:
-            - Range: 0xcecba0..0xcecc0c
+            - Range: 0xcecdc0..0xcece72
               Pieces: []
-            - Range: 0xcecc0c..0xcecc0d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcecc0d..0xcecc19
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcecba0..0xcecc19, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcecba0..0xcecc0c
-              Pieces: []
-            - Range: 0xcecc0c..0xcecc0d
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcecc0d..0xcecc19
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcecba0..0xcecc19, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcecba0..0xcecc0c
-              Pieces: []
-            - Range: 0xcecc0c..0xcecc0d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcecc0d..0xcecc19
+            - Range: 0xcece72..0xcece73
+              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
+            - Range: 0xcece73..0xcece85
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
-      Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcecc20..0xcecc9c]
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0xcecea0..0xcecf19]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 262 StructureType main.structWithArray
+          Type: 7 BaseType int
           Locations:
-            - Range: 0xcecc20..0xcecc8f
+            - Range: 0xcecea0..0xcecf0c
               Pieces: []
-            - Range: 0xcecc8f..0xcecc90
-              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcecc90..0xcecc9c
+            - Range: 0xcecf0c..0xcecf0d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcecf0d..0xcecf19
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcecea0..0xcecf19, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcecea0..0xcecf0c
+              Pieces: []
+            - Range: 0xcecf0c..0xcecf0d
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcecf0d..0xcecf19
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcecea0..0xcecf19, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcecea0..0xcecf0c
+              Pieces: []
+            - Range: 0xcecf0c..0xcecf0d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcecf0d..0xcecf19
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
-      Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcecca0..0xceccfb]
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0xcecf20..0xcecf9c]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcecca0..0xceccfb, Pieces: []}]
+          Type: 262 StructureType main.structWithArray
+          Locations:
+            - Range: 0xcecf20..0xcecf8f
+              Pieces: []
+            - Range: 0xcecf8f..0xcecf90
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xcecf90..0xcecf9c
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
-      Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xcecd00..0xcecd67]
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0xcecfa0..0xcecffb]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 17 BaseType float32
-          Locations: [{Range: 0xcecd00..0xcecd67, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xcecd00..0xcecd67, Pieces: []}]
+          Locations: [{Range: 0xcecfa0..0xcecffb, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0xced000..0xced067]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 17 BaseType float32
+          Locations: [{Range: 0xced000..0xced067, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xced000..0xced067, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcecd80..0xcecddd]
+      OutOfLinePCRanges: [0xced080..0xced0dd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcecd80..0xcecdd0
+            - Range: 0xced080..0xced0d0
               Pieces: []
-            - Range: 0xcecdd0..0xcecdd1
+            - Range: 0xced0d0..0xced0d1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcecdd1..0xcecddd
+            - Range: 0xced0d1..0xced0dd
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xcecd80..0xcecdd0
+            - Range: 0xced080..0xced0d0
               Pieces: []
-            - Range: 0xcecdd0..0xcecdd1
+            - Range: 0xced0d0..0xced0d1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcecdd1..0xcecddd
+            - Range: 0xced0d1..0xced0dd
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 123
+    - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcecde0..0xcecf5d]
+      OutOfLinePCRanges: [0xced0e0..0xced25d]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xcecde0..0xcecf5d
+            - Range: 0xced0e0..0xced25d
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xcecde0..0xcecf4d
+            - Range: 0xced0e0..0xced24d
               Pieces: []
-            - Range: 0xcecf4d..0xcecf4e
+            - Range: 0xced24d..0xced24e
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcecf4e..0xcecf5d
+            - Range: 0xced24e..0xced25d
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 124
+    - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcecf60..0xced03a]
+      OutOfLinePCRanges: [0xced260..0xced33a]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xcecf60..0xced03a
+            - Range: 0xced260..0xced33a
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xcecf60..0xced02a
+            - Range: 0xced260..0xced32a
               Pieces: []
-            - Range: 0xced02a..0xced02b
+            - Range: 0xced32a..0xced32b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xced02b..0xced03a
+            - Range: 0xced32b..0xced33a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xced040..0xced27b]
+      OutOfLinePCRanges: [0xced340..0xced57b]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xced040..0xced27b
+            - Range: 0xced340..0xced57b
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s2
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xced040..0xced27b
+            - Range: 0xced340..0xced57b
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xced040..0xced26b
+            - Range: 0xced340..0xced56b
               Pieces: []
-            - Range: 0xced26b..0xced26c
+            - Range: 0xced56b..0xced56c
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xced26c..0xced27b
+            - Range: 0xced56c..0xced57b
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 126
+    - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xced280..0xced52f]
+      OutOfLinePCRanges: [0xced580..0xced82f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced280..0xced347
+            - Range: 0xced580..0xced647
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xced347..0xced52f
+            - Range: 0xced647..0xced82f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced280..0xced347
+            - Range: 0xced580..0xced647
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xced347..0xced52f
+            - Range: 0xced647..0xced82f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced280..0xced2ea
+            - Range: 0xced580..0xced5ea
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xced2ea..0xced52f
+            - Range: 0xced5ea..0xced82f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced280..0xced347
+            - Range: 0xced580..0xced647
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xced347..0xced52f
+            - Range: 0xced647..0xced82f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced280..0xced347
+            - Range: 0xced580..0xced647
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xced347..0xced52f
+            - Range: 0xced647..0xced82f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced280..0xced347
+            - Range: 0xced580..0xced647
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xced347..0xced52f
+            - Range: 0xced647..0xced82f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced280..0xced347
+            - Range: 0xced580..0xced647
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xced347..0xced52f
+            - Range: 0xced647..0xced82f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced280..0xced347
+            - Range: 0xced580..0xced647
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xced347..0xced52f
+            - Range: 0xced647..0xced82f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced280..0xced347
+            - Range: 0xced580..0xced647
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xced347..0xced52f
+            - Range: 0xced647..0xced82f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xced280..0xced4c2
+            - Range: 0xced580..0xced7c2
               Pieces: []
-            - Range: 0xced4c2..0xced4c3
+            - Range: 0xced7c2..0xced7c3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xced4c3..0xced52f
+            - Range: 0xced7c3..0xced82f
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 127
+    - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xced540..0xced805]
+      OutOfLinePCRanges: [0xced840..0xcedb05]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced540..0xced5ea
+            - Range: 0xced840..0xced8ea
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xced5ea..0xced805
+            - Range: 0xced8ea..0xcedb05
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced540..0xced5ea
+            - Range: 0xced840..0xced8ea
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xced5ea..0xced805
+            - Range: 0xced8ea..0xcedb05
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced540..0xced5a2
+            - Range: 0xced840..0xced8a2
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xced5a2..0xced805
+            - Range: 0xced8a2..0xcedb05
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced540..0xced5ea
+            - Range: 0xced840..0xced8ea
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xced5ea..0xced805
+            - Range: 0xced8ea..0xcedb05
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced540..0xced5ea
+            - Range: 0xced840..0xced8ea
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xced5ea..0xced805
+            - Range: 0xced8ea..0xcedb05
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced540..0xced5ea
+            - Range: 0xced840..0xced8ea
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xced5ea..0xced805
+            - Range: 0xced8ea..0xcedb05
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced540..0xced5ea
+            - Range: 0xced840..0xced8ea
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xced5ea..0xced805
+            - Range: 0xced8ea..0xcedb05
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced540..0xced5ea
+            - Range: 0xced840..0xced8ea
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xced5ea..0xced805
+            - Range: 0xced8ea..0xcedb05
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xced540..0xced805
+            - Range: 0xced840..0xcedb05
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -8894,219 +8947,200 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xced540..0xced782
+            - Range: 0xced840..0xceda82
               Pieces: []
-            - Range: 0xced782..0xced783
+            - Range: 0xceda82..0xceda83
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xced783..0xced805
+            - Range: 0xceda83..0xcedb05
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 128
+    - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xced820..0xced8ae]
+      OutOfLinePCRanges: [0xcedb20..0xcedbae]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0xced820..0xced8ae
+            - Range: 0xcedb20..0xcedbae
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced820..0xced89e
+            - Range: 0xcedb20..0xcedb9e
               Pieces: []
-            - Range: 0xced89e..0xced89f
+            - Range: 0xcedb9e..0xcedb9f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xced89f..0xced8ae
+            - Range: 0xcedb9f..0xcedbae
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced820..0xced89e
+            - Range: 0xcedb20..0xcedb9e
               Pieces: []
-            - Range: 0xced89e..0xced89f
+            - Range: 0xcedb9e..0xcedb9f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xced89f..0xced8ae
+            - Range: 0xcedb9f..0xcedbae
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced820..0xced89e
+            - Range: 0xcedb20..0xcedb9e
               Pieces: []
-            - Range: 0xced89e..0xced89f
+            - Range: 0xcedb9e..0xcedb9f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xced89f..0xced8ae
+            - Range: 0xcedb9f..0xcedbae
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 129
+    - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xced8c0..0xced9ad]
+      OutOfLinePCRanges: [0xcedbc0..0xcedcad]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xced8c0..0xced9ad
+            - Range: 0xcedbc0..0xcedcad
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xced8c0..0xced9ad
+            - Range: 0xcedbc0..0xcedcad
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced8c0..0xced99d
+            - Range: 0xcedbc0..0xcedc9d
               Pieces: []
-            - Range: 0xced99d..0xced99e
+            - Range: 0xcedc9d..0xcedc9e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xced99e..0xced9ad
+            - Range: 0xcedc9e..0xcedcad
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xced8c0..0xced99d
+            - Range: 0xcedbc0..0xcedc9d
               Pieces: []
-            - Range: 0xced99d..0xced99e
+            - Range: 0xcedc9d..0xcedc9e
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xced99e..0xced9ad
+            - Range: 0xcedc9e..0xcedcad
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 130
+    - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xced9c0..0xceda94]
+      OutOfLinePCRanges: [0xcedcc0..0xcedd94]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0xced9c0..0xceda94
+            - Range: 0xcedcc0..0xcedd94
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xced9c0..0xceda84
+            - Range: 0xcedcc0..0xcedd84
               Pieces: []
-            - Range: 0xceda84..0xceda85
+            - Range: 0xcedd84..0xcedd85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceda85..0xceda94
+            - Range: 0xcedd85..0xcedd94
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0xced9c0..0xceda84
+            - Range: 0xcedcc0..0xcedd84
               Pieces: []
-            - Range: 0xceda84..0xceda85
+            - Range: 0xcedd84..0xcedd85
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xceda85..0xceda94
+            - Range: 0xcedd85..0xcedd94
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceda4e..0xceda94
+            - Range: 0xcedd4e..0xcedd94
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
-    - ID: 131
+    - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcedaa0..0xcedb46]
+      OutOfLinePCRanges: [0xcedda0..0xcede46]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 ArrayType [0]int
-          Locations: [{Range: 0xcedaa0..0xcedb46, Pieces: []}]
+          Locations: [{Range: 0xcedda0..0xcede46, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcedaa0..0xcedae5
+            - Range: 0xcedda0..0xcedde5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedae5..0xcedb07
+            - Range: 0xcedde5..0xcede07
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcedb07..0xcedb1a
+            - Range: 0xcede07..0xcede1a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcedb1a..0xcedb46
+            - Range: 0xcede1a..0xcede46
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcedaa0..0xcedb2c
+            - Range: 0xcedda0..0xcede2c
               Pieces: []
-            - Range: 0xcedb2c..0xcedb2d
+            - Range: 0xcede2c..0xcede2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcedb2d..0xcedb46
+            - Range: 0xcede2d..0xcede46
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0xcedaa0..0xcedb2c
+            - Range: 0xcedda0..0xcede2c
               Pieces: []
-            - Range: 0xcedb2c..0xcedb2d
+            - Range: 0xcede2c..0xcede2d
               Pieces: []
-            - Range: 0xcedb2d..0xcedb46
+            - Range: 0xcede2d..0xcede46
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 132
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcee080..0xcee081]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcee080..0xcee081
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
     - ID: 133
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcee0a0..0xcee0a1]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcee3a0..0xcee3a1]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcee0a0..0xcee0a1
+            - Range: 0xcee3a0..0xcee3a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9118,14 +9152,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 134
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcee0c0..0xcee0c1]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcee3c0..0xcee3c1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 264 GoSliceHeaderType [][]uint
+          Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcee0c0..0xcee0c1
+            - Range: 0xcee3c0..0xcee3c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9137,14 +9171,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 135
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcee0e0..0xcee0e1]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcee3e0..0xcee3e1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 264 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xcee0e0..0xcee0e1
+            - Range: 0xcee3e0..0xcee3e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9152,25 +9186,18 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcee0e0..0xcee0e1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 136
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcee100..0xcee101]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcee400..0xcee401]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 266 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcee100..0xcee101
+            - Range: 0xcee400..0xcee401
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9183,20 +9210,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcee100..0xcee101
+            - Range: 0xcee400..0xcee401
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcee120..0xcee121]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcee420..0xcee421]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 266 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcee120..0xcee121
+            - Range: 0xcee420..0xcee421
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9209,20 +9236,46 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcee120..0xcee121
+            - Range: 0xcee420..0xcee421
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcee440..0xcee441]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcee440..0xcee441
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcee440..0xcee441
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcee140..0xcee141]
+      OutOfLinePCRanges: [0xcee460..0xcee461]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 269 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcee140..0xcee141
+            - Range: 0xcee460..0xcee461
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9233,22 +9286,22 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 139
+    - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcee160..0xcee161]
+      OutOfLinePCRanges: [0xcee480..0xcee481]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 20 BaseType int8
           Locations:
-            - Range: 0xcee160..0xcee161
+            - Range: 0xcee480..0xcee481
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 270 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcee160..0xcee161
+            - Range: 0xcee480..0xcee481
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9261,39 +9314,20 @@ Subprograms:
         - Name: x
           Type: 14 BaseType uint
           Locations:
-            - Range: 0xcee160..0xcee161
+            - Range: 0xcee480..0xcee481
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
+    - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcee180..0xcee181]
+      OutOfLinePCRanges: [0xcee4a0..0xcee4a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcee180..0xcee181
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcee1a0..0xcee1a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcee1a0..0xcee1a1
+            - Range: 0xcee4a0..0xcee4a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9305,14 +9339,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 142
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xcee1c0..0xcee1c1]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcee4c0..0xcee4c1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 272 GoSliceHeaderType []struct {}
+          Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcee1c0..0xcee1c1
+            - Range: 0xcee4c0..0xcee4c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9324,14 +9358,33 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xcee4e0..0xcee4e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 272 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xcee4e0..0xcee4e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0xcee1e0..0xcee1e1]
+      OutOfLinePCRanges: [0xcee500..0xcee501]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcee1e0..0xcee1e1
+            - Range: 0xcee500..0xcee501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9344,7 +9397,7 @@ Subprograms:
         - Name: bs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcee1e0..0xcee1e1
+            - Range: 0xcee500..0xcee501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -9357,7 +9410,7 @@ Subprograms:
         - Name: cs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcee1e0..0xcee1e1
+            - Range: 0xcee500..0xcee501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9368,36 +9421,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
+    - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0xcee540..0xcee592]
+      OutOfLinePCRanges: [0xcee860..0xcee8b2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee540..0xcee585
+            - Range: 0xcee860..0xcee8a5
               Pieces: []
-            - Range: 0xcee585..0xcee586
+            - Range: 0xcee8a5..0xcee8a6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcee586..0xcee592
+            - Range: 0xcee8a6..0xcee8b2
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 145
+    - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcee5a0..0xcee5a1]
+      OutOfLinePCRanges: [0xcee8c0..0xcee8c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee5a0..0xcee5a1
+            - Range: 0xcee8c0..0xcee8c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9406,15 +9459,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcee5c0..0xcee5c1]
+      OutOfLinePCRanges: [0xcee8e0..0xcee8e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee5c0..0xcee5c1
+            - Range: 0xcee8e0..0xcee8e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9425,7 +9478,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee5c0..0xcee5c1
+            - Range: 0xcee8e0..0xcee8e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9436,7 +9489,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee5c0..0xcee5c1
+            - Range: 0xcee8e0..0xcee8e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9445,15 +9498,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 147
+    - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcee5e0..0xcee5e1]
+      OutOfLinePCRanges: [0xcee900..0xcee901]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcee5e0..0xcee5e1
+            - Range: 0xcee900..0xcee901
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9470,58 +9523,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 148
+    - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcee600..0xcee601]
+      OutOfLinePCRanges: [0xcee920..0xcee921]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 275 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcee600..0xcee601
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcee620..0xcee621]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 276 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0xcee620..0xcee621
+            - Range: 0xcee920..0xcee921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcee640..0xcee641]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0xcee940..0xcee941]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 276 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcee640..0xcee641
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcee940..0xcee941
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcee660..0xcee661]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xcee960..0xcee961]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee660..0xcee661
+            - Range: 0xcee960..0xcee961
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9531,14 +9567,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 152
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcee680..0xcee681]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xcee980..0xcee981]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee680..0xcee681
+            - Range: 0xcee980..0xcee981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9548,14 +9584,31 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 153
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcee9a0..0xcee9a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcee9a0..0xcee9a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0xcee6a0..0xcee6a1]
+      OutOfLinePCRanges: [0xcee9c0..0xcee9c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee6a0..0xcee6a1
+            - Range: 0xcee9c0..0xcee9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9566,7 +9619,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee6a0..0xcee6a1
+            - Range: 0xcee9c0..0xcee9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9577,7 +9630,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcee6a0..0xcee6a1
+            - Range: 0xcee9c0..0xcee9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9586,28 +9639,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
+    - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcee820..0xcee821]
+      OutOfLinePCRanges: [0xceeb40..0xceeb41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcee820..0xcee821
+            - Range: 0xceeb40..0xceeb41
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
+    - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcee840..0xcee841]
+      OutOfLinePCRanges: [0xceeb60..0xceeb61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 291 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcee840..0xcee841
+            - Range: 0xceeb60..0xceeb61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9624,15 +9677,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
+    - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcee980..0xcee981]
+      OutOfLinePCRanges: [0xceeca0..0xceeca1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 322 StructureType main.aStruct
           Locations:
-            - Range: 0xcee980..0xcee981
+            - Range: 0xceeca0..0xceeca1
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9651,151 +9704,151 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 157
+    - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xceea40..0xceea41]
+      OutOfLinePCRanges: [0xceed60..0xceed61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xceea40..0xceea41
+            - Range: 0xceed60..0xceed61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 158
+    - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0xceea60..0xceea61]
+      OutOfLinePCRanges: [0xceed80..0xceed81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 325 StructureType main.tenStrings
           Locations:
-            - Range: 0xceea60..0xceea61
+            - Range: 0xceed80..0xceed81
               Pieces: [{Size: 160, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 159
+    - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xceeac0..0xceeac1]
+      OutOfLinePCRanges: [0xceede0..0xceede1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 326 StructureType main.emptyStruct
-          Locations: [{Range: 0xceeac0..0xceeac1, Pieces: []}]
+          Locations: [{Range: 0xceede0..0xceede1, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 160
+    - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xceeae0..0xceeae1]
+      OutOfLinePCRanges: [0xceee00..0xceee01]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 327 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xceeae0..0xceeae1
+            - Range: 0xceee00..0xceee01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 161
+    - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0xcf0a40..0xcf0a44]
+      OutOfLinePCRanges: [0xcf0d60..0xcf0d64]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf0a40..0xcf0a44
+            - Range: 0xcf0d60..0xcf0d64
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf0a40..0xcf0a43
+            - Range: 0xcf0d60..0xcf0d63
               Pieces: []
-            - Range: 0xcf0a43..0xcf0a44
+            - Range: 0xcf0d63..0xcf0d64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 162
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0xcf0a60..0xcf0a6c]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 330 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0xcf0a60..0xcf0a6b
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf0a6b..0xcf0a6c
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0xcf0a60..0xcf0a6b
-              Pieces: []
-            - Range: 0xcf0a6b..0xcf0a6c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0xcf0d80..0xcf0d8c]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 330 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0xcf0d80..0xcf0d8b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcf0d8b..0xcf0d8c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0xcf0d80..0xcf0d8b
+              Pieces: []
+            - Range: 0xcf0d8b..0xcf0d8c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0xcf0a80..0xcf0a84]
+      OutOfLinePCRanges: [0xcf0da0..0xcf0da4]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf0a80..0xcf0a84
+            - Range: 0xcf0da0..0xcf0da4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf0a80..0xcf0a83
+            - Range: 0xcf0da0..0xcf0da3
               Pieces: []
-            - Range: 0xcf0a83..0xcf0a84
+            - Range: 0xcf0da3..0xcf0da4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 164
+    - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0xcf0aa0..0xcf0aac]
+      OutOfLinePCRanges: [0xcf0dc0..0xcf0dcc]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf0aa0..0xcf0aab
+            - Range: 0xcf0dc0..0xcf0dcb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf0aab..0xcf0aac
+            - Range: 0xcf0dcb..0xcf0dcc
               Pieces:
                 - Size: 8
                   Op: null
@@ -9806,9 +9859,9 @@ Subprograms:
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf0aa0..0xcf0aab
+            - Range: 0xcf0dc0..0xcf0dcb
               Pieces: []
-            - Range: 0xcf0aab..0xcf0aac
+            - Range: 0xcf0dcb..0xcf0dcc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9817,15 +9870,15 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0xcf0b20..0xcf0d05]
+      OutOfLinePCRanges: [0xcf0e40..0xcf1025]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf0b20..0xcf0b5e
+            - Range: 0xcf0e40..0xcf0e7e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9833,7 +9886,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf0b5e..0xcf0b69
+            - Range: 0xcf0e7e..0xcf0e89
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9841,7 +9894,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: null
-            - Range: 0xcf0b69..0xcf0d05
+            - Range: 0xcf0e89..0xcf1025
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -9854,18 +9907,18 @@ Subprograms:
         - Name: pred
           Type: 334 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0xcf0b20..0xcf0b69
+            - Range: 0xcf0e40..0xcf0e89
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcf0b69..0xcf0d05
+            - Range: 0xcf0e89..0xcf1025
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf0b20..0xcf0cba
+            - Range: 0xcf0e40..0xcf0fda
               Pieces: []
-            - Range: 0xcf0cba..0xcf0cbb
+            - Range: 0xcf0fda..0xcf0fdb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9873,14 +9926,14 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf0cbb..0xcf0d05
+            - Range: 0xcf0fdb..0xcf1025
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf0b69..0xcf0b96
+            - Range: 0xcf0e89..0xcf0eb6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9888,7 +9941,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf0b96..0xcf0b96
+            - Range: 0xcf0eb6..0xcf0eb6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9896,7 +9949,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf0b96..0xcf0bcc
+            - Range: 0xcf0eb6..0xcf0eec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9904,7 +9957,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf0bcc..0xcf0c85
+            - Range: 0xcf0eec..0xcf0fa5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -24}
@@ -9912,7 +9965,7 @@ Subprograms:
                   Op: {CfaOffset: -88}
                 - Size: 8
                   Op: {CfaOffset: -80}
-            - Range: 0xcf0c85..0xcf0c96
+            - Range: 0xcf0fa5..0xcf0fb6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -9920,7 +9973,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf0c96..0xcf0ca8
+            - Range: 0xcf0fb6..0xcf0fc8
               Pieces:
                 - Size: 8
                   Op: null
@@ -9928,7 +9981,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf0cb1..0xcf0cb7
+            - Range: 0xcf0fd1..0xcf0fd7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9936,7 +9989,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0xcf0cb7..0xcf0d05
+            - Range: 0xcf0fd7..0xcf1025
               Pieces:
                 - Size: 8
                   Op: null
@@ -9949,132 +10002,132 @@ Subprograms:
         - Name: item
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf0bbf..0xcf0bcc
+            - Range: 0xcf0edf..0xcf0eec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf0bcc..0xcf0c85
+            - Range: 0xcf0eec..0xcf0fa5
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 166
+    - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf0d20..0xcf0d64]
+      OutOfLinePCRanges: [0xcf1040..0xcf1084]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0xcf0d20..0xcf0d39
+            - Range: 0xcf1040..0xcf1059
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 335 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0xcf0d20..0xcf0d39
+            - Range: 0xcf1040..0xcf1059
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0xcf0d20..0xcf0d39
+            - Range: 0xcf1040..0xcf1059
               Pieces: []
-            - Range: 0xcf0d39..0xcf0d3a
+            - Range: 0xcf1059..0xcf105a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf0d3a..0xcf0d64
+            - Range: 0xcf105a..0xcf1084
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 167
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0xcf0fa0..0xcf0fa4]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 333 PointerType *go.shape.int
-          Locations:
-            - Range: 0xcf0fa0..0xcf0fa4
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 333 PointerType *go.shape.int
-          Locations:
-            - Range: 0xcf0fa0..0xcf0fa3
-              Pieces: []
-            - Range: 0xcf0fa3..0xcf0fa4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 168
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0xcf0fc0..0xcf0fc4]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0xcf12c0..0xcf12c4]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 336 PointerType *go.shape.struct { Name string }
+          Type: 333 PointerType *go.shape.int
           Locations:
-            - Range: 0xcf0fc0..0xcf0fc4
+            - Range: 0xcf12c0..0xcf12c4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 336 PointerType *go.shape.struct { Name string }
+          Type: 333 PointerType *go.shape.int
           Locations:
-            - Range: 0xcf0fc0..0xcf0fc3
+            - Range: 0xcf12c0..0xcf12c3
               Pieces: []
-            - Range: 0xcf0fc3..0xcf0fc4
+            - Range: 0xcf12c3..0xcf12c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0xcf12e0..0xcf12e4]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 336 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0xcf12e0..0xcf12e4
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 336 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0xcf12e0..0xcf12e3
+              Pieces: []
+            - Range: 0xcf12e3..0xcf12e4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0xcf0fe0..0xcf0fe4]
+      OutOfLinePCRanges: [0xcf1300..0xcf1304]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 338 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xcf0fe0..0xcf0fe4
+            - Range: 0xcf1300..0xcf1304
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 338 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0xcf0fe0..0xcf0fe3
+            - Range: 0xcf1300..0xcf1303
               Pieces: []
-            - Range: 0xcf0fe3..0xcf0fe4
+            - Range: 0xcf1303..0xcf1304
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
+    - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0xcf1000..0xcf1011]
+      OutOfLinePCRanges: [0xcf1320..0xcf1331]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0xcf1000..0xcf1011
+            - Range: 0xcf1320..0xcf1331
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1000..0xcf1010
+            - Range: 0xcf1320..0xcf1330
               Pieces: []
-            - Range: 0xcf1010..0xcf1011
+            - Range: 0xcf1330..0xcf1331
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10083,71 +10136,71 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 171
+    - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0xcf10e0..0xcf10e9]
+      OutOfLinePCRanges: [0xcf1400..0xcf1409]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 342 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0xcf10e0..0xcf10e9
+            - Range: 0xcf1400..0xcf1409
               Pieces: [{Size: 136, Op: {CfaOffset: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf10e0..0xcf10e8
+            - Range: 0xcf1400..0xcf1408
               Pieces: []
-            - Range: 0xcf10e8..0xcf10e9
+            - Range: 0xcf1408..0xcf1409
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
+    - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0xcf11a0..0xcf11a8]
+      OutOfLinePCRanges: [0xcf14c0..0xcf14c8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 343 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0xcf11a0..0xcf11a8
+            - Range: 0xcf14c0..0xcf14c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf11a0..0xcf11a8
+            - Range: 0xcf14c0..0xcf14c8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf11a0..0xcf11a8
+            - Range: 0xcf14c0..0xcf14c8
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 173
+    - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0xcf1220..0xcf128e]
+      OutOfLinePCRanges: [0xcf1540..0xcf15ae]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0xcf1220..0xcf128e
+            - Range: 0xcf1540..0xcf15ae
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1220..0xcf128e
+            - Range: 0xcf1540..0xcf15ae
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10158,20 +10211,20 @@ Subprograms:
         - Name: v
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf1220..0xcf128e
+            - Range: 0xcf1540..0xcf15ae
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 3
-    - ID: 174
+    - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0xcf1300..0xcf1308]
+      OutOfLinePCRanges: [0xcf1620..0xcf1628]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1300..0xcf1308
+            - Range: 0xcf1620..0xcf1628
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10182,25 +10235,25 @@ Subprograms:
         - Name: b
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf1300..0xcf1308
+            - Range: 0xcf1620..0xcf1628
               Pieces: [{Size: 1, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0xcf1300..0xcf1307
+            - Range: 0xcf1620..0xcf1627
               Pieces: []
-            - Range: 0xcf1307..0xcf1308
+            - Range: 0xcf1627..0xcf1628
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1300..0xcf1307
+            - Range: 0xcf1620..0xcf1627
               Pieces: []
-            - Range: 0xcf1307..0xcf1308
+            - Range: 0xcf1627..0xcf1628
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10209,28 +10262,28 @@ Subprograms:
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 175
+    - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0xcf1320..0xcf132f]
+      OutOfLinePCRanges: [0xcf1640..0xcf164f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf1320..0xcf132e
+            - Range: 0xcf1640..0xcf164e
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1320..0xcf132b
+            - Range: 0xcf1640..0xcf164b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf132b..0xcf132f
+            - Range: 0xcf164b..0xcf164f
               Pieces:
                 - Size: 8
                   Op: null
@@ -10241,9 +10294,9 @@ Subprograms:
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf1320..0xcf132e
+            - Range: 0xcf1640..0xcf164e
               Pieces: []
-            - Range: 0xcf132e..0xcf132f
+            - Range: 0xcf164e..0xcf164f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10254,56 +10307,56 @@ Subprograms:
         - Name: ~r1
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf1320..0xcf132e
+            - Range: 0xcf1640..0xcf164e
               Pieces: []
-            - Range: 0xcf132e..0xcf132f
+            - Range: 0xcf164e..0xcf164f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 176
+    - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0xcf1340..0xcf137a]
+      OutOfLinePCRanges: [0xcf1660..0xcf169a]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 348 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0xcf1340..0xcf1359
+            - Range: 0xcf1660..0xcf1679
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcf1340..0xcf1359
+            - Range: 0xcf1660..0xcf1679
               Pieces: []
-            - Range: 0xcf1359..0xcf135a
+            - Range: 0xcf1679..0xcf167a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf135a..0xcf137a
+            - Range: 0xcf167a..0xcf169a
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 177
+    - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0xcf1380..0xcf13cd]
+      OutOfLinePCRanges: [0xcf16a0..0xcf16ed]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 349 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0xcf1380..0xcf139f
+            - Range: 0xcf16a0..0xcf16bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xcf139f..0xcf13a2
+            - Range: 0xcf16bf..0xcf16c2
               Pieces:
                 - Size: 8
                   Op: null
@@ -10314,37 +10367,37 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcf1380..0xcf13a2
+            - Range: 0xcf16a0..0xcf16c2
               Pieces: []
-            - Range: 0xcf13a2..0xcf13a3
+            - Range: 0xcf16c2..0xcf16c3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf13a3..0xcf13cd
+            - Range: 0xcf16c3..0xcf16ed
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 178
+    - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0xcf13e0..0xcf13e8]
+      OutOfLinePCRanges: [0xcf1700..0xcf1708]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 350 PointerType *go.shape.string
           Locations:
-            - Range: 0xcf13e0..0xcf13e7
+            - Range: 0xcf1700..0xcf1707
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf13e0..0xcf13e7
+            - Range: 0xcf1700..0xcf1707
               Pieces: []
-            - Range: 0xcf13e7..0xcf13e8
+            - Range: 0xcf1707..0xcf1708
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10353,24 +10406,24 @@ Subprograms:
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 179
+    - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0xcf1400..0xcf145b]
+      OutOfLinePCRanges: [0xcf1720..0xcf177b]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf1400..0xcf1441
+            - Range: 0xcf1720..0xcf1761
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0xcf1400..0xcf1455
+            - Range: 0xcf1720..0xcf1775
               Pieces: []
-            - Range: 0xcf1455..0xcf1456
+            - Range: 0xcf1775..0xcf1776
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10384,20 +10437,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf1456..0xcf145b
+            - Range: 0xcf1776..0xcf177b
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 180
+    - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0xcf1460..0xcf1484]
+      OutOfLinePCRanges: [0xcf1780..0xcf17a4]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0xcf1460..0xcf1484
+            - Range: 0xcf1780..0xcf17a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10410,33 +10463,33 @@ Subprograms:
         - Name: needle
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf1460..0xcf1484
+            - Range: 0xcf1780..0xcf17a4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcf1460..0xcf1480
+            - Range: 0xcf1780..0xcf17a0
               Pieces: []
-            - Range: 0xcf1480..0xcf1481
+            - Range: 0xcf17a0..0xcf17a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf1481..0xcf1483
+            - Range: 0xcf17a1..0xcf17a3
               Pieces: []
-            - Range: 0xcf1483..0xcf1484
+            - Range: 0xcf17a3..0xcf17a4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 181
+    - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0xcf14a0..0xcf155f]
+      OutOfLinePCRanges: [0xcf17c0..0xcf187f]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 353 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0xcf14a0..0xcf14bd
+            - Range: 0xcf17c0..0xcf17dd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10444,7 +10497,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcf14bd..0xcf14bf
+            - Range: 0xcf17dd..0xcf17df
               Pieces:
                 - Size: 8
                   Op: null
@@ -10457,13 +10510,13 @@ Subprograms:
         - Name: needle
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf14a0..0xcf14ec
+            - Range: 0xcf17c0..0xcf180c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0xcf14ec..0xcf155f
+            - Range: 0xcf180c..0xcf187f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -10474,28 +10527,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcf14a0..0xcf150b
+            - Range: 0xcf17c0..0xcf182b
               Pieces: []
-            - Range: 0xcf150b..0xcf150c
+            - Range: 0xcf182b..0xcf182c
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf150c..0xcf1513
+            - Range: 0xcf182c..0xcf1833
               Pieces: []
-            - Range: 0xcf1513..0xcf1514
+            - Range: 0xcf1833..0xcf1834
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf1514..0xcf155f
+            - Range: 0xcf1834..0xcf187f
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf14cf..0xcf14e1
+            - Range: 0xcf17ef..0xcf1801
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xcf14e1..0xcf14ec
+            - Range: 0xcf1801..0xcf180c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10504,56 +10557,56 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 182
+    - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0xcf1560..0xcf1567]
+      OutOfLinePCRanges: [0xcf1880..0xcf1887]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 354 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0xcf1560..0xcf1566
+            - Range: 0xcf1880..0xcf1886
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0xcf1560..0xcf1567
+            - Range: 0xcf1880..0xcf1887
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcf1560..0xcf1566
+            - Range: 0xcf1880..0xcf1886
               Pieces: []
-            - Range: 0xcf1566..0xcf1567
+            - Range: 0xcf1886..0xcf1887
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
           DictIndex: -1
       DictRegister: 3
-    - ID: 183
+    - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0xcf15c0..0xcf162c]
+      OutOfLinePCRanges: [0xcf18e0..0xcf194c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 355 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0xcf15c0..0xcf15e0
+            - Range: 0xcf18e0..0xcf1900
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf15e0..0xcf15e8
+            - Range: 0xcf1900..0xcf1908
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcf15e8..0xcf15ed
+            - Range: 0xcf1908..0xcf190d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10564,7 +10617,7 @@ Subprograms:
         - Name: value
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0xcf15c0..0xcf15ed
+            - Range: 0xcf18e0..0xcf190d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -10575,16 +10628,16 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcf15c0..0xcf15ed
+            - Range: 0xcf18e0..0xcf190d
               Pieces: []
-            - Range: 0xcf15ed..0xcf15ee
+            - Range: 0xcf190d..0xcf190e
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcf15ee..0xcf162c
+            - Range: 0xcf190e..0xcf194c
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 184
+    - ID: 185
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x53dfc0..0x53e1a5]
       InlinePCRanges: []
@@ -10723,7 +10776,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 185
+    - ID: 186
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xce84e0..0xce8542]
       InlinePCRanges:
@@ -10754,7 +10807,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 186
+    - ID: 187
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10762,7 +10815,7 @@ Subprograms:
           RootRanges: [0xce8720..0xce87e5]
       Variables: []
       DictRegister: null
-    - ID: 187
+    - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10770,7 +10823,7 @@ Subprograms:
           RootRanges: [0xce8880..0xce8985]
       Variables: []
       DictRegister: null
-    - ID: 188
+    - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10778,7 +10831,7 @@ Subprograms:
           RootRanges: [0xce8880..0xce8985]
       Variables: []
       DictRegister: null
-    - ID: 189
+    - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10793,7 +10846,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 191
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10812,12 +10865,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 191
+    - ID: 192
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xce8bc0..0xce8c26]
       InlinePCRanges:
-        - Ranges: [0xcf16ba..0xcf16e8]
-          RootRanges: [0xcf16a0..0xcf1705]
+        - Ranges: [0xcf19da..0xcf1a08]
+          RootRanges: [0xcf19c0..0xcf1a25]
       Variables:
         - Name: b
           Type: 360 StructureType main.firstBehavior
@@ -10846,7 +10899,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 192
+    - ID: 193
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -14261,7 +14314,7 @@ Types:
       GoKind: 22
       Pointee: 867 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14280,7 +14333,7 @@ Types:
             Type: 356 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14291,7 +14344,7 @@ Types:
             Type: 356 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14302,12 +14355,12 @@ Types:
             Type: 359 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: pred}
+                  Variable: {subprogram: 185, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14320,12 +14373,12 @@ Types:
             Type: 356 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 185, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1625
+      ID: 1626
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14344,7 +14397,7 @@ Types:
             Type: 332 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14355,7 +14408,7 @@ Types:
             Type: 332 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14366,12 +14419,12 @@ Types:
             Type: 334 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: pred}
+                  Variable: {subprogram: 166, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1626
+      ID: 1627
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14384,15 +14437,15 @@ Types:
             Type: 332 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 2, name: ~r0}
+                  Variable: {subprogram: 166, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1683
+      ID: 1684
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1629
+      ID: 1630
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14411,7 +14464,7 @@ Types:
             Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14422,7 +14475,7 @@ Types:
             Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14433,12 +14486,12 @@ Types:
             Type: 335 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: f}
+                  Variable: {subprogram: 167, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1630
+      ID: 1631
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14451,12 +14504,12 @@ Types:
             Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 2, name: ~r0}
+                  Variable: {subprogram: 167, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14478,7 +14531,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14489,7 +14542,7 @@ Types:
             Type: 343 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: x}
+                  Variable: {subprogram: 173, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14500,7 +14553,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14511,15 +14564,15 @@ Types:
             Type: 345 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 2, name: v}
+                  Variable: {subprogram: 173, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1642
+      ID: 1643
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1643
+      ID: 1644
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14541,7 +14594,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14552,7 +14605,7 @@ Types:
             Type: 346 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: x}
+                  Variable: {subprogram: 174, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14563,7 +14616,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14574,15 +14627,15 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 2, name: v}
+                  Variable: {subprogram: 174, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1644
+      ID: 1645
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1681
+      ID: 1682
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14594,12 +14647,12 @@ Types:
             Type: 360 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 0, name: b}
+                  Variable: {subprogram: 192, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1682
+      ID: 1683
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14611,12 +14664,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 1, name: ~r0}
+                  Variable: {subprogram: 192, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1657
+      ID: 1658
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14635,7 +14688,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14646,7 +14699,7 @@ Types:
             Type: 332 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14657,14 +14710,14 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1661
+      ID: 1662
       Name: Probe[main.genericContains[go.shape.int]]Line
-      ByteSize: 50
+      ByteSize: 49
       ExprStatusArraySize: 1
       DictEntries:
         - DictIndex: 0
@@ -14681,7 +14734,7 @@ Types:
             Type: 332 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14692,23 +14745,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
-        - Name: '@return'
-          Offset: 49
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14720,12 +14762,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1659
+      ID: 1660
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14744,7 +14786,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14755,7 +14797,7 @@ Types:
             Type: 353 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: haystack}
+                  Variable: {subprogram: 182, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14766,14 +14808,14 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.genericContains[go.shape.string]]Line
-      ByteSize: 26
+      ByteSize: 25
       ExprStatusArraySize: 1
       DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
       Expressions:
@@ -14784,23 +14826,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
-        - Name: '@return'
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14812,12 +14843,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1653
+      ID: 1654
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14830,7 +14861,7 @@ Types:
             Type: 350 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14841,12 +14872,12 @@ Types:
             Type: 350 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1654
+      ID: 1655
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14859,12 +14890,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Variable: {subprogram: 179, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1655
+      ID: 1656
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14877,7 +14908,7 @@ Types:
             Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14888,12 +14919,12 @@ Types:
             Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1656
+      ID: 1657
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14906,12 +14937,12 @@ Types:
             Type: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: ~r0}
+                  Variable: {subprogram: 180, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1649
+      ID: 1650
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14924,7 +14955,7 @@ Types:
             Type: 348 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14935,59 +14966,13 @@ Types:
             Type: 348 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1650
-      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: '@return'
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1651
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
-      Expressions:
-        - Name: val
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 349 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-        - Name: val
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 349 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-    - __kind: EventRootType
-      ID: 1652
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -15003,7 +14988,53 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1631
+      ID: 1652
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
+      Expressions:
+        - Name: val
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 349 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+        - Name: val
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 349 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+    - __kind: EventRootType
+      ID: 1653
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1632
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15016,7 +15047,7 @@ Types:
             Type: 333 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15027,12 +15058,12 @@ Types:
             Type: 333 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1632
+      ID: 1633
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15045,12 +15076,12 @@ Types:
             Type: 333 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1633
+      ID: 1634
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15063,7 +15094,7 @@ Types:
             Type: 336 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15074,12 +15105,12 @@ Types:
             Type: 336 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1634
+      ID: 1635
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15092,12 +15123,12 @@ Types:
             Type: 336 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1635
+      ID: 1636
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15110,7 +15141,7 @@ Types:
             Type: 338 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15121,12 +15152,12 @@ Types:
             Type: 338 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1636
+      ID: 1637
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15139,12 +15170,12 @@ Types:
             Type: 338 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1647
+      ID: 1648
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15163,7 +15194,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15174,7 +15205,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15185,12 +15216,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: b}
+                  Variable: {subprogram: 176, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1648
+      ID: 1649
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15209,7 +15240,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 2, name: ~r0}
+                  Variable: {subprogram: 176, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -15220,12 +15251,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 3, name: ~r1}
+                  Variable: {subprogram: 176, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1645
+      ID: 1646
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15244,7 +15275,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15255,7 +15286,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15266,12 +15297,12 @@ Types:
             Type: 345 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: b}
+                  Variable: {subprogram: 175, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15290,7 +15321,7 @@ Types:
             Type: 345 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 2, name: ~r0}
+                  Variable: {subprogram: 175, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
@@ -15301,12 +15332,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 3, name: ~r1}
+                  Variable: {subprogram: 175, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15319,7 +15350,7 @@ Types:
             Type: 342 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
@@ -15330,12 +15361,12 @@ Types:
             Type: 342 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1640
+      ID: 1641
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15348,12 +15379,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 172, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1637
+      ID: 1638
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15366,7 +15397,7 @@ Types:
             Type: 340 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
@@ -15377,12 +15408,12 @@ Types:
             Type: 340 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1638
+      ID: 1639
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15395,12 +15426,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1621
+      ID: 1622
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15413,7 +15444,7 @@ Types:
             Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15424,12 +15455,12 @@ Types:
             Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15442,12 +15473,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1623
+      ID: 1624
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15460,7 +15491,7 @@ Types:
             Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15471,12 +15502,12 @@ Types:
             Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1624
+      ID: 1625
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15489,15 +15520,15 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15509,7 +15540,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: ~r0}
+                  Variable: {subprogram: 145, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -15604,7 +15635,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15616,7 +15647,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -15627,12 +15658,12 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15644,7 +15675,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16343,7 +16374,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16355,7 +16386,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16366,7 +16397,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16377,7 +16408,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16388,12 +16419,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16405,7 +16436,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16416,12 +16447,12 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1604
+      ID: 1605
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16433,7 +16464,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -16444,12 +16475,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16461,7 +16492,7 @@ Types:
             Type: 327 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16472,12 +16503,12 @@ Types:
             Type: 327 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16489,7 +16520,7 @@ Types:
             Type: 326 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -16500,18 +16531,18 @@ Types:
             Type: 326 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
       ID: 1402
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 58
-      ExprStatusArraySize: 2
+      ByteSize: 49
+      ExprStatusArraySize: 1
       Expressions:
         - Name: x
-          Offset: 2
+          Offset: 1
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -16522,7 +16553,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 10
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 15 GoInterfaceType error
@@ -16532,19 +16563,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: '@return'
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
         - Name: x
-          Offset: 34
+          Offset: 25
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16555,7 +16575,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 42
+          Offset: 33
           Kind: local
           Expression:
             Type: 15 GoInterfaceType error
@@ -16686,7 +16706,7 @@ Types:
     - __kind: EventRootType
       ID: 1430
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 89
+      ByteSize: 81
       ExprStatusArraySize: 1
       Expressions:
         - Name: a
@@ -16710,17 +16730,6 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-          DictIndex: -1
-        - Name: '@return'
-          Offset: 81
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1429
@@ -16847,7 +16856,7 @@ Types:
       ID: 1423
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1673
+      ID: 1674
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1420
@@ -16903,16 +16912,16 @@ Types:
       ID: 1421
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1674
+      ID: 1675
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1675
+      ID: 1676
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1676
+      ID: 1677
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1677
+      ID: 1678
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1424
@@ -16921,7 +16930,7 @@ Types:
       ID: 1425
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1670
+      ID: 1671
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16933,7 +16942,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16944,24 +16953,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1667
-      Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x_val
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16978,12 +16970,29 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1669
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 186, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1670
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16995,7 +17004,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17006,12 +17015,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1672
+      ID: 1673
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17023,7 +17032,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17034,15 +17043,15 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1671
+      ID: 1672
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1678
+      ID: 1679
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17054,7 +17063,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17065,12 +17074,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1679
+      ID: 1680
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17082,7 +17091,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17093,12 +17102,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1680
+      ID: 1681
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17110,7 +17119,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17121,7 +17130,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17294,7 +17303,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -17306,7 +17315,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17317,12 +17326,12 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17334,7 +17343,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: ~r0}
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17448,7 +17457,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -17460,7 +17469,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17471,7 +17480,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17482,7 +17491,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17493,7 +17502,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17504,7 +17513,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17515,7 +17524,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17526,7 +17535,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17537,7 +17546,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17548,7 +17557,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17559,7 +17568,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17570,7 +17579,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17581,7 +17590,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17592,7 +17601,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17603,7 +17612,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17614,7 +17623,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17625,7 +17634,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17636,7 +17645,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17647,12 +17656,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17664,7 +17673,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 9, name: ~r0}
+                  Variable: {subprogram: 127, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18229,34 +18238,6 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1602
       Name: Probe[main.testMassiveString]
       ByteSize: 33
@@ -18269,7 +18250,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18280,12 +18261,40 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1569
+      ID: 1603
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1570
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -18297,7 +18306,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18308,7 +18317,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18319,7 +18328,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18330,7 +18339,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18341,7 +18350,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18352,7 +18361,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18363,7 +18372,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18374,7 +18383,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18385,7 +18394,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18396,7 +18405,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18407,7 +18416,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18418,7 +18427,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18429,7 +18438,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18440,7 +18449,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18451,7 +18460,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18462,7 +18471,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18473,7 +18482,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18484,12 +18493,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18501,12 +18510,12 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 9, name: ~r0}
+                  Variable: {subprogram: 128, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18518,7 +18527,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18529,7 +18538,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -18540,7 +18549,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18551,12 +18560,12 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -18568,7 +18577,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18579,12 +18588,12 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -18596,7 +18605,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18607,7 +18616,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18618,7 +18627,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18629,12 +18638,12 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18646,7 +18655,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -19299,7 +19308,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19311,7 +19320,7 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19322,12 +19331,12 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19339,7 +19348,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19350,10 +19359,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19365,7 +19374,7 @@ Types:
             Type: 129 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19426,7 +19435,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1585
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -19438,7 +19447,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19449,7 +19458,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19460,7 +19469,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19471,12 +19480,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -19488,7 +19497,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19499,7 +19508,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19510,7 +19519,7 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19521,7 +19530,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19532,7 +19541,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19543,12 +19552,12 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1588
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -19560,7 +19569,7 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19571,12 +19580,12 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1601
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19588,7 +19597,7 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19599,7 +19608,7 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19811,10 +19820,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -19826,15 +19835,15 @@ Types:
             Type: 258 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -19846,15 +19855,15 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19866,15 +19875,15 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -19886,7 +19895,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19897,7 +19906,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19908,7 +19917,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19919,7 +19928,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19930,7 +19939,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19941,7 +19950,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 5, name: ~r5}
+                  Variable: {subprogram: 117, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19952,7 +19961,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 6, name: ~r6}
+                  Variable: {subprogram: 117, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19963,7 +19972,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 7, name: ~r7}
+                  Variable: {subprogram: 117, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19974,15 +19983,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 8, name: ~r8}
+                  Variable: {subprogram: 117, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -19994,7 +20003,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: ~r0}
+                  Variable: {subprogram: 123, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20005,15 +20014,15 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r1}
+                  Variable: {subprogram: 123, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20025,7 +20034,7 @@ Types:
             Type: 102 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20036,7 +20045,7 @@ Types:
             Type: 18 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: ~r1}
+                  Variable: {subprogram: 111, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -20499,10 +20508,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -20514,15 +20523,15 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -20534,7 +20543,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20545,7 +20554,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: ~r1}
+                  Variable: {subprogram: 110, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20556,7 +20565,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 2, name: ~r2}
+                  Variable: {subprogram: 110, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20567,7 +20576,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 3, name: ~r3}
+                  Variable: {subprogram: 110, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20578,7 +20587,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 4, name: ~r4}
+                  Variable: {subprogram: 110, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20589,7 +20598,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 5, name: ~r5}
+                  Variable: {subprogram: 110, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20600,7 +20609,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 6, name: ~r6}
+                  Variable: {subprogram: 110, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20611,7 +20620,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 7, name: ~r7}
+                  Variable: {subprogram: 110, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20622,7 +20631,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 8, name: ~r8}
+                  Variable: {subprogram: 110, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20633,7 +20642,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 9, name: ~r9}
+                  Variable: {subprogram: 110, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20644,7 +20653,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 10, name: ~r10}
+                  Variable: {subprogram: 110, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20655,7 +20664,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 11, name: ~r11}
+                  Variable: {subprogram: 110, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20666,7 +20675,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 12, name: ~r12}
+                  Variable: {subprogram: 110, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20677,7 +20686,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 13, name: ~r13}
+                  Variable: {subprogram: 110, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20688,7 +20697,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 14, name: ~r14}
+                  Variable: {subprogram: 110, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20699,7 +20708,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 110, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20710,15 +20719,15 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 110, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20730,15 +20739,15 @@ Types:
             Type: 260 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20750,7 +20759,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20761,7 +20770,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20772,7 +20781,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 2, name: ~r2}
+                  Variable: {subprogram: 119, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20783,7 +20792,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 3, name: ~r3}
+                  Variable: {subprogram: 119, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20794,15 +20803,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 4, name: ~r4}
+                  Variable: {subprogram: 119, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -20814,7 +20823,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: ~r0}
+                  Variable: {subprogram: 122, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20825,15 +20834,65 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r1}
+                  Variable: {subprogram: 122, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
-      Name: Probe[main.testReturnsOnlyFloat]
+      ID: 1531
+      Name: Probe[main.testReturnsNamedDeferLine]Line
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: a
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 1556
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1557
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20845,15 +20904,15 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -20865,7 +20924,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20876,7 +20935,7 @@ Types:
             Type: 109 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -20887,7 +20946,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: ~r2}
+                  Variable: {subprogram: 109, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20898,7 +20957,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 3, name: ~r3}
+                  Variable: {subprogram: 109, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20909,7 +20968,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 4, name: ~r4}
+                  Variable: {subprogram: 109, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20920,7 +20979,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 5, name: ~r5}
+                  Variable: {subprogram: 109, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -20931,7 +20990,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 6, name: ~r6}
+                  Variable: {subprogram: 109, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20942,15 +21001,15 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 7, name: ~r7}
+                  Variable: {subprogram: 109, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20962,15 +21021,15 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -20982,7 +21041,7 @@ Types:
             Type: 261 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
           DictIndex: -1
@@ -21267,7 +21326,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21279,7 +21338,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21290,7 +21349,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21435,7 +21494,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1591
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21447,7 +21506,7 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21458,12 +21517,12 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21475,7 +21534,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21486,7 +21545,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21740,7 +21799,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -21752,7 +21811,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -21763,12 +21822,12 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21780,7 +21839,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21791,7 +21850,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21802,7 +21861,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r2}
+                  Variable: {subprogram: 129, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21863,7 +21922,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1586
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21875,7 +21934,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21886,7 +21945,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21947,7 +22006,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -21959,7 +22018,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21970,7 +22029,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21981,7 +22040,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21992,7 +22051,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22025,7 +22084,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22037,7 +22096,7 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22048,12 +22107,12 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22065,7 +22124,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 1, name: ~r0}
+                  Variable: {subprogram: 131, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22076,12 +22135,12 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 2, name: ~r1}
+                  Variable: {subprogram: 131, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22093,7 +22152,7 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22104,12 +22163,12 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -22121,7 +22180,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22132,7 +22191,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22165,7 +22224,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22177,12 +22236,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -22194,7 +22253,7 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
@@ -22205,12 +22264,12 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -22222,7 +22281,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22233,7 +22292,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22244,7 +22303,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22255,7 +22314,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22266,7 +22325,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22277,12 +22336,12 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22294,7 +22353,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22305,7 +22364,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22316,7 +22375,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22327,7 +22386,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22338,7 +22397,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22349,12 +22408,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -22366,12 +22425,12 @@ Types:
             Type: 325 StructureType main.tenStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 160
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1599
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22383,7 +22442,7 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22394,12 +22453,12 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22411,7 +22470,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22425,7 +22484,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22439,7 +22498,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22447,7 +22506,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1597
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22459,7 +22518,7 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22470,12 +22529,12 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22487,7 +22546,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22498,7 +22557,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
           DictIndex: -1
@@ -22509,12 +22568,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22526,7 +22585,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22537,7 +22596,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22548,7 +22607,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22559,7 +22618,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22570,7 +22629,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22581,7 +22640,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22782,7 +22841,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22794,7 +22853,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22805,12 +22864,12 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1604
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22822,7 +22881,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22833,7 +22892,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22894,34 +22953,6 @@ Types:
                   ByteSize: 800
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1589
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -22934,7 +22965,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22945,12 +22976,40 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1590
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1578
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22962,7 +23021,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -22973,7 +23032,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22984,7 +23043,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -22995,12 +23054,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23012,7 +23071,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 2, name: ~r0}
+                  Variable: {subprogram: 132, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -23023,12 +23082,12 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 3, name: ~r1}
+                  Variable: {subprogram: 132, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23047,7 +23106,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -23058,7 +23117,7 @@ Types:
             Type: 354 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: x}
+                  Variable: {subprogram: 183, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23069,12 +23128,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23086,12 +23145,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 2, name: ~r0}
+                  Variable: {subprogram: 183, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23110,7 +23169,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -23121,7 +23180,7 @@ Types:
             Type: 355 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: x}
+                  Variable: {subprogram: 184, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23132,12 +23191,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23149,12 +23208,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 2, name: ~r0}
+                  Variable: {subprogram: 184, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1618
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23167,7 +23226,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23178,12 +23237,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23196,12 +23255,12 @@ Types:
             Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 1, name: ~r0}
+                  Variable: {subprogram: 162, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1619
+      ID: 1620
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23214,7 +23273,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23225,12 +23284,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23243,7 +23302,7 @@ Types:
             Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 1, name: ~r0}
+                  Variable: {subprogram: 163, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -32248,7 +32307,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 1.008128e+06
       GoKind: 5
-MaxTypeID: 1683
+MaxTypeID: 1684
 Issues:
     - probe_definition:
         id: testReturnCondBadField
@@ -32280,10 +32339,10 @@ Issues:
       issue:
         Kind: 7
         Message: return value selector (e.g., @return.r0) must be used for multi-value returns
-GoModuledataInfo: {FirstModuledataAddr: "0x1860d00", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x1861d00", TypesOffset: 296}
 GoMapHashInfo:
-    UseAeshashAddr: "0x196222a"
-    AeskeyschedAddr: "0x1963300"
+    UseAeshashAddr: "0x196322a"
+    AeskeyschedAddr: "0x1964300"
 CommonTypes:
     G: 23 StructureType runtime.g
     M: 30 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -9,15 +9,15 @@ Probes:
       segments: [stackC]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 144}
+        - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1398 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x894528", Frameless: false}]
+              Type: 1399 EventRootType Probe[main.stackC]
+              InjectionPoints: [{PC: "0x8947d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1399 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x89455c", Frameless: false}]
+              Type: 1400 EventRootType Probe[main.stackC]Return
+              InjectionPoints: [{PC: "0x89480c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -80,15 +80,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 124}
+        - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1369 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x89328c", Frameless: false}]
+              Type: 1370 EventRootType Probe[main.testArrayArgAndReturn]
+              InjectionPoints: [{PC: "0x89352c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1370 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x893324", Frameless: false}]
+              Type: 1371 EventRootType Probe[main.testArrayArgAndReturn]Return
+              InjectionPoints: [{PC: "0x8935c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -338,15 +338,15 @@ Probes:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1417 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x894880", Frameless: true}]
+              Type: 1418 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x894b30", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1418 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x89489c", Frameless: true}]
+              Type: 1419 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0x894b4c", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1478 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1479 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x88f138"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1479 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1480 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x88f138"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 185, index: 0, name: x}
+                      Variable: {subprogram: 186, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -433,10 +433,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1480 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1481 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x88f138"
                   Frameless: false
@@ -515,16 +515,16 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 158}
+        - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1425 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x894930", Frameless: true}]
+              Type: 1426 EventRootType Probe[main.testTenStrings]
+              InjectionPoints: [{PC: "0x894be0", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 158, index: 0, name: x}
+                      Variable: {subprogram: 159, index: 0, name: x}
                       Offset: 144
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -789,11 +789,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 133}
+        - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1386 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x894150", Frameless: true}]
+              Type: 1387 EventRootType Probe[main.testEmptySlice]
+              InjectionPoints: [{PC: "0x894400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -816,11 +816,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 136}
+        - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1389 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x894180", Frameless: true}]
+              Type: 1390 EventRootType Probe[main.testEmptySliceOfStructs]
+              InjectionPoints: [{PC: "0x894430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -844,11 +844,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 152}
+        - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1412 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x894600", Frameless: true}]
+              Type: 1413 EventRootType Probe[main.testEmptyString]
+              InjectionPoints: [{PC: "0x8948b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -866,11 +866,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 159}
+        - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1426 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x894980", Frameless: true}]
+              Type: 1427 EventRootType Probe[main.testEmptyStruct]
+              InjectionPoints: [{PC: "0x894c30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -887,11 +887,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 160}
+        - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1427 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x894990", Frameless: true}]
+              Type: 1428 EventRootType Probe[main.testEmptyStructPointer]
+              InjectionPoints: [{PC: "0x894c40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1100,15 +1100,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1464 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x896cf0", Frameless: true}]
+              Type: 1465 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0x896fa0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1465 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x896cf8", Frameless: true}]
+              Type: 1466 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x896fa8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1118,15 +1118,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1466 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x896d10", Frameless: false}]
+              Type: 1467 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0x896fc0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1467 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x896d4c", Frameless: false}]
+              Type: 1468 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0x896ffc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1145,15 +1145,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1460 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x896c58", Frameless: false}]
+              Type: 1461 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0x896f08", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1461 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x896c68", Frameless: false}]
+              Type: 1462 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0x896f18", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1163,15 +1163,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1462 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x896ca8", Frameless: false}]
+              Type: 1463 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0x896f58", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1463 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x896cc0", Frameless: false}]
+              Type: 1464 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0x896f70", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1190,18 +1190,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1468 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x896d60", Frameless: true}]
+              Type: 1469 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0x897010", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1469 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1470 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x896d88"
+                - PC: "0x897038"
                   Frameless: true
-                - PC: "0x896d90"
+                - PC: "0x897040"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1212,18 +1212,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1470 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x896db8", Frameless: false}]
+              Type: 1471 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0x897068", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1471 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1472 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x896e18"
+                - PC: "0x8970c8"
                   Frameless: false
-                - PC: "0x896e28"
+                - PC: "0x8970d8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1246,11 +1246,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Line
-              Type: 1472 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x896d64", Frameless: true}]
+              Type: 1473 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0x897014", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1258,11 +1258,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Line
-              Type: 1473 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x896dc8", Frameless: false}]
+              Type: 1474 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0x897078", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1279,15 +1279,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1448 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x896930", Frameless: true}]
+              Type: 1449 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0x896be0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1449 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x896938", Frameless: true}]
+              Type: 1450 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0x896be8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1297,15 +1297,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1450 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x8969c0", Frameless: true}]
+              Type: 1451 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0x896c70", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1451 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x8969c4", Frameless: true}]
+              Type: 1452 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0x896c74", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1325,15 +1325,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 166}
           events:
             - Kind: Entry
-              Type: 1436 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x8964d8", Frameless: false}]
+              Type: 1437 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0x896788", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1437 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x8965ac", Frameless: false}]
+              Type: 1438 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x89685c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1343,14 +1343,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1438 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1439 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x12acf8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1439 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1440 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x12adcc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1371,15 +1371,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 167}
           events:
             - Kind: Entry
-              Type: 1440 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x896608", Frameless: false}]
+              Type: 1441 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x8968b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1441 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x896618", Frameless: false}]
+              Type: 1442 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x8968c8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1398,15 +1398,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1474 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x896e70", Frameless: true}]
+              Type: 1475 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0x897120", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1475 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x896e78", Frameless: true}]
+              Type: 1476 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0x897128", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1416,15 +1416,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1476 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x896f18", Frameless: false}]
+              Type: 1477 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0x8971c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1477 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x896f3c", Frameless: false}]
+              Type: 1478 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0x8971ec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1443,15 +1443,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 163}
+        - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1432 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x896430", Frameless: true}]
+              Type: 1433 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0x8966e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1433 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x896434", Frameless: true}]
+              Type: 1434 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x8966e4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1461,15 +1461,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 164}
+        - subprogram: {subprogram: 165}
           events:
             - Kind: Entry
-              Type: 1434 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x896440", Frameless: true}]
+              Type: 1435 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0x8966f0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1435 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x89644c", Frameless: true}]
+              Type: 1436 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x8966fc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1488,15 +1488,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1452 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x896a60", Frameless: true}]
+              Type: 1453 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0x896d10", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1453 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x896a68", Frameless: true}]
+              Type: 1454 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0x896d18", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1506,15 +1506,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1454 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x896b08", Frameless: false}]
+              Type: 1455 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0x896db8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1455 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x896b34", Frameless: false}]
+              Type: 1456 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0x896de4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1533,33 +1533,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
-          events:
-            - Kind: Entry
-              Type: 1442 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x896900", Frameless: true}]
-              Condition: null
-            - Kind: Return
-              Type: 1443 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x896904", Frameless: true}]
-              Condition: null
-          probeTemplate:
-            TemplateString: p={p}
-            Segments:
-                - p=
-                - JSON: {Ref: p}
-                  DSL: p
-                  EventKind: Entry
-                  EventExpressionIndex: 0
         - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1444 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x896910", Frameless: true}]
+              Type: 1443 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x896bb0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1445 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x896914", Frameless: true}]
+              Type: 1444 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x896bb4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1572,12 +1554,30 @@ Probes:
         - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1446 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x896920", Frameless: true}]
+              Type: 1445 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0x896bc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1447 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x896924", Frameless: true}]
+              Type: 1446 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0x896bc4", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: p={p}
+            Segments:
+                - p=
+                - JSON: {Ref: p}
+                  DSL: p
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+        - subprogram: {subprogram: 170}
+          events:
+            - Kind: Entry
+              Type: 1447 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0x896bd0", Frameless: true}]
+              Condition: null
+            - Kind: Return
+              Type: 1448 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0x896bd4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1596,15 +1596,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1456 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x896c10", Frameless: true}]
+              Type: 1457 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0x896ec0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1457 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x896c18", Frameless: true}]
+              Type: 1458 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0x896ec8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1614,15 +1614,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1458 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x896c20", Frameless: true}]
+              Type: 1459 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x896ed0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1459 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x896c30", Frameless: true}]
+              Type: 1460 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x896ee0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1641,15 +1641,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 161}
+        - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1428 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x896410", Frameless: true}]
+              Type: 1429 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0x8966c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1429 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x896414", Frameless: true}]
+              Type: 1430 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x8966c4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1659,15 +1659,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 162}
+        - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1430 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x896420", Frameless: true}]
+              Type: 1431 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0x8966d0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1431 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x89642c", Frameless: true}]
+              Type: 1432 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x8966dc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1774,10 +1774,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1484 EventRootType Probe[main.testInlinedBBB]
+              Type: 1485 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0x88f3b8", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1814,10 +1814,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1485 EventRootType Probe[main.testInlinedBCA]
+              Type: 1486 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0x88f4bc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1835,10 +1835,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1486 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1487 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0x88f4bc", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1853,10 +1853,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1487 EventRootType Probe[main.testInlinedBCB]
+              Type: 1488 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0x88f570", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1874,10 +1874,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Line
-              Type: 1488 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1489 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0x88f570", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1892,10 +1892,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1494 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1495 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x12a824"
                   Frameless: true
@@ -1915,10 +1915,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1481 EventRootType Probe[main.testInlinedPrint]
+              Type: 1482 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0x88f138"
                   Frameless: false
@@ -1932,7 +1932,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1482 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1483 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0x88f170", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1954,10 +1954,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1483 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1484 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x88f138"
                   Frameless: false
@@ -1986,10 +1986,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1489 EventRootType Probe[main.testInlinedSq]
+              Type: 1490 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0x88f5c4", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2011,10 +2011,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Line
-              Type: 1490 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1491 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0x88f5c4", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2034,10 +2034,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1491 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1492 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0x88f5f4"
                   Frameless: false
@@ -2191,15 +2191,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 123}
+        - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1367 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x8930b0", Frameless: false}]
+              Type: 1368 EventRootType Probe[main.testLargeArgAndReturn]
+              InjectionPoints: [{PC: "0x893350", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1368 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x893208", Frameless: false}]
+              Type: 1369 EventRootType Probe[main.testLargeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x8934a8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2329,15 +2329,15 @@ Probes:
           dsl: i
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 126}
+        - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1373 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x8935bc", Frameless: false}]
+              Type: 1374 EventRootType Probe[main.testManyArgsArrayReturn]
+              InjectionPoints: [{PC: "0x89385c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1374 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x89372c", Frameless: false}]
+              Type: 1375 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              InjectionPoints: [{PC: "0x8939cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2841,11 +2841,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1409 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x8945e0", Frameless: true}]
+              Type: 1410 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x894890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2864,11 +2864,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1410 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x8945e0", Frameless: true}]
+              Type: 1411 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x894890", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2911,15 +2911,15 @@ Probes:
           dsl: s
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 127}
+        - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1375 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x8937b0", Frameless: false}]
+              Type: 1376 EventRootType Probe[main.testMixedArgsStackReturn]
+              InjectionPoints: [{PC: "0x893a50", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1376 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x893960", Frameless: false}]
+              Type: 1377 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              InjectionPoints: [{PC: "0x893c00", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2981,15 +2981,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 129}
+        - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1379 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x893a8c", Frameless: false}]
+              Type: 1380 EventRootType Probe[main.testMultipleArrayArgs]
+              InjectionPoints: [{PC: "0x893d2c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1380 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x893b30", Frameless: false}]
+              Type: 1381 EventRootType Probe[main.testMultipleArrayArgs]Return
+              InjectionPoints: [{PC: "0x893dd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3016,15 +3016,15 @@ Probes:
           dsl: s2
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 125}
+        - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1371 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x893360", Frameless: false}]
+              Type: 1372 EventRootType Probe[main.testMultipleLargeArgs]
+              InjectionPoints: [{PC: "0x893600", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1372 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x893530", Frameless: false}]
+              Type: 1373 EventRootType Probe[main.testMultipleLargeArgs]Return
+              InjectionPoints: [{PC: "0x8937d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3271,11 +3271,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1421 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894920", Frameless: true}]
+              Type: 1422 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x894bd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3296,11 +3296,11 @@ Probes:
           dsl: x.nested.anotherString
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1422 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894920", Frameless: true}]
+              Type: 1423 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x894bd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3327,11 +3327,11 @@ Probes:
           dsl: x.notAMember
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1423 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894920", Frameless: true}]
+              Type: 1424 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x894bd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3352,11 +3352,11 @@ Probes:
           dsl: x.nested
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1424 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x894920", Frameless: true}]
+              Type: 1425 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x894bd0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3406,11 +3406,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 140}
+        - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1393 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x8941c0", Frameless: true}]
+              Type: 1394 EventRootType Probe[main.testNilSlice]
+              InjectionPoints: [{PC: "0x894470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3433,11 +3433,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 137}
+        - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1390 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x894190", Frameless: true}]
+              Type: 1391 EventRootType Probe[main.testNilSliceOfStructs]
+              InjectionPoints: [{PC: "0x894440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3468,11 +3468,11 @@ Probes:
           dsl: x
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 139}
+        - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1392 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x8941b0", Frameless: true}]
+              Type: 1393 EventRootType Probe[main.testNilSliceWithOtherParams]
+              InjectionPoints: [{PC: "0x894460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3500,11 +3500,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 149}
+        - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1408 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x8945d0", Frameless: true}]
+              Type: 1409 EventRootType Probe[main.testOneStringInStructPointer]
+              InjectionPoints: [{PC: "0x894880", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3941,15 +3941,15 @@ Probes:
       segments: [testReturnsArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 112}
+        - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1345 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x892abc", Frameless: false}]
+              Type: 1346 EventRootType Probe[main.testReturnsArray]
+              InjectionPoints: [{PC: "0x892d5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1346 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x892b10", Frameless: false}]
+              Type: 1347 EventRootType Probe[main.testReturnsArray]Return
+              InjectionPoints: [{PC: "0x892db0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3962,15 +3962,15 @@ Probes:
       segments: [testReturnsArrayOne]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 113}
+        - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1347 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x892b48", Frameless: false}]
+              Type: 1348 EventRootType Probe[main.testReturnsArrayOne]
+              InjectionPoints: [{PC: "0x892de8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1348 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x892b84", Frameless: false}]
+              Type: 1349 EventRootType Probe[main.testReturnsArrayOne]Return
+              InjectionPoints: [{PC: "0x892e24", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3983,15 +3983,15 @@ Probes:
       segments: [testReturnsArrayZero]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 114}
+        - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1349 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x892bb8", Frameless: false}]
+              Type: 1350 EventRootType Probe[main.testReturnsArrayZero]
+              InjectionPoints: [{PC: "0x892e58", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1350 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x892bf0", Frameless: false}]
+              Type: 1351 EventRootType Probe[main.testReturnsArrayZero]Return
+              InjectionPoints: [{PC: "0x892e90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4004,15 +4004,15 @@ Probes:
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 116}
+        - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1353 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x892ca8", Frameless: false}]
+              Type: 1354 EventRootType Probe[main.testReturnsBacktrackInt]
+              InjectionPoints: [{PC: "0x892f48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1354 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x892d0c", Frameless: false}]
+              Type: 1355 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              InjectionPoints: [{PC: "0x892fac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4025,15 +4025,15 @@ Probes:
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 122}
+        - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1365 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x893038", Frameless: false}]
+              Type: 1366 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              InjectionPoints: [{PC: "0x8932d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1366 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x893078", Frameless: false}]
+              Type: 1367 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              InjectionPoints: [{PC: "0x893318", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4046,15 +4046,15 @@ Probes:
       segments: [testReturnsComplex]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 110}
+        - subprogram: {subprogram: 111}
           events:
             - Kind: Entry
-              Type: 1341 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x892968", Frameless: false}]
+              Type: 1342 EventRootType Probe[main.testReturnsComplex]
+              InjectionPoints: [{PC: "0x892c08", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1342 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x8929b4", Frameless: false}]
+              Type: 1343 EventRootType Probe[main.testReturnsComplex]Return
+              InjectionPoints: [{PC: "0x892c54", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4202,15 +4202,15 @@ Probes:
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 111}
+        - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1343 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x8929f0", Frameless: false}]
+              Type: 1344 EventRootType Probe[main.testReturnsLargeStruct]
+              InjectionPoints: [{PC: "0x892c90", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1344 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x892a84", Frameless: false}]
+              Type: 1345 EventRootType Probe[main.testReturnsLargeStruct]Return
+              InjectionPoints: [{PC: "0x892d24", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4223,15 +4223,15 @@ Probes:
       segments: [testReturnsManyFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 109}
+        - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1339 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x8928a8", Frameless: false}]
+              Type: 1340 EventRootType Probe[main.testReturnsManyFloats]
+              InjectionPoints: [{PC: "0x892b48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1340 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x89292c", Frameless: false}]
+              Type: 1341 EventRootType Probe[main.testReturnsManyFloats]Return
+              InjectionPoints: [{PC: "0x892bcc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4244,15 +4244,15 @@ Probes:
       segments: [testReturnsMixed]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 118}
+        - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1357 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x892e28", Frameless: false}]
+              Type: 1358 EventRootType Probe[main.testReturnsMixed]
+              InjectionPoints: [{PC: "0x8930c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1358 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x892e80", Frameless: false}]
+              Type: 1359 EventRootType Probe[main.testReturnsMixed]Return
+              InjectionPoints: [{PC: "0x893120", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4265,15 +4265,15 @@ Probes:
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 115}
+        - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1351 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x892c28", Frameless: false}]
+              Type: 1352 EventRootType Probe[main.testReturnsMixedStruct]
+              InjectionPoints: [{PC: "0x892ec8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1352 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x892c70", Frameless: false}]
+              Type: 1353 EventRootType Probe[main.testReturnsMixedStruct]Return
+              InjectionPoints: [{PC: "0x892f10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4286,19 +4286,43 @@ Probes:
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 121}
+        - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1363 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x892fb8", Frameless: false}]
+              Type: 1364 EventRootType Probe[main.testReturnsMultipleFloats]
+              InjectionPoints: [{PC: "0x893258", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1364 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x892ffc", Frameless: false}]
+              Type: 1365 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              InjectionPoints: [{PC: "0x89329c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
             Segments: [testReturnsMultipleFloats]
+    - id: testReturnsNamedDeferLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testReturnsNamedDeferLine
+        sourceFile: returns.go
+        lines: ["121"]
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 108}
+          events:
+            - Kind: Line
+              Type: 1337 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              InjectionPoints: [{PC: "0x8928d8", Frameless: false}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{i}'
+            Segments:
+                - JSON: {Ref: i}
+                  DSL: i
+                  EventKind: Line
+                  EventExpressionIndex: 0
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -4307,15 +4331,15 @@ Probes:
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 120}
+        - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1361 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x892f48", Frameless: false}]
+              Type: 1362 EventRootType Probe[main.testReturnsOnlyFloat]
+              InjectionPoints: [{PC: "0x8931e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1362 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x892f88", Frameless: false}]
+              Type: 1363 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              InjectionPoints: [{PC: "0x893228", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4328,15 +4352,15 @@ Probes:
       segments: [testReturnsPrimitives]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 108}
+        - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1337 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x892818", Frameless: false}]
+              Type: 1338 EventRootType Probe[main.testReturnsPrimitives]
+              InjectionPoints: [{PC: "0x892ab8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1338 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x892870", Frameless: false}]
+              Type: 1339 EventRootType Probe[main.testReturnsPrimitives]Return
+              InjectionPoints: [{PC: "0x892b10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4349,15 +4373,15 @@ Probes:
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 119}
+        - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1359 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x892ebc", Frameless: false}]
+              Type: 1360 EventRootType Probe[main.testReturnsStructWithArray]
+              InjectionPoints: [{PC: "0x89315c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1360 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x892f10", Frameless: false}]
+              Type: 1361 EventRootType Probe[main.testReturnsStructWithArray]Return
+              InjectionPoints: [{PC: "0x8931b0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4370,15 +4394,15 @@ Probes:
       segments: [testReturnsWideStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 117}
+        - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1355 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x892d50", Frameless: false}]
+              Type: 1356 EventRootType Probe[main.testReturnsWideStruct]
+              InjectionPoints: [{PC: "0x892ff0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1356 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x892df4", Frameless: false}]
+              Type: 1357 EventRootType Probe[main.testReturnsWideStruct]Return
+              InjectionPoints: [{PC: "0x893094", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4706,11 +4730,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 145}
+        - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1400 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x894580", Frameless: true}]
+              Type: 1401 EventRootType Probe[main.testSingleString]
+              InjectionPoints: [{PC: "0x894830", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4838,11 +4862,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 142}
+        - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1396 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x8941e0", Frameless: true}]
+              Type: 1397 EventRootType Probe[main.testSliceEmptyStructs]
+              InjectionPoints: [{PC: "0x894490", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4860,11 +4884,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 134}
+        - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1387 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x894160", Frameless: true}]
+              Type: 1388 EventRootType Probe[main.testSliceOfSlices]
+              InjectionPoints: [{PC: "0x894410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4928,15 +4952,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 128}
+        - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1377 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x8939e8", Frameless: false}]
+              Type: 1378 EventRootType Probe[main.testStackArgRegReturns]
+              InjectionPoints: [{PC: "0x893c88", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1378 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x893a4c", Frameless: false}]
+              Type: 1379 EventRootType Probe[main.testStackArgRegReturns]Return
+              InjectionPoints: [{PC: "0x893cec", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4998,11 +5022,11 @@ Probes:
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 138}
+        - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1391 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x8941a0", Frameless: true}]
+              Type: 1392 EventRootType Probe[main.testStringSlice]
+              InjectionPoints: [{PC: "0x894450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5064,15 +5088,15 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1419 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x894880", Frameless: true}]
+              Type: 1420 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x894b30", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1420 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x89489c", Frameless: true}]
+              Type: 1421 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0x894b4c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5095,11 +5119,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 135}
+        - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1388 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x894170", Frameless: true}]
+              Type: 1389 EventRootType Probe[main.testStructSlice]
+              InjectionPoints: [{PC: "0x894420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5143,15 +5167,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 130}
+        - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1381 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x893b6c", Frameless: false}]
+              Type: 1382 EventRootType Probe[main.testStructWithArrayArg]
+              InjectionPoints: [{PC: "0x893e0c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1382 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x893bfc", Frameless: false}]
+              Type: 1383 EventRootType Probe[main.testStructWithArrayArg]Return
+              InjectionPoints: [{PC: "0x893e9c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5169,15 +5193,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 155}
+        - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1415 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x894790", Frameless: true}]
+              Type: 1416 EventRootType Probe[main.testStructWithCyclicMaps]
+              InjectionPoints: [{PC: "0x894a40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1416 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x8947a8", Frameless: true}]
+              Type: 1417 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              InjectionPoints: [{PC: "0x894a58", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5194,11 +5218,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 154}
+        - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1414 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x894780", Frameless: true}]
+              Type: 1415 EventRootType Probe[main.testStructWithCyclicSlices]
+              InjectionPoints: [{PC: "0x894a30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5253,11 +5277,11 @@ Probes:
           dsl: cs
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 143}
+        - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1397 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x8941f0", Frameless: true}]
+              Type: 1398 EventRootType Probe[main.testSubslices]
+              InjectionPoints: [{PC: "0x8944a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5293,11 +5317,11 @@ Probes:
           dsl: c
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 153}
+        - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1413 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x894610", Frameless: true}]
+              Type: 1414 EventRootType Probe[main.testSubstrings]
+              InjectionPoints: [{PC: "0x8948c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5411,11 +5435,11 @@ Probes:
           dsl: z
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 146}
+        - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1401 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x894590", Frameless: true}]
+              Type: 1402 EventRootType Probe[main.testThreeStrings]
+              InjectionPoints: [{PC: "0x894840", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5443,15 +5467,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1402 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x8945a0", Frameless: true}]
+              Type: 1403 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x894850", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1403 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x8945b8", Frameless: true}]
+              Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0x894868", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5477,15 +5501,15 @@ Probes:
           dsl: t.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x8945a0", Frameless: true}]
+              Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x894850", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x8945b8", Frameless: true}]
+              Type: 1406 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0x894868", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5513,11 +5537,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1406 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x8945c0", Frameless: true}]
+              Type: 1407 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x894870", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5543,11 +5567,11 @@ Probes:
           dsl: a.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1407 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x8945c0", Frameless: true}]
+              Type: 1408 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x894870", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5729,11 +5753,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 132}
+        - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1385 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x894140", Frameless: true}]
+              Type: 1386 EventRootType Probe[main.testUintSlice]
+              InjectionPoints: [{PC: "0x8943f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5751,11 +5775,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 151}
+        - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1411 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x8945f0", Frameless: true}]
+              Type: 1412 EventRootType Probe[main.testUnitializedString]
+              InjectionPoints: [{PC: "0x8948a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5817,11 +5841,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1394 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8941d0", Frameless: true}]
+              Type: 1395 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x894480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5839,11 +5863,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1395 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x8941d0", Frameless: true}]
+              Type: 1396 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x894480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5861,18 +5885,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1492 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1493 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0x88f798"
                   Frameless: false
-                - PC: "0x89703c"
+                - PC: "0x8972ec"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1493 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1494 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0x88f7d0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5891,15 +5915,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 131}
+        - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1383 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x893c38", Frameless: false}]
+              Type: 1384 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              InjectionPoints: [{PC: "0x893ed8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1384 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x893ca4", Frameless: false}]
+              Type: 1385 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x893f44", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -8118,223 +8142,252 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 108
+      Name: main.testReturnsNamedDeferLine
+      OutOfLinePCRanges: [0x892800..0x8929c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x892800..0x892864
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x892864..0x8929c0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x89282c..0x8929c0
+              Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
+          Role: Return
+          DictIndex: -1
+        - Name: b
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x892830..0x8929c0
+              Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x892800..0x892890]
+      OutOfLinePCRanges: [0x892aa0..0x892b30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x892800..0x892870
+            - Range: 0x892aa0..0x892b10
               Pieces: []
-            - Range: 0x892870..0x892871
+            - Range: 0x892b10..0x892b11
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892871..0x892890
+            - Range: 0x892b11..0x892b30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 89 BaseType int16
           Locations:
-            - Range: 0x892800..0x892870
+            - Range: 0x892aa0..0x892b10
               Pieces: []
-            - Range: 0x892870..0x892871
+            - Range: 0x892b10..0x892b11
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x892871..0x892890
+            - Range: 0x892b11..0x892b30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x892800..0x892870
+            - Range: 0x892aa0..0x892b10
               Pieces: []
-            - Range: 0x892870..0x892871
+            - Range: 0x892b10..0x892b11
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x892871..0x892890
+            - Range: 0x892b11..0x892b30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x892800..0x892870
+            - Range: 0x892aa0..0x892b10
               Pieces: []
-            - Range: 0x892870..0x892871
+            - Range: 0x892b10..0x892b11
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x892871..0x892890
+            - Range: 0x892b11..0x892b30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x892800..0x892870
+            - Range: 0x892aa0..0x892b10
               Pieces: []
-            - Range: 0x892870..0x892871
+            - Range: 0x892b10..0x892b11
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x892871..0x892890
+            - Range: 0x892b11..0x892b30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x892800..0x892870
+            - Range: 0x892aa0..0x892b10
               Pieces: []
-            - Range: 0x892870..0x892871
+            - Range: 0x892b10..0x892b11
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x892871..0x892890
+            - Range: 0x892b11..0x892b30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x892800..0x892870
+            - Range: 0x892aa0..0x892b10
               Pieces: []
-            - Range: 0x892870..0x892871
+            - Range: 0x892b10..0x892b11
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x892871..0x892890
+            - Range: 0x892b11..0x892b30
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x892800..0x892870
+            - Range: 0x892aa0..0x892b10
               Pieces: []
-            - Range: 0x892870..0x892871
+            - Range: 0x892b10..0x892b11
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x892871..0x892890
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 109
-      Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x892890..0x892950]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r5
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r6
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r7
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r8
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r9
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r10
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r11
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r12
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r13
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r14
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: onlyOnAmd64_16
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892890..0x892950, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: bothArmAndAmd64
-          Type: 17 BaseType float64
-          Locations:
-            - Range: 0x892890..0x89292c
-              Pieces: []
-            - Range: 0x89292c..0x89292d
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x89292d..0x892950
+            - Range: 0x892b11..0x892b30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
-      Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x892950..0x8929d0]
+      Name: main.testReturnsManyFloats
+      OutOfLinePCRanges: [0x892b30..0x892bf0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 90 BaseType complex64
-          Locations: [{Range: 0x892950..0x8929d0, Pieces: []}]
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
-          Type: 91 BaseType complex128
-          Locations: [{Range: 0x892950..0x8929d0, Pieces: []}]
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r5
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r6
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r7
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r8
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r9
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r10
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r11
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r12
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r13
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r14
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: onlyOnAmd64_16
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x892b30..0x892bf0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: bothArmAndAmd64
+          Type: 17 BaseType float64
+          Locations:
+            - Range: 0x892b30..0x892bcc
+              Pieces: []
+            - Range: 0x892bcc..0x892bcd
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x892bcd..0x892bf0
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0x892bf0..0x892c70]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 90 BaseType complex64
+          Locations: [{Range: 0x892bf0..0x892c70, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 91 BaseType complex128
+          Locations: [{Range: 0x892bf0..0x892c70, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x8929d0..0x892aa0]
+      OutOfLinePCRanges: [0x892c70..0x892d40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x8929d0..0x892a84
+            - Range: 0x892c70..0x892d24
               Pieces: []
-            - Range: 0x892a84..0x892a85
+            - Range: 0x892d24..0x892d25
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8356,193 +8409,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x892a85..0x892aa0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 112
-      Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x892aa0..0x892b30]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 246 ArrayType [3]int
-          Locations:
-            - Range: 0x892aa0..0x892b10
-              Pieces: []
-            - Range: 0x892b10..0x892b11
-              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x892b11..0x892b30
+            - Range: 0x892d25..0x892d40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
-      Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x892b30..0x892ba0]
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0x892d40..0x892dd0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 247 ArrayType [1]int
+          Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x892b30..0x892b84
+            - Range: 0x892d40..0x892db0
               Pieces: []
-            - Range: 0x892b84..0x892b85
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892b85..0x892ba0
+            - Range: 0x892db0..0x892db1
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x892db1..0x892dd0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
-      Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x892ba0..0x892c10]
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0x892dd0..0x892e40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 248 ArrayType [0]int
+          Type: 247 ArrayType [1]int
           Locations:
-            - Range: 0x892ba0..0x892bf0
+            - Range: 0x892dd0..0x892e24
               Pieces: []
-            - Range: 0x892bf0..0x892bf1
-              Pieces: []
-            - Range: 0x892bf1..0x892c10
+            - Range: 0x892e24..0x892e25
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x892e25..0x892e40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
-      Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x892c10..0x892c90]
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0x892e40..0x892eb0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 249 StructureType main.mixedStruct
-          Locations: [{Range: 0x892c10..0x892c90, Pieces: []}]
+          Type: 248 ArrayType [0]int
+          Locations:
+            - Range: 0x892e40..0x892e90
+              Pieces: []
+            - Range: 0x892e90..0x892e91
+              Pieces: []
+            - Range: 0x892e91..0x892eb0
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0x892eb0..0x892f30]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 249 StructureType main.mixedStruct
+          Locations: [{Range: 0x892eb0..0x892f30, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x892c90..0x892d30]
+      OutOfLinePCRanges: [0x892f30..0x892fd0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892c90..0x892d0c
+            - Range: 0x892f30..0x892fac
               Pieces: []
-            - Range: 0x892d0c..0x892d0d
+            - Range: 0x892fac..0x892fad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892d0d..0x892d30
+            - Range: 0x892fad..0x892fd0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892c90..0x892d0c
+            - Range: 0x892f30..0x892fac
               Pieces: []
-            - Range: 0x892d0c..0x892d0d
+            - Range: 0x892fac..0x892fad
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x892d0d..0x892d30
+            - Range: 0x892fad..0x892fd0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892c90..0x892d0c
+            - Range: 0x892f30..0x892fac
               Pieces: []
-            - Range: 0x892d0c..0x892d0d
+            - Range: 0x892fac..0x892fad
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x892d0d..0x892d30
+            - Range: 0x892fad..0x892fd0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892c90..0x892d0c
+            - Range: 0x892f30..0x892fac
               Pieces: []
-            - Range: 0x892d0c..0x892d0d
+            - Range: 0x892fac..0x892fad
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x892d0d..0x892d30
+            - Range: 0x892fad..0x892fd0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892c90..0x892d0c
+            - Range: 0x892f30..0x892fac
               Pieces: []
-            - Range: 0x892d0c..0x892d0d
+            - Range: 0x892fac..0x892fad
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x892d0d..0x892d30
+            - Range: 0x892fad..0x892fd0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892c90..0x892d0c
+            - Range: 0x892f30..0x892fac
               Pieces: []
-            - Range: 0x892d0c..0x892d0d
+            - Range: 0x892fac..0x892fad
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x892d0d..0x892d30
+            - Range: 0x892fad..0x892fd0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892c90..0x892d0c
+            - Range: 0x892f30..0x892fac
               Pieces: []
-            - Range: 0x892d0c..0x892d0d
+            - Range: 0x892fac..0x892fad
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x892d0d..0x892d30
+            - Range: 0x892fad..0x892fd0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0x892c90..0x892d0c
+            - Range: 0x892f30..0x892fac
               Pieces: []
-            - Range: 0x892d0c..0x892d0d
+            - Range: 0x892fac..0x892fad
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x892d0d..0x892d30
+            - Range: 0x892fad..0x892fd0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892c90..0x892d0c
+            - Range: 0x892f30..0x892fac
               Pieces: []
-            - Range: 0x892d0c..0x892d0d
+            - Range: 0x892fac..0x892fad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x892d0d..0x892d30
+            - Range: 0x892fad..0x892fd0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x892d30..0x892e10]
+      OutOfLinePCRanges: [0x892fd0..0x8930b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.wideStruct
           Locations:
-            - Range: 0x892d30..0x892df4
+            - Range: 0x892fd0..0x893094
               Pieces: []
-            - Range: 0x892df4..0x892df5
+            - Range: 0x893094..0x893095
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8566,145 +8619,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x892df5..0x892e10
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 118
-      Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x892e10..0x892ea0]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x892e10..0x892e80
-              Pieces: []
-            - Range: 0x892e80..0x892e81
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892e81..0x892ea0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892e10..0x892ea0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x892e10..0x892e80
-              Pieces: []
-            - Range: 0x892e80..0x892e81
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x892e81..0x892ea0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892e10..0x892ea0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x892e10..0x892e80
-              Pieces: []
-            - Range: 0x892e80..0x892e81
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x892e81..0x892ea0
+            - Range: 0x893095..0x8930b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
-      Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x892ea0..0x892f30]
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0x8930b0..0x893140]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 251 StructureType main.structWithArray
+          Type: 9 BaseType int
           Locations:
-            - Range: 0x892ea0..0x892f10
+            - Range: 0x8930b0..0x893120
               Pieces: []
-            - Range: 0x892f10..0x892f11
-              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x892f11..0x892f30
+            - Range: 0x893120..0x893121
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x893121..0x893140
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x8930b0..0x893140, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x8930b0..0x893120
+              Pieces: []
+            - Range: 0x893120..0x893121
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x893121..0x893140
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x8930b0..0x893140, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x8930b0..0x893120
+              Pieces: []
+            - Range: 0x893120..0x893121
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x893121..0x893140
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
-      Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x892f30..0x892fa0]
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0x893140..0x8931d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 17 BaseType float64
-          Locations: [{Range: 0x892f30..0x892fa0, Pieces: []}]
+          Type: 251 StructureType main.structWithArray
+          Locations:
+            - Range: 0x893140..0x8931b0
+              Pieces: []
+            - Range: 0x8931b0..0x8931b1
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x8931b1..0x8931d0
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
-      Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x892fa0..0x893020]
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0x8931d0..0x893240]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 16 BaseType float32
-          Locations: [{Range: 0x892fa0..0x893020, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x892fa0..0x893020, Pieces: []}]
+          Locations: [{Range: 0x8931d0..0x893240, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0x893240..0x8932c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 16 BaseType float32
+          Locations: [{Range: 0x893240..0x8932c0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x893240..0x8932c0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x893020..0x893090]
+      OutOfLinePCRanges: [0x8932c0..0x893330]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x893020..0x893078
+            - Range: 0x8932c0..0x893318
               Pieces: []
-            - Range: 0x893078..0x893079
+            - Range: 0x893318..0x893319
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893079..0x893090
+            - Range: 0x893319..0x893330
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x893020..0x893078
+            - Range: 0x8932c0..0x893318
               Pieces: []
-            - Range: 0x893078..0x893079
+            - Range: 0x893318..0x893319
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893079..0x893090
+            - Range: 0x893319..0x893330
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 123
+    - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x893090..0x893270]
+      OutOfLinePCRanges: [0x893330..0x893510]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893090..0x8930fc
+            - Range: 0x893330..0x89339c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8726,7 +8779,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8930fc..0x893110
+            - Range: 0x89339c..0x8933b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8748,7 +8801,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893110..0x893114
+            - Range: 0x8933b0..0x8933b4
               Pieces:
                 - Size: 8
                   Op: null
@@ -8775,9 +8828,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893090..0x893208
+            - Range: 0x893330..0x8934a8
               Pieces: []
-            - Range: 0x893208..0x893209
+            - Range: 0x8934a8..0x8934a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8799,44 +8852,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893209..0x893270
+            - Range: 0x8934a9..0x893510
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 124
+    - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x893270..0x893340]
+      OutOfLinePCRanges: [0x893510..0x8935e0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x893270..0x893340
+            - Range: 0x893510..0x8935e0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x893270..0x893324
+            - Range: 0x893510..0x8935c4
               Pieces: []
-            - Range: 0x893324..0x893325
+            - Range: 0x8935c4..0x8935c5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x893325..0x893340
+            - Range: 0x8935c5..0x8935e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x893340..0x8935a0]
+      OutOfLinePCRanges: [0x8935e0..0x893840]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893340..0x8933b0
+            - Range: 0x8935e0..0x893650
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8858,7 +8911,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8933b0..0x8933c4
+            - Range: 0x893650..0x893664
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8880,7 +8933,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8933c4..0x8933c8
+            - Range: 0x893664..0x893668
               Pieces:
                 - Size: 8
                   Op: null
@@ -8907,16 +8960,16 @@ Subprograms:
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893340..0x8935a0
+            - Range: 0x8935e0..0x893840
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893340..0x893530
+            - Range: 0x8935e0..0x8937d0
               Pieces: []
-            - Range: 0x893530..0x893531
+            - Range: 0x8937d0..0x8937d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8938,196 +8991,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893531..0x8935a0
+            - Range: 0x8937d1..0x893840
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 126
+    - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x8935a0..0x893790]
+      OutOfLinePCRanges: [0x893840..0x893a30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8935a0..0x893618
+            - Range: 0x893840..0x8938b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893618..0x893790
+            - Range: 0x8938b8..0x893a30
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8935a0..0x893618
+            - Range: 0x893840..0x8938b8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893618..0x893790
+            - Range: 0x8938b8..0x893a30
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8935a0..0x893618
+            - Range: 0x893840..0x8938b8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x893618..0x893790
+            - Range: 0x8938b8..0x893a30
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8935a0..0x893618
+            - Range: 0x893840..0x8938b8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x893618..0x893790
+            - Range: 0x8938b8..0x893a30
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8935a0..0x893618
+            - Range: 0x893840..0x8938b8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x893618..0x893790
+            - Range: 0x8938b8..0x893a30
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8935a0..0x893618
+            - Range: 0x893840..0x8938b8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x893618..0x893790
+            - Range: 0x8938b8..0x893a30
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8935a0..0x893618
+            - Range: 0x893840..0x8938b8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x893618..0x893790
+            - Range: 0x8938b8..0x893a30
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8935a0..0x893618
+            - Range: 0x893840..0x8938b8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x893618..0x893790
+            - Range: 0x8938b8..0x893a30
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8935a0..0x893618
+            - Range: 0x893840..0x8938b8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x893618..0x893790
+            - Range: 0x8938b8..0x893a30
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x8935a0..0x89372c
+            - Range: 0x893840..0x8939cc
               Pieces: []
-            - Range: 0x89372c..0x89372d
+            - Range: 0x8939cc..0x8939cd
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x89372d..0x893790
+            - Range: 0x8939cd..0x893a30
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 127
+    - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x893790..0x8939d0]
+      OutOfLinePCRanges: [0x893a30..0x893c70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893790..0x893818
+            - Range: 0x893a30..0x893ab8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893818..0x8939d0
+            - Range: 0x893ab8..0x893c70
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893790..0x893818
+            - Range: 0x893a30..0x893ab8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893818..0x8939d0
+            - Range: 0x893ab8..0x893c70
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893790..0x893818
+            - Range: 0x893a30..0x893ab8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x893818..0x8939d0
+            - Range: 0x893ab8..0x893c70
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893790..0x893818
+            - Range: 0x893a30..0x893ab8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x893818..0x8939d0
+            - Range: 0x893ab8..0x893c70
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893790..0x893818
+            - Range: 0x893a30..0x893ab8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x893818..0x8939d0
+            - Range: 0x893ab8..0x893c70
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893790..0x893818
+            - Range: 0x893a30..0x893ab8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x893818..0x8939d0
+            - Range: 0x893ab8..0x893c70
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893790..0x893818
+            - Range: 0x893a30..0x893ab8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x893818..0x8939d0
+            - Range: 0x893ab8..0x893c70
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893790..0x893818
+            - Range: 0x893a30..0x893ab8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x893818..0x8939d0
+            - Range: 0x893ab8..0x893c70
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x893790..0x893818
+            - Range: 0x893a30..0x893ab8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893818..0x8939d0
+            - Range: 0x893ab8..0x893c70
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9138,9 +9191,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x893790..0x893960
+            - Range: 0x893a30..0x893c00
               Pieces: []
-            - Range: 0x893960..0x893961
+            - Range: 0x893c00..0x893c01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9162,215 +9215,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x893961..0x8939d0
+            - Range: 0x893c01..0x893c70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 128
+    - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x8939d0..0x893a70]
+      OutOfLinePCRanges: [0x893c70..0x893d10]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x8939d0..0x893a70
+            - Range: 0x893c70..0x893d10
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8939d0..0x893a4c
+            - Range: 0x893c70..0x893cec
               Pieces: []
-            - Range: 0x893a4c..0x893a4d
+            - Range: 0x893cec..0x893ced
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893a4d..0x893a70
+            - Range: 0x893ced..0x893d10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8939d0..0x893a4c
+            - Range: 0x893c70..0x893cec
               Pieces: []
-            - Range: 0x893a4c..0x893a4d
+            - Range: 0x893cec..0x893ced
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x893a4d..0x893a70
+            - Range: 0x893ced..0x893d10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8939d0..0x893a4c
+            - Range: 0x893c70..0x893cec
               Pieces: []
-            - Range: 0x893a4c..0x893a4d
+            - Range: 0x893cec..0x893ced
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x893a4d..0x893a70
+            - Range: 0x893ced..0x893d10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 129
+    - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x893a70..0x893b50]
+      OutOfLinePCRanges: [0x893d10..0x893df0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x893a70..0x893b50
+            - Range: 0x893d10..0x893df0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x893a70..0x893b50
+            - Range: 0x893d10..0x893df0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893a70..0x893b30
+            - Range: 0x893d10..0x893dd0
               Pieces: []
-            - Range: 0x893b30..0x893b31
+            - Range: 0x893dd0..0x893dd1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893b31..0x893b50
+            - Range: 0x893dd1..0x893df0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x893a70..0x893b30
+            - Range: 0x893d10..0x893dd0
               Pieces: []
-            - Range: 0x893b30..0x893b31
+            - Range: 0x893dd0..0x893dd1
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x893b31..0x893b50
+            - Range: 0x893dd1..0x893df0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 130
+    - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x893b50..0x893c20]
+      OutOfLinePCRanges: [0x893df0..0x893ec0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x893b50..0x893c20
+            - Range: 0x893df0..0x893ec0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893b50..0x893bfc
+            - Range: 0x893df0..0x893e9c
               Pieces: []
-            - Range: 0x893bfc..0x893bfd
+            - Range: 0x893e9c..0x893e9d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893bfd..0x893c20
+            - Range: 0x893e9d..0x893ec0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x893b50..0x893bfc
+            - Range: 0x893df0..0x893e9c
               Pieces: []
-            - Range: 0x893bfc..0x893bfd
+            - Range: 0x893e9c..0x893e9d
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x893bfd..0x893c20
+            - Range: 0x893e9d..0x893ec0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893bd0..0x893c20
+            - Range: 0x893e70..0x893ec0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
-    - ID: 131
+    - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x893c20..0x893cd0]
+      OutOfLinePCRanges: [0x893ec0..0x893f70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 248 ArrayType [0]int
-          Locations: [{Range: 0x893c20..0x893cd0, Pieces: []}]
+          Locations: [{Range: 0x893ec0..0x893f70, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893c20..0x893c60
+            - Range: 0x893ec0..0x893f00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893c60..0x893c7c
+            - Range: 0x893f00..0x893f1c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x893c7c..0x893c98
+            - Range: 0x893f1c..0x893f38
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x893c98..0x893cd0
+            - Range: 0x893f38..0x893f70
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x893c20..0x893ca4
+            - Range: 0x893ec0..0x893f44
               Pieces: []
-            - Range: 0x893ca4..0x893ca5
+            - Range: 0x893f44..0x893f45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x893ca5..0x893cd0
+            - Range: 0x893f45..0x893f70
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0x893c20..0x893ca4
+            - Range: 0x893ec0..0x893f44
               Pieces: []
-            - Range: 0x893ca4..0x893ca5
+            - Range: 0x893f44..0x893f45
               Pieces: []
-            - Range: 0x893ca5..0x893cd0
+            - Range: 0x893f45..0x893f70
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 132
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x894140..0x894150]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x894140..0x894150
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
     - ID: 133
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x894150..0x894160]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x8943f0..0x894400]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x894150..0x894160
+            - Range: 0x8943f0..0x894400
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9382,14 +9416,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 134
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x894160..0x894170]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x894400..0x894410]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 253 GoSliceHeaderType [][]uint
+          Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x894160..0x894170
+            - Range: 0x894400..0x894410
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9401,14 +9435,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 135
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x894170..0x894180]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x894410..0x894420]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 253 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x894170..0x894180
+            - Range: 0x894410..0x894420
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9416,25 +9450,18 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x894170..0x894180
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 136
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x894180..0x894190]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x894420..0x894430]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x894180..0x894190
+            - Range: 0x894420..0x894430
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9447,20 +9474,20 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x894180..0x894190
+            - Range: 0x894420..0x894430
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x894190..0x8941a0]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x894430..0x894440]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x894190..0x8941a0
+            - Range: 0x894430..0x894440
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9473,20 +9500,46 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x894190..0x8941a0
+            - Range: 0x894430..0x894440
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x894440..0x894450]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x894440..0x894450
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x894440..0x894450
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x8941a0..0x8941b0]
+      OutOfLinePCRanges: [0x894450..0x894460]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 258 GoSliceHeaderType []string
           Locations:
-            - Range: 0x8941a0..0x8941b0
+            - Range: 0x894450..0x894460
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9497,22 +9550,22 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 139
+    - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x8941b0..0x8941c0]
+      OutOfLinePCRanges: [0x894460..0x894470]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x8941b0..0x8941c0
+            - Range: 0x894460..0x894470
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 259 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x8941b0..0x8941c0
+            - Range: 0x894460..0x894470
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9525,39 +9578,20 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x8941b0..0x8941c0
+            - Range: 0x894460..0x894470
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
+    - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x8941c0..0x8941d0]
+      OutOfLinePCRanges: [0x894470..0x894480]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x8941c0..0x8941d0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x8941d0..0x8941e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x8941d0..0x8941e0
+            - Range: 0x894470..0x894480
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9569,14 +9603,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 142
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x8941e0..0x8941f0]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x894480..0x894490]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 261 GoSliceHeaderType []struct {}
+          Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8941e0..0x8941f0
+            - Range: 0x894480..0x894490
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9588,14 +9622,33 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x894490..0x8944a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 261 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x894490..0x8944a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x8941f0..0x894200]
+      OutOfLinePCRanges: [0x8944a0..0x8944b0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8941f0..0x894200
+            - Range: 0x8944a0..0x8944b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9608,7 +9661,7 @@ Subprograms:
         - Name: bs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8941f0..0x894200
+            - Range: 0x8944a0..0x8944b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9621,7 +9674,7 @@ Subprograms:
         - Name: cs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8941f0..0x894200
+            - Range: 0x8944a0..0x8944b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9632,36 +9685,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
+    - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x894510..0x894580]
+      OutOfLinePCRanges: [0x8947c0..0x894830]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894510..0x89455c
+            - Range: 0x8947c0..0x89480c
               Pieces: []
-            - Range: 0x89455c..0x89455d
+            - Range: 0x89480c..0x89480d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89455d..0x894580
+            - Range: 0x89480d..0x894830
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 145
+    - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x894580..0x894590]
+      OutOfLinePCRanges: [0x894830..0x894840]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894580..0x894590
+            - Range: 0x894830..0x894840
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9670,15 +9723,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x894590..0x8945a0]
+      OutOfLinePCRanges: [0x894840..0x894850]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894590..0x8945a0
+            - Range: 0x894840..0x894850
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9689,7 +9742,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894590..0x8945a0
+            - Range: 0x894840..0x894850
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9700,7 +9753,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894590..0x8945a0
+            - Range: 0x894840..0x894850
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9709,15 +9762,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 147
+    - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x8945a0..0x8945c0]
+      OutOfLinePCRanges: [0x894850..0x894870]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 263 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x8945a0..0x8945c0
+            - Range: 0x894850..0x894870
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9734,58 +9787,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 148
+    - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x8945c0..0x8945d0]
+      OutOfLinePCRanges: [0x894870..0x894880]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x8945c0..0x8945d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x8945d0..0x8945e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 265 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0x8945d0..0x8945e0
+            - Range: 0x894870..0x894880
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x8945e0..0x8945f0]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x894880..0x894890]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
+        - Name: a
+          Type: 265 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x8945e0..0x8945f0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x894880..0x894890
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x8945f0..0x894600]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x894890..0x8948a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8945f0..0x894600
+            - Range: 0x894890..0x8948a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9795,14 +9831,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 152
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x894600..0x894610]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x8948a0..0x8948b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894600..0x894610
+            - Range: 0x8948a0..0x8948b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9812,14 +9848,31 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 153
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x8948b0..0x8948c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x8948b0..0x8948c0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x894610..0x894620]
+      OutOfLinePCRanges: [0x8948c0..0x8948d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894610..0x894620
+            - Range: 0x8948c0..0x8948d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9830,7 +9883,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894610..0x894620
+            - Range: 0x8948c0..0x8948d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9841,7 +9894,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x894610..0x894620
+            - Range: 0x8948c0..0x8948d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9850,28 +9903,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
+    - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x894780..0x894790]
+      OutOfLinePCRanges: [0x894a30..0x894a40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x894780..0x894790
+            - Range: 0x894a30..0x894a40
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
+    - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x894790..0x8947b0]
+      OutOfLinePCRanges: [0x894a40..0x894a60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x894790..0x8947b0
+            - Range: 0x894a40..0x894a60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9888,15 +9941,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
+    - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x894880..0x8948a0]
+      OutOfLinePCRanges: [0x894b30..0x894b50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0x894880..0x8948a0
+            - Range: 0x894b30..0x894b50
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9915,157 +9968,157 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 157
+    - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x894920..0x894930]
+      OutOfLinePCRanges: [0x894bd0..0x894be0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 312 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x894920..0x894930
+            - Range: 0x894bd0..0x894be0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 158
+    - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x894930..0x894940]
+      OutOfLinePCRanges: [0x894be0..0x894bf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.tenStrings
           Locations:
-            - Range: 0x894930..0x894940
+            - Range: 0x894be0..0x894bf0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 159
+    - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x894980..0x894990]
+      OutOfLinePCRanges: [0x894c30..0x894c40]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 315 StructureType main.emptyStruct
-          Locations: [{Range: 0x894980..0x894990, Pieces: []}]
+          Locations: [{Range: 0x894c30..0x894c40, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 160
+    - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x894990..0x8949a0]
+      OutOfLinePCRanges: [0x894c40..0x894c50]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 316 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x894990..0x8949a0
+            - Range: 0x894c40..0x894c50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 161
+    - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x896410..0x896420]
+      OutOfLinePCRanges: [0x8966c0..0x8966d0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896410..0x896420
+            - Range: 0x8966c0..0x8966d0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x896410..0x896414
+            - Range: 0x8966c0..0x8966c4
               Pieces: []
-            - Range: 0x896414..0x896415
+            - Range: 0x8966c4..0x8966c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896415..0x896420
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 162
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x896420..0x896430]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 319 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x896420..0x89642c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89642c..0x896430
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x896420..0x89642c
-              Pieces: []
-            - Range: 0x89642c..0x89642d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89642d..0x896430
+            - Range: 0x8966c5..0x8966d0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0x8966d0..0x8966e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 319 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x8966d0..0x8966dc
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x8966dc..0x8966e0
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x8966d0..0x8966dc
+              Pieces: []
+            - Range: 0x8966dc..0x8966dd
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8966dd..0x8966e0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x896430..0x896440]
+      OutOfLinePCRanges: [0x8966e0..0x8966f0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x896430..0x896440
+            - Range: 0x8966e0..0x8966f0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896430..0x896434
+            - Range: 0x8966e0..0x8966e4
               Pieces: []
-            - Range: 0x896434..0x896435
+            - Range: 0x8966e4..0x8966e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896435..0x896440
+            - Range: 0x8966e5..0x8966f0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 164
+    - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x896440..0x896450]
+      OutOfLinePCRanges: [0x8966f0..0x896700]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x896440..0x89644c
+            - Range: 0x8966f0..0x8966fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x89644c..0x896450
+            - Range: 0x8966fc..0x896700
               Pieces:
                 - Size: 8
                   Op: null
@@ -10076,28 +10129,28 @@ Subprograms:
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896440..0x89644c
+            - Range: 0x8966f0..0x8966fc
               Pieces: []
-            - Range: 0x89644c..0x89644d
+            - Range: 0x8966fc..0x8966fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89644d..0x896450
+            - Range: 0x8966fd..0x896700
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x8964c0..0x8965f0]
+      OutOfLinePCRanges: [0x896770..0x8968a0]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8964c0..0x8964ec
+            - Range: 0x896770..0x89679c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10105,7 +10158,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8964ec..0x8964fc
+            - Range: 0x89679c..0x8967ac
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10113,7 +10166,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x8964fc..0x8965f0
+            - Range: 0x8967ac..0x8968a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10126,18 +10179,18 @@ Subprograms:
         - Name: pred
           Type: 323 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x8964c0..0x8964fc
+            - Range: 0x896770..0x8967ac
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8964fc..0x8965f0
+            - Range: 0x8967ac..0x8968a0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8964c0..0x8965ac
+            - Range: 0x896770..0x89685c
               Pieces: []
-            - Range: 0x8965ac..0x8965ad
+            - Range: 0x89685c..0x89685d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10145,14 +10198,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8965ad..0x8965f0
+            - Range: 0x89685d..0x8968a0
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8964fc..0x896518
+            - Range: 0x8967ac..0x8967c8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10160,7 +10213,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x896518..0x89651c
+            - Range: 0x8967c8..0x8967cc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10168,7 +10221,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x89651c..0x896520
+            - Range: 0x8967cc..0x8967d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10176,7 +10229,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x896520..0x896520
+            - Range: 0x8967d0..0x8967d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10184,7 +10237,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x896520..0x89654c
+            - Range: 0x8967d0..0x8967fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10192,7 +10245,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x89654c..0x8965a0
+            - Range: 0x8967fc..0x896850
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10200,7 +10253,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x8965a0..0x8965f0
+            - Range: 0x896850..0x8968a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10213,215 +10266,215 @@ Subprograms:
         - Name: item
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x89653c..0x89654c
+            - Range: 0x8967ec..0x8967fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89654c..0x8965a0
+            - Range: 0x8967fc..0x896850
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 166
+    - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x8965f0..0x896650]
+      OutOfLinePCRanges: [0x8968a0..0x896900]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8965f0..0x896618
+            - Range: 0x8968a0..0x8968c8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 324 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x8965f0..0x896618
+            - Range: 0x8968a0..0x8968c8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x8965f0..0x896618
+            - Range: 0x8968a0..0x8968c8
               Pieces: []
-            - Range: 0x896618..0x896619
+            - Range: 0x8968c8..0x8968c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896619..0x896650
+            - Range: 0x8968c9..0x896900
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 167
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x896900..0x896910]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 322 PointerType *go.shape.int
-          Locations:
-            - Range: 0x896900..0x896910
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 322 PointerType *go.shape.int
-          Locations:
-            - Range: 0x896900..0x896904
-              Pieces: []
-            - Range: 0x896904..0x896905
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896905..0x896910
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 168
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x896910..0x896920]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0x896bb0..0x896bc0]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 325 PointerType *go.shape.struct { Name string }
+          Type: 322 PointerType *go.shape.int
           Locations:
-            - Range: 0x896910..0x896920
+            - Range: 0x896bb0..0x896bc0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 325 PointerType *go.shape.struct { Name string }
+          Type: 322 PointerType *go.shape.int
           Locations:
-            - Range: 0x896910..0x896914
+            - Range: 0x896bb0..0x896bb4
               Pieces: []
-            - Range: 0x896914..0x896915
+            - Range: 0x896bb4..0x896bb5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896915..0x896920
+            - Range: 0x896bb5..0x896bc0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x896bc0..0x896bd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 325 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x896bc0..0x896bd0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 325 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x896bc0..0x896bc4
+              Pieces: []
+            - Range: 0x896bc4..0x896bc5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x896bc5..0x896bd0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x896920..0x896930]
+      OutOfLinePCRanges: [0x896bd0..0x896be0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 327 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x896920..0x896930
+            - Range: 0x896bd0..0x896be0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 327 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x896920..0x896924
+            - Range: 0x896bd0..0x896bd4
               Pieces: []
-            - Range: 0x896924..0x896925
+            - Range: 0x896bd4..0x896bd5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896925..0x896930
+            - Range: 0x896bd5..0x896be0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
+    - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x896930..0x896940]
+      OutOfLinePCRanges: [0x896be0..0x896bf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 329 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x896930..0x896940
+            - Range: 0x896be0..0x896bf0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896930..0x896938
+            - Range: 0x896be0..0x896be8
               Pieces: []
-            - Range: 0x896938..0x896939
+            - Range: 0x896be8..0x896be9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896939..0x896940
+            - Range: 0x896be9..0x896bf0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 171
+    - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x8969c0..0x8969d0]
+      OutOfLinePCRanges: [0x896c70..0x896c80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 331 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x8969c0..0x8969d0
+            - Range: 0x896c70..0x896c80
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x8969c0..0x8969c4
+            - Range: 0x896c70..0x896c74
               Pieces: []
-            - Range: 0x8969c4..0x8969c5
+            - Range: 0x896c74..0x896c75
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8969c5..0x8969d0
+            - Range: 0x896c75..0x896c80
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
+    - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x896a60..0x896a70]
+      OutOfLinePCRanges: [0x896d10..0x896d20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x896a60..0x896a70
+            - Range: 0x896d10..0x896d20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896a60..0x896a70
+            - Range: 0x896d10..0x896d20
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0x896a60..0x896a70
+            - Range: 0x896d10..0x896d20
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 173
+    - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x896af0..0x896b80]
+      OutOfLinePCRanges: [0x896da0..0x896e30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x896af0..0x896b80
+            - Range: 0x896da0..0x896e30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896af0..0x896b80
+            - Range: 0x896da0..0x896e30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10432,20 +10485,20 @@ Subprograms:
         - Name: v
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896af0..0x896b80
+            - Range: 0x896da0..0x896e30
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 174
+    - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x896c10..0x896c20]
+      OutOfLinePCRanges: [0x896ec0..0x896ed0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896c10..0x896c20
+            - Range: 0x896ec0..0x896ed0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10456,59 +10509,59 @@ Subprograms:
         - Name: b
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0x896c10..0x896c20
+            - Range: 0x896ec0..0x896ed0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 334 BaseType go.shape.bool
           Locations:
-            - Range: 0x896c10..0x896c18
+            - Range: 0x896ec0..0x896ec8
               Pieces: []
-            - Range: 0x896c18..0x896c19
+            - Range: 0x896ec8..0x896ec9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896c19..0x896c20
+            - Range: 0x896ec9..0x896ed0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896c10..0x896c18
+            - Range: 0x896ec0..0x896ec8
               Pieces: []
-            - Range: 0x896c18..0x896c19
+            - Range: 0x896ec8..0x896ec9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x896c19..0x896c20
+            - Range: 0x896ec9..0x896ed0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 175
+    - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x896c20..0x896c40]
+      OutOfLinePCRanges: [0x896ed0..0x896ef0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896c20..0x896c30
+            - Range: 0x896ed0..0x896ee0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896c20..0x896c2c
+            - Range: 0x896ed0..0x896edc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x896c2c..0x896c40
+            - Range: 0x896edc..0x896ef0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10519,73 +10572,73 @@ Subprograms:
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896c20..0x896c30
+            - Range: 0x896ed0..0x896ee0
               Pieces: []
-            - Range: 0x896c30..0x896c31
+            - Range: 0x896ee0..0x896ee1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896c31..0x896c40
+            - Range: 0x896ee1..0x896ef0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896c20..0x896c30
+            - Range: 0x896ed0..0x896ee0
               Pieces: []
-            - Range: 0x896c30..0x896c31
+            - Range: 0x896ee0..0x896ee1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x896c31..0x896c40
+            - Range: 0x896ee1..0x896ef0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 176
+    - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x896c40..0x896c90]
+      OutOfLinePCRanges: [0x896ef0..0x896f40]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 337 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x896c40..0x896c68
+            - Range: 0x896ef0..0x896f18
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x896c40..0x896c68
+            - Range: 0x896ef0..0x896f18
               Pieces: []
-            - Range: 0x896c68..0x896c69
+            - Range: 0x896f18..0x896f19
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896c69..0x896c90
+            - Range: 0x896f19..0x896f40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 177
+    - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x896c90..0x896cf0]
+      OutOfLinePCRanges: [0x896f40..0x896fa0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 338 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x896c90..0x896cbc
+            - Range: 0x896f40..0x896f6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x896cbc..0x896cc0
+            - Range: 0x896f6c..0x896f70
               Pieces:
                 - Size: 8
                   Op: null
@@ -10596,65 +10649,65 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x896c90..0x896cc0
+            - Range: 0x896f40..0x896f70
               Pieces: []
-            - Range: 0x896cc0..0x896cc1
+            - Range: 0x896f70..0x896f71
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896cc1..0x896cf0
+            - Range: 0x896f71..0x896fa0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 178
+    - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x896cf0..0x896d00]
+      OutOfLinePCRanges: [0x896fa0..0x896fb0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 339 PointerType *go.shape.string
           Locations:
-            - Range: 0x896cf0..0x896cf8
+            - Range: 0x896fa0..0x896fa8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896cf0..0x896cf8
+            - Range: 0x896fa0..0x896fa8
               Pieces: []
-            - Range: 0x896cf8..0x896cf9
+            - Range: 0x896fa8..0x896fa9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896cf9..0x896d00
+            - Range: 0x896fa9..0x896fb0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 179
+    - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x896d00..0x896d60]
+      OutOfLinePCRanges: [0x896fb0..0x897010]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 340 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x896d00..0x896d3c
+            - Range: 0x896fb0..0x896fec
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 341 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x896d00..0x896d4c
+            - Range: 0x896fb0..0x896ffc
               Pieces: []
-            - Range: 0x896d4c..0x896d4d
+            - Range: 0x896ffc..0x896ffd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10668,20 +10721,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x896d4d..0x896d60
+            - Range: 0x896ffd..0x897010
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 180
+    - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x896d60..0x896da0]
+      OutOfLinePCRanges: [0x897010..0x897050]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 321 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x896d60..0x896d6c
+            - Range: 0x897010..0x89701c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10689,7 +10742,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x896d6c..0x896da0
+            - Range: 0x89701c..0x897050
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10702,42 +10755,42 @@ Subprograms:
         - Name: needle
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896d60..0x896da0
+            - Range: 0x897010..0x897050
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x896d60..0x896d88
+            - Range: 0x897010..0x897038
               Pieces: []
-            - Range: 0x896d88..0x896d89
+            - Range: 0x897038..0x897039
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896d89..0x896d90
+            - Range: 0x897039..0x897040
               Pieces: []
-            - Range: 0x896d90..0x896d91
+            - Range: 0x897040..0x897041
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896d91..0x896da0
+            - Range: 0x897041..0x897050
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896d7c..0x896d8c
+            - Range: 0x89702c..0x89703c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 181
+    - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x896da0..0x896e70]
+      OutOfLinePCRanges: [0x897050..0x897120]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 342 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x896da0..0x896dc4
+            - Range: 0x897050..0x897074
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10745,7 +10798,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x896dc4..0x896dc8
+            - Range: 0x897074..0x897078
               Pieces:
                 - Size: 8
                   Op: null
@@ -10758,13 +10811,13 @@ Subprograms:
         - Name: needle
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896da0..0x896dfc
+            - Range: 0x897050..0x8970ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x896dfc..0x896e70
+            - Range: 0x8970ac..0x897120
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10775,28 +10828,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x896da0..0x896e18
+            - Range: 0x897050..0x8970c8
               Pieces: []
-            - Range: 0x896e18..0x896e19
+            - Range: 0x8970c8..0x8970c9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896e19..0x896e28
+            - Range: 0x8970c9..0x8970d8
               Pieces: []
-            - Range: 0x896e28..0x896e29
+            - Range: 0x8970d8..0x8970d9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896e29..0x896e70
+            - Range: 0x8970d9..0x897120
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896ddc..0x896df0
+            - Range: 0x89708c..0x8970a0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x896df0..0x896dfc
+            - Range: 0x8970a0..0x8970ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10805,58 +10858,58 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 182
+    - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x896e70..0x896e80]
+      OutOfLinePCRanges: [0x897120..0x897130]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 343 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x896e70..0x896e78
+            - Range: 0x897120..0x897128
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 317 BaseType go.shape.int
           Locations:
-            - Range: 0x896e70..0x896e80
+            - Range: 0x897120..0x897130
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x896e70..0x896e78
+            - Range: 0x897120..0x897128
               Pieces: []
-            - Range: 0x896e78..0x896e79
+            - Range: 0x897128..0x897129
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896e79..0x896e80
+            - Range: 0x897129..0x897130
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
-    - ID: 183
+    - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x896f00..0x896f80]
+      OutOfLinePCRanges: [0x8971b0..0x897230]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 344 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x896f00..0x896f2c
+            - Range: 0x8971b0..0x8971dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896f2c..0x896f38
+            - Range: 0x8971dc..0x8971e8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x896f38..0x896f3c
+            - Range: 0x8971e8..0x8971ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10867,7 +10920,7 @@ Subprograms:
         - Name: value
           Type: 319 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x896f00..0x896f3c
+            - Range: 0x8971b0..0x8971ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10878,16 +10931,16 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x896f00..0x896f3c
+            - Range: 0x8971b0..0x8971ec
               Pieces: []
-            - Range: 0x896f3c..0x896f3d
+            - Range: 0x8971ec..0x8971ed
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x896f3d..0x896f80
+            - Range: 0x8971ed..0x897230
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 184
+    - ID: 185
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x12ace0..0x12ae10]
       InlinePCRanges: []
@@ -11018,7 +11071,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 185
+    - ID: 186
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x88f120..0x88f190]
       InlinePCRanges:
@@ -11049,7 +11102,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 186
+    - ID: 187
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11057,7 +11110,7 @@ Subprograms:
           RootRanges: [0x88f350..0x88f420]
       Variables: []
       DictRegister: null
-    - ID: 187
+    - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11065,7 +11118,7 @@ Subprograms:
           RootRanges: [0x88f4a0..0x88f5c0]
       Variables: []
       DictRegister: null
-    - ID: 188
+    - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11073,7 +11126,7 @@ Subprograms:
           RootRanges: [0x88f4a0..0x88f5c0]
       Variables: []
       DictRegister: null
-    - ID: 189
+    - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11088,7 +11141,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 191
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11107,12 +11160,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 191
+    - ID: 192
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x88f780..0x88f800]
       InlinePCRanges:
-        - Ranges: [0x89703c..0x897070]
-          RootRanges: [0x897010..0x8970c0]
+        - Ranges: [0x8972ec..0x897320]
+          RootRanges: [0x8972c0..0x897370]
       Variables:
         - Name: b
           Type: 349 StructureType main.firstBehavior
@@ -11147,7 +11200,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 192
+    - ID: 193
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -14181,7 +14234,7 @@ Types:
       GoKind: 22
       Pointee: 715 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1438
+      ID: 1439
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14200,7 +14253,7 @@ Types:
             Type: 345 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14211,7 +14264,7 @@ Types:
             Type: 345 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14222,12 +14275,12 @@ Types:
             Type: 348 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: pred}
+                  Variable: {subprogram: 185, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1439
+      ID: 1440
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14240,12 +14293,12 @@ Types:
             Type: 345 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 185, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1436
+      ID: 1437
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14264,7 +14317,7 @@ Types:
             Type: 321 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14275,7 +14328,7 @@ Types:
             Type: 321 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14286,12 +14339,12 @@ Types:
             Type: 323 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: pred}
+                  Variable: {subprogram: 166, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1437
+      ID: 1438
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14304,15 +14357,15 @@ Types:
             Type: 321 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 2, name: ~r0}
+                  Variable: {subprogram: 166, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1494
+      ID: 1495
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1440
+      ID: 1441
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14331,7 +14384,7 @@ Types:
             Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14342,7 +14395,7 @@ Types:
             Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14353,12 +14406,12 @@ Types:
             Type: 324 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: f}
+                  Variable: {subprogram: 167, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1441
+      ID: 1442
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14371,12 +14424,12 @@ Types:
             Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 2, name: ~r0}
+                  Variable: {subprogram: 167, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1452
+      ID: 1453
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14398,7 +14451,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14409,7 +14462,7 @@ Types:
             Type: 332 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: x}
+                  Variable: {subprogram: 173, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14420,7 +14473,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14431,15 +14484,15 @@ Types:
             Type: 334 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 2, name: v}
+                  Variable: {subprogram: 173, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1453
+      ID: 1454
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1454
+      ID: 1455
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14461,7 +14514,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14472,7 +14525,7 @@ Types:
             Type: 335 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: x}
+                  Variable: {subprogram: 174, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14483,7 +14536,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14494,15 +14547,15 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 2, name: v}
+                  Variable: {subprogram: 174, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1455
+      ID: 1456
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1492
+      ID: 1493
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14514,12 +14567,12 @@ Types:
             Type: 349 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 0, name: b}
+                  Variable: {subprogram: 192, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1493
+      ID: 1494
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14531,12 +14584,12 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 1, name: ~r0}
+                  Variable: {subprogram: 192, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1468
+      ID: 1469
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14555,7 +14608,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14566,7 +14619,7 @@ Types:
             Type: 321 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14577,14 +14630,14 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1472
+      ID: 1473
       Name: Probe[main.genericContains[go.shape.int]]Line
-      ByteSize: 50
+      ByteSize: 49
       ExprStatusArraySize: 1
       DictEntries:
         - DictIndex: 0
@@ -14601,7 +14654,7 @@ Types:
             Type: 321 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14612,23 +14665,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
-        - Name: '@return'
-          Offset: 49
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1469
+      ID: 1470
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14640,12 +14682,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1470
+      ID: 1471
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14664,7 +14706,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14675,7 +14717,7 @@ Types:
             Type: 342 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: haystack}
+                  Variable: {subprogram: 182, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14686,14 +14728,14 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1473
+      ID: 1474
       Name: Probe[main.genericContains[go.shape.string]]Line
-      ByteSize: 26
+      ByteSize: 25
       ExprStatusArraySize: 1
       DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
       Expressions:
@@ -14704,23 +14746,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
-        - Name: '@return'
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1471
+      ID: 1472
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14732,12 +14763,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1464
+      ID: 1465
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14750,7 +14781,7 @@ Types:
             Type: 339 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14761,12 +14792,12 @@ Types:
             Type: 339 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1465
+      ID: 1466
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14779,12 +14810,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Variable: {subprogram: 179, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1466
+      ID: 1467
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14797,7 +14828,7 @@ Types:
             Type: 340 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14808,12 +14839,12 @@ Types:
             Type: 340 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1467
+      ID: 1468
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14826,12 +14857,12 @@ Types:
             Type: 341 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: ~r0}
+                  Variable: {subprogram: 180, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1460
+      ID: 1461
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14844,7 +14875,7 @@ Types:
             Type: 337 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14855,59 +14886,13 @@ Types:
             Type: 337 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1461
-      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: '@return'
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1462
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
-      Expressions:
-        - Name: val
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 338 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-        - Name: val
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 338 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-    - __kind: EventRootType
-      ID: 1463
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -14923,7 +14908,53 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1463
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
+      Expressions:
+        - Name: val
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 338 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+        - Name: val
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 338 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+    - __kind: EventRootType
+      ID: 1464
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1443
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14936,7 +14967,7 @@ Types:
             Type: 322 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14947,12 +14978,12 @@ Types:
             Type: 322 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1443
+      ID: 1444
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14965,12 +14996,12 @@ Types:
             Type: 322 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1444
+      ID: 1445
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14983,7 +15014,7 @@ Types:
             Type: 325 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14994,12 +15025,12 @@ Types:
             Type: 325 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1445
+      ID: 1446
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15012,12 +15043,12 @@ Types:
             Type: 325 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1446
+      ID: 1447
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15030,7 +15061,7 @@ Types:
             Type: 327 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15041,12 +15072,12 @@ Types:
             Type: 327 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1447
+      ID: 1448
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15059,12 +15090,12 @@ Types:
             Type: 327 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1458
+      ID: 1459
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15083,7 +15114,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15094,7 +15125,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15105,12 +15136,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: b}
+                  Variable: {subprogram: 176, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1459
+      ID: 1460
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15129,7 +15160,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 2, name: ~r0}
+                  Variable: {subprogram: 176, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -15140,12 +15171,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 3, name: ~r1}
+                  Variable: {subprogram: 176, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1456
+      ID: 1457
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15164,7 +15195,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15175,7 +15206,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15186,12 +15217,12 @@ Types:
             Type: 334 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: b}
+                  Variable: {subprogram: 175, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1457
+      ID: 1458
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15210,7 +15241,7 @@ Types:
             Type: 334 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 2, name: ~r0}
+                  Variable: {subprogram: 175, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
@@ -15221,12 +15252,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 3, name: ~r1}
+                  Variable: {subprogram: 175, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1450
+      ID: 1451
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15239,7 +15270,7 @@ Types:
             Type: 331 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
@@ -15250,12 +15281,12 @@ Types:
             Type: 331 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1451
+      ID: 1452
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15268,12 +15299,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 172, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1448
+      ID: 1449
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15286,7 +15317,7 @@ Types:
             Type: 329 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
@@ -15297,12 +15328,12 @@ Types:
             Type: 329 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1449
+      ID: 1450
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15315,12 +15346,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1432
+      ID: 1433
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15333,7 +15364,7 @@ Types:
             Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15344,12 +15375,12 @@ Types:
             Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1433
+      ID: 1434
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15362,12 +15393,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1434
+      ID: 1435
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15380,7 +15411,7 @@ Types:
             Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15391,12 +15422,12 @@ Types:
             Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1435
+      ID: 1436
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15409,15 +15440,15 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1398
+      ID: 1399
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1399
+      ID: 1400
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15429,7 +15460,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: ~r0}
+                  Variable: {subprogram: 145, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -15524,7 +15555,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1369
+      ID: 1370
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15536,7 +15567,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -15547,12 +15578,12 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1370
+      ID: 1371
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15564,7 +15595,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16266,7 +16297,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1389
+      ID: 1390
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16278,7 +16309,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16289,7 +16320,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16300,7 +16331,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16311,12 +16342,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1386
+      ID: 1387
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16328,7 +16359,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16339,12 +16370,12 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1412
+      ID: 1413
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16356,7 +16387,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -16367,12 +16398,12 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1427
+      ID: 1428
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16384,7 +16415,7 @@ Types:
             Type: 316 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16395,12 +16426,12 @@ Types:
             Type: 316 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1426
+      ID: 1427
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16412,7 +16443,7 @@ Types:
             Type: 315 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -16423,18 +16454,18 @@ Types:
             Type: 315 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
       ID: 1208
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 58
-      ExprStatusArraySize: 2
+      ByteSize: 49
+      ExprStatusArraySize: 1
       Expressions:
         - Name: x
-          Offset: 2
+          Offset: 1
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -16445,7 +16476,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 10
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 18 GoInterfaceType error
@@ -16455,19 +16486,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: '@return'
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
         - Name: x
-          Offset: 34
+          Offset: 25
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -16478,7 +16498,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 42
+          Offset: 33
           Kind: local
           Expression:
             Type: 18 GoInterfaceType error
@@ -16609,7 +16629,7 @@ Types:
     - __kind: EventRootType
       ID: 1236
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 89
+      ByteSize: 81
       ExprStatusArraySize: 1
       Expressions:
         - Name: a
@@ -16633,17 +16653,6 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-          DictIndex: -1
-        - Name: '@return'
-          Offset: 81
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1235
@@ -16770,7 +16779,7 @@ Types:
       ID: 1229
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1484
+      ID: 1485
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1226
@@ -16826,16 +16835,16 @@ Types:
       ID: 1227
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1485
+      ID: 1486
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1487
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1487
+      ID: 1488
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1489
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1230
@@ -16844,7 +16853,7 @@ Types:
       ID: 1231
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1481
+      ID: 1482
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16856,7 +16865,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16867,24 +16876,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1478
-      Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x_val
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16901,12 +16893,29 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1480
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 186, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1481
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16918,7 +16927,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16929,12 +16938,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1483
+      ID: 1484
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16946,7 +16955,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16957,15 +16966,15 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1482
+      ID: 1483
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1489
+      ID: 1490
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16977,7 +16986,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16988,12 +16997,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1490
+      ID: 1491
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17005,7 +17014,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17016,12 +17025,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1491
+      ID: 1492
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17033,7 +17042,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17044,7 +17053,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17217,7 +17226,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1367
+      ID: 1368
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -17229,7 +17238,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17240,12 +17249,12 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1368
+      ID: 1369
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17257,7 +17266,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: ~r0}
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17349,7 +17358,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1373
+      ID: 1374
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -17361,7 +17370,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17372,7 +17381,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17383,7 +17392,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17394,7 +17403,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17405,7 +17414,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17416,7 +17425,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17427,7 +17436,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17438,7 +17447,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17449,7 +17458,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17460,7 +17469,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17471,7 +17480,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17482,7 +17491,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17493,7 +17502,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17504,7 +17513,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17515,7 +17524,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17526,7 +17535,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17537,7 +17546,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17548,12 +17557,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1374
+      ID: 1375
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17565,7 +17574,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 9, name: ~r0}
+                  Variable: {subprogram: 127, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18130,34 +18139,6 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1409
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1410
       Name: Probe[main.testMassiveString]
       ByteSize: 33
@@ -18170,7 +18151,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18181,12 +18162,40 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1375
+      ID: 1411
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1376
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -18198,7 +18207,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18209,7 +18218,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18220,7 +18229,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18231,7 +18240,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18242,7 +18251,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18253,7 +18262,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18264,7 +18273,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18275,7 +18284,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18286,7 +18295,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18297,7 +18306,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18308,7 +18317,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18319,7 +18328,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18330,7 +18339,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18341,7 +18350,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18352,7 +18361,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18363,7 +18372,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18374,7 +18383,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18385,12 +18394,12 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1376
+      ID: 1377
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18402,12 +18411,12 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 9, name: ~r0}
+                  Variable: {subprogram: 128, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1379
+      ID: 1380
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18419,7 +18428,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18430,7 +18439,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -18441,7 +18450,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18452,12 +18461,12 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1380
+      ID: 1381
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -18469,7 +18478,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18480,12 +18489,12 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1371
+      ID: 1372
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -18497,7 +18506,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18508,7 +18517,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18519,7 +18528,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18530,12 +18539,12 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1372
+      ID: 1373
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18547,7 +18556,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -19200,7 +19209,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1421
+      ID: 1422
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19212,7 +19221,7 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19223,12 +19232,12 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1422
+      ID: 1423
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19240,7 +19249,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19251,10 +19260,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1423
+      ID: 1424
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1424
+      ID: 1425
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19266,7 +19275,7 @@ Types:
             Type: 116 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19327,7 +19336,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1390
+      ID: 1391
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -19339,7 +19348,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19350,7 +19359,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19361,7 +19370,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19372,12 +19381,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1392
+      ID: 1393
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -19389,7 +19398,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19400,7 +19409,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19411,7 +19420,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19422,7 +19431,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19433,7 +19442,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19444,12 +19453,12 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1393
+      ID: 1394
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -19461,7 +19470,7 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19472,12 +19481,12 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1408
+      ID: 1409
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19489,7 +19498,7 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19500,7 +19509,7 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19712,10 +19721,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1347
+      ID: 1348
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1348
+      ID: 1349
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -19727,15 +19736,15 @@ Types:
             Type: 247 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1349
+      ID: 1350
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1350
+      ID: 1351
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -19747,15 +19756,15 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1345
+      ID: 1346
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1346
+      ID: 1347
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19767,15 +19776,15 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1353
+      ID: 1354
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1354
+      ID: 1355
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -19787,7 +19796,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19798,7 +19807,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19809,7 +19818,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19820,7 +19829,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19831,7 +19840,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19842,7 +19851,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 5, name: ~r5}
+                  Variable: {subprogram: 117, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19853,7 +19862,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 6, name: ~r6}
+                  Variable: {subprogram: 117, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19864,7 +19873,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 7, name: ~r7}
+                  Variable: {subprogram: 117, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19875,15 +19884,15 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 8, name: ~r8}
+                  Variable: {subprogram: 117, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1365
+      ID: 1366
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1366
+      ID: 1367
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -19895,7 +19904,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: ~r0}
+                  Variable: {subprogram: 123, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19906,15 +19915,15 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r1}
+                  Variable: {subprogram: 123, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1341
+      ID: 1342
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1342
+      ID: 1343
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19926,7 +19935,7 @@ Types:
             Type: 90 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19937,7 +19946,7 @@ Types:
             Type: 91 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: ~r1}
+                  Variable: {subprogram: 111, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -20400,10 +20409,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1343
+      ID: 1344
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1344
+      ID: 1345
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -20415,15 +20424,15 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1339
+      ID: 1340
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1340
+      ID: 1341
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -20435,7 +20444,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20446,7 +20455,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: ~r1}
+                  Variable: {subprogram: 110, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20457,7 +20466,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 2, name: ~r2}
+                  Variable: {subprogram: 110, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20468,7 +20477,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 3, name: ~r3}
+                  Variable: {subprogram: 110, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20479,7 +20488,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 4, name: ~r4}
+                  Variable: {subprogram: 110, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20490,7 +20499,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 5, name: ~r5}
+                  Variable: {subprogram: 110, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20501,7 +20510,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 6, name: ~r6}
+                  Variable: {subprogram: 110, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20512,7 +20521,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 7, name: ~r7}
+                  Variable: {subprogram: 110, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20523,7 +20532,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 8, name: ~r8}
+                  Variable: {subprogram: 110, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20534,7 +20543,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 9, name: ~r9}
+                  Variable: {subprogram: 110, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20545,7 +20554,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 10, name: ~r10}
+                  Variable: {subprogram: 110, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20556,7 +20565,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 11, name: ~r11}
+                  Variable: {subprogram: 110, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20567,7 +20576,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 12, name: ~r12}
+                  Variable: {subprogram: 110, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20578,7 +20587,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 13, name: ~r13}
+                  Variable: {subprogram: 110, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20589,7 +20598,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 14, name: ~r14}
+                  Variable: {subprogram: 110, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20600,7 +20609,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 110, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20611,15 +20620,15 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 110, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1351
+      ID: 1352
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1352
+      ID: 1353
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20631,15 +20640,15 @@ Types:
             Type: 249 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1357
+      ID: 1358
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1358
+      ID: 1359
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20651,7 +20660,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20662,7 +20671,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20673,7 +20682,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 2, name: ~r2}
+                  Variable: {subprogram: 119, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20684,7 +20693,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 3, name: ~r3}
+                  Variable: {subprogram: 119, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20695,15 +20704,15 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 4, name: ~r4}
+                  Variable: {subprogram: 119, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1363
+      ID: 1364
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1364
+      ID: 1365
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -20715,7 +20724,7 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: ~r0}
+                  Variable: {subprogram: 122, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20726,15 +20735,65 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r1}
+                  Variable: {subprogram: 122, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1361
-      Name: Probe[main.testReturnsOnlyFloat]
+      ID: 1337
+      Name: Probe[main.testReturnsNamedDeferLine]Line
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: a
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 1362
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1363
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20746,15 +20805,15 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1337
+      ID: 1338
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1338
+      ID: 1339
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -20766,7 +20825,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20777,7 +20836,7 @@ Types:
             Type: 89 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -20788,7 +20847,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: ~r2}
+                  Variable: {subprogram: 109, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20799,7 +20858,7 @@ Types:
             Type: 14 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 3, name: ~r3}
+                  Variable: {subprogram: 109, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20810,7 +20869,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 4, name: ~r4}
+                  Variable: {subprogram: 109, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20821,7 +20880,7 @@ Types:
             Type: 7 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 5, name: ~r5}
+                  Variable: {subprogram: 109, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -20832,7 +20891,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 6, name: ~r6}
+                  Variable: {subprogram: 109, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -20843,15 +20902,15 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 7, name: ~r7}
+                  Variable: {subprogram: 109, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1359
+      ID: 1360
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1360
+      ID: 1361
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20863,15 +20922,15 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1355
+      ID: 1356
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1356
+      ID: 1357
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -20883,7 +20942,7 @@ Types:
             Type: 250 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
           DictIndex: -1
@@ -21168,7 +21227,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1400
+      ID: 1401
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21180,7 +21239,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21191,7 +21250,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21336,7 +21395,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1396
+      ID: 1397
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21348,7 +21407,7 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21359,12 +21418,12 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1387
+      ID: 1388
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21376,7 +21435,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21387,7 +21446,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21641,7 +21700,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1377
+      ID: 1378
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -21653,7 +21712,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -21664,12 +21723,12 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1378
+      ID: 1379
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21681,7 +21740,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21692,7 +21751,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21703,7 +21762,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r2}
+                  Variable: {subprogram: 129, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21764,7 +21823,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1391
+      ID: 1392
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21776,7 +21835,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21787,7 +21846,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21848,7 +21907,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1388
+      ID: 1389
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -21860,7 +21919,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21871,7 +21930,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21882,7 +21941,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21893,7 +21952,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21926,7 +21985,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1381
+      ID: 1382
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21938,7 +21997,7 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21949,12 +22008,12 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1382
+      ID: 1383
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21966,7 +22025,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 1, name: ~r0}
+                  Variable: {subprogram: 131, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21977,12 +22036,12 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 2, name: ~r1}
+                  Variable: {subprogram: 131, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1415
+      ID: 1416
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -21994,7 +22053,7 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22005,15 +22064,15 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1416
+      ID: 1417
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1414
+      ID: 1415
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -22025,7 +22084,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22036,7 +22095,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22069,7 +22128,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1417
+      ID: 1418
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22081,12 +22140,12 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1419
+      ID: 1420
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -22098,7 +22157,7 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
@@ -22109,18 +22168,18 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1418
+      ID: 1419
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1420
+      ID: 1421
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1397
+      ID: 1398
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -22132,7 +22191,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22143,7 +22202,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22154,7 +22213,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22165,7 +22224,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22176,7 +22235,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22187,12 +22246,12 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1413
+      ID: 1414
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22204,7 +22263,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22215,7 +22274,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22226,7 +22285,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22237,7 +22296,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22248,7 +22307,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22259,12 +22318,12 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1425
+      ID: 1426
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -22276,12 +22335,12 @@ Types:
             Type: 314 StructureType main.tenStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 160
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1406
+      ID: 1407
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22293,7 +22352,7 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22304,12 +22363,12 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1407
+      ID: 1408
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22321,7 +22380,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22335,7 +22394,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22349,7 +22408,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22357,7 +22416,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1402
+      ID: 1403
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22369,7 +22428,7 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22380,12 +22439,12 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1404
+      ID: 1405
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22397,7 +22456,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22408,7 +22467,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
           DictIndex: -1
@@ -22419,18 +22478,18 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1403
+      ID: 1404
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1405
+      ID: 1406
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1401
+      ID: 1402
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22442,7 +22501,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22453,7 +22512,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22464,7 +22523,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22475,7 +22534,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22486,7 +22545,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22497,7 +22556,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22698,7 +22757,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1385
+      ID: 1386
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22710,7 +22769,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22721,12 +22780,12 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1411
+      ID: 1412
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22738,7 +22797,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22749,7 +22808,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22810,34 +22869,6 @@ Types:
                   ByteSize: 800
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1394
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1395
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -22850,7 +22881,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22861,12 +22892,40 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1383
+      ID: 1396
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1384
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22878,7 +22937,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -22889,7 +22948,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22900,7 +22959,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -22911,12 +22970,12 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1384
+      ID: 1385
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -22928,7 +22987,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 2, name: ~r0}
+                  Variable: {subprogram: 132, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22939,12 +22998,12 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 3, name: ~r1}
+                  Variable: {subprogram: 132, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1474
+      ID: 1475
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -22963,7 +23022,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -22974,7 +23033,7 @@ Types:
             Type: 343 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: x}
+                  Variable: {subprogram: 183, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -22985,12 +23044,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1475
+      ID: 1476
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23002,12 +23061,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 2, name: ~r0}
+                  Variable: {subprogram: 183, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1476
+      ID: 1477
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23026,7 +23085,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -23037,7 +23096,7 @@ Types:
             Type: 344 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: x}
+                  Variable: {subprogram: 184, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23048,12 +23107,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1477
+      ID: 1478
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23065,12 +23124,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 2, name: ~r0}
+                  Variable: {subprogram: 184, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1428
+      ID: 1429
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23083,7 +23142,7 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23094,12 +23153,12 @@ Types:
             Type: 317 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1429
+      ID: 1430
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23112,12 +23171,12 @@ Types:
             Type: 318 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 1, name: ~r0}
+                  Variable: {subprogram: 162, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1430
+      ID: 1431
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23130,7 +23189,7 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23141,12 +23200,12 @@ Types:
             Type: 319 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1431
+      ID: 1432
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23159,7 +23218,7 @@ Types:
             Type: 320 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 1, name: ~r0}
+                  Variable: {subprogram: 163, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -30556,7 +30615,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 956576
       GoKind: 5
-MaxTypeID: 1494
+MaxTypeID: 1495
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -9,15 +9,15 @@ Probes:
       segments: [stackC]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 144}
+        - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1573 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x851a98", Frameless: false}]
+              Type: 1574 EventRootType Probe[main.stackC]
+              InjectionPoints: [{PC: "0x851d48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1574 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x851acc", Frameless: false}]
+              Type: 1575 EventRootType Probe[main.stackC]Return
+              InjectionPoints: [{PC: "0x851d7c", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -80,15 +80,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 124}
+        - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1544 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x85089c", Frameless: false}]
+              Type: 1545 EventRootType Probe[main.testArrayArgAndReturn]
+              InjectionPoints: [{PC: "0x850b3c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1545 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x850934", Frameless: false}]
+              Type: 1546 EventRootType Probe[main.testArrayArgAndReturn]Return
+              InjectionPoints: [{PC: "0x850bd4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -338,15 +338,15 @@ Probes:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x851df0", Frameless: true}]
+              Type: 1593 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x8520a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1593 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x851e0c", Frameless: true}]
+              Type: 1594 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0x8520bc", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1653 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1654 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x84c7c8"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1654 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1655 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x84c7c8"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 185, index: 0, name: x}
+                      Variable: {subprogram: 186, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -433,10 +433,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1655 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1656 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x84c7c8"
                   Frameless: false
@@ -515,16 +515,16 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 158}
+        - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x851ea0", Frameless: true}]
+              Type: 1601 EventRootType Probe[main.testTenStrings]
+              InjectionPoints: [{PC: "0x852150", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 158, index: 0, name: x}
+                      Variable: {subprogram: 159, index: 0, name: x}
                       Offset: 144
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -789,11 +789,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 133}
+        - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1561 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x8516c0", Frameless: true}]
+              Type: 1562 EventRootType Probe[main.testEmptySlice]
+              InjectionPoints: [{PC: "0x851970", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -816,11 +816,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 136}
+        - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1564 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x8516f0", Frameless: true}]
+              Type: 1565 EventRootType Probe[main.testEmptySliceOfStructs]
+              InjectionPoints: [{PC: "0x8519a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -844,11 +844,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 152}
+        - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x851b70", Frameless: true}]
+              Type: 1588 EventRootType Probe[main.testEmptyString]
+              InjectionPoints: [{PC: "0x851e20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -866,11 +866,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 159}
+        - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x851ef0", Frameless: true}]
+              Type: 1602 EventRootType Probe[main.testEmptyStruct]
+              InjectionPoints: [{PC: "0x8521a0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -887,11 +887,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 160}
+        - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x851f00", Frameless: true}]
+              Type: 1603 EventRootType Probe[main.testEmptyStructPointer]
+              InjectionPoints: [{PC: "0x8521b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1100,15 +1100,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1639 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x854060", Frameless: true}]
+              Type: 1640 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0x854310", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1640 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x854068", Frameless: true}]
+              Type: 1641 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x854318", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1118,15 +1118,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1641 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x854080", Frameless: false}]
+              Type: 1642 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0x854330", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1642 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x8540bc", Frameless: false}]
+              Type: 1643 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0x85436c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1145,15 +1145,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1635 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x853fc8", Frameless: false}]
+              Type: 1636 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0x854278", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1636 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x853fd8", Frameless: false}]
+              Type: 1637 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0x854288", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1163,15 +1163,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1637 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x854018", Frameless: false}]
+              Type: 1638 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0x8542c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1638 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x854030", Frameless: false}]
+              Type: 1639 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0x8542e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1190,18 +1190,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1643 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x8540d0", Frameless: true}]
+              Type: 1644 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0x854380", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1644 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1645 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x8540f8"
+                - PC: "0x8543a8"
                   Frameless: true
-                - PC: "0x854100"
+                - PC: "0x8543b0"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1212,18 +1212,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1645 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x854128", Frameless: false}]
+              Type: 1646 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0x8543d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1646 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1647 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x854188"
+                - PC: "0x854438"
                   Frameless: false
-                - PC: "0x854198"
+                - PC: "0x854448"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1246,11 +1246,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Line
-              Type: 1647 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x8540d4", Frameless: true}]
+              Type: 1648 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0x854384", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1258,11 +1258,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Line
-              Type: 1648 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x854138", Frameless: false}]
+              Type: 1649 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0x8543e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1279,15 +1279,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1623 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x853cc0", Frameless: true}]
+              Type: 1624 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0x853f70", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1624 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x853cc8", Frameless: true}]
+              Type: 1625 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0x853f78", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1297,15 +1297,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1625 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x853d50", Frameless: true}]
+              Type: 1626 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0x854000", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1626 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x853d54", Frameless: true}]
+              Type: 1627 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0x854004", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1325,15 +1325,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 166}
           events:
             - Kind: Entry
-              Type: 1611 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x8538c8", Frameless: false}]
+              Type: 1612 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0x853b78", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1612 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x85399c", Frameless: false}]
+              Type: 1613 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x853c4c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1343,14 +1343,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1613 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1614 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x12a058", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1614 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1615 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x12a12c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1371,15 +1371,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 167}
           events:
             - Kind: Entry
-              Type: 1615 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x8539e8", Frameless: false}]
+              Type: 1616 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x853c98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1616 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x8539f8", Frameless: false}]
+              Type: 1617 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x853ca8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1398,15 +1398,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1649 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x8541d0", Frameless: true}]
+              Type: 1650 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0x854480", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1650 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x8541d8", Frameless: true}]
+              Type: 1651 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0x854488", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1416,15 +1416,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1651 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x854268", Frameless: false}]
+              Type: 1652 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0x854518", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1652 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x85428c", Frameless: false}]
+              Type: 1653 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0x85453c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1443,15 +1443,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 163}
+        - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1607 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x853830", Frameless: true}]
+              Type: 1608 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0x853ae0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1608 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x853834", Frameless: true}]
+              Type: 1609 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x853ae4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1461,15 +1461,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 164}
+        - subprogram: {subprogram: 165}
           events:
             - Kind: Entry
-              Type: 1609 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x853840", Frameless: true}]
+              Type: 1610 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0x853af0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1610 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x85384c", Frameless: true}]
+              Type: 1611 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x853afc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1488,15 +1488,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1627 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x853df0", Frameless: true}]
+              Type: 1628 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0x8540a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1628 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x853df8", Frameless: true}]
+              Type: 1629 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0x8540a8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1506,15 +1506,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1629 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x853e98", Frameless: false}]
+              Type: 1630 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0x854148", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1630 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x853ec4", Frameless: false}]
+              Type: 1631 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0x854174", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1533,33 +1533,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
-          events:
-            - Kind: Entry
-              Type: 1617 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x853c90", Frameless: true}]
-              Condition: null
-            - Kind: Return
-              Type: 1618 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x853c94", Frameless: true}]
-              Condition: null
-          probeTemplate:
-            TemplateString: p={p}
-            Segments:
-                - p=
-                - JSON: {Ref: p}
-                  DSL: p
-                  EventKind: Entry
-                  EventExpressionIndex: 0
         - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1619 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x853ca0", Frameless: true}]
+              Type: 1618 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x853f40", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1620 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x853ca4", Frameless: true}]
+              Type: 1619 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x853f44", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1572,12 +1554,30 @@ Probes:
         - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1621 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x853cb0", Frameless: true}]
+              Type: 1620 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0x853f50", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1622 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x853cb4", Frameless: true}]
+              Type: 1621 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0x853f54", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: p={p}
+            Segments:
+                - p=
+                - JSON: {Ref: p}
+                  DSL: p
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+        - subprogram: {subprogram: 170}
+          events:
+            - Kind: Entry
+              Type: 1622 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0x853f60", Frameless: true}]
+              Condition: null
+            - Kind: Return
+              Type: 1623 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0x853f64", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1596,15 +1596,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1631 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x853f80", Frameless: true}]
+              Type: 1632 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0x854230", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1632 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x853f88", Frameless: true}]
+              Type: 1633 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0x854238", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1614,15 +1614,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1633 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x853f90", Frameless: true}]
+              Type: 1634 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x854240", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1634 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x853fa0", Frameless: true}]
+              Type: 1635 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x854250", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1641,15 +1641,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 161}
+        - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1603 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x853810", Frameless: true}]
+              Type: 1604 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0x853ac0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1604 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x853814", Frameless: true}]
+              Type: 1605 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x853ac4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1659,15 +1659,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 162}
+        - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1605 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x853820", Frameless: true}]
+              Type: 1606 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0x853ad0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1606 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x85382c", Frameless: true}]
+              Type: 1607 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x853adc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1774,10 +1774,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1659 EventRootType Probe[main.testInlinedBBB]
+              Type: 1660 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0x84ca48", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1814,10 +1814,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1660 EventRootType Probe[main.testInlinedBCA]
+              Type: 1661 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0x84cb3c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1835,10 +1835,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1661 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1662 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0x84cb3c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1853,10 +1853,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1662 EventRootType Probe[main.testInlinedBCB]
+              Type: 1663 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0x84cbf0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1874,10 +1874,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Line
-              Type: 1663 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1664 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0x84cbf0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1892,10 +1892,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1669 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1670 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x129ba8"
                   Frameless: true
@@ -1915,10 +1915,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1656 EventRootType Probe[main.testInlinedPrint]
+              Type: 1657 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0x84c7c8"
                   Frameless: false
@@ -1932,7 +1932,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1657 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1658 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0x84c800", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1954,10 +1954,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1658 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1659 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x84c7c8"
                   Frameless: false
@@ -1986,10 +1986,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1664 EventRootType Probe[main.testInlinedSq]
+              Type: 1665 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0x84cc44", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2011,10 +2011,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Line
-              Type: 1665 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1666 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0x84cc44", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2034,10 +2034,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1666 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1667 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0x84cc74"
                   Frameless: false
@@ -2191,15 +2191,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 123}
+        - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1542 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x8506e0", Frameless: false}]
+              Type: 1543 EventRootType Probe[main.testLargeArgAndReturn]
+              InjectionPoints: [{PC: "0x850980", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1543 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x850838", Frameless: false}]
+              Type: 1544 EventRootType Probe[main.testLargeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x850ad8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2329,15 +2329,15 @@ Probes:
           dsl: i
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 126}
+        - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1548 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x850b9c", Frameless: false}]
+              Type: 1549 EventRootType Probe[main.testManyArgsArrayReturn]
+              InjectionPoints: [{PC: "0x850e3c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1549 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x850d08", Frameless: false}]
+              Type: 1550 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              InjectionPoints: [{PC: "0x850fa8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2841,11 +2841,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x851b50", Frameless: true}]
+              Type: 1585 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x851e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2864,11 +2864,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x851b50", Frameless: true}]
+              Type: 1586 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x851e00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2911,15 +2911,15 @@ Probes:
           dsl: s
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 127}
+        - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1550 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x850d70", Frameless: false}]
+              Type: 1551 EventRootType Probe[main.testMixedArgsStackReturn]
+              InjectionPoints: [{PC: "0x851010", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1551 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x850f1c", Frameless: false}]
+              Type: 1552 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              InjectionPoints: [{PC: "0x8511bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2981,15 +2981,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 129}
+        - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1554 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x85101c", Frameless: false}]
+              Type: 1555 EventRootType Probe[main.testMultipleArrayArgs]
+              InjectionPoints: [{PC: "0x8512bc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1555 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x8510c4", Frameless: false}]
+              Type: 1556 EventRootType Probe[main.testMultipleArrayArgs]Return
+              InjectionPoints: [{PC: "0x851364", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3016,15 +3016,15 @@ Probes:
           dsl: s2
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 125}
+        - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1546 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x850970", Frameless: false}]
+              Type: 1547 EventRootType Probe[main.testMultipleLargeArgs]
+              InjectionPoints: [{PC: "0x850c10", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1547 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x850b40", Frameless: false}]
+              Type: 1548 EventRootType Probe[main.testMultipleLargeArgs]Return
+              InjectionPoints: [{PC: "0x850de0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3271,11 +3271,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x851e90", Frameless: true}]
+              Type: 1597 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x852140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3296,11 +3296,11 @@ Probes:
           dsl: x.nested.anotherString
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x851e90", Frameless: true}]
+              Type: 1598 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x852140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3327,11 +3327,11 @@ Probes:
           dsl: x.notAMember
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x851e90", Frameless: true}]
+              Type: 1599 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x852140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3352,11 +3352,11 @@ Probes:
           dsl: x.nested
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1599 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x851e90", Frameless: true}]
+              Type: 1600 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x852140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3406,11 +3406,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 140}
+        - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1568 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x851730", Frameless: true}]
+              Type: 1569 EventRootType Probe[main.testNilSlice]
+              InjectionPoints: [{PC: "0x8519e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3433,11 +3433,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 137}
+        - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1565 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x851700", Frameless: true}]
+              Type: 1566 EventRootType Probe[main.testNilSliceOfStructs]
+              InjectionPoints: [{PC: "0x8519b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3468,11 +3468,11 @@ Probes:
           dsl: x
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 139}
+        - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1567 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x851720", Frameless: true}]
+              Type: 1568 EventRootType Probe[main.testNilSliceWithOtherParams]
+              InjectionPoints: [{PC: "0x8519d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3500,11 +3500,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 149}
+        - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x851b40", Frameless: true}]
+              Type: 1584 EventRootType Probe[main.testOneStringInStructPointer]
+              InjectionPoints: [{PC: "0x851df0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3941,15 +3941,15 @@ Probes:
       segments: [testReturnsArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 112}
+        - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1520 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x8500ec", Frameless: false}]
+              Type: 1521 EventRootType Probe[main.testReturnsArray]
+              InjectionPoints: [{PC: "0x85038c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1521 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x850140", Frameless: false}]
+              Type: 1522 EventRootType Probe[main.testReturnsArray]Return
+              InjectionPoints: [{PC: "0x8503e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3962,15 +3962,15 @@ Probes:
       segments: [testReturnsArrayOne]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 113}
+        - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1522 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x850178", Frameless: false}]
+              Type: 1523 EventRootType Probe[main.testReturnsArrayOne]
+              InjectionPoints: [{PC: "0x850418", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1523 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x8501b4", Frameless: false}]
+              Type: 1524 EventRootType Probe[main.testReturnsArrayOne]Return
+              InjectionPoints: [{PC: "0x850454", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3983,15 +3983,15 @@ Probes:
       segments: [testReturnsArrayZero]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 114}
+        - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1524 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x8501e8", Frameless: false}]
+              Type: 1525 EventRootType Probe[main.testReturnsArrayZero]
+              InjectionPoints: [{PC: "0x850488", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1525 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x850220", Frameless: false}]
+              Type: 1526 EventRootType Probe[main.testReturnsArrayZero]Return
+              InjectionPoints: [{PC: "0x8504c0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4004,15 +4004,15 @@ Probes:
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 116}
+        - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1528 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x8502d8", Frameless: false}]
+              Type: 1529 EventRootType Probe[main.testReturnsBacktrackInt]
+              InjectionPoints: [{PC: "0x850578", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1529 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x85033c", Frameless: false}]
+              Type: 1530 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              InjectionPoints: [{PC: "0x8505dc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4025,15 +4025,15 @@ Probes:
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 122}
+        - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1540 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x850668", Frameless: false}]
+              Type: 1541 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              InjectionPoints: [{PC: "0x850908", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1541 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x8506a8", Frameless: false}]
+              Type: 1542 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              InjectionPoints: [{PC: "0x850948", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4046,15 +4046,15 @@ Probes:
       segments: [testReturnsComplex]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 110}
+        - subprogram: {subprogram: 111}
           events:
             - Kind: Entry
-              Type: 1516 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x84ff98", Frameless: false}]
+              Type: 1517 EventRootType Probe[main.testReturnsComplex]
+              InjectionPoints: [{PC: "0x850238", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1517 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x84ffe4", Frameless: false}]
+              Type: 1518 EventRootType Probe[main.testReturnsComplex]Return
+              InjectionPoints: [{PC: "0x850284", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4202,15 +4202,15 @@ Probes:
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 111}
+        - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1518 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x850020", Frameless: false}]
+              Type: 1519 EventRootType Probe[main.testReturnsLargeStruct]
+              InjectionPoints: [{PC: "0x8502c0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1519 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x8500b4", Frameless: false}]
+              Type: 1520 EventRootType Probe[main.testReturnsLargeStruct]Return
+              InjectionPoints: [{PC: "0x850354", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4223,15 +4223,15 @@ Probes:
       segments: [testReturnsManyFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 109}
+        - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1514 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x84fed8", Frameless: false}]
+              Type: 1515 EventRootType Probe[main.testReturnsManyFloats]
+              InjectionPoints: [{PC: "0x850178", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1515 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x84ff5c", Frameless: false}]
+              Type: 1516 EventRootType Probe[main.testReturnsManyFloats]Return
+              InjectionPoints: [{PC: "0x8501fc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4244,15 +4244,15 @@ Probes:
       segments: [testReturnsMixed]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 118}
+        - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1532 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x850458", Frameless: false}]
+              Type: 1533 EventRootType Probe[main.testReturnsMixed]
+              InjectionPoints: [{PC: "0x8506f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1533 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x8504b0", Frameless: false}]
+              Type: 1534 EventRootType Probe[main.testReturnsMixed]Return
+              InjectionPoints: [{PC: "0x850750", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4265,15 +4265,15 @@ Probes:
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 115}
+        - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1526 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x850258", Frameless: false}]
+              Type: 1527 EventRootType Probe[main.testReturnsMixedStruct]
+              InjectionPoints: [{PC: "0x8504f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1527 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x8502a0", Frameless: false}]
+              Type: 1528 EventRootType Probe[main.testReturnsMixedStruct]Return
+              InjectionPoints: [{PC: "0x850540", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4286,19 +4286,43 @@ Probes:
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 121}
+        - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1538 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x8505e8", Frameless: false}]
+              Type: 1539 EventRootType Probe[main.testReturnsMultipleFloats]
+              InjectionPoints: [{PC: "0x850888", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1539 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x85062c", Frameless: false}]
+              Type: 1540 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              InjectionPoints: [{PC: "0x8508cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
             Segments: [testReturnsMultipleFloats]
+    - id: testReturnsNamedDeferLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testReturnsNamedDeferLine
+        sourceFile: returns.go
+        lines: ["121"]
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 108}
+          events:
+            - Kind: Line
+              Type: 1512 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              InjectionPoints: [{PC: "0x84ff08", Frameless: false}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{i}'
+            Segments:
+                - JSON: {Ref: i}
+                  DSL: i
+                  EventKind: Line
+                  EventExpressionIndex: 0
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -4307,15 +4331,15 @@ Probes:
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 120}
+        - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1536 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x850578", Frameless: false}]
+              Type: 1537 EventRootType Probe[main.testReturnsOnlyFloat]
+              InjectionPoints: [{PC: "0x850818", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1537 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x8505b8", Frameless: false}]
+              Type: 1538 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              InjectionPoints: [{PC: "0x850858", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4328,15 +4352,15 @@ Probes:
       segments: [testReturnsPrimitives]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 108}
+        - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1512 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x84fe48", Frameless: false}]
+              Type: 1513 EventRootType Probe[main.testReturnsPrimitives]
+              InjectionPoints: [{PC: "0x8500e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1513 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x84fea0", Frameless: false}]
+              Type: 1514 EventRootType Probe[main.testReturnsPrimitives]Return
+              InjectionPoints: [{PC: "0x850140", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4349,15 +4373,15 @@ Probes:
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 119}
+        - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1534 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x8504ec", Frameless: false}]
+              Type: 1535 EventRootType Probe[main.testReturnsStructWithArray]
+              InjectionPoints: [{PC: "0x85078c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1535 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x850540", Frameless: false}]
+              Type: 1536 EventRootType Probe[main.testReturnsStructWithArray]Return
+              InjectionPoints: [{PC: "0x8507e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4370,15 +4394,15 @@ Probes:
       segments: [testReturnsWideStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 117}
+        - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1530 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x850380", Frameless: false}]
+              Type: 1531 EventRootType Probe[main.testReturnsWideStruct]
+              InjectionPoints: [{PC: "0x850620", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1531 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x850424", Frameless: false}]
+              Type: 1532 EventRootType Probe[main.testReturnsWideStruct]Return
+              InjectionPoints: [{PC: "0x8506c4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4706,11 +4730,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 145}
+        - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1575 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x851af0", Frameless: true}]
+              Type: 1576 EventRootType Probe[main.testSingleString]
+              InjectionPoints: [{PC: "0x851da0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4838,11 +4862,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 142}
+        - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1571 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x851750", Frameless: true}]
+              Type: 1572 EventRootType Probe[main.testSliceEmptyStructs]
+              InjectionPoints: [{PC: "0x851a00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4860,11 +4884,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 134}
+        - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1562 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x8516d0", Frameless: true}]
+              Type: 1563 EventRootType Probe[main.testSliceOfSlices]
+              InjectionPoints: [{PC: "0x851980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4928,15 +4952,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 128}
+        - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1552 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x850f78", Frameless: false}]
+              Type: 1553 EventRootType Probe[main.testStackArgRegReturns]
+              InjectionPoints: [{PC: "0x851218", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1553 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x850fdc", Frameless: false}]
+              Type: 1554 EventRootType Probe[main.testStackArgRegReturns]Return
+              InjectionPoints: [{PC: "0x85127c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4998,11 +5022,11 @@ Probes:
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 138}
+        - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1566 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x851710", Frameless: true}]
+              Type: 1567 EventRootType Probe[main.testStringSlice]
+              InjectionPoints: [{PC: "0x8519c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5064,15 +5088,15 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x851df0", Frameless: true}]
+              Type: 1595 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x8520a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1595 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x851e0c", Frameless: true}]
+              Type: 1596 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0x8520bc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5095,11 +5119,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 135}
+        - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1563 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x8516e0", Frameless: true}]
+              Type: 1564 EventRootType Probe[main.testStructSlice]
+              InjectionPoints: [{PC: "0x851990", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5143,15 +5167,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 130}
+        - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1556 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x8510fc", Frameless: false}]
+              Type: 1557 EventRootType Probe[main.testStructWithArrayArg]
+              InjectionPoints: [{PC: "0x85139c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1557 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x85118c", Frameless: false}]
+              Type: 1558 EventRootType Probe[main.testStructWithArrayArg]Return
+              InjectionPoints: [{PC: "0x85142c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5169,15 +5193,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 155}
+        - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x851d00", Frameless: true}]
+              Type: 1591 EventRootType Probe[main.testStructWithCyclicMaps]
+              InjectionPoints: [{PC: "0x851fb0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1591 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x851d18", Frameless: true}]
+              Type: 1592 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              InjectionPoints: [{PC: "0x851fc8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5194,11 +5218,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 154}
+        - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x851cf0", Frameless: true}]
+              Type: 1590 EventRootType Probe[main.testStructWithCyclicSlices]
+              InjectionPoints: [{PC: "0x851fa0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5253,11 +5277,11 @@ Probes:
           dsl: cs
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 143}
+        - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1572 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x851760", Frameless: true}]
+              Type: 1573 EventRootType Probe[main.testSubslices]
+              InjectionPoints: [{PC: "0x851a10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5293,11 +5317,11 @@ Probes:
           dsl: c
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 153}
+        - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1588 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x851b80", Frameless: true}]
+              Type: 1589 EventRootType Probe[main.testSubstrings]
+              InjectionPoints: [{PC: "0x851e30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5411,11 +5435,11 @@ Probes:
           dsl: z
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 146}
+        - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1576 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x851b00", Frameless: true}]
+              Type: 1577 EventRootType Probe[main.testThreeStrings]
+              InjectionPoints: [{PC: "0x851db0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5443,15 +5467,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x851b10", Frameless: true}]
+              Type: 1578 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x851dc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1578 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x851b28", Frameless: true}]
+              Type: 1579 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0x851dd8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5477,15 +5501,15 @@ Probes:
           dsl: t.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x851b10", Frameless: true}]
+              Type: 1580 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x851dc0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1580 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x851b28", Frameless: true}]
+              Type: 1581 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0x851dd8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5513,11 +5537,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x851b30", Frameless: true}]
+              Type: 1582 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x851de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5543,11 +5567,11 @@ Probes:
           dsl: a.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x851b30", Frameless: true}]
+              Type: 1583 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x851de0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5729,11 +5753,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 132}
+        - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1560 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x8516b0", Frameless: true}]
+              Type: 1561 EventRootType Probe[main.testUintSlice]
+              InjectionPoints: [{PC: "0x851960", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5751,11 +5775,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 151}
+        - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x851b60", Frameless: true}]
+              Type: 1587 EventRootType Probe[main.testUnitializedString]
+              InjectionPoints: [{PC: "0x851e10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5817,11 +5841,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1569 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x851740", Frameless: true}]
+              Type: 1570 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x8519f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5839,11 +5863,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1570 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x851740", Frameless: true}]
+              Type: 1571 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x8519f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5861,18 +5885,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1667 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1668 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0x84ce18"
                   Frameless: false
-                - PC: "0x85436c"
+                - PC: "0x85461c"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1668 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1669 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0x84ce50", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5891,15 +5915,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 131}
+        - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1558 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x8511c8", Frameless: false}]
+              Type: 1559 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              InjectionPoints: [{PC: "0x851468", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1559 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x851230", Frameless: false}]
+              Type: 1560 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x8514d0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -8118,223 +8142,252 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 108
+      Name: main.testReturnsNamedDeferLine
+      OutOfLinePCRanges: [0x84fe30..0x84fff0]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84fe30..0x84fe94
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84fe94..0x84fff0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84fe5c..0x84fff0
+              Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
+          Role: Return
+          DictIndex: -1
+        - Name: b
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84fe60..0x84fff0
+              Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x84fe30..0x84fec0]
+      OutOfLinePCRanges: [0x8500d0..0x850160]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84fe30..0x84fea0
+            - Range: 0x8500d0..0x850140
               Pieces: []
-            - Range: 0x84fea0..0x84fea1
+            - Range: 0x850140..0x850141
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84fea1..0x84fec0
+            - Range: 0x850141..0x850160
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 94 BaseType int16
           Locations:
-            - Range: 0x84fe30..0x84fea0
+            - Range: 0x8500d0..0x850140
               Pieces: []
-            - Range: 0x84fea0..0x84fea1
+            - Range: 0x850140..0x850141
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84fea1..0x84fec0
+            - Range: 0x850141..0x850160
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84fe30..0x84fea0
+            - Range: 0x8500d0..0x850140
               Pieces: []
-            - Range: 0x84fea0..0x84fea1
+            - Range: 0x850140..0x850141
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84fea1..0x84fec0
+            - Range: 0x850141..0x850160
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x84fe30..0x84fea0
+            - Range: 0x8500d0..0x850140
               Pieces: []
-            - Range: 0x84fea0..0x84fea1
+            - Range: 0x850140..0x850141
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84fea1..0x84fec0
+            - Range: 0x850141..0x850160
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84fe30..0x84fea0
+            - Range: 0x8500d0..0x850140
               Pieces: []
-            - Range: 0x84fea0..0x84fea1
+            - Range: 0x850140..0x850141
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x84fea1..0x84fec0
+            - Range: 0x850141..0x850160
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x84fe30..0x84fea0
+            - Range: 0x8500d0..0x850140
               Pieces: []
-            - Range: 0x84fea0..0x84fea1
+            - Range: 0x850140..0x850141
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x84fea1..0x84fec0
+            - Range: 0x850141..0x850160
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x84fe30..0x84fea0
+            - Range: 0x8500d0..0x850140
               Pieces: []
-            - Range: 0x84fea0..0x84fea1
+            - Range: 0x850140..0x850141
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x84fea1..0x84fec0
+            - Range: 0x850141..0x850160
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x84fe30..0x84fea0
+            - Range: 0x8500d0..0x850140
               Pieces: []
-            - Range: 0x84fea0..0x84fea1
+            - Range: 0x850140..0x850141
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x84fea1..0x84fec0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 109
-      Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x84fec0..0x84ff80]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r5
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r6
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r7
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r8
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r9
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r10
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r11
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r12
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r13
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r14
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: onlyOnAmd64_16
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x84fec0..0x84ff80, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: bothArmAndAmd64
-          Type: 18 BaseType float64
-          Locations:
-            - Range: 0x84fec0..0x84ff5c
-              Pieces: []
-            - Range: 0x84ff5c..0x84ff5d
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x84ff5d..0x84ff80
+            - Range: 0x850141..0x850160
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
-      Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x84ff80..0x850000]
+      Name: main.testReturnsManyFloats
+      OutOfLinePCRanges: [0x850160..0x850220]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 95 BaseType complex64
-          Locations: [{Range: 0x84ff80..0x850000, Pieces: []}]
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
-          Type: 96 BaseType complex128
-          Locations: [{Range: 0x84ff80..0x850000, Pieces: []}]
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r5
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r6
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r7
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r8
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r9
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r10
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r11
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r12
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r13
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r14
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: onlyOnAmd64_16
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850160..0x850220, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: bothArmAndAmd64
+          Type: 18 BaseType float64
+          Locations:
+            - Range: 0x850160..0x8501fc
+              Pieces: []
+            - Range: 0x8501fc..0x8501fd
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x8501fd..0x850220
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0x850220..0x8502a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 95 BaseType complex64
+          Locations: [{Range: 0x850220..0x8502a0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 96 BaseType complex128
+          Locations: [{Range: 0x850220..0x8502a0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x850000..0x8500d0]
+      OutOfLinePCRanges: [0x8502a0..0x850370]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850000..0x8500b4
+            - Range: 0x8502a0..0x850354
               Pieces: []
-            - Range: 0x8500b4..0x8500b5
+            - Range: 0x850354..0x850355
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8356,193 +8409,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8500b5..0x8500d0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 112
-      Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x8500d0..0x850160]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 249 ArrayType [3]int
-          Locations:
-            - Range: 0x8500d0..0x850140
-              Pieces: []
-            - Range: 0x850140..0x850141
-              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x850141..0x850160
+            - Range: 0x850355..0x850370
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
-      Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x850160..0x8501d0]
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0x850370..0x850400]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 250 ArrayType [1]int
+          Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x850160..0x8501b4
+            - Range: 0x850370..0x8503e0
               Pieces: []
-            - Range: 0x8501b4..0x8501b5
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8501b5..0x8501d0
+            - Range: 0x8503e0..0x8503e1
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x8503e1..0x850400
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
-      Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x8501d0..0x850240]
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0x850400..0x850470]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 251 ArrayType [0]int
+          Type: 250 ArrayType [1]int
           Locations:
-            - Range: 0x8501d0..0x850220
+            - Range: 0x850400..0x850454
               Pieces: []
-            - Range: 0x850220..0x850221
-              Pieces: []
-            - Range: 0x850221..0x850240
+            - Range: 0x850454..0x850455
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x850455..0x850470
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
-      Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x850240..0x8502c0]
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0x850470..0x8504e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 252 StructureType main.mixedStruct
-          Locations: [{Range: 0x850240..0x8502c0, Pieces: []}]
+          Type: 251 ArrayType [0]int
+          Locations:
+            - Range: 0x850470..0x8504c0
+              Pieces: []
+            - Range: 0x8504c0..0x8504c1
+              Pieces: []
+            - Range: 0x8504c1..0x8504e0
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0x8504e0..0x850560]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 252 StructureType main.mixedStruct
+          Locations: [{Range: 0x8504e0..0x850560, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x8502c0..0x850360]
+      OutOfLinePCRanges: [0x850560..0x850600]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8502c0..0x85033c
+            - Range: 0x850560..0x8505dc
               Pieces: []
-            - Range: 0x85033c..0x85033d
+            - Range: 0x8505dc..0x8505dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85033d..0x850360
+            - Range: 0x8505dd..0x850600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8502c0..0x85033c
+            - Range: 0x850560..0x8505dc
               Pieces: []
-            - Range: 0x85033c..0x85033d
+            - Range: 0x8505dc..0x8505dd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x85033d..0x850360
+            - Range: 0x8505dd..0x850600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8502c0..0x85033c
+            - Range: 0x850560..0x8505dc
               Pieces: []
-            - Range: 0x85033c..0x85033d
+            - Range: 0x8505dc..0x8505dd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x85033d..0x850360
+            - Range: 0x8505dd..0x850600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8502c0..0x85033c
+            - Range: 0x850560..0x8505dc
               Pieces: []
-            - Range: 0x85033c..0x85033d
+            - Range: 0x8505dc..0x8505dd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x85033d..0x850360
+            - Range: 0x8505dd..0x850600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8502c0..0x85033c
+            - Range: 0x850560..0x8505dc
               Pieces: []
-            - Range: 0x85033c..0x85033d
+            - Range: 0x8505dc..0x8505dd
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x85033d..0x850360
+            - Range: 0x8505dd..0x850600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8502c0..0x85033c
+            - Range: 0x850560..0x8505dc
               Pieces: []
-            - Range: 0x85033c..0x85033d
+            - Range: 0x8505dc..0x8505dd
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x85033d..0x850360
+            - Range: 0x8505dd..0x850600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8502c0..0x85033c
+            - Range: 0x850560..0x8505dc
               Pieces: []
-            - Range: 0x85033c..0x85033d
+            - Range: 0x8505dc..0x8505dd
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x85033d..0x850360
+            - Range: 0x8505dd..0x850600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8502c0..0x85033c
+            - Range: 0x850560..0x8505dc
               Pieces: []
-            - Range: 0x85033c..0x85033d
+            - Range: 0x8505dc..0x8505dd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x85033d..0x850360
+            - Range: 0x8505dd..0x850600
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8502c0..0x85033c
+            - Range: 0x850560..0x8505dc
               Pieces: []
-            - Range: 0x85033c..0x85033d
+            - Range: 0x8505dc..0x8505dd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x85033d..0x850360
+            - Range: 0x8505dd..0x850600
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x850360..0x850440]
+      OutOfLinePCRanges: [0x850600..0x8506e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.wideStruct
           Locations:
-            - Range: 0x850360..0x850424
+            - Range: 0x850600..0x8506c4
               Pieces: []
-            - Range: 0x850424..0x850425
+            - Range: 0x8506c4..0x8506c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8566,145 +8619,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x850425..0x850440
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 118
-      Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x850440..0x8504d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x850440..0x8504b0
-              Pieces: []
-            - Range: 0x8504b0..0x8504b1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8504b1..0x8504d0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x850440..0x8504d0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x850440..0x8504b0
-              Pieces: []
-            - Range: 0x8504b0..0x8504b1
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8504b1..0x8504d0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x850440..0x8504d0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x850440..0x8504b0
-              Pieces: []
-            - Range: 0x8504b0..0x8504b1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8504b1..0x8504d0
+            - Range: 0x8506c5..0x8506e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
-      Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x8504d0..0x850560]
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0x8506e0..0x850770]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 254 StructureType main.structWithArray
+          Type: 7 BaseType int
           Locations:
-            - Range: 0x8504d0..0x850540
+            - Range: 0x8506e0..0x850750
               Pieces: []
-            - Range: 0x850540..0x850541
-              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x850541..0x850560
+            - Range: 0x850750..0x850751
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x850751..0x850770
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x8506e0..0x850770, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x8506e0..0x850750
+              Pieces: []
+            - Range: 0x850750..0x850751
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x850751..0x850770
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x8506e0..0x850770, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x8506e0..0x850750
+              Pieces: []
+            - Range: 0x850750..0x850751
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x850751..0x850770
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
-      Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x850560..0x8505d0]
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0x850770..0x850800]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 18 BaseType float64
-          Locations: [{Range: 0x850560..0x8505d0, Pieces: []}]
+          Type: 254 StructureType main.structWithArray
+          Locations:
+            - Range: 0x850770..0x8507e0
+              Pieces: []
+            - Range: 0x8507e0..0x8507e1
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x8507e1..0x850800
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
-      Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x8505d0..0x850650]
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0x850800..0x850870]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 17 BaseType float32
-          Locations: [{Range: 0x8505d0..0x850650, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x8505d0..0x850650, Pieces: []}]
+          Locations: [{Range: 0x850800..0x850870, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0x850870..0x8508f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 17 BaseType float32
+          Locations: [{Range: 0x850870..0x8508f0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x850870..0x8508f0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x850650..0x8506c0]
+      OutOfLinePCRanges: [0x8508f0..0x850960]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x850650..0x8506a8
+            - Range: 0x8508f0..0x850948
               Pieces: []
-            - Range: 0x8506a8..0x8506a9
+            - Range: 0x850948..0x850949
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8506a9..0x8506c0
+            - Range: 0x850949..0x850960
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x850650..0x8506a8
+            - Range: 0x8508f0..0x850948
               Pieces: []
-            - Range: 0x8506a8..0x8506a9
+            - Range: 0x850948..0x850949
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8506a9..0x8506c0
+            - Range: 0x850949..0x850960
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 123
+    - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x8506c0..0x850880]
+      OutOfLinePCRanges: [0x850960..0x850b20]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x8506c0..0x85072c
+            - Range: 0x850960..0x8509cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8726,7 +8779,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x85072c..0x850740
+            - Range: 0x8509cc..0x8509e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8748,7 +8801,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850740..0x850744
+            - Range: 0x8509e0..0x8509e4
               Pieces:
                 - Size: 8
                   Op: null
@@ -8775,9 +8828,9 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x8506c0..0x850838
+            - Range: 0x850960..0x850ad8
               Pieces: []
-            - Range: 0x850838..0x850839
+            - Range: 0x850ad8..0x850ad9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8799,44 +8852,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850839..0x850880
+            - Range: 0x850ad9..0x850b20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 124
+    - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x850880..0x850950]
+      OutOfLinePCRanges: [0x850b20..0x850bf0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x850880..0x850950
+            - Range: 0x850b20..0x850bf0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x850880..0x850934
+            - Range: 0x850b20..0x850bd4
               Pieces: []
-            - Range: 0x850934..0x850935
+            - Range: 0x850bd4..0x850bd5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x850935..0x850950
+            - Range: 0x850bd5..0x850bf0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x850950..0x850b80]
+      OutOfLinePCRanges: [0x850bf0..0x850e20]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850950..0x8509c0
+            - Range: 0x850bf0..0x850c60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8858,7 +8911,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8509c0..0x8509d4
+            - Range: 0x850c60..0x850c74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8880,7 +8933,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8509d4..0x8509d8
+            - Range: 0x850c74..0x850c78
               Pieces:
                 - Size: 8
                   Op: null
@@ -8907,16 +8960,16 @@ Subprograms:
         - Name: s2
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850950..0x850b80
+            - Range: 0x850bf0..0x850e20
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850950..0x850b40
+            - Range: 0x850bf0..0x850de0
               Pieces: []
-            - Range: 0x850b40..0x850b41
+            - Range: 0x850de0..0x850de1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8938,196 +8991,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850b41..0x850b80
+            - Range: 0x850de1..0x850e20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 126
+    - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x850b80..0x850d50]
+      OutOfLinePCRanges: [0x850e20..0x850ff0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850b80..0x850bf8
+            - Range: 0x850e20..0x850e98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850bf8..0x850d50
+            - Range: 0x850e98..0x850ff0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850b80..0x850be4
+            - Range: 0x850e20..0x850e84
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x850be4..0x850d50
+            - Range: 0x850e84..0x850ff0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850b80..0x850bf8
+            - Range: 0x850e20..0x850e98
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x850bf8..0x850d50
+            - Range: 0x850e98..0x850ff0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850b80..0x850bf8
+            - Range: 0x850e20..0x850e98
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x850bf8..0x850d50
+            - Range: 0x850e98..0x850ff0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850b80..0x850bf8
+            - Range: 0x850e20..0x850e98
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x850bf8..0x850d50
+            - Range: 0x850e98..0x850ff0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850b80..0x850bf8
+            - Range: 0x850e20..0x850e98
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x850bf8..0x850d50
+            - Range: 0x850e98..0x850ff0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850b80..0x850bf8
+            - Range: 0x850e20..0x850e98
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x850bf8..0x850d50
+            - Range: 0x850e98..0x850ff0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850b80..0x850bf8
+            - Range: 0x850e20..0x850e98
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x850bf8..0x850d50
+            - Range: 0x850e98..0x850ff0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850b80..0x850bf8
+            - Range: 0x850e20..0x850e98
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x850bf8..0x850d50
+            - Range: 0x850e98..0x850ff0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x850b80..0x850d08
+            - Range: 0x850e20..0x850fa8
               Pieces: []
-            - Range: 0x850d08..0x850d09
+            - Range: 0x850fa8..0x850fa9
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x850d09..0x850d50
+            - Range: 0x850fa9..0x850ff0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 127
+    - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x850d50..0x850f60]
+      OutOfLinePCRanges: [0x850ff0..0x851200]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850d50..0x850dd8
+            - Range: 0x850ff0..0x851078
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850dd8..0x850f60
+            - Range: 0x851078..0x851200
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850d50..0x850dc4
+            - Range: 0x850ff0..0x851064
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x850dc4..0x850f60
+            - Range: 0x851064..0x851200
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850d50..0x850dd8
+            - Range: 0x850ff0..0x851078
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x850dd8..0x850f60
+            - Range: 0x851078..0x851200
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850d50..0x850dd8
+            - Range: 0x850ff0..0x851078
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x850dd8..0x850f60
+            - Range: 0x851078..0x851200
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850d50..0x850dd8
+            - Range: 0x850ff0..0x851078
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x850dd8..0x850f60
+            - Range: 0x851078..0x851200
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850d50..0x850dd8
+            - Range: 0x850ff0..0x851078
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x850dd8..0x850f60
+            - Range: 0x851078..0x851200
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850d50..0x850dd8
+            - Range: 0x850ff0..0x851078
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x850dd8..0x850f60
+            - Range: 0x851078..0x851200
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850d50..0x850dd8
+            - Range: 0x850ff0..0x851078
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x850dd8..0x850f60
+            - Range: 0x851078..0x851200
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x850d50..0x850dd8
+            - Range: 0x850ff0..0x851078
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850dd8..0x850f60
+            - Range: 0x851078..0x851200
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9138,9 +9191,9 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x850d50..0x850f1c
+            - Range: 0x850ff0..0x8511bc
               Pieces: []
-            - Range: 0x850f1c..0x850f1d
+            - Range: 0x8511bc..0x8511bd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9162,215 +9215,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x850f1d..0x850f60
+            - Range: 0x8511bd..0x851200
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 128
+    - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x850f60..0x851000]
+      OutOfLinePCRanges: [0x851200..0x8512a0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0x850f60..0x851000
+            - Range: 0x851200..0x8512a0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850f60..0x850fdc
+            - Range: 0x851200..0x85127c
               Pieces: []
-            - Range: 0x850fdc..0x850fdd
+            - Range: 0x85127c..0x85127d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x850fdd..0x851000
+            - Range: 0x85127d..0x8512a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850f60..0x850fdc
+            - Range: 0x851200..0x85127c
               Pieces: []
-            - Range: 0x850fdc..0x850fdd
+            - Range: 0x85127c..0x85127d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x850fdd..0x851000
+            - Range: 0x85127d..0x8512a0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x850f60..0x850fdc
+            - Range: 0x851200..0x85127c
               Pieces: []
-            - Range: 0x850fdc..0x850fdd
+            - Range: 0x85127c..0x85127d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x850fdd..0x851000
+            - Range: 0x85127d..0x8512a0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 129
+    - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x851000..0x8510e0]
+      OutOfLinePCRanges: [0x8512a0..0x851380]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x851000..0x8510e0
+            - Range: 0x8512a0..0x851380
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x851000..0x8510e0
+            - Range: 0x8512a0..0x851380
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851000..0x8510c4
+            - Range: 0x8512a0..0x851364
               Pieces: []
-            - Range: 0x8510c4..0x8510c5
+            - Range: 0x851364..0x851365
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8510c5..0x8510e0
+            - Range: 0x851365..0x851380
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x851000..0x8510c4
+            - Range: 0x8512a0..0x851364
               Pieces: []
-            - Range: 0x8510c4..0x8510c5
+            - Range: 0x851364..0x851365
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x8510c5..0x8510e0
+            - Range: 0x851365..0x851380
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 130
+    - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x8510e0..0x8511b0]
+      OutOfLinePCRanges: [0x851380..0x851450]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x8510e0..0x8511b0
+            - Range: 0x851380..0x851450
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8510e0..0x85118c
+            - Range: 0x851380..0x85142c
               Pieces: []
-            - Range: 0x85118c..0x85118d
+            - Range: 0x85142c..0x85142d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85118d..0x8511b0
+            - Range: 0x85142d..0x851450
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x8510e0..0x85118c
+            - Range: 0x851380..0x85142c
               Pieces: []
-            - Range: 0x85118c..0x85118d
+            - Range: 0x85142c..0x85142d
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x85118d..0x8511b0
+            - Range: 0x85142d..0x851450
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851160..0x8511b0
+            - Range: 0x851400..0x851450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
-    - ID: 131
+    - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x8511b0..0x851250]
+      OutOfLinePCRanges: [0x851450..0x8514f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 ArrayType [0]int
-          Locations: [{Range: 0x8511b0..0x851250, Pieces: []}]
+          Locations: [{Range: 0x851450..0x8514f0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8511b0..0x8511f0
+            - Range: 0x851450..0x851490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8511f0..0x85120c
+            - Range: 0x851490..0x8514ac
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x85120c..0x851214
+            - Range: 0x8514ac..0x8514b4
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x851214..0x851250
+            - Range: 0x8514b4..0x8514f0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8511b0..0x851230
+            - Range: 0x851450..0x8514d0
               Pieces: []
-            - Range: 0x851230..0x851231
+            - Range: 0x8514d0..0x8514d1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x851231..0x851250
+            - Range: 0x8514d1..0x8514f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0x8511b0..0x851230
+            - Range: 0x851450..0x8514d0
               Pieces: []
-            - Range: 0x851230..0x851231
+            - Range: 0x8514d0..0x8514d1
               Pieces: []
-            - Range: 0x851231..0x851250
+            - Range: 0x8514d1..0x8514f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 132
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x8516b0..0x8516c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x8516b0..0x8516c0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
     - ID: 133
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x8516c0..0x8516d0]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x851960..0x851970]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8516c0..0x8516d0
+            - Range: 0x851960..0x851970
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9382,14 +9416,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 134
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x8516d0..0x8516e0]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x851970..0x851980]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 256 GoSliceHeaderType [][]uint
+          Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8516d0..0x8516e0
+            - Range: 0x851970..0x851980
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9401,14 +9435,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 135
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x8516e0..0x8516f0]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x851980..0x851990]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 256 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x8516e0..0x8516f0
+            - Range: 0x851980..0x851990
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9416,25 +9450,18 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x8516e0..0x8516f0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 136
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x8516f0..0x851700]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x851990..0x8519a0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x8516f0..0x851700
+            - Range: 0x851990..0x8519a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9447,20 +9474,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8516f0..0x851700
+            - Range: 0x851990..0x8519a0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x851700..0x851710]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x8519a0..0x8519b0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x851700..0x851710
+            - Range: 0x8519a0..0x8519b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9473,20 +9500,46 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x851700..0x851710
+            - Range: 0x8519a0..0x8519b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x8519b0..0x8519c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x8519b0..0x8519c0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x8519b0..0x8519c0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x851710..0x851720]
+      OutOfLinePCRanges: [0x8519c0..0x8519d0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 261 GoSliceHeaderType []string
           Locations:
-            - Range: 0x851710..0x851720
+            - Range: 0x8519c0..0x8519d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9497,22 +9550,22 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 139
+    - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x851720..0x851730]
+      OutOfLinePCRanges: [0x8519d0..0x8519e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x851720..0x851730
+            - Range: 0x8519d0..0x8519e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 262 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x851720..0x851730
+            - Range: 0x8519d0..0x8519e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9525,39 +9578,20 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x851720..0x851730
+            - Range: 0x8519d0..0x8519e0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
+    - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x851730..0x851740]
+      OutOfLinePCRanges: [0x8519e0..0x8519f0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x851730..0x851740
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x851740..0x851750]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x851740..0x851750
+            - Range: 0x8519e0..0x8519f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9569,14 +9603,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 142
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x851750..0x851760]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x8519f0..0x851a00]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 264 GoSliceHeaderType []struct {}
+          Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851750..0x851760
+            - Range: 0x8519f0..0x851a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9588,14 +9622,33 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x851a00..0x851a10]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 264 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x851a00..0x851a10
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x851760..0x851770]
+      OutOfLinePCRanges: [0x851a10..0x851a20]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851760..0x851770
+            - Range: 0x851a10..0x851a20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9608,7 +9661,7 @@ Subprograms:
         - Name: bs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851760..0x851770
+            - Range: 0x851a10..0x851a20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9621,7 +9674,7 @@ Subprograms:
         - Name: cs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x851760..0x851770
+            - Range: 0x851a10..0x851a20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9632,36 +9685,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
+    - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x851a80..0x851af0]
+      OutOfLinePCRanges: [0x851d30..0x851da0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851a80..0x851acc
+            - Range: 0x851d30..0x851d7c
               Pieces: []
-            - Range: 0x851acc..0x851acd
+            - Range: 0x851d7c..0x851d7d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x851acd..0x851af0
+            - Range: 0x851d7d..0x851da0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 145
+    - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x851af0..0x851b00]
+      OutOfLinePCRanges: [0x851da0..0x851db0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851af0..0x851b00
+            - Range: 0x851da0..0x851db0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9670,15 +9723,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x851b00..0x851b10]
+      OutOfLinePCRanges: [0x851db0..0x851dc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851b00..0x851b10
+            - Range: 0x851db0..0x851dc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9689,7 +9742,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851b00..0x851b10
+            - Range: 0x851db0..0x851dc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9700,7 +9753,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851b00..0x851b10
+            - Range: 0x851db0..0x851dc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9709,15 +9762,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 147
+    - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x851b10..0x851b30]
+      OutOfLinePCRanges: [0x851dc0..0x851de0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x851b10..0x851b30
+            - Range: 0x851dc0..0x851de0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9734,58 +9787,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 148
+    - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x851b30..0x851b40]
+      OutOfLinePCRanges: [0x851de0..0x851df0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x851b30..0x851b40
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x851b40..0x851b50]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 268 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0x851b40..0x851b50
+            - Range: 0x851de0..0x851df0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x851b50..0x851b60]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x851df0..0x851e00]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 268 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x851b50..0x851b60
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x851df0..0x851e00
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x851b60..0x851b70]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x851e00..0x851e10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851b60..0x851b70
+            - Range: 0x851e00..0x851e10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9795,14 +9831,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 152
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x851b70..0x851b80]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x851e10..0x851e20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851b70..0x851b80
+            - Range: 0x851e10..0x851e20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9812,14 +9848,31 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 153
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x851e20..0x851e30]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x851e20..0x851e30
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x851b80..0x851b90]
+      OutOfLinePCRanges: [0x851e30..0x851e40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851b80..0x851b90
+            - Range: 0x851e30..0x851e40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9830,7 +9883,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851b80..0x851b90
+            - Range: 0x851e30..0x851e40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9841,7 +9894,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x851b80..0x851b90
+            - Range: 0x851e30..0x851e40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9850,28 +9903,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
+    - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x851cf0..0x851d00]
+      OutOfLinePCRanges: [0x851fa0..0x851fb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x851cf0..0x851d00
+            - Range: 0x851fa0..0x851fb0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
+    - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x851d00..0x851d20]
+      OutOfLinePCRanges: [0x851fb0..0x851fd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 283 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x851d00..0x851d20
+            - Range: 0x851fb0..0x851fd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9888,15 +9941,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
+    - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x851df0..0x851e10]
+      OutOfLinePCRanges: [0x8520a0..0x8520c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.aStruct
           Locations:
-            - Range: 0x851df0..0x851e10
+            - Range: 0x8520a0..0x8520c0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9915,157 +9968,157 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 157
+    - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x851e90..0x851ea0]
+      OutOfLinePCRanges: [0x852140..0x852150]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x851e90..0x851ea0
+            - Range: 0x852140..0x852150
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 158
+    - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x851ea0..0x851eb0]
+      OutOfLinePCRanges: [0x852150..0x852160]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 StructureType main.tenStrings
           Locations:
-            - Range: 0x851ea0..0x851eb0
+            - Range: 0x852150..0x852160
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 159
+    - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x851ef0..0x851f00]
+      OutOfLinePCRanges: [0x8521a0..0x8521b0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 318 StructureType main.emptyStruct
-          Locations: [{Range: 0x851ef0..0x851f00, Pieces: []}]
+          Locations: [{Range: 0x8521a0..0x8521b0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 160
+    - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x851f00..0x851f10]
+      OutOfLinePCRanges: [0x8521b0..0x8521c0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x851f00..0x851f10
+            - Range: 0x8521b0..0x8521c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 161
+    - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x853810..0x853820]
+      OutOfLinePCRanges: [0x853ac0..0x853ad0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853810..0x853820
+            - Range: 0x853ac0..0x853ad0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x853810..0x853814
+            - Range: 0x853ac0..0x853ac4
               Pieces: []
-            - Range: 0x853814..0x853815
+            - Range: 0x853ac4..0x853ac5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853815..0x853820
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 162
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x853820..0x853830]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 322 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x853820..0x85382c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x85382c..0x853830
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x853820..0x85382c
-              Pieces: []
-            - Range: 0x85382c..0x85382d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85382d..0x853830
+            - Range: 0x853ac5..0x853ad0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0x853ad0..0x853ae0]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 322 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x853ad0..0x853adc
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x853adc..0x853ae0
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x853ad0..0x853adc
+              Pieces: []
+            - Range: 0x853adc..0x853add
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x853add..0x853ae0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x853830..0x853840]
+      OutOfLinePCRanges: [0x853ae0..0x853af0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x853830..0x853840
+            - Range: 0x853ae0..0x853af0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853830..0x853834
+            - Range: 0x853ae0..0x853ae4
               Pieces: []
-            - Range: 0x853834..0x853835
+            - Range: 0x853ae4..0x853ae5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853835..0x853840
+            - Range: 0x853ae5..0x853af0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 164
+    - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x853840..0x853850]
+      OutOfLinePCRanges: [0x853af0..0x853b00]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x853840..0x85384c
+            - Range: 0x853af0..0x853afc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x85384c..0x853850
+            - Range: 0x853afc..0x853b00
               Pieces:
                 - Size: 8
                   Op: null
@@ -10076,28 +10129,28 @@ Subprograms:
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853840..0x85384c
+            - Range: 0x853af0..0x853afc
               Pieces: []
-            - Range: 0x85384c..0x85384d
+            - Range: 0x853afc..0x853afd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85384d..0x853850
+            - Range: 0x853afd..0x853b00
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x8538b0..0x8539d0]
+      OutOfLinePCRanges: [0x853b60..0x853c80]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8538b0..0x8538dc
+            - Range: 0x853b60..0x853b8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10105,7 +10158,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8538dc..0x8538ec
+            - Range: 0x853b8c..0x853b9c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10113,7 +10166,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x8538ec..0x8539d0
+            - Range: 0x853b9c..0x853c80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10126,18 +10179,18 @@ Subprograms:
         - Name: pred
           Type: 326 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x8538b0..0x8538ec
+            - Range: 0x853b60..0x853b9c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8538ec..0x8539d0
+            - Range: 0x853b9c..0x853c80
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8538b0..0x85399c
+            - Range: 0x853b60..0x853c4c
               Pieces: []
-            - Range: 0x85399c..0x85399d
+            - Range: 0x853c4c..0x853c4d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10145,14 +10198,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x85399d..0x8539d0
+            - Range: 0x853c4d..0x853c80
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8538ec..0x853908
+            - Range: 0x853b9c..0x853bb8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10160,7 +10213,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853908..0x85390c
+            - Range: 0x853bb8..0x853bbc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10168,7 +10221,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x85390c..0x853910
+            - Range: 0x853bbc..0x853bc0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10176,7 +10229,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853910..0x853910
+            - Range: 0x853bc0..0x853bc0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10184,7 +10237,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853910..0x85393c
+            - Range: 0x853bc0..0x853bec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10192,7 +10245,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85393c..0x853990
+            - Range: 0x853bec..0x853c40
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10200,7 +10253,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x853990..0x8539d0
+            - Range: 0x853c40..0x853c80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10213,215 +10266,215 @@ Subprograms:
         - Name: item
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x85392c..0x85393c
+            - Range: 0x853bdc..0x853bec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85393c..0x853990
+            - Range: 0x853bec..0x853c40
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 166
+    - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x8539d0..0x853a20]
+      OutOfLinePCRanges: [0x853c80..0x853cd0]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x8539d0..0x8539f8
+            - Range: 0x853c80..0x853ca8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 327 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x8539d0..0x8539f8
+            - Range: 0x853c80..0x853ca8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x8539d0..0x8539f8
+            - Range: 0x853c80..0x853ca8
               Pieces: []
-            - Range: 0x8539f8..0x8539f9
+            - Range: 0x853ca8..0x853ca9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8539f9..0x853a20
+            - Range: 0x853ca9..0x853cd0
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 167
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x853c90..0x853ca0]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 325 PointerType *go.shape.int
-          Locations:
-            - Range: 0x853c90..0x853ca0
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 325 PointerType *go.shape.int
-          Locations:
-            - Range: 0x853c90..0x853c94
-              Pieces: []
-            - Range: 0x853c94..0x853c95
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853c95..0x853ca0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 168
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x853ca0..0x853cb0]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0x853f40..0x853f50]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 328 PointerType *go.shape.struct { Name string }
+          Type: 325 PointerType *go.shape.int
           Locations:
-            - Range: 0x853ca0..0x853cb0
+            - Range: 0x853f40..0x853f50
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 328 PointerType *go.shape.struct { Name string }
+          Type: 325 PointerType *go.shape.int
           Locations:
-            - Range: 0x853ca0..0x853ca4
+            - Range: 0x853f40..0x853f44
               Pieces: []
-            - Range: 0x853ca4..0x853ca5
+            - Range: 0x853f44..0x853f45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853ca5..0x853cb0
+            - Range: 0x853f45..0x853f50
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x853f50..0x853f60]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 328 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x853f50..0x853f60
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 328 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x853f50..0x853f54
+              Pieces: []
+            - Range: 0x853f54..0x853f55
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x853f55..0x853f60
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x853cb0..0x853cc0]
+      OutOfLinePCRanges: [0x853f60..0x853f70]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 330 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x853cb0..0x853cc0
+            - Range: 0x853f60..0x853f70
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x853cb0..0x853cb4
+            - Range: 0x853f60..0x853f64
               Pieces: []
-            - Range: 0x853cb4..0x853cb5
+            - Range: 0x853f64..0x853f65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853cb5..0x853cc0
+            - Range: 0x853f65..0x853f70
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
+    - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x853cc0..0x853cd0]
+      OutOfLinePCRanges: [0x853f70..0x853f80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 332 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x853cc0..0x853cd0
+            - Range: 0x853f70..0x853f80
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853cc0..0x853cc8
+            - Range: 0x853f70..0x853f78
               Pieces: []
-            - Range: 0x853cc8..0x853cc9
+            - Range: 0x853f78..0x853f79
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853cc9..0x853cd0
+            - Range: 0x853f79..0x853f80
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 171
+    - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x853d50..0x853d60]
+      OutOfLinePCRanges: [0x854000..0x854010]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x853d50..0x853d60
+            - Range: 0x854000..0x854010
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853d50..0x853d54
+            - Range: 0x854000..0x854004
               Pieces: []
-            - Range: 0x853d54..0x853d55
+            - Range: 0x854004..0x854005
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853d55..0x853d60
+            - Range: 0x854005..0x854010
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
+    - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x853df0..0x853e00]
+      OutOfLinePCRanges: [0x8540a0..0x8540b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 335 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x853df0..0x853e00
+            - Range: 0x8540a0..0x8540b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853df0..0x853e00
+            - Range: 0x8540a0..0x8540b0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0x853df0..0x853e00
+            - Range: 0x8540a0..0x8540b0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 173
+    - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x853e80..0x853f00]
+      OutOfLinePCRanges: [0x854130..0x8541b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 338 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x853e80..0x853f00
+            - Range: 0x854130..0x8541b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853e80..0x853f00
+            - Range: 0x854130..0x8541b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10432,20 +10485,20 @@ Subprograms:
         - Name: v
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853e80..0x853f00
+            - Range: 0x854130..0x8541b0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 174
+    - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x853f80..0x853f90]
+      OutOfLinePCRanges: [0x854230..0x854240]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853f80..0x853f90
+            - Range: 0x854230..0x854240
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10456,59 +10509,59 @@ Subprograms:
         - Name: b
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0x853f80..0x853f90
+            - Range: 0x854230..0x854240
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 337 BaseType go.shape.bool
           Locations:
-            - Range: 0x853f80..0x853f88
+            - Range: 0x854230..0x854238
               Pieces: []
-            - Range: 0x853f88..0x853f89
+            - Range: 0x854238..0x854239
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x853f89..0x853f90
+            - Range: 0x854239..0x854240
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853f80..0x853f88
+            - Range: 0x854230..0x854238
               Pieces: []
-            - Range: 0x853f88..0x853f89
+            - Range: 0x854238..0x854239
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x853f89..0x853f90
+            - Range: 0x854239..0x854240
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 175
+    - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x853f90..0x853fb0]
+      OutOfLinePCRanges: [0x854240..0x854260]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853f90..0x853fa0
+            - Range: 0x854240..0x854250
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853f90..0x853f9c
+            - Range: 0x854240..0x85424c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x853f9c..0x853fb0
+            - Range: 0x85424c..0x854260
               Pieces:
                 - Size: 8
                   Op: null
@@ -10519,73 +10572,73 @@ Subprograms:
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x853f90..0x853fa0
+            - Range: 0x854240..0x854250
               Pieces: []
-            - Range: 0x853fa0..0x853fa1
+            - Range: 0x854250..0x854251
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853fa1..0x853fb0
+            - Range: 0x854251..0x854260
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x853f90..0x853fa0
+            - Range: 0x854240..0x854250
               Pieces: []
-            - Range: 0x853fa0..0x853fa1
+            - Range: 0x854250..0x854251
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x853fa1..0x853fb0
+            - Range: 0x854251..0x854260
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 176
+    - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x853fb0..0x854000]
+      OutOfLinePCRanges: [0x854260..0x8542b0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 340 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x853fb0..0x853fd8
+            - Range: 0x854260..0x854288
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x853fb0..0x853fd8
+            - Range: 0x854260..0x854288
               Pieces: []
-            - Range: 0x853fd8..0x853fd9
+            - Range: 0x854288..0x854289
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x853fd9..0x854000
+            - Range: 0x854289..0x8542b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 177
+    - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x854000..0x854060]
+      OutOfLinePCRanges: [0x8542b0..0x854310]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 341 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x854000..0x85402c
+            - Range: 0x8542b0..0x8542dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x85402c..0x854030
+            - Range: 0x8542dc..0x8542e0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10596,65 +10649,65 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x854000..0x854030
+            - Range: 0x8542b0..0x8542e0
               Pieces: []
-            - Range: 0x854030..0x854031
+            - Range: 0x8542e0..0x8542e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854031..0x854060
+            - Range: 0x8542e1..0x854310
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 178
+    - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x854060..0x854070]
+      OutOfLinePCRanges: [0x854310..0x854320]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 342 PointerType *go.shape.string
           Locations:
-            - Range: 0x854060..0x854068
+            - Range: 0x854310..0x854318
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854060..0x854068
+            - Range: 0x854310..0x854318
               Pieces: []
-            - Range: 0x854068..0x854069
+            - Range: 0x854318..0x854319
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854069..0x854070
+            - Range: 0x854319..0x854320
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 179
+    - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x854070..0x8540d0]
+      OutOfLinePCRanges: [0x854320..0x854380]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 343 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x854070..0x8540ac
+            - Range: 0x854320..0x85435c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 344 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x854070..0x8540bc
+            - Range: 0x854320..0x85436c
               Pieces: []
-            - Range: 0x8540bc..0x8540bd
+            - Range: 0x85436c..0x85436d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10668,20 +10721,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x8540bd..0x8540d0
+            - Range: 0x85436d..0x854380
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 180
+    - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x8540d0..0x854110]
+      OutOfLinePCRanges: [0x854380..0x8543c0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 324 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x8540d0..0x8540dc
+            - Range: 0x854380..0x85438c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10689,7 +10742,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8540dc..0x854110
+            - Range: 0x85438c..0x8543c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10702,42 +10755,42 @@ Subprograms:
         - Name: needle
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x8540d0..0x854110
+            - Range: 0x854380..0x8543c0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8540d0..0x8540f8
+            - Range: 0x854380..0x8543a8
               Pieces: []
-            - Range: 0x8540f8..0x8540f9
+            - Range: 0x8543a8..0x8543a9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8540f9..0x854100
+            - Range: 0x8543a9..0x8543b0
               Pieces: []
-            - Range: 0x854100..0x854101
+            - Range: 0x8543b0..0x8543b1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854101..0x854110
+            - Range: 0x8543b1..0x8543c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x8540ec..0x8540fc
+            - Range: 0x85439c..0x8543ac
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 181
+    - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x854110..0x8541d0]
+      OutOfLinePCRanges: [0x8543c0..0x854480]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 345 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x854110..0x854134
+            - Range: 0x8543c0..0x8543e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10745,7 +10798,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x854134..0x854138
+            - Range: 0x8543e4..0x8543e8
               Pieces:
                 - Size: 8
                   Op: null
@@ -10758,13 +10811,13 @@ Subprograms:
         - Name: needle
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854110..0x85416c
+            - Range: 0x8543c0..0x85441c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x85416c..0x8541d0
+            - Range: 0x85441c..0x854480
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10775,28 +10828,28 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x854110..0x854188
+            - Range: 0x8543c0..0x854438
               Pieces: []
-            - Range: 0x854188..0x854189
+            - Range: 0x854438..0x854439
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854189..0x854198
+            - Range: 0x854439..0x854448
               Pieces: []
-            - Range: 0x854198..0x854199
+            - Range: 0x854448..0x854449
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x854199..0x8541d0
+            - Range: 0x854449..0x854480
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x85414c..0x854160
+            - Range: 0x8543fc..0x854410
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x854160..0x85416c
+            - Range: 0x854410..0x85441c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10805,58 +10858,58 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 182
+    - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x8541d0..0x8541e0]
+      OutOfLinePCRanges: [0x854480..0x854490]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x8541d0..0x8541d8
+            - Range: 0x854480..0x854488
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 320 BaseType go.shape.int
           Locations:
-            - Range: 0x8541d0..0x8541e0
+            - Range: 0x854480..0x854490
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8541d0..0x8541d8
+            - Range: 0x854480..0x854488
               Pieces: []
-            - Range: 0x8541d8..0x8541d9
+            - Range: 0x854488..0x854489
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8541d9..0x8541e0
+            - Range: 0x854489..0x854490
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
-    - ID: 183
+    - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x854250..0x8542c0]
+      OutOfLinePCRanges: [0x854500..0x854570]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 347 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x854250..0x85427c
+            - Range: 0x854500..0x85452c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85427c..0x854288
+            - Range: 0x85452c..0x854538
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x854288..0x85428c
+            - Range: 0x854538..0x85453c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10867,7 +10920,7 @@ Subprograms:
         - Name: value
           Type: 322 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x854250..0x85428c
+            - Range: 0x854500..0x85453c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10878,16 +10931,16 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x854250..0x85428c
+            - Range: 0x854500..0x85453c
               Pieces: []
-            - Range: 0x85428c..0x85428d
+            - Range: 0x85453c..0x85453d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85428d..0x8542c0
+            - Range: 0x85453d..0x854570
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 184
+    - ID: 185
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x12a040..0x12a160]
       InlinePCRanges: []
@@ -11018,7 +11071,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 185
+    - ID: 186
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x84c7b0..0x84c820]
       InlinePCRanges:
@@ -11049,7 +11102,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 186
+    - ID: 187
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11057,7 +11110,7 @@ Subprograms:
           RootRanges: [0x84c9e0..0x84caa0]
       Variables: []
       DictRegister: null
-    - ID: 187
+    - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11065,7 +11118,7 @@ Subprograms:
           RootRanges: [0x84cb20..0x84cc40]
       Variables: []
       DictRegister: null
-    - ID: 188
+    - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11073,7 +11126,7 @@ Subprograms:
           RootRanges: [0x84cb20..0x84cc40]
       Variables: []
       DictRegister: null
-    - ID: 189
+    - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11088,7 +11141,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 191
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11107,12 +11160,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 191
+    - ID: 192
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x84ce00..0x84ce70]
       InlinePCRanges:
-        - Ranges: [0x85436c..0x8543a0]
-          RootRanges: [0x854340..0x8543f0]
+        - Ranges: [0x85461c..0x854650]
+          RootRanges: [0x8545f0..0x8546a0]
       Variables:
         - Name: b
           Type: 352 StructureType main.firstBehavior
@@ -11147,7 +11200,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 192
+    - ID: 193
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -14486,7 +14539,7 @@ Types:
       GoKind: 22
       Pointee: 852 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14505,7 +14558,7 @@ Types:
             Type: 348 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14516,7 +14569,7 @@ Types:
             Type: 348 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14527,12 +14580,12 @@ Types:
             Type: 351 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: pred}
+                  Variable: {subprogram: 185, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14545,12 +14598,12 @@ Types:
             Type: 348 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 185, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14569,7 +14622,7 @@ Types:
             Type: 324 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14580,7 +14633,7 @@ Types:
             Type: 324 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14591,12 +14644,12 @@ Types:
             Type: 326 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: pred}
+                  Variable: {subprogram: 166, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14609,15 +14662,15 @@ Types:
             Type: 324 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 2, name: ~r0}
+                  Variable: {subprogram: 166, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1669
+      ID: 1670
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14636,7 +14689,7 @@ Types:
             Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14647,7 +14700,7 @@ Types:
             Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14658,12 +14711,12 @@ Types:
             Type: 327 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: f}
+                  Variable: {subprogram: 167, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14676,12 +14729,12 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 2, name: ~r0}
+                  Variable: {subprogram: 167, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14703,7 +14756,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14714,7 +14767,7 @@ Types:
             Type: 335 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: x}
+                  Variable: {subprogram: 173, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14725,7 +14778,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14736,15 +14789,15 @@ Types:
             Type: 337 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 2, name: v}
+                  Variable: {subprogram: 173, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1629
+      ID: 1630
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14766,7 +14819,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14777,7 +14830,7 @@ Types:
             Type: 338 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: x}
+                  Variable: {subprogram: 174, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14788,7 +14841,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14799,15 +14852,15 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 2, name: v}
+                  Variable: {subprogram: 174, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1630
+      ID: 1631
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1667
+      ID: 1668
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14819,12 +14872,12 @@ Types:
             Type: 352 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 0, name: b}
+                  Variable: {subprogram: 192, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1668
+      ID: 1669
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14836,12 +14889,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 1, name: ~r0}
+                  Variable: {subprogram: 192, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1643
+      ID: 1644
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14860,7 +14913,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14871,7 +14924,7 @@ Types:
             Type: 324 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14882,14 +14935,14 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1647
+      ID: 1648
       Name: Probe[main.genericContains[go.shape.int]]Line
-      ByteSize: 50
+      ByteSize: 49
       ExprStatusArraySize: 1
       DictEntries:
         - DictIndex: 0
@@ -14906,7 +14959,7 @@ Types:
             Type: 324 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14917,23 +14970,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
-        - Name: '@return'
-          Offset: 49
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1644
+      ID: 1645
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -14945,12 +14987,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1645
+      ID: 1646
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14969,7 +15011,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14980,7 +15022,7 @@ Types:
             Type: 345 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: haystack}
+                  Variable: {subprogram: 182, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14991,14 +15033,14 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1648
+      ID: 1649
       Name: Probe[main.genericContains[go.shape.string]]Line
-      ByteSize: 26
+      ByteSize: 25
       ExprStatusArraySize: 1
       DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
       Expressions:
@@ -15009,23 +15051,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
-        - Name: '@return'
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15037,12 +15068,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15055,7 +15086,7 @@ Types:
             Type: 342 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15066,12 +15097,12 @@ Types:
             Type: 342 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1640
+      ID: 1641
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15084,12 +15115,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Variable: {subprogram: 179, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15102,7 +15133,7 @@ Types:
             Type: 343 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15113,12 +15144,12 @@ Types:
             Type: 343 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1642
+      ID: 1643
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15131,12 +15162,12 @@ Types:
             Type: 344 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: ~r0}
+                  Variable: {subprogram: 180, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1635
+      ID: 1636
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15149,7 +15180,7 @@ Types:
             Type: 340 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -15160,59 +15191,13 @@ Types:
             Type: 340 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1636
-      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: '@return'
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1637
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
-      Expressions:
-        - Name: val
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 341 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-        - Name: val
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 341 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-    - __kind: EventRootType
-      ID: 1638
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -15228,7 +15213,53 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1638
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
+      Expressions:
+        - Name: val
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 341 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+        - Name: val
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 341 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+    - __kind: EventRootType
+      ID: 1639
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1618
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15241,7 +15272,7 @@ Types:
             Type: 325 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15252,12 +15283,12 @@ Types:
             Type: 325 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15270,12 +15301,12 @@ Types:
             Type: 325 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1619
+      ID: 1620
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15288,7 +15319,7 @@ Types:
             Type: 328 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15299,12 +15330,12 @@ Types:
             Type: 328 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15317,12 +15348,12 @@ Types:
             Type: 328 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1621
+      ID: 1622
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15335,7 +15366,7 @@ Types:
             Type: 330 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15346,12 +15377,12 @@ Types:
             Type: 330 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15364,12 +15395,12 @@ Types:
             Type: 330 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1633
+      ID: 1634
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15388,7 +15419,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15399,7 +15430,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15410,12 +15441,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: b}
+                  Variable: {subprogram: 176, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1634
+      ID: 1635
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15434,7 +15465,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 2, name: ~r0}
+                  Variable: {subprogram: 176, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -15445,12 +15476,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 3, name: ~r1}
+                  Variable: {subprogram: 176, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1631
+      ID: 1632
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15469,7 +15500,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15480,7 +15511,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15491,12 +15522,12 @@ Types:
             Type: 337 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: b}
+                  Variable: {subprogram: 175, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1632
+      ID: 1633
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15515,7 +15546,7 @@ Types:
             Type: 337 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 2, name: ~r0}
+                  Variable: {subprogram: 175, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
@@ -15526,12 +15557,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 3, name: ~r1}
+                  Variable: {subprogram: 175, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1625
+      ID: 1626
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15544,7 +15575,7 @@ Types:
             Type: 334 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
@@ -15555,12 +15586,12 @@ Types:
             Type: 334 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1626
+      ID: 1627
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15573,12 +15604,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 172, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1623
+      ID: 1624
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15591,7 +15622,7 @@ Types:
             Type: 332 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
@@ -15602,12 +15633,12 @@ Types:
             Type: 332 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1624
+      ID: 1625
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15620,12 +15651,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15638,7 +15669,7 @@ Types:
             Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15649,12 +15680,12 @@ Types:
             Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15667,12 +15698,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15685,7 +15716,7 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15696,12 +15727,12 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15714,15 +15745,15 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15734,7 +15765,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: ~r0}
+                  Variable: {subprogram: 145, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -15829,7 +15860,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15841,7 +15872,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -15852,12 +15883,12 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15869,7 +15900,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16571,7 +16602,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16583,7 +16614,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16594,7 +16625,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16605,7 +16636,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16616,12 +16647,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16633,7 +16664,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16644,12 +16675,12 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1588
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16661,7 +16692,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -16672,12 +16703,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1602
+      ID: 1603
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16689,7 +16720,7 @@ Types:
             Type: 319 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16700,12 +16731,12 @@ Types:
             Type: 319 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1602
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16717,7 +16748,7 @@ Types:
             Type: 318 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -16728,18 +16759,18 @@ Types:
             Type: 318 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
       ID: 1383
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 58
-      ExprStatusArraySize: 2
+      ByteSize: 49
+      ExprStatusArraySize: 1
       Expressions:
         - Name: x
-          Offset: 2
+          Offset: 1
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -16750,7 +16781,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 10
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 14 GoInterfaceType error
@@ -16760,19 +16791,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: '@return'
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
         - Name: x
-          Offset: 34
+          Offset: 25
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16783,7 +16803,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 42
+          Offset: 33
           Kind: local
           Expression:
             Type: 14 GoInterfaceType error
@@ -16914,7 +16934,7 @@ Types:
     - __kind: EventRootType
       ID: 1411
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 89
+      ByteSize: 81
       ExprStatusArraySize: 1
       Expressions:
         - Name: a
@@ -16938,17 +16958,6 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-          DictIndex: -1
-        - Name: '@return'
-          Offset: 81
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1410
@@ -17075,7 +17084,7 @@ Types:
       ID: 1404
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1659
+      ID: 1660
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1401
@@ -17131,16 +17140,16 @@ Types:
       ID: 1402
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1661
+      ID: 1662
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1405
@@ -17149,7 +17158,7 @@ Types:
       ID: 1406
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1656
+      ID: 1657
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17161,7 +17170,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17172,24 +17181,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1653
-      Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x_val
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17206,12 +17198,29 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1655
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 186, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1656
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17223,7 +17232,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17234,12 +17243,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17251,7 +17260,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17262,15 +17271,15 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1657
+      ID: 1658
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17282,7 +17291,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17293,12 +17302,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17310,7 +17319,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17321,12 +17330,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17338,7 +17347,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17349,7 +17358,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17522,7 +17531,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -17534,7 +17543,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17545,12 +17554,12 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17562,7 +17571,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: ~r0}
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17654,7 +17663,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -17666,7 +17675,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17677,7 +17686,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17688,7 +17697,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17699,7 +17708,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17710,7 +17719,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17721,7 +17730,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17732,7 +17741,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17743,7 +17752,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17754,7 +17763,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17765,7 +17774,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17776,7 +17785,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17787,7 +17796,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17798,7 +17807,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17809,7 +17818,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17820,7 +17829,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17831,7 +17840,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17842,7 +17851,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17853,12 +17862,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17870,7 +17879,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 9, name: ~r0}
+                  Variable: {subprogram: 127, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18435,34 +18444,6 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1585
       Name: Probe[main.testMassiveString]
       ByteSize: 33
@@ -18475,7 +18456,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18486,12 +18467,40 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1550
+      ID: 1586
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1551
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -18503,7 +18512,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18514,7 +18523,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18525,7 +18534,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18536,7 +18545,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18547,7 +18556,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18558,7 +18567,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18569,7 +18578,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18580,7 +18589,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18591,7 +18600,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18602,7 +18611,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18613,7 +18622,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18624,7 +18633,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18635,7 +18644,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18646,7 +18655,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18657,7 +18666,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18668,7 +18677,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18679,7 +18688,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18690,12 +18699,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18707,12 +18716,12 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 9, name: ~r0}
+                  Variable: {subprogram: 128, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18724,7 +18733,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18735,7 +18744,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -18746,7 +18755,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18757,12 +18766,12 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
+      ID: 1556
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -18774,7 +18783,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18785,12 +18794,12 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -18802,7 +18811,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18813,7 +18822,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18824,7 +18833,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18835,12 +18844,12 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18852,7 +18861,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -19505,7 +19514,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1597
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19517,7 +19526,7 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19528,12 +19537,12 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19545,7 +19554,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19556,10 +19565,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1599
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19571,7 +19580,7 @@ Types:
             Type: 121 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19632,7 +19641,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -19644,7 +19653,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19655,7 +19664,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19666,7 +19675,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19677,12 +19686,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -19694,7 +19703,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19705,7 +19714,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19716,7 +19725,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19727,7 +19736,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19738,7 +19747,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19749,12 +19758,12 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -19766,7 +19775,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19777,12 +19786,12 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19794,7 +19803,7 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19805,7 +19814,7 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20017,10 +20026,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1522
+      ID: 1523
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1523
+      ID: 1524
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20032,15 +20041,15 @@ Types:
             Type: 250 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1524
+      ID: 1525
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1525
+      ID: 1526
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -20052,15 +20061,15 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1520
+      ID: 1521
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1521
+      ID: 1522
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20072,15 +20081,15 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1528
+      ID: 1529
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1529
+      ID: 1530
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -20092,7 +20101,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20103,7 +20112,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20114,7 +20123,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20125,7 +20134,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20136,7 +20145,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20147,7 +20156,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 5, name: ~r5}
+                  Variable: {subprogram: 117, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20158,7 +20167,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 6, name: ~r6}
+                  Variable: {subprogram: 117, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20169,7 +20178,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 7, name: ~r7}
+                  Variable: {subprogram: 117, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20180,15 +20189,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 8, name: ~r8}
+                  Variable: {subprogram: 117, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -20200,7 +20209,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: ~r0}
+                  Variable: {subprogram: 123, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20211,15 +20220,15 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r1}
+                  Variable: {subprogram: 123, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1516
+      ID: 1517
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1517
+      ID: 1518
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20231,7 +20240,7 @@ Types:
             Type: 95 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20242,7 +20251,7 @@ Types:
             Type: 96 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: ~r1}
+                  Variable: {subprogram: 111, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -20705,10 +20714,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1518
+      ID: 1519
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1519
+      ID: 1520
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -20720,15 +20729,15 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1514
+      ID: 1515
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1515
+      ID: 1516
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -20740,7 +20749,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20751,7 +20760,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: ~r1}
+                  Variable: {subprogram: 110, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20762,7 +20771,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 2, name: ~r2}
+                  Variable: {subprogram: 110, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20773,7 +20782,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 3, name: ~r3}
+                  Variable: {subprogram: 110, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20784,7 +20793,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 4, name: ~r4}
+                  Variable: {subprogram: 110, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20795,7 +20804,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 5, name: ~r5}
+                  Variable: {subprogram: 110, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20806,7 +20815,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 6, name: ~r6}
+                  Variable: {subprogram: 110, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20817,7 +20826,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 7, name: ~r7}
+                  Variable: {subprogram: 110, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20828,7 +20837,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 8, name: ~r8}
+                  Variable: {subprogram: 110, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20839,7 +20848,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 9, name: ~r9}
+                  Variable: {subprogram: 110, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20850,7 +20859,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 10, name: ~r10}
+                  Variable: {subprogram: 110, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20861,7 +20870,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 11, name: ~r11}
+                  Variable: {subprogram: 110, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20872,7 +20881,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 12, name: ~r12}
+                  Variable: {subprogram: 110, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20883,7 +20892,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 13, name: ~r13}
+                  Variable: {subprogram: 110, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20894,7 +20903,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 14, name: ~r14}
+                  Variable: {subprogram: 110, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20905,7 +20914,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 110, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20916,15 +20925,15 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 110, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1526
+      ID: 1527
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1528
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20936,15 +20945,15 @@ Types:
             Type: 252 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -20956,7 +20965,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20967,7 +20976,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20978,7 +20987,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 2, name: ~r2}
+                  Variable: {subprogram: 119, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20989,7 +20998,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 3, name: ~r3}
+                  Variable: {subprogram: 119, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21000,15 +21009,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 4, name: ~r4}
+                  Variable: {subprogram: 119, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -21020,7 +21029,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: ~r0}
+                  Variable: {subprogram: 122, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -21031,15 +21040,65 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r1}
+                  Variable: {subprogram: 122, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1536
-      Name: Probe[main.testReturnsOnlyFloat]
+      ID: 1512
+      Name: Probe[main.testReturnsNamedDeferLine]Line
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: a
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 1537
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1538
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21051,15 +21110,15 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1512
+      ID: 1513
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1513
+      ID: 1514
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -21071,7 +21130,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -21082,7 +21141,7 @@ Types:
             Type: 94 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -21093,7 +21152,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: ~r2}
+                  Variable: {subprogram: 109, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -21104,7 +21163,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 3, name: ~r3}
+                  Variable: {subprogram: 109, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21115,7 +21174,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 4, name: ~r4}
+                  Variable: {subprogram: 109, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -21126,7 +21185,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 5, name: ~r5}
+                  Variable: {subprogram: 109, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -21137,7 +21196,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 6, name: ~r6}
+                  Variable: {subprogram: 109, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -21148,15 +21207,15 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 7, name: ~r7}
+                  Variable: {subprogram: 109, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21168,15 +21227,15 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1530
+      ID: 1531
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -21188,7 +21247,7 @@ Types:
             Type: 253 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
           DictIndex: -1
@@ -21473,7 +21532,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21485,7 +21544,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21496,7 +21555,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21641,7 +21700,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21653,7 +21712,7 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21664,12 +21723,12 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21681,7 +21740,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21692,7 +21751,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21946,7 +22005,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -21958,7 +22017,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -21969,12 +22028,12 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21986,7 +22045,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21997,7 +22056,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22008,7 +22067,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r2}
+                  Variable: {subprogram: 129, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22069,7 +22128,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22081,7 +22140,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22092,7 +22151,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22153,7 +22212,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -22165,7 +22224,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22176,7 +22235,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22187,7 +22246,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22198,7 +22257,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22231,7 +22290,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1556
+      ID: 1557
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22243,7 +22302,7 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22254,12 +22313,12 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22271,7 +22330,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 1, name: ~r0}
+                  Variable: {subprogram: 131, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22282,12 +22341,12 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 2, name: ~r1}
+                  Variable: {subprogram: 131, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1591
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22299,7 +22358,7 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22310,15 +22369,15 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1589
+      ID: 1590
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -22330,7 +22389,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22341,7 +22400,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22374,7 +22433,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22386,12 +22445,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -22403,7 +22462,7 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
@@ -22414,18 +22473,18 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -22437,7 +22496,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22448,7 +22507,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22459,7 +22518,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22470,7 +22529,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22481,7 +22540,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22492,12 +22551,12 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
+      ID: 1589
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22509,7 +22568,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22520,7 +22579,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22531,7 +22590,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22542,7 +22601,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22553,7 +22612,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22564,12 +22623,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1601
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -22581,12 +22640,12 @@ Types:
             Type: 317 StructureType main.tenStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 160
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22598,7 +22657,7 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22609,12 +22668,12 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22626,7 +22685,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22640,7 +22699,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22654,7 +22713,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22662,7 +22721,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1578
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22674,7 +22733,7 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22685,12 +22744,12 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22702,7 +22761,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22713,7 +22772,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
           DictIndex: -1
@@ -22724,18 +22783,18 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22747,7 +22806,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22758,7 +22817,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22769,7 +22828,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22780,7 +22839,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22791,7 +22850,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22802,7 +22861,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -23003,7 +23062,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23015,7 +23074,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -23026,12 +23085,12 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23043,7 +23102,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -23054,7 +23113,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -23115,34 +23174,6 @@ Types:
                   ByteSize: 800
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1569
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1570
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -23155,7 +23186,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -23166,12 +23197,40 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1558
+      ID: 1571
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1559
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23183,7 +23242,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -23194,7 +23253,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -23205,7 +23264,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -23216,12 +23275,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23233,7 +23292,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 2, name: ~r0}
+                  Variable: {subprogram: 132, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -23244,12 +23303,12 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 3, name: ~r1}
+                  Variable: {subprogram: 132, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1649
+      ID: 1650
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23268,7 +23327,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -23279,7 +23338,7 @@ Types:
             Type: 346 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: x}
+                  Variable: {subprogram: 183, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23290,12 +23349,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1650
+      ID: 1651
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23307,12 +23366,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 2, name: ~r0}
+                  Variable: {subprogram: 183, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1651
+      ID: 1652
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23331,7 +23390,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -23342,7 +23401,7 @@ Types:
             Type: 347 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: x}
+                  Variable: {subprogram: 184, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23353,12 +23412,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1652
+      ID: 1653
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23370,12 +23429,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 2, name: ~r0}
+                  Variable: {subprogram: 184, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1604
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23388,7 +23447,7 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23399,12 +23458,12 @@ Types:
             Type: 320 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1604
+      ID: 1605
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23417,12 +23476,12 @@ Types:
             Type: 321 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 1, name: ~r0}
+                  Variable: {subprogram: 162, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23435,7 +23494,7 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23446,12 +23505,12 @@ Types:
             Type: 322 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23464,7 +23523,7 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 1, name: ~r0}
+                  Variable: {subprogram: 163, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -32315,7 +32374,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 993920
       GoKind: 5
-MaxTypeID: 1669
+MaxTypeID: 1670
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -9,15 +9,15 @@ Probes:
       segments: [stackC]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 144}
+        - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x80de48", Frameless: false}]
+              Type: 1593 EventRootType Probe[main.stackC]
+              InjectionPoints: [{PC: "0x80e0b8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1593 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x80de78", Frameless: false}]
+              Type: 1594 EventRootType Probe[main.stackC]Return
+              InjectionPoints: [{PC: "0x80e0e8", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -80,15 +80,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 124}
+        - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1563 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80cd4c", Frameless: false}]
+              Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]
+              InjectionPoints: [{PC: "0x80cfbc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80cdd8", Frameless: false}]
+              Type: 1565 EventRootType Probe[main.testArrayArgAndReturn]Return
+              InjectionPoints: [{PC: "0x80d048", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -338,15 +338,15 @@ Probes:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1611 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80e130", Frameless: true}]
+              Type: 1612 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x80e3a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1612 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x80e140", Frameless: true}]
+              Type: 1613 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0x80e3b0", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -361,10 +361,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1672 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x808f08"
                   Frameless: false
@@ -391,10 +391,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1674 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x808f08"
                   Frameless: false
@@ -410,7 +410,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 185, index: 0, name: x}
+                      Variable: {subprogram: 186, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -433,10 +433,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1674 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1675 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x808f08"
                   Frameless: false
@@ -515,16 +515,16 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 158}
+        - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1619 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x80e1d0", Frameless: true}]
+              Type: 1620 EventRootType Probe[main.testTenStrings]
+              InjectionPoints: [{PC: "0x80e440", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 158, index: 0, name: x}
+                      Variable: {subprogram: 159, index: 0, name: x}
                       Offset: 144
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -789,11 +789,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 133}
+        - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80daa0", Frameless: true}]
+              Type: 1581 EventRootType Probe[main.testEmptySlice]
+              InjectionPoints: [{PC: "0x80dd10", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -816,11 +816,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 136}
+        - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80dad0", Frameless: true}]
+              Type: 1584 EventRootType Probe[main.testEmptySliceOfStructs]
+              InjectionPoints: [{PC: "0x80dd40", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -844,11 +844,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 152}
+        - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1606 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x80df00", Frameless: true}]
+              Type: 1607 EventRootType Probe[main.testEmptyString]
+              InjectionPoints: [{PC: "0x80e170", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -866,11 +866,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 159}
+        - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1620 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x80e200", Frameless: true}]
+              Type: 1621 EventRootType Probe[main.testEmptyStruct]
+              InjectionPoints: [{PC: "0x80e470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -887,11 +887,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 160}
+        - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1621 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x80e210", Frameless: true}]
+              Type: 1622 EventRootType Probe[main.testEmptyStructPointer]
+              InjectionPoints: [{PC: "0x80e480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1100,15 +1100,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1658 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x810220", Frameless: true}]
+              Type: 1659 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0x810490", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1659 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x810224", Frameless: true}]
+              Type: 1660 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x810494", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1118,15 +1118,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1660 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x810240", Frameless: false}]
+              Type: 1661 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0x8104b0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1661 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x810270", Frameless: false}]
+              Type: 1662 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0x8104e0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1145,15 +1145,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1654 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x810188", Frameless: false}]
+              Type: 1655 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0x8103f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1655 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x810198", Frameless: false}]
+              Type: 1656 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0x810408", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1163,15 +1163,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1656 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x8101d8", Frameless: false}]
+              Type: 1657 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0x810448", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1657 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x8101f0", Frameless: false}]
+              Type: 1658 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0x810460", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1190,18 +1190,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1662 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x810280", Frameless: true}]
+              Type: 1663 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0x8104f0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1663 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1664 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x8102a8"
+                - PC: "0x810518"
                   Frameless: true
-                - PC: "0x8102b0"
+                - PC: "0x810520"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1212,18 +1212,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1664 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x8102d8", Frameless: false}]
+              Type: 1665 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0x810548", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1665 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1666 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x810334"
+                - PC: "0x8105a4"
                   Frameless: false
-                - PC: "0x810344"
+                - PC: "0x8105b4"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1246,11 +1246,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Line
-              Type: 1666 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x810284", Frameless: true}]
+              Type: 1667 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0x8104f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1258,11 +1258,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Line
-              Type: 1667 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x8102e8", Frameless: false}]
+              Type: 1668 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0x810558", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1279,15 +1279,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1642 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x80fe90", Frameless: true}]
+              Type: 1643 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0x810100", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1643 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x80fe94", Frameless: true}]
+              Type: 1644 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0x810104", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1297,15 +1297,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1644 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x80ff20", Frameless: true}]
+              Type: 1645 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0x810190", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1645 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x80ff24", Frameless: true}]
+              Type: 1646 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0x810194", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1325,15 +1325,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 166}
           events:
             - Kind: Entry
-              Type: 1630 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x80fa98", Frameless: false}]
+              Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0x80fd08", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80fb6c", Frameless: false}]
+              Type: 1632 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x80fddc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1343,14 +1343,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1632 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1633 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x12c6c8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1633 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1634 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x12c79c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1371,15 +1371,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 167}
           events:
             - Kind: Entry
-              Type: 1634 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80fbb8", Frameless: false}]
+              Type: 1635 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x80fe28", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1635 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80fbc8", Frameless: false}]
+              Type: 1636 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80fe38", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1398,15 +1398,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1668 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x810380", Frameless: true}]
+              Type: 1669 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0x8105f0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1669 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x810388", Frameless: true}]
+              Type: 1670 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0x8105f8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1416,15 +1416,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1670 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x810418", Frameless: false}]
+              Type: 1671 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0x810688", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1671 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x81043c", Frameless: false}]
+              Type: 1672 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0x8106ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1443,15 +1443,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 163}
+        - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1626 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x80fa00", Frameless: true}]
+              Type: 1627 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0x80fc70", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1627 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80fa04", Frameless: true}]
+              Type: 1628 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x80fc74", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1461,15 +1461,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 164}
+        - subprogram: {subprogram: 165}
           events:
             - Kind: Entry
-              Type: 1628 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x80fa10", Frameless: true}]
+              Type: 1629 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0x80fc80", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1629 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80fa1c", Frameless: true}]
+              Type: 1630 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80fc8c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1488,15 +1488,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1646 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x80ffc0", Frameless: true}]
+              Type: 1647 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0x810230", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1647 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x80ffc8", Frameless: true}]
+              Type: 1648 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0x810238", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1506,15 +1506,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1648 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x810068", Frameless: false}]
+              Type: 1649 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0x8102d8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1649 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x810090", Frameless: false}]
+              Type: 1650 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0x810300", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1533,33 +1533,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
-          events:
-            - Kind: Entry
-              Type: 1636 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x80fe60", Frameless: true}]
-              Condition: null
-            - Kind: Return
-              Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80fe64", Frameless: true}]
-              Condition: null
-          probeTemplate:
-            TemplateString: p={p}
-            Segments:
-                - p=
-                - JSON: {Ref: p}
-                  DSL: p
-                  EventKind: Entry
-                  EventExpressionIndex: 0
         - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1638 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x80fe70", Frameless: true}]
+              Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x8100d0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1639 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x80fe74", Frameless: true}]
+              Type: 1638 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x8100d4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1572,12 +1554,30 @@ Probes:
         - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1640 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x80fe80", Frameless: true}]
+              Type: 1639 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0x8100e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1641 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x80fe84", Frameless: true}]
+              Type: 1640 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0x8100e4", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: p={p}
+            Segments:
+                - p=
+                - JSON: {Ref: p}
+                  DSL: p
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+        - subprogram: {subprogram: 170}
+          events:
+            - Kind: Entry
+              Type: 1641 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0x8100f0", Frameless: true}]
+              Condition: null
+            - Kind: Return
+              Type: 1642 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0x8100f4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1596,15 +1596,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1650 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x810140", Frameless: true}]
+              Type: 1651 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0x8103b0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1651 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x810148", Frameless: true}]
+              Type: 1652 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0x8103b8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1614,15 +1614,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1652 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x810150", Frameless: true}]
+              Type: 1653 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x8103c0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1653 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x810160", Frameless: true}]
+              Type: 1654 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x8103d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1641,15 +1641,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 161}
+        - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1622 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x80f9e0", Frameless: true}]
+              Type: 1623 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0x80fc50", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1623 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80f9e4", Frameless: true}]
+              Type: 1624 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x80fc54", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1659,15 +1659,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 162}
+        - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1624 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x80f9f0", Frameless: true}]
+              Type: 1625 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0x80fc60", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1625 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80f9fc", Frameless: true}]
+              Type: 1626 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80fc6c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1774,10 +1774,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1678 EventRootType Probe[main.testInlinedBBB]
+              Type: 1679 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0x809174", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1814,10 +1814,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1679 EventRootType Probe[main.testInlinedBCA]
+              Type: 1680 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0x80925c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1835,10 +1835,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1680 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1681 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0x80925c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1853,10 +1853,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1681 EventRootType Probe[main.testInlinedBCB]
+              Type: 1682 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0x809300", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1874,10 +1874,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Line
-              Type: 1682 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1683 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0x809300", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1892,10 +1892,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1688 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1689 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x12c238"
                   Frameless: true
@@ -1915,10 +1915,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1675 EventRootType Probe[main.testInlinedPrint]
+              Type: 1676 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0x808f08"
                   Frameless: false
@@ -1932,7 +1932,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1676 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1677 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0x808f3c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1954,10 +1954,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1677 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1678 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x808f08"
                   Frameless: false
@@ -1986,10 +1986,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1683 EventRootType Probe[main.testInlinedSq]
+              Type: 1684 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0x809354", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2011,10 +2011,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Line
-              Type: 1684 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1685 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0x809354", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2034,10 +2034,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1685 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1686 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0x809384"
                   Frameless: false
@@ -2191,15 +2191,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 123}
+        - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1561 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x80cbc0", Frameless: false}]
+              Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]
+              InjectionPoints: [{PC: "0x80ce30", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80cce8", Frameless: false}]
+              Type: 1563 EventRootType Probe[main.testLargeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x80cf58", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2329,15 +2329,15 @@ Probes:
           dsl: i
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 126}
+        - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1567 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x80d01c", Frameless: false}]
+              Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]
+              InjectionPoints: [{PC: "0x80d28c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x80d15c", Frameless: false}]
+              Type: 1569 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              InjectionPoints: [{PC: "0x80d3cc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2841,11 +2841,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1603 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80dee0", Frameless: true}]
+              Type: 1604 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x80e150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2864,11 +2864,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80dee0", Frameless: true}]
+              Type: 1605 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x80e150", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2911,15 +2911,15 @@ Probes:
           dsl: s
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 127}
+        - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1569 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x80d1c0", Frameless: false}]
+              Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]
+              InjectionPoints: [{PC: "0x80d430", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x80d348", Frameless: false}]
+              Type: 1571 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              InjectionPoints: [{PC: "0x80d5b8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2981,15 +2981,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 129}
+        - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1573 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x80d43c", Frameless: false}]
+              Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]
+              InjectionPoints: [{PC: "0x80d6ac", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x80d4d4", Frameless: false}]
+              Type: 1575 EventRootType Probe[main.testMultipleArrayArgs]Return
+              InjectionPoints: [{PC: "0x80d744", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3016,15 +3016,15 @@ Probes:
           dsl: s2
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 125}
+        - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1565 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x80ce10", Frameless: false}]
+              Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]
+              InjectionPoints: [{PC: "0x80d080", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x80cfb4", Frameless: false}]
+              Type: 1567 EventRootType Probe[main.testMultipleLargeArgs]Return
+              InjectionPoints: [{PC: "0x80d224", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3271,11 +3271,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1615 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e1c0", Frameless: true}]
+              Type: 1616 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80e430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3296,11 +3296,11 @@ Probes:
           dsl: x.nested.anotherString
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1616 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e1c0", Frameless: true}]
+              Type: 1617 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80e430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3327,11 +3327,11 @@ Probes:
           dsl: x.notAMember
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1617 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e1c0", Frameless: true}]
+              Type: 1618 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80e430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3352,11 +3352,11 @@ Probes:
           dsl: x.nested
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1618 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80e1c0", Frameless: true}]
+              Type: 1619 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80e430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3406,11 +3406,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 140}
+        - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80db10", Frameless: true}]
+              Type: 1588 EventRootType Probe[main.testNilSlice]
+              InjectionPoints: [{PC: "0x80dd80", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3433,11 +3433,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 137}
+        - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80dae0", Frameless: true}]
+              Type: 1585 EventRootType Probe[main.testNilSliceOfStructs]
+              InjectionPoints: [{PC: "0x80dd50", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3468,11 +3468,11 @@ Probes:
           dsl: x
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 139}
+        - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80db00", Frameless: true}]
+              Type: 1587 EventRootType Probe[main.testNilSliceWithOtherParams]
+              InjectionPoints: [{PC: "0x80dd70", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3500,11 +3500,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 149}
+        - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x80ded0", Frameless: true}]
+              Type: 1603 EventRootType Probe[main.testOneStringInStructPointer]
+              InjectionPoints: [{PC: "0x80e140", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3941,15 +3941,15 @@ Probes:
       segments: [testReturnsArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 112}
+        - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1539 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x80c61c", Frameless: false}]
+              Type: 1540 EventRootType Probe[main.testReturnsArray]
+              InjectionPoints: [{PC: "0x80c88c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1540 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x80c668", Frameless: false}]
+              Type: 1541 EventRootType Probe[main.testReturnsArray]Return
+              InjectionPoints: [{PC: "0x80c8d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3962,15 +3962,15 @@ Probes:
       segments: [testReturnsArrayOne]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 113}
+        - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1541 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x80c698", Frameless: false}]
+              Type: 1542 EventRootType Probe[main.testReturnsArrayOne]
+              InjectionPoints: [{PC: "0x80c908", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1542 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x80c6d0", Frameless: false}]
+              Type: 1543 EventRootType Probe[main.testReturnsArrayOne]Return
+              InjectionPoints: [{PC: "0x80c940", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3983,15 +3983,15 @@ Probes:
       segments: [testReturnsArrayZero]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 114}
+        - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1543 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x80c708", Frameless: false}]
+              Type: 1544 EventRootType Probe[main.testReturnsArrayZero]
+              InjectionPoints: [{PC: "0x80c978", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1544 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x80c73c", Frameless: false}]
+              Type: 1545 EventRootType Probe[main.testReturnsArrayZero]Return
+              InjectionPoints: [{PC: "0x80c9ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -4004,15 +4004,15 @@ Probes:
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 116}
+        - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1547 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x80c7f8", Frameless: false}]
+              Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]
+              InjectionPoints: [{PC: "0x80ca68", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x80c858", Frameless: false}]
+              Type: 1549 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              InjectionPoints: [{PC: "0x80cac8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4025,15 +4025,15 @@ Probes:
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 122}
+        - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1559 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x80cb48", Frameless: false}]
+              Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              InjectionPoints: [{PC: "0x80cdb8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x80cb84", Frameless: false}]
+              Type: 1561 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              InjectionPoints: [{PC: "0x80cdf4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4046,15 +4046,15 @@ Probes:
       segments: [testReturnsComplex]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 110}
+        - subprogram: {subprogram: 111}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x80c4d8", Frameless: false}]
+              Type: 1536 EventRootType Probe[main.testReturnsComplex]
+              InjectionPoints: [{PC: "0x80c748", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1536 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x80c520", Frameless: false}]
+              Type: 1537 EventRootType Probe[main.testReturnsComplex]Return
+              InjectionPoints: [{PC: "0x80c790", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4202,15 +4202,15 @@ Probes:
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 111}
+        - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x80c560", Frameless: false}]
+              Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]
+              InjectionPoints: [{PC: "0x80c7d0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x80c5dc", Frameless: false}]
+              Type: 1539 EventRootType Probe[main.testReturnsLargeStruct]Return
+              InjectionPoints: [{PC: "0x80c84c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4223,15 +4223,15 @@ Probes:
       segments: [testReturnsManyFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 109}
+        - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x80c428", Frameless: false}]
+              Type: 1534 EventRootType Probe[main.testReturnsManyFloats]
+              InjectionPoints: [{PC: "0x80c698", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1534 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x80c4a8", Frameless: false}]
+              Type: 1535 EventRootType Probe[main.testReturnsManyFloats]Return
+              InjectionPoints: [{PC: "0x80c718", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4244,15 +4244,15 @@ Probes:
       segments: [testReturnsMixed]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 118}
+        - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1551 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x80c958", Frameless: false}]
+              Type: 1552 EventRootType Probe[main.testReturnsMixed]
+              InjectionPoints: [{PC: "0x80cbc8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1552 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x80c9ac", Frameless: false}]
+              Type: 1553 EventRootType Probe[main.testReturnsMixed]Return
+              InjectionPoints: [{PC: "0x80cc1c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4265,15 +4265,15 @@ Probes:
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 115}
+        - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1545 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x80c778", Frameless: false}]
+              Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]
+              InjectionPoints: [{PC: "0x80c9e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x80c7bc", Frameless: false}]
+              Type: 1547 EventRootType Probe[main.testReturnsMixedStruct]Return
+              InjectionPoints: [{PC: "0x80ca2c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4286,19 +4286,43 @@ Probes:
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 121}
+        - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1557 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x80cad8", Frameless: false}]
+              Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]
+              InjectionPoints: [{PC: "0x80cd48", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x80cb18", Frameless: false}]
+              Type: 1559 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              InjectionPoints: [{PC: "0x80cd88", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
             Segments: [testReturnsMultipleFloats]
+    - id: testReturnsNamedDeferLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testReturnsNamedDeferLine
+        sourceFile: returns.go
+        lines: ["121"]
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 108}
+          events:
+            - Kind: Line
+              Type: 1531 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              InjectionPoints: [{PC: "0x80c460", Frameless: false}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{i}'
+            Segments:
+                - JSON: {Ref: i}
+                  DSL: i
+                  EventKind: Line
+                  EventExpressionIndex: 0
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -4307,15 +4331,15 @@ Probes:
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 120}
+        - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1555 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x80ca68", Frameless: false}]
+              Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]
+              InjectionPoints: [{PC: "0x80ccd8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x80caa4", Frameless: false}]
+              Type: 1557 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              InjectionPoints: [{PC: "0x80cd14", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4328,15 +4352,15 @@ Probes:
       segments: [testReturnsPrimitives]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 108}
+        - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1531 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x80c398", Frameless: false}]
+              Type: 1532 EventRootType Probe[main.testReturnsPrimitives]
+              InjectionPoints: [{PC: "0x80c608", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1532 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x80c3ec", Frameless: false}]
+              Type: 1533 EventRootType Probe[main.testReturnsPrimitives]Return
+              InjectionPoints: [{PC: "0x80c65c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4349,15 +4373,15 @@ Probes:
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 119}
+        - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1553 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x80c9ec", Frameless: false}]
+              Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]
+              InjectionPoints: [{PC: "0x80cc5c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x80ca38", Frameless: false}]
+              Type: 1555 EventRootType Probe[main.testReturnsStructWithArray]Return
+              InjectionPoints: [{PC: "0x80cca8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4370,15 +4394,15 @@ Probes:
       segments: [testReturnsWideStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 117}
+        - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1549 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x80c890", Frameless: false}]
+              Type: 1550 EventRootType Probe[main.testReturnsWideStruct]
+              InjectionPoints: [{PC: "0x80cb00", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1550 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x80c91c", Frameless: false}]
+              Type: 1551 EventRootType Probe[main.testReturnsWideStruct]Return
+              InjectionPoints: [{PC: "0x80cb8c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4706,11 +4730,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 145}
+        - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x80de90", Frameless: true}]
+              Type: 1595 EventRootType Probe[main.testSingleString]
+              InjectionPoints: [{PC: "0x80e100", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4838,11 +4862,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 142}
+        - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80db30", Frameless: true}]
+              Type: 1591 EventRootType Probe[main.testSliceEmptyStructs]
+              InjectionPoints: [{PC: "0x80dda0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4860,11 +4884,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 134}
+        - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80dab0", Frameless: true}]
+              Type: 1582 EventRootType Probe[main.testSliceOfSlices]
+              InjectionPoints: [{PC: "0x80dd20", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4928,15 +4952,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 128}
+        - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1571 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x80d3a8", Frameless: false}]
+              Type: 1572 EventRootType Probe[main.testStackArgRegReturns]
+              InjectionPoints: [{PC: "0x80d618", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1572 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x80d400", Frameless: false}]
+              Type: 1573 EventRootType Probe[main.testStackArgRegReturns]Return
+              InjectionPoints: [{PC: "0x80d670", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4998,11 +5022,11 @@ Probes:
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 138}
+        - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80daf0", Frameless: true}]
+              Type: 1586 EventRootType Probe[main.testStringSlice]
+              InjectionPoints: [{PC: "0x80dd60", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5064,15 +5088,15 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1613 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80e130", Frameless: true}]
+              Type: 1614 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x80e3a0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1614 EventRootType Probe[main.testStruct]Return
-              InjectionPoints: [{PC: "0x80e140", Frameless: true}]
+              Type: 1615 EventRootType Probe[main.testStruct]Return
+              InjectionPoints: [{PC: "0x80e3b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5095,11 +5119,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 135}
+        - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80dac0", Frameless: true}]
+              Type: 1583 EventRootType Probe[main.testStructSlice]
+              InjectionPoints: [{PC: "0x80dd30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5143,15 +5167,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 130}
+        - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1575 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x80d50c", Frameless: false}]
+              Type: 1576 EventRootType Probe[main.testStructWithArrayArg]
+              InjectionPoints: [{PC: "0x80d77c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1576 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x80d590", Frameless: false}]
+              Type: 1577 EventRootType Probe[main.testStructWithArrayArg]Return
+              InjectionPoints: [{PC: "0x80d800", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5169,15 +5193,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 155}
+        - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1609 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x80e080", Frameless: true}]
+              Type: 1610 EventRootType Probe[main.testStructWithCyclicMaps]
+              InjectionPoints: [{PC: "0x80e2f0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1610 EventRootType Probe[main.testStructWithCyclicMaps]Return
-              InjectionPoints: [{PC: "0x80e08c", Frameless: true}]
+              Type: 1611 EventRootType Probe[main.testStructWithCyclicMaps]Return
+              InjectionPoints: [{PC: "0x80e2fc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5194,11 +5218,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 154}
+        - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1608 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x80e070", Frameless: true}]
+              Type: 1609 EventRootType Probe[main.testStructWithCyclicSlices]
+              InjectionPoints: [{PC: "0x80e2e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5253,11 +5277,11 @@ Probes:
           dsl: cs
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 143}
+        - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80db40", Frameless: true}]
+              Type: 1592 EventRootType Probe[main.testSubslices]
+              InjectionPoints: [{PC: "0x80ddb0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5293,11 +5317,11 @@ Probes:
           dsl: c
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 153}
+        - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1607 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x80df10", Frameless: true}]
+              Type: 1608 EventRootType Probe[main.testSubstrings]
+              InjectionPoints: [{PC: "0x80e180", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5411,11 +5435,11 @@ Probes:
           dsl: z
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 146}
+        - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x80dea0", Frameless: true}]
+              Type: 1596 EventRootType Probe[main.testThreeStrings]
+              InjectionPoints: [{PC: "0x80e110", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5443,15 +5467,15 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80deb0", Frameless: true}]
+              Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x80e120", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x80debc", Frameless: true}]
+              Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0x80e12c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5477,15 +5501,15 @@ Probes:
           dsl: t.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80deb0", Frameless: true}]
+              Type: 1599 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x80e120", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1599 EventRootType Probe[main.testThreeStringsInStruct]Return
-              InjectionPoints: [{PC: "0x80debc", Frameless: true}]
+              Type: 1600 EventRootType Probe[main.testThreeStringsInStruct]Return
+              InjectionPoints: [{PC: "0x80e12c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5513,11 +5537,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80dec0", Frameless: true}]
+              Type: 1601 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x80e130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5543,11 +5567,11 @@ Probes:
           dsl: a.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80dec0", Frameless: true}]
+              Type: 1602 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x80e130", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5729,11 +5753,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 132}
+        - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80da90", Frameless: true}]
+              Type: 1580 EventRootType Probe[main.testUintSlice]
+              InjectionPoints: [{PC: "0x80dd00", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5751,11 +5775,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 151}
+        - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1605 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x80def0", Frameless: true}]
+              Type: 1606 EventRootType Probe[main.testUnitializedString]
+              InjectionPoints: [{PC: "0x80e160", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5817,11 +5841,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1588 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80db20", Frameless: true}]
+              Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x80dd90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5839,11 +5863,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80db20", Frameless: true}]
+              Type: 1590 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x80dd90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5861,18 +5885,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1686 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1687 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0x809508"
                   Frameless: false
-                - PC: "0x810518"
+                - PC: "0x810788"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1687 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1688 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0x809530", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5891,15 +5915,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 131}
+        - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x80d5c8", Frameless: false}]
+              Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              InjectionPoints: [{PC: "0x80d838", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x80d628", Frameless: false}]
+              Type: 1579 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x80d898", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -8106,223 +8130,252 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 108
+      Name: main.testReturnsNamedDeferLine
+      OutOfLinePCRanges: [0x80c380..0x80c530]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80c380..0x80c3e8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80c3e8..0x80c530
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80c3ac..0x80c530
+              Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
+          Role: Return
+          DictIndex: -1
+        - Name: b
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80c3b0..0x80c530
+              Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80c380..0x80c410]
+      OutOfLinePCRanges: [0x80c5f0..0x80c680]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80c380..0x80c3ec
+            - Range: 0x80c5f0..0x80c65c
               Pieces: []
-            - Range: 0x80c3ec..0x80c3ed
+            - Range: 0x80c65c..0x80c65d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c3ed..0x80c410
+            - Range: 0x80c65d..0x80c680
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 96 BaseType int16
           Locations:
-            - Range: 0x80c380..0x80c3ec
+            - Range: 0x80c5f0..0x80c65c
               Pieces: []
-            - Range: 0x80c3ec..0x80c3ed
+            - Range: 0x80c65c..0x80c65d
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c3ed..0x80c410
+            - Range: 0x80c65d..0x80c680
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x80c380..0x80c3ec
+            - Range: 0x80c5f0..0x80c65c
               Pieces: []
-            - Range: 0x80c3ec..0x80c3ed
+            - Range: 0x80c65c..0x80c65d
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80c3ed..0x80c410
+            - Range: 0x80c65d..0x80c680
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x80c380..0x80c3ec
+            - Range: 0x80c5f0..0x80c65c
               Pieces: []
-            - Range: 0x80c3ec..0x80c3ed
+            - Range: 0x80c65c..0x80c65d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80c3ed..0x80c410
+            - Range: 0x80c65d..0x80c680
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80c380..0x80c3ec
+            - Range: 0x80c5f0..0x80c65c
               Pieces: []
-            - Range: 0x80c3ec..0x80c3ed
+            - Range: 0x80c65c..0x80c65d
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80c3ed..0x80c410
+            - Range: 0x80c65d..0x80c680
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x80c380..0x80c3ec
+            - Range: 0x80c5f0..0x80c65c
               Pieces: []
-            - Range: 0x80c3ec..0x80c3ed
+            - Range: 0x80c65c..0x80c65d
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80c3ed..0x80c410
+            - Range: 0x80c65d..0x80c680
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x80c380..0x80c3ec
+            - Range: 0x80c5f0..0x80c65c
               Pieces: []
-            - Range: 0x80c3ec..0x80c3ed
+            - Range: 0x80c65c..0x80c65d
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80c3ed..0x80c410
+            - Range: 0x80c65d..0x80c680
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x80c380..0x80c3ec
+            - Range: 0x80c5f0..0x80c65c
               Pieces: []
-            - Range: 0x80c3ec..0x80c3ed
+            - Range: 0x80c65c..0x80c65d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80c3ed..0x80c410
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 109
-      Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80c410..0x80c4c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r5
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r6
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r7
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r8
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r9
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r10
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r11
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r12
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r13
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r14
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: onlyOnAmd64_16
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c410..0x80c4c0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: bothArmAndAmd64
-          Type: 16 BaseType float64
-          Locations:
-            - Range: 0x80c410..0x80c4a8
-              Pieces: []
-            - Range: 0x80c4a8..0x80c4a9
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80c4a9..0x80c4c0
+            - Range: 0x80c65d..0x80c680
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
-      Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80c4c0..0x80c540]
+      Name: main.testReturnsManyFloats
+      OutOfLinePCRanges: [0x80c680..0x80c730]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 97 BaseType complex64
-          Locations: [{Range: 0x80c4c0..0x80c540, Pieces: []}]
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
-          Type: 98 BaseType complex128
-          Locations: [{Range: 0x80c4c0..0x80c540, Pieces: []}]
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r5
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r6
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r7
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r8
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r9
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r10
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r11
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r12
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r13
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r14
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: onlyOnAmd64_16
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80c680..0x80c730, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: bothArmAndAmd64
+          Type: 16 BaseType float64
+          Locations:
+            - Range: 0x80c680..0x80c718
+              Pieces: []
+            - Range: 0x80c718..0x80c719
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x80c719..0x80c730
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0x80c730..0x80c7b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 97 BaseType complex64
+          Locations: [{Range: 0x80c730..0x80c7b0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 98 BaseType complex128
+          Locations: [{Range: 0x80c730..0x80c7b0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80c540..0x80c600]
+      OutOfLinePCRanges: [0x80c7b0..0x80c870]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80c540..0x80c5dc
+            - Range: 0x80c7b0..0x80c84c
               Pieces: []
-            - Range: 0x80c5dc..0x80c5dd
+            - Range: 0x80c84c..0x80c84d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8344,193 +8397,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c5dd..0x80c600
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 112
-      Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80c600..0x80c680]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 251 ArrayType [3]int
-          Locations:
-            - Range: 0x80c600..0x80c668
-              Pieces: []
-            - Range: 0x80c668..0x80c669
-              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80c669..0x80c680
+            - Range: 0x80c84d..0x80c870
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
-      Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80c680..0x80c6f0]
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0x80c870..0x80c8f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 252 ArrayType [1]int
+          Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80c680..0x80c6d0
+            - Range: 0x80c870..0x80c8d8
               Pieces: []
-            - Range: 0x80c6d0..0x80c6d1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c6d1..0x80c6f0
+            - Range: 0x80c8d8..0x80c8d9
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x80c8d9..0x80c8f0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
-      Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80c6f0..0x80c760]
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0x80c8f0..0x80c960]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 253 ArrayType [0]int
+          Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0x80c6f0..0x80c73c
+            - Range: 0x80c8f0..0x80c940
               Pieces: []
-            - Range: 0x80c73c..0x80c73d
-              Pieces: []
-            - Range: 0x80c73d..0x80c760
+            - Range: 0x80c940..0x80c941
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80c941..0x80c960
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
-      Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80c760..0x80c7e0]
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0x80c960..0x80c9d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0x80c760..0x80c7e0, Pieces: []}]
+          Type: 253 ArrayType [0]int
+          Locations:
+            - Range: 0x80c960..0x80c9ac
+              Pieces: []
+            - Range: 0x80c9ac..0x80c9ad
+              Pieces: []
+            - Range: 0x80c9ad..0x80c9d0
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0x80c9d0..0x80ca50]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 254 StructureType main.mixedStruct
+          Locations: [{Range: 0x80c9d0..0x80ca50, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80c7e0..0x80c870]
+      OutOfLinePCRanges: [0x80ca50..0x80cae0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c7e0..0x80c858
+            - Range: 0x80ca50..0x80cac8
               Pieces: []
-            - Range: 0x80c858..0x80c859
+            - Range: 0x80cac8..0x80cac9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c859..0x80c870
+            - Range: 0x80cac9..0x80cae0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c7e0..0x80c858
+            - Range: 0x80ca50..0x80cac8
               Pieces: []
-            - Range: 0x80c858..0x80c859
+            - Range: 0x80cac8..0x80cac9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c859..0x80c870
+            - Range: 0x80cac9..0x80cae0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c7e0..0x80c858
+            - Range: 0x80ca50..0x80cac8
               Pieces: []
-            - Range: 0x80c858..0x80c859
+            - Range: 0x80cac8..0x80cac9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80c859..0x80c870
+            - Range: 0x80cac9..0x80cae0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c7e0..0x80c858
+            - Range: 0x80ca50..0x80cac8
               Pieces: []
-            - Range: 0x80c858..0x80c859
+            - Range: 0x80cac8..0x80cac9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80c859..0x80c870
+            - Range: 0x80cac9..0x80cae0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c7e0..0x80c858
+            - Range: 0x80ca50..0x80cac8
               Pieces: []
-            - Range: 0x80c858..0x80c859
+            - Range: 0x80cac8..0x80cac9
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80c859..0x80c870
+            - Range: 0x80cac9..0x80cae0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c7e0..0x80c858
+            - Range: 0x80ca50..0x80cac8
               Pieces: []
-            - Range: 0x80c858..0x80c859
+            - Range: 0x80cac8..0x80cac9
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80c859..0x80c870
+            - Range: 0x80cac9..0x80cae0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c7e0..0x80c858
+            - Range: 0x80ca50..0x80cac8
               Pieces: []
-            - Range: 0x80c858..0x80c859
+            - Range: 0x80cac8..0x80cac9
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80c859..0x80c870
+            - Range: 0x80cac9..0x80cae0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80c7e0..0x80c858
+            - Range: 0x80ca50..0x80cac8
               Pieces: []
-            - Range: 0x80c858..0x80c859
+            - Range: 0x80cac8..0x80cac9
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80c859..0x80c870
+            - Range: 0x80cac9..0x80cae0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c7e0..0x80c858
+            - Range: 0x80ca50..0x80cac8
               Pieces: []
-            - Range: 0x80c858..0x80c859
+            - Range: 0x80cac8..0x80cac9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80c859..0x80c870
+            - Range: 0x80cac9..0x80cae0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80c870..0x80c940]
+      OutOfLinePCRanges: [0x80cae0..0x80cbb0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0x80c870..0x80c91c
+            - Range: 0x80cae0..0x80cb8c
               Pieces: []
-            - Range: 0x80c91c..0x80c91d
+            - Range: 0x80cb8c..0x80cb8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8554,145 +8607,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80c91d..0x80c940
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 118
-      Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80c940..0x80c9d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80c940..0x80c9ac
-              Pieces: []
-            - Range: 0x80c9ac..0x80c9ad
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c9ad..0x80c9d0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c940..0x80c9d0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80c940..0x80c9ac
-              Pieces: []
-            - Range: 0x80c9ac..0x80c9ad
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80c9ad..0x80c9d0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80c940..0x80c9d0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x80c940..0x80c9ac
-              Pieces: []
-            - Range: 0x80c9ac..0x80c9ad
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c9ad..0x80c9d0
+            - Range: 0x80cb8d..0x80cbb0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
-      Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80c9d0..0x80ca50]
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0x80cbb0..0x80cc40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 256 StructureType main.structWithArray
+          Type: 7 BaseType int
           Locations:
-            - Range: 0x80c9d0..0x80ca38
+            - Range: 0x80cbb0..0x80cc1c
               Pieces: []
-            - Range: 0x80ca38..0x80ca39
-              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80ca39..0x80ca50
+            - Range: 0x80cc1c..0x80cc1d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80cc1d..0x80cc40
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80cbb0..0x80cc40, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80cbb0..0x80cc1c
+              Pieces: []
+            - Range: 0x80cc1c..0x80cc1d
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80cc1d..0x80cc40
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80cbb0..0x80cc40, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80cbb0..0x80cc1c
+              Pieces: []
+            - Range: 0x80cc1c..0x80cc1d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x80cc1d..0x80cc40
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
-      Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80ca50..0x80cac0]
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0x80cc40..0x80ccc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 16 BaseType float64
-          Locations: [{Range: 0x80ca50..0x80cac0, Pieces: []}]
+          Type: 256 StructureType main.structWithArray
+          Locations:
+            - Range: 0x80cc40..0x80cca8
+              Pieces: []
+            - Range: 0x80cca8..0x80cca9
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x80cca9..0x80ccc0
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
-      Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80cac0..0x80cb30]
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0x80ccc0..0x80cd30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 18 BaseType float32
-          Locations: [{Range: 0x80cac0..0x80cb30, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80cac0..0x80cb30, Pieces: []}]
+          Locations: [{Range: 0x80ccc0..0x80cd30, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0x80cd30..0x80cda0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 18 BaseType float32
+          Locations: [{Range: 0x80cd30..0x80cda0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80cd30..0x80cda0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80cb30..0x80cba0]
+      OutOfLinePCRanges: [0x80cda0..0x80ce10]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80cb30..0x80cb84
+            - Range: 0x80cda0..0x80cdf4
               Pieces: []
-            - Range: 0x80cb84..0x80cb85
+            - Range: 0x80cdf4..0x80cdf5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80cb85..0x80cba0
+            - Range: 0x80cdf5..0x80ce10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x80cb30..0x80cb84
+            - Range: 0x80cda0..0x80cdf4
               Pieces: []
-            - Range: 0x80cb84..0x80cb85
+            - Range: 0x80cdf4..0x80cdf5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80cb85..0x80cba0
+            - Range: 0x80cdf5..0x80ce10
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 123
+    - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80cba0..0x80cd30]
+      OutOfLinePCRanges: [0x80ce10..0x80cfa0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80cba0..0x80cbf8
+            - Range: 0x80ce10..0x80ce68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8714,7 +8767,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80cbf8..0x80cc00
+            - Range: 0x80ce68..0x80ce70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8736,7 +8789,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80cc00..0x80cc08
+            - Range: 0x80ce70..0x80ce78
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8758,7 +8811,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80cc08..0x80cc0c
+            - Range: 0x80ce78..0x80ce7c
               Pieces:
                 - Size: 8
                   Op: null
@@ -8785,9 +8838,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80cba0..0x80cce8
+            - Range: 0x80ce10..0x80cf58
               Pieces: []
-            - Range: 0x80cce8..0x80cce9
+            - Range: 0x80cf58..0x80cf59
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8809,44 +8862,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80cce9..0x80cd30
+            - Range: 0x80cf59..0x80cfa0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 124
+    - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80cd30..0x80cdf0]
+      OutOfLinePCRanges: [0x80cfa0..0x80d060]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80cd30..0x80cdf0
+            - Range: 0x80cfa0..0x80d060
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80cd30..0x80cdd8
+            - Range: 0x80cfa0..0x80d048
               Pieces: []
-            - Range: 0x80cdd8..0x80cdd9
+            - Range: 0x80d048..0x80d049
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80cdd9..0x80cdf0
+            - Range: 0x80d049..0x80d060
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80cdf0..0x80d000]
+      OutOfLinePCRanges: [0x80d060..0x80d270]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80cdf0..0x80ce4c
+            - Range: 0x80d060..0x80d0bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8868,7 +8921,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ce4c..0x80ce54
+            - Range: 0x80d0bc..0x80d0c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8890,7 +8943,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ce54..0x80ce5c
+            - Range: 0x80d0c4..0x80d0cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8912,7 +8965,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ce5c..0x80ce60
+            - Range: 0x80d0cc..0x80d0d0
               Pieces:
                 - Size: 8
                   Op: null
@@ -8939,16 +8992,16 @@ Subprograms:
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80cdf0..0x80d000
+            - Range: 0x80d060..0x80d270
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80cdf0..0x80cfb4
+            - Range: 0x80d060..0x80d224
               Pieces: []
-            - Range: 0x80cfb4..0x80cfb5
+            - Range: 0x80d224..0x80d225
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8970,196 +9023,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80cfb5..0x80d000
+            - Range: 0x80d225..0x80d270
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 126
+    - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80d000..0x80d1a0]
+      OutOfLinePCRanges: [0x80d270..0x80d410]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d000..0x80d074
+            - Range: 0x80d270..0x80d2e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d074..0x80d1a0
+            - Range: 0x80d2e4..0x80d410
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d000..0x80d064
+            - Range: 0x80d270..0x80d2d4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d064..0x80d1a0
+            - Range: 0x80d2d4..0x80d410
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d000..0x80d06c
+            - Range: 0x80d270..0x80d2dc
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80d06c..0x80d1a0
+            - Range: 0x80d2dc..0x80d410
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d000..0x80d074
+            - Range: 0x80d270..0x80d2e4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80d074..0x80d1a0
+            - Range: 0x80d2e4..0x80d410
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d000..0x80d074
+            - Range: 0x80d270..0x80d2e4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80d074..0x80d1a0
+            - Range: 0x80d2e4..0x80d410
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d000..0x80d074
+            - Range: 0x80d270..0x80d2e4
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80d074..0x80d1a0
+            - Range: 0x80d2e4..0x80d410
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d000..0x80d074
+            - Range: 0x80d270..0x80d2e4
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80d074..0x80d1a0
+            - Range: 0x80d2e4..0x80d410
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d000..0x80d074
+            - Range: 0x80d270..0x80d2e4
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80d074..0x80d1a0
+            - Range: 0x80d2e4..0x80d410
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d000..0x80d074
+            - Range: 0x80d270..0x80d2e4
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80d074..0x80d1a0
+            - Range: 0x80d2e4..0x80d410
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80d000..0x80d15c
+            - Range: 0x80d270..0x80d3cc
               Pieces: []
-            - Range: 0x80d15c..0x80d15d
+            - Range: 0x80d3cc..0x80d3cd
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x80d15d..0x80d1a0
+            - Range: 0x80d3cd..0x80d410
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 127
+    - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x80d1a0..0x80d390]
+      OutOfLinePCRanges: [0x80d410..0x80d600]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d1a0..0x80d224
+            - Range: 0x80d410..0x80d494
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d224..0x80d390
+            - Range: 0x80d494..0x80d600
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d1a0..0x80d214
+            - Range: 0x80d410..0x80d484
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d214..0x80d390
+            - Range: 0x80d484..0x80d600
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d1a0..0x80d21c
+            - Range: 0x80d410..0x80d48c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80d21c..0x80d390
+            - Range: 0x80d48c..0x80d600
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d1a0..0x80d224
+            - Range: 0x80d410..0x80d494
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80d224..0x80d390
+            - Range: 0x80d494..0x80d600
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d1a0..0x80d224
+            - Range: 0x80d410..0x80d494
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80d224..0x80d390
+            - Range: 0x80d494..0x80d600
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d1a0..0x80d224
+            - Range: 0x80d410..0x80d494
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80d224..0x80d390
+            - Range: 0x80d494..0x80d600
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d1a0..0x80d224
+            - Range: 0x80d410..0x80d494
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80d224..0x80d390
+            - Range: 0x80d494..0x80d600
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d1a0..0x80d224
+            - Range: 0x80d410..0x80d494
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80d224..0x80d390
+            - Range: 0x80d494..0x80d600
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80d1a0..0x80d224
+            - Range: 0x80d410..0x80d494
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d224..0x80d390
+            - Range: 0x80d494..0x80d600
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9170,9 +9223,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80d1a0..0x80d348
+            - Range: 0x80d410..0x80d5b8
               Pieces: []
-            - Range: 0x80d348..0x80d349
+            - Range: 0x80d5b8..0x80d5b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9194,215 +9247,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80d349..0x80d390
+            - Range: 0x80d5b9..0x80d600
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 128
+    - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x80d390..0x80d420]
+      OutOfLinePCRanges: [0x80d600..0x80d690]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x80d390..0x80d420
+            - Range: 0x80d600..0x80d690
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d390..0x80d400
+            - Range: 0x80d600..0x80d670
               Pieces: []
-            - Range: 0x80d400..0x80d401
+            - Range: 0x80d670..0x80d671
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d401..0x80d420
+            - Range: 0x80d671..0x80d690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d390..0x80d400
+            - Range: 0x80d600..0x80d670
               Pieces: []
-            - Range: 0x80d400..0x80d401
+            - Range: 0x80d670..0x80d671
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80d401..0x80d420
+            - Range: 0x80d671..0x80d690
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d390..0x80d400
+            - Range: 0x80d600..0x80d670
               Pieces: []
-            - Range: 0x80d400..0x80d401
+            - Range: 0x80d670..0x80d671
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80d401..0x80d420
+            - Range: 0x80d671..0x80d690
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 129
+    - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x80d420..0x80d4f0]
+      OutOfLinePCRanges: [0x80d690..0x80d760]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80d420..0x80d4f0
+            - Range: 0x80d690..0x80d760
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80d420..0x80d4f0
+            - Range: 0x80d690..0x80d760
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d420..0x80d4d4
+            - Range: 0x80d690..0x80d744
               Pieces: []
-            - Range: 0x80d4d4..0x80d4d5
+            - Range: 0x80d744..0x80d745
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d4d5..0x80d4f0
+            - Range: 0x80d745..0x80d760
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80d420..0x80d4d4
+            - Range: 0x80d690..0x80d744
               Pieces: []
-            - Range: 0x80d4d4..0x80d4d5
+            - Range: 0x80d744..0x80d745
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x80d4d5..0x80d4f0
+            - Range: 0x80d745..0x80d760
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 130
+    - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x80d4f0..0x80d5b0]
+      OutOfLinePCRanges: [0x80d760..0x80d820]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80d4f0..0x80d5b0
+            - Range: 0x80d760..0x80d820
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d4f0..0x80d590
+            - Range: 0x80d760..0x80d800
               Pieces: []
-            - Range: 0x80d590..0x80d591
+            - Range: 0x80d800..0x80d801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d591..0x80d5b0
+            - Range: 0x80d801..0x80d820
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80d4f0..0x80d590
+            - Range: 0x80d760..0x80d800
               Pieces: []
-            - Range: 0x80d590..0x80d591
+            - Range: 0x80d800..0x80d801
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80d591..0x80d5b0
+            - Range: 0x80d801..0x80d820
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d568..0x80d5b0
+            - Range: 0x80d7d8..0x80d820
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
-    - ID: 131
+    - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x80d5b0..0x80d650]
+      OutOfLinePCRanges: [0x80d820..0x80d8c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0x80d5b0..0x80d650, Pieces: []}]
+          Locations: [{Range: 0x80d820..0x80d8c0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d5b0..0x80d5ec
+            - Range: 0x80d820..0x80d85c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d5ec..0x80d604
+            - Range: 0x80d85c..0x80d874
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80d604..0x80d60c
+            - Range: 0x80d874..0x80d87c
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80d60c..0x80d650
+            - Range: 0x80d87c..0x80d8c0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80d5b0..0x80d628
+            - Range: 0x80d820..0x80d898
               Pieces: []
-            - Range: 0x80d628..0x80d629
+            - Range: 0x80d898..0x80d899
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80d629..0x80d650
+            - Range: 0x80d899..0x80d8c0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x80d5b0..0x80d628
+            - Range: 0x80d820..0x80d898
               Pieces: []
-            - Range: 0x80d628..0x80d629
+            - Range: 0x80d898..0x80d899
               Pieces: []
-            - Range: 0x80d629..0x80d650
+            - Range: 0x80d899..0x80d8c0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 132
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80da90..0x80daa0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80da90..0x80daa0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
     - ID: 133
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80daa0..0x80dab0]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x80dd00..0x80dd10]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80daa0..0x80dab0
+            - Range: 0x80dd00..0x80dd10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9414,14 +9448,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 134
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x80dab0..0x80dac0]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x80dd10..0x80dd20]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 258 GoSliceHeaderType [][]uint
+          Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80dab0..0x80dac0
+            - Range: 0x80dd10..0x80dd20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9433,14 +9467,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 135
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x80dac0..0x80dad0]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x80dd20..0x80dd30]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x80dac0..0x80dad0
+            - Range: 0x80dd20..0x80dd30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9448,25 +9482,18 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80dac0..0x80dad0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 136
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x80dad0..0x80dae0]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x80dd30..0x80dd40]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80dad0..0x80dae0
+            - Range: 0x80dd30..0x80dd40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9479,20 +9506,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80dad0..0x80dae0
+            - Range: 0x80dd30..0x80dd40
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x80dae0..0x80daf0]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x80dd40..0x80dd50]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80dae0..0x80daf0
+            - Range: 0x80dd40..0x80dd50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9505,20 +9532,46 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80dae0..0x80daf0
+            - Range: 0x80dd40..0x80dd50
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x80dd50..0x80dd60]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x80dd50..0x80dd60
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80dd50..0x80dd60
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80daf0..0x80db00]
+      OutOfLinePCRanges: [0x80dd60..0x80dd70]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 263 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80daf0..0x80db00
+            - Range: 0x80dd60..0x80dd70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9529,22 +9582,22 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 139
+    - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80db00..0x80db10]
+      OutOfLinePCRanges: [0x80dd70..0x80dd80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80db00..0x80db10
+            - Range: 0x80dd70..0x80dd80
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 264 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80db00..0x80db10
+            - Range: 0x80dd70..0x80dd80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9557,39 +9610,20 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x80db00..0x80db10
+            - Range: 0x80dd70..0x80dd80
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
+    - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80db10..0x80db20]
+      OutOfLinePCRanges: [0x80dd80..0x80dd90]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x80db10..0x80db20
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x80db20..0x80db30]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80db20..0x80db30
+            - Range: 0x80dd80..0x80dd90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9601,14 +9635,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 142
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x80db30..0x80db40]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x80dd90..0x80dda0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 266 GoSliceHeaderType []struct {}
+          Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80db30..0x80db40
+            - Range: 0x80dd90..0x80dda0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9620,14 +9654,33 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x80dda0..0x80ddb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x80dda0..0x80ddb0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80db40..0x80db50]
+      OutOfLinePCRanges: [0x80ddb0..0x80ddc0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80db40..0x80db50
+            - Range: 0x80ddb0..0x80ddc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9640,7 +9693,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80db40..0x80db50
+            - Range: 0x80ddb0..0x80ddc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9653,7 +9706,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80db40..0x80db50
+            - Range: 0x80ddb0..0x80ddc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9664,36 +9717,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
+    - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x80de30..0x80de90]
+      OutOfLinePCRanges: [0x80e0a0..0x80e100]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80de30..0x80de78
+            - Range: 0x80e0a0..0x80e0e8
               Pieces: []
-            - Range: 0x80de78..0x80de79
+            - Range: 0x80e0e8..0x80e0e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80de79..0x80de90
+            - Range: 0x80e0e9..0x80e100
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 145
+    - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80de90..0x80dea0]
+      OutOfLinePCRanges: [0x80e100..0x80e110]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80de90..0x80dea0
+            - Range: 0x80e100..0x80e110
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9702,15 +9755,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80dea0..0x80deb0]
+      OutOfLinePCRanges: [0x80e110..0x80e120]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80dea0..0x80deb0
+            - Range: 0x80e110..0x80e120
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9721,7 +9774,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80dea0..0x80deb0
+            - Range: 0x80e110..0x80e120
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9732,7 +9785,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80dea0..0x80deb0
+            - Range: 0x80e110..0x80e120
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9741,15 +9794,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 147
+    - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80deb0..0x80dec0]
+      OutOfLinePCRanges: [0x80e120..0x80e130]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80deb0..0x80dec0
+            - Range: 0x80e120..0x80e130
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9766,58 +9819,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 148
+    - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80dec0..0x80ded0]
+      OutOfLinePCRanges: [0x80e130..0x80e140]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 269 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80dec0..0x80ded0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80ded0..0x80dee0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 270 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0x80ded0..0x80dee0
+            - Range: 0x80e130..0x80e140
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80dee0..0x80def0]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x80e140..0x80e150]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 270 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80dee0..0x80def0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80e140..0x80e150
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80def0..0x80df00]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x80e150..0x80e160]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80def0..0x80df00
+            - Range: 0x80e150..0x80e160
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9827,14 +9863,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 152
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80df00..0x80df10]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x80e160..0x80e170]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80df00..0x80df10
+            - Range: 0x80e160..0x80e170
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9844,14 +9880,31 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 153
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x80e170..0x80e180]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80e170..0x80e180
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x80df10..0x80df20]
+      OutOfLinePCRanges: [0x80e180..0x80e190]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80df10..0x80df20
+            - Range: 0x80e180..0x80e190
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9862,7 +9915,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80df10..0x80df20
+            - Range: 0x80e180..0x80e190
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9873,7 +9926,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80df10..0x80df20
+            - Range: 0x80e180..0x80e190
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9882,28 +9935,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
+    - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80e070..0x80e080]
+      OutOfLinePCRanges: [0x80e2e0..0x80e2f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80e070..0x80e080
+            - Range: 0x80e2e0..0x80e2f0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
+    - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80e080..0x80e090]
+      OutOfLinePCRanges: [0x80e2f0..0x80e300]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 285 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80e080..0x80e090
+            - Range: 0x80e2f0..0x80e300
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9920,15 +9973,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
+    - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80e130..0x80e150]
+      OutOfLinePCRanges: [0x80e3a0..0x80e3c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 StructureType main.aStruct
           Locations:
-            - Range: 0x80e130..0x80e150
+            - Range: 0x80e3a0..0x80e3c0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9947,157 +10000,157 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 157
+    - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80e1c0..0x80e1d0]
+      OutOfLinePCRanges: [0x80e430..0x80e440]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80e1c0..0x80e1d0
+            - Range: 0x80e430..0x80e440
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 158
+    - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x80e1d0..0x80e1e0]
+      OutOfLinePCRanges: [0x80e440..0x80e450]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 319 StructureType main.tenStrings
           Locations:
-            - Range: 0x80e1d0..0x80e1e0
+            - Range: 0x80e440..0x80e450
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 159
+    - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80e200..0x80e210]
+      OutOfLinePCRanges: [0x80e470..0x80e480]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 StructureType main.emptyStruct
-          Locations: [{Range: 0x80e200..0x80e210, Pieces: []}]
+          Locations: [{Range: 0x80e470..0x80e480, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 160
+    - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80e210..0x80e220]
+      OutOfLinePCRanges: [0x80e480..0x80e490]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 321 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80e210..0x80e220
+            - Range: 0x80e480..0x80e490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 161
+    - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x80f9e0..0x80f9f0]
+      OutOfLinePCRanges: [0x80fc50..0x80fc60]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x80f9e0..0x80f9f0
+            - Range: 0x80fc50..0x80fc60
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80f9e0..0x80f9e4
+            - Range: 0x80fc50..0x80fc54
               Pieces: []
-            - Range: 0x80f9e4..0x80f9e5
+            - Range: 0x80fc54..0x80fc55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80f9e5..0x80f9f0
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 162
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x80f9f0..0x80fa00]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 324 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x80f9f0..0x80f9fc
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80f9fc..0x80fa00
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x80f9f0..0x80f9fc
-              Pieces: []
-            - Range: 0x80f9fc..0x80f9fd
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80f9fd..0x80fa00
+            - Range: 0x80fc55..0x80fc60
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0x80fc60..0x80fc70]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 324 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x80fc60..0x80fc6c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x80fc6c..0x80fc70
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x80fc60..0x80fc6c
+              Pieces: []
+            - Range: 0x80fc6c..0x80fc6d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80fc6d..0x80fc70
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x80fa00..0x80fa10]
+      OutOfLinePCRanges: [0x80fc70..0x80fc80]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80fa00..0x80fa10
+            - Range: 0x80fc70..0x80fc80
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x80fa00..0x80fa04
+            - Range: 0x80fc70..0x80fc74
               Pieces: []
-            - Range: 0x80fa04..0x80fa05
+            - Range: 0x80fc74..0x80fc75
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fa05..0x80fa10
+            - Range: 0x80fc75..0x80fc80
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 164
+    - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x80fa10..0x80fa20]
+      OutOfLinePCRanges: [0x80fc80..0x80fc90]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80fa10..0x80fa1c
+            - Range: 0x80fc80..0x80fc8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80fa1c..0x80fa20
+            - Range: 0x80fc8c..0x80fc90
               Pieces:
                 - Size: 8
                   Op: null
@@ -10108,28 +10161,28 @@ Subprograms:
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80fa10..0x80fa1c
+            - Range: 0x80fc80..0x80fc8c
               Pieces: []
-            - Range: 0x80fa1c..0x80fa1d
+            - Range: 0x80fc8c..0x80fc8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fa1d..0x80fa20
+            - Range: 0x80fc8d..0x80fc90
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x80fa80..0x80fba0]
+      OutOfLinePCRanges: [0x80fcf0..0x80fe10]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80fa80..0x80faac
+            - Range: 0x80fcf0..0x80fd1c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10137,7 +10190,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80faac..0x80fabc
+            - Range: 0x80fd1c..0x80fd2c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10145,7 +10198,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x80fabc..0x80fba0
+            - Range: 0x80fd2c..0x80fe10
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10158,18 +10211,18 @@ Subprograms:
         - Name: pred
           Type: 328 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x80fa80..0x80fabc
+            - Range: 0x80fcf0..0x80fd2c
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80fabc..0x80fba0
+            - Range: 0x80fd2c..0x80fe10
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80fa80..0x80fb6c
+            - Range: 0x80fcf0..0x80fddc
               Pieces: []
-            - Range: 0x80fb6c..0x80fb6d
+            - Range: 0x80fddc..0x80fddd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10177,14 +10230,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80fb6d..0x80fba0
+            - Range: 0x80fddd..0x80fe10
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80faac..0x80fabc
+            - Range: 0x80fd1c..0x80fd2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10192,7 +10245,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80fabc..0x80fad8
+            - Range: 0x80fd2c..0x80fd48
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10200,7 +10253,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fad8..0x80fadc
+            - Range: 0x80fd48..0x80fd4c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10208,7 +10261,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fadc..0x80fae0
+            - Range: 0x80fd4c..0x80fd50
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10216,7 +10269,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fae0..0x80fae0
+            - Range: 0x80fd50..0x80fd50
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10224,7 +10277,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fae0..0x80fb0c
+            - Range: 0x80fd50..0x80fd7c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10232,7 +10285,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80fb0c..0x80fb60
+            - Range: 0x80fd7c..0x80fdd0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10240,7 +10293,7 @@ Subprograms:
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: -40}
-            - Range: 0x80fb60..0x80fba0
+            - Range: 0x80fdd0..0x80fe10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10253,215 +10306,215 @@ Subprograms:
         - Name: item
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x80fafc..0x80fb0c
+            - Range: 0x80fd6c..0x80fd7c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fb0c..0x80fb60
+            - Range: 0x80fd7c..0x80fdd0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 166
+    - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80fba0..0x80fbf0]
+      OutOfLinePCRanges: [0x80fe10..0x80fe60]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80fba0..0x80fbc8
+            - Range: 0x80fe10..0x80fe38
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 329 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x80fba0..0x80fbc8
+            - Range: 0x80fe10..0x80fe38
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80fba0..0x80fbc8
+            - Range: 0x80fe10..0x80fe38
               Pieces: []
-            - Range: 0x80fbc8..0x80fbc9
+            - Range: 0x80fe38..0x80fe39
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fbc9..0x80fbf0
+            - Range: 0x80fe39..0x80fe60
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 167
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x80fe60..0x80fe70]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 327 PointerType *go.shape.int
-          Locations:
-            - Range: 0x80fe60..0x80fe70
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 327 PointerType *go.shape.int
-          Locations:
-            - Range: 0x80fe60..0x80fe64
-              Pieces: []
-            - Range: 0x80fe64..0x80fe65
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fe65..0x80fe70
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 168
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x80fe70..0x80fe80]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0x8100d0..0x8100e0]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 330 PointerType *go.shape.struct { Name string }
+          Type: 327 PointerType *go.shape.int
           Locations:
-            - Range: 0x80fe70..0x80fe80
+            - Range: 0x8100d0..0x8100e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 330 PointerType *go.shape.struct { Name string }
+          Type: 327 PointerType *go.shape.int
           Locations:
-            - Range: 0x80fe70..0x80fe74
+            - Range: 0x8100d0..0x8100d4
               Pieces: []
-            - Range: 0x80fe74..0x80fe75
+            - Range: 0x8100d4..0x8100d5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fe75..0x80fe80
+            - Range: 0x8100d5..0x8100e0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x8100e0..0x8100f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 330 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x8100e0..0x8100f0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 330 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x8100e0..0x8100e4
+              Pieces: []
+            - Range: 0x8100e4..0x8100e5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8100e5..0x8100f0
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x80fe80..0x80fe90]
+      OutOfLinePCRanges: [0x8100f0..0x810100]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 332 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x80fe80..0x80fe90
+            - Range: 0x8100f0..0x810100
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 332 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x80fe80..0x80fe84
+            - Range: 0x8100f0..0x8100f4
               Pieces: []
-            - Range: 0x80fe84..0x80fe85
+            - Range: 0x8100f4..0x8100f5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80fe85..0x80fe90
+            - Range: 0x8100f5..0x810100
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
+    - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x80fe90..0x80fea0]
+      OutOfLinePCRanges: [0x810100..0x810110]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 334 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x80fe90..0x80fea0
+            - Range: 0x810100..0x810110
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80fe90..0x80fe94
+            - Range: 0x810100..0x810104
               Pieces: []
-            - Range: 0x80fe94..0x80fe95
+            - Range: 0x810104..0x810105
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80fe95..0x80fea0
+            - Range: 0x810105..0x810110
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 171
+    - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x80ff20..0x80ff30]
+      OutOfLinePCRanges: [0x810190..0x8101a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 336 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x80ff20..0x80ff30
+            - Range: 0x810190..0x8101a0
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x80ff20..0x80ff24
+            - Range: 0x810190..0x810194
               Pieces: []
-            - Range: 0x80ff24..0x80ff25
+            - Range: 0x810194..0x810195
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ff25..0x80ff30
+            - Range: 0x810195..0x8101a0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
+    - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x80ffc0..0x80ffd0]
+      OutOfLinePCRanges: [0x810230..0x810240]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 337 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x80ffc0..0x80ffd0
+            - Range: 0x810230..0x810240
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x80ffc0..0x80ffd0
+            - Range: 0x810230..0x810240
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0x80ffc0..0x80ffd0
+            - Range: 0x810230..0x810240
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 173
+    - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x810050..0x8100c0]
+      OutOfLinePCRanges: [0x8102c0..0x810330]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x810050..0x8100c0
+            - Range: 0x8102c0..0x810330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810050..0x8100c0
+            - Range: 0x8102c0..0x810330
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10472,20 +10525,20 @@ Subprograms:
         - Name: v
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x810050..0x8100c0
+            - Range: 0x8102c0..0x810330
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 174
+    - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x810140..0x810150]
+      OutOfLinePCRanges: [0x8103b0..0x8103c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810140..0x810150
+            - Range: 0x8103b0..0x8103c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10496,59 +10549,59 @@ Subprograms:
         - Name: b
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0x810140..0x810150
+            - Range: 0x8103b0..0x8103c0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 339 BaseType go.shape.bool
           Locations:
-            - Range: 0x810140..0x810148
+            - Range: 0x8103b0..0x8103b8
               Pieces: []
-            - Range: 0x810148..0x810149
+            - Range: 0x8103b8..0x8103b9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810149..0x810150
+            - Range: 0x8103b9..0x8103c0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810140..0x810148
+            - Range: 0x8103b0..0x8103b8
               Pieces: []
-            - Range: 0x810148..0x810149
+            - Range: 0x8103b8..0x8103b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x810149..0x810150
+            - Range: 0x8103b9..0x8103c0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 175
+    - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x810150..0x810170]
+      OutOfLinePCRanges: [0x8103c0..0x8103e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x810150..0x810160
+            - Range: 0x8103c0..0x8103d0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810150..0x81015c
+            - Range: 0x8103c0..0x8103cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x81015c..0x810170
+            - Range: 0x8103cc..0x8103e0
               Pieces:
                 - Size: 8
                   Op: null
@@ -10559,73 +10612,73 @@ Subprograms:
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810150..0x810160
+            - Range: 0x8103c0..0x8103d0
               Pieces: []
-            - Range: 0x810160..0x810161
+            - Range: 0x8103d0..0x8103d1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810161..0x810170
+            - Range: 0x8103d1..0x8103e0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x810150..0x810160
+            - Range: 0x8103c0..0x8103d0
               Pieces: []
-            - Range: 0x810160..0x810161
+            - Range: 0x8103d0..0x8103d1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x810161..0x810170
+            - Range: 0x8103d1..0x8103e0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 176
+    - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x810170..0x8101c0]
+      OutOfLinePCRanges: [0x8103e0..0x810430]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 342 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x810170..0x810198
+            - Range: 0x8103e0..0x810408
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x810170..0x810198
+            - Range: 0x8103e0..0x810408
               Pieces: []
-            - Range: 0x810198..0x810199
+            - Range: 0x810408..0x810409
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810199..0x8101c0
+            - Range: 0x810409..0x810430
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 177
+    - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x8101c0..0x810220]
+      OutOfLinePCRanges: [0x810430..0x810490]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 343 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x8101c0..0x8101ec
+            - Range: 0x810430..0x81045c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x8101ec..0x8101f0
+            - Range: 0x81045c..0x810460
               Pieces:
                 - Size: 8
                   Op: null
@@ -10636,65 +10689,65 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8101c0..0x8101f0
+            - Range: 0x810430..0x810460
               Pieces: []
-            - Range: 0x8101f0..0x8101f1
+            - Range: 0x810460..0x810461
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8101f1..0x810220
+            - Range: 0x810461..0x810490
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 178
+    - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x810220..0x810230]
+      OutOfLinePCRanges: [0x810490..0x8104a0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 344 PointerType *go.shape.string
           Locations:
-            - Range: 0x810220..0x810224
+            - Range: 0x810490..0x810494
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810220..0x810224
+            - Range: 0x810490..0x810494
               Pieces: []
-            - Range: 0x810224..0x810225
+            - Range: 0x810494..0x810495
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810225..0x810230
+            - Range: 0x810495..0x8104a0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 179
+    - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x810230..0x810280]
+      OutOfLinePCRanges: [0x8104a0..0x8104f0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 345 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x810230..0x81026c
+            - Range: 0x8104a0..0x8104dc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 346 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x810230..0x810270
+            - Range: 0x8104a0..0x8104e0
               Pieces: []
-            - Range: 0x810270..0x810271
+            - Range: 0x8104e0..0x8104e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10708,20 +10761,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x810271..0x810280
+            - Range: 0x8104e1..0x8104f0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 180
+    - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x810280..0x8102c0]
+      OutOfLinePCRanges: [0x8104f0..0x810530]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 326 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x810280..0x81028c
+            - Range: 0x8104f0..0x8104fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10729,7 +10782,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x81028c..0x8102c0
+            - Range: 0x8104fc..0x810530
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10742,42 +10795,42 @@ Subprograms:
         - Name: needle
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x810280..0x8102c0
+            - Range: 0x8104f0..0x810530
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x810280..0x8102a8
+            - Range: 0x8104f0..0x810518
               Pieces: []
-            - Range: 0x8102a8..0x8102a9
+            - Range: 0x810518..0x810519
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8102a9..0x8102b0
+            - Range: 0x810519..0x810520
               Pieces: []
-            - Range: 0x8102b0..0x8102b1
+            - Range: 0x810520..0x810521
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8102b1..0x8102c0
+            - Range: 0x810521..0x810530
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x81029c..0x8102ac
+            - Range: 0x81050c..0x81051c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 181
+    - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x8102c0..0x810380]
+      OutOfLinePCRanges: [0x810530..0x8105f0]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 347 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x8102c0..0x8102e4
+            - Range: 0x810530..0x810554
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10785,7 +10838,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8102e4..0x8102e8
+            - Range: 0x810554..0x810558
               Pieces:
                 - Size: 8
                   Op: null
@@ -10798,13 +10851,13 @@ Subprograms:
         - Name: needle
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x8102c0..0x810318
+            - Range: 0x810530..0x810588
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x810318..0x810380
+            - Range: 0x810588..0x8105f0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10815,22 +10868,22 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8102c0..0x810334
+            - Range: 0x810530..0x8105a4
               Pieces: []
-            - Range: 0x810334..0x810335
+            - Range: 0x8105a4..0x8105a5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810335..0x810344
+            - Range: 0x8105a5..0x8105b4
               Pieces: []
-            - Range: 0x810344..0x810345
+            - Range: 0x8105b4..0x8105b5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810345..0x810380
+            - Range: 0x8105b5..0x8105f0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810300..0x810318
+            - Range: 0x810570..0x810588
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10839,58 +10892,58 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 182
+    - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x810380..0x810390]
+      OutOfLinePCRanges: [0x8105f0..0x810600]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 348 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x810380..0x810388
+            - Range: 0x8105f0..0x8105f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 322 BaseType go.shape.int
           Locations:
-            - Range: 0x810380..0x810390
+            - Range: 0x8105f0..0x810600
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x810380..0x810388
+            - Range: 0x8105f0..0x8105f8
               Pieces: []
-            - Range: 0x810388..0x810389
+            - Range: 0x8105f8..0x8105f9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x810389..0x810390
+            - Range: 0x8105f9..0x810600
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
-    - ID: 183
+    - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x810400..0x810470]
+      OutOfLinePCRanges: [0x810670..0x8106e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 349 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x810400..0x81042c
+            - Range: 0x810670..0x81069c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x81042c..0x810438
+            - Range: 0x81069c..0x8106a8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x810438..0x81043c
+            - Range: 0x8106a8..0x8106ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10901,7 +10954,7 @@ Subprograms:
         - Name: value
           Type: 324 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x810400..0x81043c
+            - Range: 0x810670..0x8106ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10912,16 +10965,16 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x810400..0x81043c
+            - Range: 0x810670..0x8106ac
               Pieces: []
-            - Range: 0x81043c..0x81043d
+            - Range: 0x8106ac..0x8106ad
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x81043d..0x810470
+            - Range: 0x8106ad..0x8106e0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 184
+    - ID: 185
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x12c6b0..0x12c7d0]
       InlinePCRanges: []
@@ -11060,7 +11113,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 185
+    - ID: 186
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x808ef0..0x808f60]
       InlinePCRanges:
@@ -11091,7 +11144,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 186
+    - ID: 187
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11099,7 +11152,7 @@ Subprograms:
           RootRanges: [0x809110..0x8091d0]
       Variables: []
       DictRegister: null
-    - ID: 187
+    - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11107,7 +11160,7 @@ Subprograms:
           RootRanges: [0x809240..0x809350]
       Variables: []
       DictRegister: null
-    - ID: 188
+    - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11115,7 +11168,7 @@ Subprograms:
           RootRanges: [0x809240..0x809350]
       Variables: []
       DictRegister: null
-    - ID: 189
+    - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11130,7 +11183,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 191
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11149,12 +11202,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 191
+    - ID: 192
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x8094f0..0x809550]
       InlinePCRanges:
-        - Ranges: [0x810518..0x81053c]
-          RootRanges: [0x8104f0..0x810580]
+        - Ranges: [0x810788..0x8107ac]
+          RootRanges: [0x810760..0x8107f0]
       Variables:
         - Name: b
           Type: 354 StructureType main.firstBehavior
@@ -11183,7 +11236,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 192
+    - ID: 193
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -14589,7 +14642,7 @@ Types:
       GoKind: 22
       Pointee: 865 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1632
+      ID: 1633
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14608,7 +14661,7 @@ Types:
             Type: 350 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14619,7 +14672,7 @@ Types:
             Type: 350 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14630,12 +14683,12 @@ Types:
             Type: 353 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: pred}
+                  Variable: {subprogram: 185, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1633
+      ID: 1634
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14648,12 +14701,12 @@ Types:
             Type: 350 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 185, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1630
+      ID: 1631
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14672,7 +14725,7 @@ Types:
             Type: 326 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14683,7 +14736,7 @@ Types:
             Type: 326 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14694,12 +14747,12 @@ Types:
             Type: 328 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: pred}
+                  Variable: {subprogram: 166, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1631
+      ID: 1632
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14712,15 +14765,15 @@ Types:
             Type: 326 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 2, name: ~r0}
+                  Variable: {subprogram: 166, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1688
+      ID: 1689
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1634
+      ID: 1635
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14739,7 +14792,7 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14750,7 +14803,7 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14761,12 +14814,12 @@ Types:
             Type: 329 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: f}
+                  Variable: {subprogram: 167, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1635
+      ID: 1636
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14779,12 +14832,12 @@ Types:
             Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 2, name: ~r0}
+                  Variable: {subprogram: 167, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14806,7 +14859,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14817,7 +14870,7 @@ Types:
             Type: 337 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: x}
+                  Variable: {subprogram: 173, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14828,7 +14881,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14839,15 +14892,15 @@ Types:
             Type: 339 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 2, name: v}
+                  Variable: {subprogram: 173, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1647
+      ID: 1648
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1648
+      ID: 1649
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14869,7 +14922,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14880,7 +14933,7 @@ Types:
             Type: 340 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: x}
+                  Variable: {subprogram: 174, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14891,7 +14944,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14902,15 +14955,15 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 2, name: v}
+                  Variable: {subprogram: 174, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1649
+      ID: 1650
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1686
+      ID: 1687
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14922,12 +14975,12 @@ Types:
             Type: 354 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 0, name: b}
+                  Variable: {subprogram: 192, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1687
+      ID: 1688
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14939,12 +14992,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 1, name: ~r0}
+                  Variable: {subprogram: 192, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14963,7 +15016,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14974,7 +15027,7 @@ Types:
             Type: 326 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14985,14 +15038,14 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.genericContains[go.shape.int]]Line
-      ByteSize: 50
+      ByteSize: 49
       ExprStatusArraySize: 1
       DictEntries:
         - DictIndex: 0
@@ -15009,7 +15062,7 @@ Types:
             Type: 326 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -15020,23 +15073,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
-        - Name: '@return'
-          Offset: 49
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15048,12 +15090,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15072,7 +15114,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -15083,7 +15125,7 @@ Types:
             Type: 347 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: haystack}
+                  Variable: {subprogram: 182, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -15094,14 +15136,14 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1667
+      ID: 1668
       Name: Probe[main.genericContains[go.shape.string]]Line
-      ByteSize: 26
+      ByteSize: 25
       ExprStatusArraySize: 1
       DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
       Expressions:
@@ -15112,23 +15154,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
-        - Name: '@return'
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15140,12 +15171,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15158,7 +15189,7 @@ Types:
             Type: 344 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15169,12 +15200,12 @@ Types:
             Type: 344 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1659
+      ID: 1660
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15187,12 +15218,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Variable: {subprogram: 179, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15205,7 +15236,7 @@ Types:
             Type: 345 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15216,12 +15247,12 @@ Types:
             Type: 345 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1661
+      ID: 1662
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15234,12 +15265,12 @@ Types:
             Type: 346 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: ~r0}
+                  Variable: {subprogram: 180, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1654
+      ID: 1655
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15252,7 +15283,7 @@ Types:
             Type: 342 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -15263,59 +15294,13 @@ Types:
             Type: 342 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1655
-      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: '@return'
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1656
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
-      Expressions:
-        - Name: val
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 343 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-        - Name: val
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 343 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-    - __kind: EventRootType
-      ID: 1657
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -15331,7 +15316,53 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1636
+      ID: 1657
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
+      Expressions:
+        - Name: val
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 343 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+        - Name: val
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 343 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+    - __kind: EventRootType
+      ID: 1658
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1637
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15344,7 +15375,7 @@ Types:
             Type: 327 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15355,12 +15386,12 @@ Types:
             Type: 327 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1637
+      ID: 1638
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15373,12 +15404,12 @@ Types:
             Type: 327 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1638
+      ID: 1639
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15391,7 +15422,7 @@ Types:
             Type: 330 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15402,12 +15433,12 @@ Types:
             Type: 330 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15420,12 +15451,12 @@ Types:
             Type: 330 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1640
+      ID: 1641
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15438,7 +15469,7 @@ Types:
             Type: 332 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15449,12 +15480,12 @@ Types:
             Type: 332 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15467,12 +15498,12 @@ Types:
             Type: 332 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1652
+      ID: 1653
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15491,7 +15522,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15502,7 +15533,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15513,12 +15544,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: b}
+                  Variable: {subprogram: 176, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1653
+      ID: 1654
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15537,7 +15568,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 2, name: ~r0}
+                  Variable: {subprogram: 176, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -15548,12 +15579,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 3, name: ~r1}
+                  Variable: {subprogram: 176, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1650
+      ID: 1651
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15572,7 +15603,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15583,7 +15614,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15594,12 +15625,12 @@ Types:
             Type: 339 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: b}
+                  Variable: {subprogram: 175, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1651
+      ID: 1652
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15618,7 +15649,7 @@ Types:
             Type: 339 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 2, name: ~r0}
+                  Variable: {subprogram: 175, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
@@ -15629,12 +15660,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 3, name: ~r1}
+                  Variable: {subprogram: 175, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1644
+      ID: 1645
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15647,7 +15678,7 @@ Types:
             Type: 336 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
@@ -15658,12 +15689,12 @@ Types:
             Type: 336 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1645
+      ID: 1646
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15676,12 +15707,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 172, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1642
+      ID: 1643
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15694,7 +15725,7 @@ Types:
             Type: 334 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
@@ -15705,12 +15736,12 @@ Types:
             Type: 334 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1643
+      ID: 1644
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15723,12 +15754,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1626
+      ID: 1627
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15741,7 +15772,7 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15752,12 +15783,12 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15770,12 +15801,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15788,7 +15819,7 @@ Types:
             Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15799,12 +15830,12 @@ Types:
             Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1629
+      ID: 1630
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15817,15 +15848,15 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15837,7 +15868,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: ~r0}
+                  Variable: {subprogram: 145, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -15932,7 +15963,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15944,7 +15975,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -15955,12 +15986,12 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15972,7 +16003,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16674,7 +16705,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16686,7 +16717,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16697,7 +16728,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16708,7 +16739,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16719,12 +16750,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16736,7 +16767,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16747,12 +16778,12 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16764,7 +16795,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -16775,12 +16806,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1621
+      ID: 1622
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16792,7 +16823,7 @@ Types:
             Type: 321 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16803,12 +16834,12 @@ Types:
             Type: 321 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16820,7 +16851,7 @@ Types:
             Type: 320 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -16831,14 +16862,14 @@ Types:
             Type: 320 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
       ID: 1402
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 59
+      ByteSize: 51
       ExprStatusArraySize: 2
       Expressions:
         - Name: x
@@ -16874,19 +16905,8 @@ Types:
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
-        - Name: '@return'
-          Offset: 27
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
         - Name: x
-          Offset: 35
+          Offset: 27
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16897,7 +16917,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 43
+          Offset: 35
           Kind: local
           Expression:
             Type: 14 GoInterfaceType error
@@ -17028,7 +17048,7 @@ Types:
     - __kind: EventRootType
       ID: 1430
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 89
+      ByteSize: 81
       ExprStatusArraySize: 1
       Expressions:
         - Name: a
@@ -17052,17 +17072,6 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-          DictIndex: -1
-        - Name: '@return'
-          Offset: 81
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1429
@@ -17189,7 +17198,7 @@ Types:
       ID: 1423
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1678
+      ID: 1679
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1420
@@ -17245,16 +17254,16 @@ Types:
       ID: 1421
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1679
+      ID: 1680
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1680
+      ID: 1681
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1681
+      ID: 1682
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1682
+      ID: 1683
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1424
@@ -17263,7 +17272,7 @@ Types:
       ID: 1425
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1675
+      ID: 1676
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17275,7 +17284,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17286,24 +17295,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1672
-      Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x_val
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17320,12 +17312,29 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1674
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 186, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1675
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17337,7 +17346,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17348,12 +17357,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1677
+      ID: 1678
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17365,7 +17374,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17376,15 +17385,15 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1676
+      ID: 1677
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1683
+      ID: 1684
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17396,7 +17405,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17407,12 +17416,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1684
+      ID: 1685
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17424,7 +17433,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17435,12 +17444,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1685
+      ID: 1686
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17452,7 +17461,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17463,7 +17472,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17636,7 +17645,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -17648,7 +17657,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17659,12 +17668,12 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17676,7 +17685,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: ~r0}
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17768,7 +17777,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -17780,7 +17789,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17791,7 +17800,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17802,7 +17811,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17813,7 +17822,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17824,7 +17833,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17835,7 +17844,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17846,7 +17855,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17857,7 +17866,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17868,7 +17877,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17879,7 +17888,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17890,7 +17899,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17901,7 +17910,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17912,7 +17921,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17923,7 +17932,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17934,7 +17943,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17945,7 +17954,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17956,7 +17965,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17967,12 +17976,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17984,7 +17993,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 9, name: ~r0}
+                  Variable: {subprogram: 127, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18549,34 +18558,6 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1604
       Name: Probe[main.testMassiveString]
       ByteSize: 33
@@ -18589,7 +18570,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18600,12 +18581,40 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1569
+      ID: 1605
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1570
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -18617,7 +18626,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18628,7 +18637,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18639,7 +18648,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18650,7 +18659,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18661,7 +18670,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18672,7 +18681,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18683,7 +18692,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18694,7 +18703,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18705,7 +18714,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18716,7 +18725,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18727,7 +18736,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18738,7 +18747,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18749,7 +18758,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18760,7 +18769,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18771,7 +18780,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18782,7 +18791,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18793,7 +18802,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18804,12 +18813,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18821,12 +18830,12 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 9, name: ~r0}
+                  Variable: {subprogram: 128, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18838,7 +18847,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18849,7 +18858,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -18860,7 +18869,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18871,12 +18880,12 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -18888,7 +18897,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18899,12 +18908,12 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -18916,7 +18925,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18927,7 +18936,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18938,7 +18947,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18949,12 +18958,12 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18966,7 +18975,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -19619,7 +19628,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19631,7 +19640,7 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19642,12 +19651,12 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19659,7 +19668,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19670,10 +19679,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1618
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19685,7 +19694,7 @@ Types:
             Type: 123 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19746,7 +19755,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1585
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -19758,7 +19767,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19769,7 +19778,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19780,7 +19789,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19791,12 +19800,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -19808,7 +19817,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19819,7 +19828,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19830,7 +19839,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19841,7 +19850,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19852,7 +19861,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19863,12 +19872,12 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1588
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -19880,7 +19889,7 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19891,12 +19900,12 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1602
+      ID: 1603
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19908,7 +19917,7 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19919,7 +19928,7 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20131,10 +20140,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20146,15 +20155,15 @@ Types:
             Type: 252 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -20166,15 +20175,15 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20186,15 +20195,15 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -20206,7 +20215,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20217,7 +20226,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20228,7 +20237,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20239,7 +20248,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20250,7 +20259,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20261,7 +20270,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 5, name: ~r5}
+                  Variable: {subprogram: 117, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20272,7 +20281,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 6, name: ~r6}
+                  Variable: {subprogram: 117, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20283,7 +20292,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 7, name: ~r7}
+                  Variable: {subprogram: 117, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20294,15 +20303,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 8, name: ~r8}
+                  Variable: {subprogram: 117, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -20314,7 +20323,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: ~r0}
+                  Variable: {subprogram: 123, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20325,15 +20334,15 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r1}
+                  Variable: {subprogram: 123, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20345,7 +20354,7 @@ Types:
             Type: 97 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20356,7 +20365,7 @@ Types:
             Type: 98 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: ~r1}
+                  Variable: {subprogram: 111, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -20819,10 +20828,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -20834,15 +20843,15 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -20854,7 +20863,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20865,7 +20874,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: ~r1}
+                  Variable: {subprogram: 110, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20876,7 +20885,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 2, name: ~r2}
+                  Variable: {subprogram: 110, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20887,7 +20896,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 3, name: ~r3}
+                  Variable: {subprogram: 110, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20898,7 +20907,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 4, name: ~r4}
+                  Variable: {subprogram: 110, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20909,7 +20918,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 5, name: ~r5}
+                  Variable: {subprogram: 110, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20920,7 +20929,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 6, name: ~r6}
+                  Variable: {subprogram: 110, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20931,7 +20940,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 7, name: ~r7}
+                  Variable: {subprogram: 110, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20942,7 +20951,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 8, name: ~r8}
+                  Variable: {subprogram: 110, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20953,7 +20962,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 9, name: ~r9}
+                  Variable: {subprogram: 110, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20964,7 +20973,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 10, name: ~r10}
+                  Variable: {subprogram: 110, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20975,7 +20984,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 11, name: ~r11}
+                  Variable: {subprogram: 110, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20986,7 +20995,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 12, name: ~r12}
+                  Variable: {subprogram: 110, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20997,7 +21006,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 13, name: ~r13}
+                  Variable: {subprogram: 110, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21008,7 +21017,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 14, name: ~r14}
+                  Variable: {subprogram: 110, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21019,7 +21028,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 110, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21030,15 +21039,15 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 110, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21050,15 +21059,15 @@ Types:
             Type: 254 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -21070,7 +21079,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21081,7 +21090,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21092,7 +21101,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 2, name: ~r2}
+                  Variable: {subprogram: 119, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21103,7 +21112,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 3, name: ~r3}
+                  Variable: {subprogram: 119, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21114,15 +21123,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 4, name: ~r4}
+                  Variable: {subprogram: 119, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -21134,7 +21143,7 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: ~r0}
+                  Variable: {subprogram: 122, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -21145,15 +21154,65 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r1}
+                  Variable: {subprogram: 122, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
-      Name: Probe[main.testReturnsOnlyFloat]
+      ID: 1531
+      Name: Probe[main.testReturnsNamedDeferLine]Line
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: a
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 1556
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1557
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21165,15 +21224,15 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -21185,7 +21244,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -21196,7 +21255,7 @@ Types:
             Type: 96 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -21207,7 +21266,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: ~r2}
+                  Variable: {subprogram: 109, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -21218,7 +21277,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 3, name: ~r3}
+                  Variable: {subprogram: 109, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21229,7 +21288,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 4, name: ~r4}
+                  Variable: {subprogram: 109, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -21240,7 +21299,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 5, name: ~r5}
+                  Variable: {subprogram: 109, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -21251,7 +21310,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 6, name: ~r6}
+                  Variable: {subprogram: 109, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -21262,15 +21321,15 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 7, name: ~r7}
+                  Variable: {subprogram: 109, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21282,15 +21341,15 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -21302,7 +21361,7 @@ Types:
             Type: 255 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
           DictIndex: -1
@@ -21587,7 +21646,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21599,7 +21658,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21610,7 +21669,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21755,7 +21814,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1591
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21767,7 +21826,7 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21778,12 +21837,12 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21795,7 +21854,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21806,7 +21865,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22060,7 +22119,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -22072,7 +22131,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -22083,12 +22142,12 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22100,7 +22159,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22111,7 +22170,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22122,7 +22181,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r2}
+                  Variable: {subprogram: 129, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22183,7 +22242,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1586
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22195,7 +22254,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22206,7 +22265,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22267,7 +22326,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -22279,7 +22338,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22290,7 +22349,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22301,7 +22360,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22312,7 +22371,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22345,7 +22404,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22357,7 +22416,7 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22368,12 +22427,12 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22385,7 +22444,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 1, name: ~r0}
+                  Variable: {subprogram: 131, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22396,12 +22455,12 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 2, name: ~r1}
+                  Variable: {subprogram: 131, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22413,7 +22472,7 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22424,15 +22483,15 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -22444,7 +22503,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22455,7 +22514,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22488,7 +22547,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22500,12 +22559,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -22517,7 +22576,7 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
@@ -22528,18 +22587,18 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -22551,7 +22610,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22562,7 +22621,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22573,7 +22632,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22584,7 +22643,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22595,7 +22654,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22606,12 +22665,12 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22623,7 +22682,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22634,7 +22693,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22645,7 +22704,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22656,7 +22715,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22667,7 +22726,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22678,12 +22737,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1619
+      ID: 1620
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -22695,12 +22754,12 @@ Types:
             Type: 319 StructureType main.tenStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 160
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1601
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22712,7 +22771,7 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22723,12 +22782,12 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
+      ID: 1602
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22740,7 +22799,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22754,7 +22813,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22768,7 +22827,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22776,7 +22835,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1597
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22788,7 +22847,7 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22799,12 +22858,12 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1599
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22816,7 +22875,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22827,7 +22886,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
           DictIndex: -1
@@ -22838,18 +22897,18 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22861,7 +22920,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22872,7 +22931,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22883,7 +22942,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22894,7 +22953,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22905,7 +22964,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22916,7 +22975,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -23117,7 +23176,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23129,7 +23188,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -23140,12 +23199,12 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23157,7 +23216,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -23168,7 +23227,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -23229,34 +23288,6 @@ Types:
                   ByteSize: 800
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1589
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -23269,7 +23300,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -23280,12 +23311,40 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1590
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1578
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23297,7 +23356,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -23308,7 +23367,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -23319,7 +23378,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -23330,12 +23389,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23347,7 +23406,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 2, name: ~r0}
+                  Variable: {subprogram: 132, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -23358,12 +23417,12 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 3, name: ~r1}
+                  Variable: {subprogram: 132, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1668
+      ID: 1669
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23382,7 +23441,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -23393,7 +23452,7 @@ Types:
             Type: 348 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: x}
+                  Variable: {subprogram: 183, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23404,12 +23463,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1669
+      ID: 1670
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23421,12 +23480,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 2, name: ~r0}
+                  Variable: {subprogram: 183, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1670
+      ID: 1671
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23445,7 +23504,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -23456,7 +23515,7 @@ Types:
             Type: 349 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: x}
+                  Variable: {subprogram: 184, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23467,12 +23526,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1671
+      ID: 1672
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23484,12 +23543,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 2, name: ~r0}
+                  Variable: {subprogram: 184, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23502,7 +23561,7 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23513,12 +23572,12 @@ Types:
             Type: 322 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1623
+      ID: 1624
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23531,12 +23590,12 @@ Types:
             Type: 323 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 1, name: ~r0}
+                  Variable: {subprogram: 162, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1624
+      ID: 1625
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23549,7 +23608,7 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23560,12 +23619,12 @@ Types:
             Type: 324 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1625
+      ID: 1626
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23578,7 +23637,7 @@ Types:
             Type: 325 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 1, name: ~r0}
+                  Variable: {subprogram: 163, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -32589,7 +32648,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 998368
       GoKind: 5
-MaxTypeID: 1688
+MaxTypeID: 1689
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -9,15 +9,15 @@ Probes:
       segments: [stackC]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 144}
+        - subprogram: {subprogram: 145}
           events:
             - Kind: Entry
-              Type: 1592 EventRootType Probe[main.stackC]
-              InjectionPoints: [{PC: "0x80a508", Frameless: false}]
+              Type: 1593 EventRootType Probe[main.stackC]
+              InjectionPoints: [{PC: "0x80a768", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1593 EventRootType Probe[main.stackC]Return
-              InjectionPoints: [{PC: "0x80a538", Frameless: false}]
+              Type: 1594 EventRootType Probe[main.stackC]Return
+              InjectionPoints: [{PC: "0x80a798", Frameless: false}]
               Condition: null
           probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -80,15 +80,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 124}
+        - subprogram: {subprogram: 125}
           events:
             - Kind: Entry
-              Type: 1563 EventRootType Probe[main.testArrayArgAndReturn]
-              InjectionPoints: [{PC: "0x80940c", Frameless: false}]
+              Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]
+              InjectionPoints: [{PC: "0x80965c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1564 EventRootType Probe[main.testArrayArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8094a0", Frameless: false}]
+              Type: 1565 EventRootType Probe[main.testArrayArgAndReturn]Return
+              InjectionPoints: [{PC: "0x8096f0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -334,11 +334,11 @@ Probes:
             dsl: x.aString
             json: {getmember: [{ref: x}, aString]}
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1608 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80a7d0", Frameless: true}]
+              Type: 1609 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x80aa30", Frameless: true}]
               Condition: null
     - id: testCaptureExprLine
       version: 0
@@ -353,10 +353,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1667 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1668 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x8055b8"
                   Frameless: false
@@ -383,10 +383,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1668 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1669 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x8055b8"
                   Frameless: false
@@ -402,7 +402,7 @@ Probes:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 185, index: 0, name: x}
+                      Variable: {subprogram: 186, index: 0, name: x}
                       Offset: 0
                       ByteSize: 8
                     - __kind: ExprPushOffsetOp
@@ -425,10 +425,10 @@ Probes:
       captureSnapshot: false
       captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1669 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1670 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x8055b8"
                   Frameless: false
@@ -507,16 +507,16 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 158}
+        - subprogram: {subprogram: 159}
           events:
             - Kind: Entry
-              Type: 1614 EventRootType Probe[main.testTenStrings]
-              InjectionPoints: [{PC: "0x80a840", Frameless: true}]
+              Type: 1615 EventRootType Probe[main.testTenStrings]
+              InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
               Condition:
                 Type: 4 BaseType bool
                 Operations:
                     - __kind: LocationOp
-                      Variable: {subprogram: 158, index: 0, name: x}
+                      Variable: {subprogram: 159, index: 0, name: x}
                       Offset: 144
                       ByteSize: 16
                     - __kind: ExprReadStringOp
@@ -781,11 +781,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 133}
+        - subprogram: {subprogram: 134}
           events:
             - Kind: Entry
-              Type: 1580 EventRootType Probe[main.testEmptySlice]
-              InjectionPoints: [{PC: "0x80a180", Frameless: true}]
+              Type: 1581 EventRootType Probe[main.testEmptySlice]
+              InjectionPoints: [{PC: "0x80a3e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -808,11 +808,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 136}
+        - subprogram: {subprogram: 137}
           events:
             - Kind: Entry
-              Type: 1583 EventRootType Probe[main.testEmptySliceOfStructs]
-              InjectionPoints: [{PC: "0x80a1b0", Frameless: true}]
+              Type: 1584 EventRootType Probe[main.testEmptySliceOfStructs]
+              InjectionPoints: [{PC: "0x80a410", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -836,11 +836,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 152}
+        - subprogram: {subprogram: 153}
           events:
             - Kind: Entry
-              Type: 1604 EventRootType Probe[main.testEmptyString]
-              InjectionPoints: [{PC: "0x80a5c0", Frameless: true}]
+              Type: 1605 EventRootType Probe[main.testEmptyString]
+              InjectionPoints: [{PC: "0x80a820", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -858,11 +858,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 159}
+        - subprogram: {subprogram: 160}
           events:
             - Kind: Entry
-              Type: 1615 EventRootType Probe[main.testEmptyStruct]
-              InjectionPoints: [{PC: "0x80a870", Frameless: true}]
+              Type: 1616 EventRootType Probe[main.testEmptyStruct]
+              InjectionPoints: [{PC: "0x80aad0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -879,11 +879,11 @@ Probes:
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 160}
+        - subprogram: {subprogram: 161}
           events:
             - Kind: Entry
-              Type: 1616 EventRootType Probe[main.testEmptyStructPointer]
-              InjectionPoints: [{PC: "0x80a880", Frameless: true}]
+              Type: 1617 EventRootType Probe[main.testEmptyStructPointer]
+              InjectionPoints: [{PC: "0x80aae0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{e}'
@@ -1092,15 +1092,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 178}
+        - subprogram: {subprogram: 179}
           events:
             - Kind: Entry
-              Type: 1653 EventRootType Probe[main.genericDeref[go.shape.string]]
-              InjectionPoints: [{PC: "0x80c650", Frameless: true}]
+              Type: 1654 EventRootType Probe[main.genericDeref[go.shape.string]]
+              InjectionPoints: [{PC: "0x80c8b0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1654 EventRootType Probe[main.genericDeref[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c654", Frameless: true}]
+              Type: 1655 EventRootType Probe[main.genericDeref[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80c8b4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1110,15 +1110,15 @@ Probes:
                   DSL: p
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 179}
+        - subprogram: {subprogram: 180}
           events:
             - Kind: Entry
-              Type: 1655 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
-              InjectionPoints: [{PC: "0x80c670", Frameless: false}]
+              Type: 1656 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
+              InjectionPoints: [{PC: "0x80c8d0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1656 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
-              InjectionPoints: [{PC: "0x80c6a4", Frameless: false}]
+              Type: 1657 EventRootType Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
+              InjectionPoints: [{PC: "0x80c904", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1137,15 +1137,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 176}
+        - subprogram: {subprogram: 177}
           events:
             - Kind: Entry
-              Type: 1649 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
-              InjectionPoints: [{PC: "0x80c5b8", Frameless: false}]
+              Type: 1650 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]
+              InjectionPoints: [{PC: "0x80c818", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1650 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-              InjectionPoints: [{PC: "0x80c5c8", Frameless: false}]
+              Type: 1651 EventRootType Probe[main.genericDo[go.shape.struct { main.i int }]]Return
+              InjectionPoints: [{PC: "0x80c828", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1155,15 +1155,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 177}
+        - subprogram: {subprogram: 178}
           events:
             - Kind: Entry
-              Type: 1651 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
-              InjectionPoints: [{PC: "0x80c608", Frameless: false}]
+              Type: 1652 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]
+              InjectionPoints: [{PC: "0x80c868", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1652 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
-              InjectionPoints: [{PC: "0x80c620", Frameless: false}]
+              Type: 1653 EventRootType Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+              InjectionPoints: [{PC: "0x80c880", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1182,18 +1182,18 @@ Probes:
       segments: [needle=, {json: {ref: needle}, dsl: needle}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Entry
-              Type: 1657 EventRootType Probe[main.genericContains[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c6b0", Frameless: true}]
+              Type: 1658 EventRootType Probe[main.genericContains[go.shape.int]]
+              InjectionPoints: [{PC: "0x80c910", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1658 EventRootType Probe[main.genericContains[go.shape.int]]Return
+              Type: 1659 EventRootType Probe[main.genericContains[go.shape.int]]Return
               InjectionPoints:
-                - PC: "0x80c6d8"
+                - PC: "0x80c938"
                   Frameless: true
-                - PC: "0x80c6e0"
+                - PC: "0x80c940"
                   Frameless: true
               Condition: null
           probeTemplate:
@@ -1204,18 +1204,18 @@ Probes:
                   DSL: needle
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Entry
-              Type: 1659 EventRootType Probe[main.genericContains[go.shape.string]]
-              InjectionPoints: [{PC: "0x80c708", Frameless: false}]
+              Type: 1660 EventRootType Probe[main.genericContains[go.shape.string]]
+              InjectionPoints: [{PC: "0x80c968", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1660 EventRootType Probe[main.genericContains[go.shape.string]]Return
+              Type: 1661 EventRootType Probe[main.genericContains[go.shape.string]]Return
               InjectionPoints:
-                - PC: "0x80c768"
+                - PC: "0x80c9c8"
                   Frameless: false
-                - PC: "0x80c778"
+                - PC: "0x80c9d8"
                   Frameless: false
               Condition: null
           probeTemplate:
@@ -1238,11 +1238,11 @@ Probes:
       segments: [v=, {json: {ref: v}, dsl: v}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 180}
+        - subprogram: {subprogram: 181}
           events:
             - Kind: Line
-              Type: 1661 EventRootType Probe[main.genericContains[go.shape.int]]Line
-              InjectionPoints: [{PC: "0x80c6b4", Frameless: true}]
+              Type: 1662 EventRootType Probe[main.genericContains[go.shape.int]]Line
+              InjectionPoints: [{PC: "0x80c914", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1250,11 +1250,11 @@ Probes:
                 - v=
                 - Error: failed to resolve reference "v"
                   DSL: v
-        - subprogram: {subprogram: 181}
+        - subprogram: {subprogram: 182}
           events:
             - Kind: Line
-              Type: 1662 EventRootType Probe[main.genericContains[go.shape.string]]Line
-              InjectionPoints: [{PC: "0x80c718", Frameless: false}]
+              Type: 1663 EventRootType Probe[main.genericContains[go.shape.string]]Line
+              InjectionPoints: [{PC: "0x80c978", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: v={v}
@@ -1271,15 +1271,15 @@ Probes:
       segments: [x=, {json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 170}
+        - subprogram: {subprogram: 171}
           events:
             - Kind: Entry
-              Type: 1637 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
-              InjectionPoints: [{PC: "0x80c330", Frameless: true}]
+              Type: 1638 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]
+              InjectionPoints: [{PC: "0x80c590", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1638 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
-              InjectionPoints: [{PC: "0x80c334", Frameless: true}]
+              Type: 1639 EventRootType Probe[main.largeGenericType[go.shape.string].LargeGet]Return
+              InjectionPoints: [{PC: "0x80c594", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1289,15 +1289,15 @@ Probes:
                   DSL: x
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 171}
+        - subprogram: {subprogram: 172}
           events:
             - Kind: Entry
-              Type: 1639 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
-              InjectionPoints: [{PC: "0x80c3b0", Frameless: true}]
+              Type: 1640 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]
+              InjectionPoints: [{PC: "0x80c610", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1640 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
-              InjectionPoints: [{PC: "0x80c3b4", Frameless: true}]
+              Type: 1641 EventRootType Probe[main.largeGenericType[go.shape.int].LargeGet]Return
+              InjectionPoints: [{PC: "0x80c614", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: x={x}
@@ -1317,15 +1317,15 @@ Probes:
       segments: [items=, {json: {ref: items}, dsl: items}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 165}
+        - subprogram: {subprogram: 166}
           events:
             - Kind: Entry
-              Type: 1625 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
-              InjectionPoints: [{PC: "0x80bf3c", Frameless: false}]
+              Type: 1626 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
+              InjectionPoints: [{PC: "0x80c19c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1626 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80c088", Frameless: false}]
+              Type: 1627 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x80c2e8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: items={items}
@@ -1335,14 +1335,14 @@ Probes:
                   DSL: items
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 184}
+        - subprogram: {subprogram: 185}
           events:
             - Kind: Entry
-              Type: 1627 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
+              Type: 1628 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
               InjectionPoints: [{PC: "0x139acc", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1628 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
+              Type: 1629 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
               InjectionPoints: [{PC: "0x139c18", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1363,15 +1363,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 166}
+        - subprogram: {subprogram: 167}
           events:
             - Kind: Entry
-              Type: 1629 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80c0d8", Frameless: false}]
+              Type: 1630 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x80c338", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1630 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c0e8", Frameless: false}]
+              Type: 1631 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80c348", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1390,15 +1390,15 @@ Probes:
       segments: [value=, {json: {ref: value}, dsl: value}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 182}
+        - subprogram: {subprogram: 183}
           events:
             - Kind: Entry
-              Type: 1663 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
-              InjectionPoints: [{PC: "0x80c7b0", Frameless: true}]
+              Type: 1664 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]
+              InjectionPoints: [{PC: "0x80ca10", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1664 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
-              InjectionPoints: [{PC: "0x80c7b8", Frameless: true}]
+              Type: 1665 EventRootType Probe[main.typeWithGenerics[go.shape.int].Guess]Return
+              InjectionPoints: [{PC: "0x80ca18", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1408,15 +1408,15 @@ Probes:
                   DSL: value
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 183}
+        - subprogram: {subprogram: 184}
           events:
             - Kind: Entry
-              Type: 1665 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
-              InjectionPoints: [{PC: "0x80c828", Frameless: false}]
+              Type: 1666 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]
+              InjectionPoints: [{PC: "0x80ca88", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1666 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
-              InjectionPoints: [{PC: "0x80c84c", Frameless: false}]
+              Type: 1667 EventRootType Probe[main.typeWithGenerics[go.shape.string].Guess]Return
+              InjectionPoints: [{PC: "0x80caac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: value={value}
@@ -1435,15 +1435,15 @@ Probes:
       segments: [box=, {json: {ref: box}, dsl: box}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 163}
+        - subprogram: {subprogram: 164}
           events:
             - Kind: Entry
-              Type: 1621 EventRootType Probe[main.nestedGeneric[go.shape.int]]
-              InjectionPoints: [{PC: "0x80bea0", Frameless: true}]
+              Type: 1622 EventRootType Probe[main.nestedGeneric[go.shape.int]]
+              InjectionPoints: [{PC: "0x80c100", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1622 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80bea4", Frameless: true}]
+              Type: 1623 EventRootType Probe[main.nestedGeneric[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x80c104", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1453,15 +1453,15 @@ Probes:
                   DSL: box
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 164}
+        - subprogram: {subprogram: 165}
           events:
             - Kind: Entry
-              Type: 1623 EventRootType Probe[main.nestedGeneric[go.shape.string]]
-              InjectionPoints: [{PC: "0x80beb0", Frameless: true}]
+              Type: 1624 EventRootType Probe[main.nestedGeneric[go.shape.string]]
+              InjectionPoints: [{PC: "0x80c110", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1624 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80bebc", Frameless: true}]
+              Type: 1625 EventRootType Probe[main.nestedGeneric[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80c11c", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: box={box}
@@ -1480,15 +1480,15 @@ Probes:
       segments: [k=, {json: {ref: k}, dsl: k}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 172}
+        - subprogram: {subprogram: 173}
           events:
             - Kind: Entry
-              Type: 1641 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
-              InjectionPoints: [{PC: "0x80c430", Frameless: true}]
+              Type: 1642 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
+              InjectionPoints: [{PC: "0x80c690", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1642 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
-              InjectionPoints: [{PC: "0x80c438", Frameless: true}]
+              Type: 1643 EventRootType Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
+              InjectionPoints: [{PC: "0x80c698", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1498,15 +1498,15 @@ Probes:
                   DSL: k
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 173}
+        - subprogram: {subprogram: 174}
           events:
             - Kind: Entry
-              Type: 1643 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
-              InjectionPoints: [{PC: "0x80c4b8", Frameless: false}]
+              Type: 1644 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
+              InjectionPoints: [{PC: "0x80c718", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1644 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
-              InjectionPoints: [{PC: "0x80c4e0", Frameless: false}]
+              Type: 1645 EventRootType Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
+              InjectionPoints: [{PC: "0x80c740", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: k={k}
@@ -1525,33 +1525,15 @@ Probes:
       segments: [p=, {json: {ref: p}, dsl: p}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 167}
-          events:
-            - Kind: Entry
-              Type: 1631 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
-              InjectionPoints: [{PC: "0x80c300", Frameless: true}]
-              Condition: null
-            - Kind: Return
-              Type: 1632 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80c304", Frameless: true}]
-              Condition: null
-          probeTemplate:
-            TemplateString: p={p}
-            Segments:
-                - p=
-                - JSON: {Ref: p}
-                  DSL: p
-                  EventKind: Entry
-                  EventExpressionIndex: 0
         - subprogram: {subprogram: 168}
           events:
             - Kind: Entry
-              Type: 1633 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
-              InjectionPoints: [{PC: "0x80c310", Frameless: true}]
+              Type: 1632 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]
+              InjectionPoints: [{PC: "0x80c560", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1634 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
-              InjectionPoints: [{PC: "0x80c314", Frameless: true}]
+              Type: 1633 EventRootType Probe[main.genericPtrIdentity[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x80c564", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1564,12 +1546,30 @@ Probes:
         - subprogram: {subprogram: 169}
           events:
             - Kind: Entry
-              Type: 1635 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
-              InjectionPoints: [{PC: "0x80c320", Frameless: true}]
+              Type: 1634 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
+              InjectionPoints: [{PC: "0x80c570", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1636 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
-              InjectionPoints: [{PC: "0x80c324", Frameless: true}]
+              Type: 1635 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
+              InjectionPoints: [{PC: "0x80c574", Frameless: true}]
+              Condition: null
+          probeTemplate:
+            TemplateString: p={p}
+            Segments:
+                - p=
+                - JSON: {Ref: p}
+                  DSL: p
+                  EventKind: Entry
+                  EventExpressionIndex: 0
+        - subprogram: {subprogram: 170}
+          events:
+            - Kind: Entry
+              Type: 1636 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
+              InjectionPoints: [{PC: "0x80c580", Frameless: true}]
+              Condition: null
+            - Kind: Return
+              Type: 1637 EventRootType Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
+              InjectionPoints: [{PC: "0x80c584", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: p={p}
@@ -1588,15 +1588,15 @@ Probes:
       segments: [a=, {json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 174}
+        - subprogram: {subprogram: 175}
           events:
             - Kind: Entry
-              Type: 1645 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
-              InjectionPoints: [{PC: "0x80c570", Frameless: true}]
+              Type: 1646 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]
+              InjectionPoints: [{PC: "0x80c7d0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1646 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
-              InjectionPoints: [{PC: "0x80c578", Frameless: true}]
+              Type: 1647 EventRootType Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
+              InjectionPoints: [{PC: "0x80c7d8", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1606,15 +1606,15 @@ Probes:
                   DSL: a
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 175}
+        - subprogram: {subprogram: 176}
           events:
             - Kind: Entry
-              Type: 1647 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
-              InjectionPoints: [{PC: "0x80c580", Frameless: true}]
+              Type: 1648 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]
+              InjectionPoints: [{PC: "0x80c7e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1648 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80c590", Frameless: true}]
+              Type: 1649 EventRootType Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80c7f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: a={a}
@@ -1633,15 +1633,15 @@ Probes:
       segments: [val=, {json: {ref: val}, dsl: val}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 161}
+        - subprogram: {subprogram: 162}
           events:
             - Kind: Entry
-              Type: 1617 EventRootType Probe[main.wrapBox[go.shape.int]]
-              InjectionPoints: [{PC: "0x80be80", Frameless: true}]
+              Type: 1618 EventRootType Probe[main.wrapBox[go.shape.int]]
+              InjectionPoints: [{PC: "0x80c0e0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1618 EventRootType Probe[main.wrapBox[go.shape.int]]Return
-              InjectionPoints: [{PC: "0x80be84", Frameless: true}]
+              Type: 1619 EventRootType Probe[main.wrapBox[go.shape.int]]Return
+              InjectionPoints: [{PC: "0x80c0e4", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1651,15 +1651,15 @@ Probes:
                   DSL: val
                   EventKind: Entry
                   EventExpressionIndex: 0
-        - subprogram: {subprogram: 162}
+        - subprogram: {subprogram: 163}
           events:
             - Kind: Entry
-              Type: 1619 EventRootType Probe[main.wrapBox[go.shape.string]]
-              InjectionPoints: [{PC: "0x80be90", Frameless: true}]
+              Type: 1620 EventRootType Probe[main.wrapBox[go.shape.string]]
+              InjectionPoints: [{PC: "0x80c0f0", Frameless: true}]
               Condition: null
             - Kind: Return
-              Type: 1620 EventRootType Probe[main.wrapBox[go.shape.string]]Return
-              InjectionPoints: [{PC: "0x80be9c", Frameless: true}]
+              Type: 1621 EventRootType Probe[main.wrapBox[go.shape.string]]Return
+              InjectionPoints: [{PC: "0x80c0fc", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: val={val}
@@ -1766,10 +1766,10 @@ Probes:
       segments: [testInlinedBBB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 186}
+        - subprogram: {subprogram: 187}
           events:
             - Kind: Entry
-              Type: 1673 EventRootType Probe[main.testInlinedBBB]
+              Type: 1674 EventRootType Probe[main.testInlinedBBB]
               InjectionPoints: [{PC: "0x805824", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1806,10 +1806,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Entry
-              Type: 1674 EventRootType Probe[main.testInlinedBCA]
+              Type: 1675 EventRootType Probe[main.testInlinedBCA]
               InjectionPoints: [{PC: "0x80590c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1827,10 +1827,10 @@ Probes:
       segments: [testInlinedBCA]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 187}
+        - subprogram: {subprogram: 188}
           events:
             - Kind: Line
-              Type: 1675 EventRootType Probe[main.testInlinedBCA]Line
+              Type: 1676 EventRootType Probe[main.testInlinedBCA]Line
               InjectionPoints: [{PC: "0x80590c", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1845,10 +1845,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Entry
-              Type: 1676 EventRootType Probe[main.testInlinedBCB]
+              Type: 1677 EventRootType Probe[main.testInlinedBCB]
               InjectionPoints: [{PC: "0x8059b0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1866,10 +1866,10 @@ Probes:
       segments: [testInlinedBCB]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 188}
+        - subprogram: {subprogram: 189}
           events:
             - Kind: Line
-              Type: 1677 EventRootType Probe[main.testInlinedBCB]Line
+              Type: 1678 EventRootType Probe[main.testInlinedBCB]Line
               InjectionPoints: [{PC: "0x8059b0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1884,10 +1884,10 @@ Probes:
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 192}
+        - subprogram: {subprogram: 193}
           events:
             - Kind: Entry
-              Type: 1683 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+              Type: 1684 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
               InjectionPoints:
                 - PC: "0x139638"
                   Frameless: true
@@ -1907,10 +1907,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Entry
-              Type: 1670 EventRootType Probe[main.testInlinedPrint]
+              Type: 1671 EventRootType Probe[main.testInlinedPrint]
               InjectionPoints:
                 - PC: "0x8055b8"
                   Frameless: false
@@ -1924,7 +1924,7 @@ Probes:
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1671 EventRootType Probe[main.testInlinedPrint]Return
+              Type: 1672 EventRootType Probe[main.testInlinedPrint]Return
               InjectionPoints: [{PC: "0x8055ec", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -1946,10 +1946,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 185}
+        - subprogram: {subprogram: 186}
           events:
             - Kind: Line
-              Type: 1672 EventRootType Probe[main.testInlinedPrint]Line
+              Type: 1673 EventRootType Probe[main.testInlinedPrint]Line
               InjectionPoints:
                 - PC: "0x8055b8"
                   Frameless: false
@@ -1978,10 +1978,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Entry
-              Type: 1678 EventRootType Probe[main.testInlinedSq]
+              Type: 1679 EventRootType Probe[main.testInlinedSq]
               InjectionPoints: [{PC: "0x805a04", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2003,10 +2003,10 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 189}
+        - subprogram: {subprogram: 190}
           events:
             - Kind: Line
-              Type: 1679 EventRootType Probe[main.testInlinedSq]Line
+              Type: 1680 EventRootType Probe[main.testInlinedSq]Line
               InjectionPoints: [{PC: "0x805a04", Frameless: true}]
               Condition: null
           probeTemplate:
@@ -2026,10 +2026,10 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 190}
+        - subprogram: {subprogram: 191}
           events:
             - Kind: Entry
-              Type: 1680 EventRootType Probe[main.testInlinedSumArray]
+              Type: 1681 EventRootType Probe[main.testInlinedSumArray]
               InjectionPoints:
                 - PC: "0x805a34"
                   Frameless: false
@@ -2183,15 +2183,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 123}
+        - subprogram: {subprogram: 124}
           events:
             - Kind: Entry
-              Type: 1561 EventRootType Probe[main.testLargeArgAndReturn]
-              InjectionPoints: [{PC: "0x809280", Frameless: false}]
+              Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]
+              InjectionPoints: [{PC: "0x8094d0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1562 EventRootType Probe[main.testLargeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x8093b0", Frameless: false}]
+              Type: 1563 EventRootType Probe[main.testLargeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x809600", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -2321,15 +2321,15 @@ Probes:
           dsl: i
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 126}
+        - subprogram: {subprogram: 127}
           events:
             - Kind: Entry
-              Type: 1567 EventRootType Probe[main.testManyArgsArrayReturn]
-              InjectionPoints: [{PC: "0x8096ec", Frameless: false}]
+              Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]
+              InjectionPoints: [{PC: "0x80993c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1568 EventRootType Probe[main.testManyArgsArrayReturn]Return
-              InjectionPoints: [{PC: "0x809840", Frameless: false}]
+              Type: 1569 EventRootType Probe[main.testManyArgsArrayReturn]Return
+              InjectionPoints: [{PC: "0x809a90", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -2833,11 +2833,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1601 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80a5a0", Frameless: true}]
+              Type: 1602 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x80a800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2856,11 +2856,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 150}
+        - subprogram: {subprogram: 151}
           events:
             - Kind: Entry
-              Type: 1602 EventRootType Probe[main.testMassiveString]
-              InjectionPoints: [{PC: "0x80a5a0", Frameless: true}]
+              Type: 1603 EventRootType Probe[main.testMassiveString]
+              InjectionPoints: [{PC: "0x80a800", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -2903,15 +2903,15 @@ Probes:
           dsl: s
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 127}
+        - subprogram: {subprogram: 128}
           events:
             - Kind: Entry
-              Type: 1569 EventRootType Probe[main.testMixedArgsStackReturn]
-              InjectionPoints: [{PC: "0x8098a0", Frameless: false}]
+              Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]
+              InjectionPoints: [{PC: "0x809af0", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1570 EventRootType Probe[main.testMixedArgsStackReturn]Return
-              InjectionPoints: [{PC: "0x809a2c", Frameless: false}]
+              Type: 1571 EventRootType Probe[main.testMixedArgsStackReturn]Return
+              InjectionPoints: [{PC: "0x809c7c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2973,15 +2973,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 129}
+        - subprogram: {subprogram: 130}
           events:
             - Kind: Entry
-              Type: 1573 EventRootType Probe[main.testMultipleArrayArgs]
-              InjectionPoints: [{PC: "0x809b1c", Frameless: false}]
+              Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]
+              InjectionPoints: [{PC: "0x809d6c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1574 EventRootType Probe[main.testMultipleArrayArgs]Return
-              InjectionPoints: [{PC: "0x809bb8", Frameless: false}]
+              Type: 1575 EventRootType Probe[main.testMultipleArrayArgs]Return
+              InjectionPoints: [{PC: "0x809e08", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -3008,15 +3008,15 @@ Probes:
           dsl: s2
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 125}
+        - subprogram: {subprogram: 126}
           events:
             - Kind: Entry
-              Type: 1565 EventRootType Probe[main.testMultipleLargeArgs]
-              InjectionPoints: [{PC: "0x8094e0", Frameless: false}]
+              Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]
+              InjectionPoints: [{PC: "0x809730", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1566 EventRootType Probe[main.testMultipleLargeArgs]Return
-              InjectionPoints: [{PC: "0x809688", Frameless: false}]
+              Type: 1567 EventRootType Probe[main.testMultipleLargeArgs]Return
+              InjectionPoints: [{PC: "0x8098d8", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{s1}, {s2}'
@@ -3263,11 +3263,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1610 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80a830", Frameless: true}]
+              Type: 1611 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -3288,11 +3288,11 @@ Probes:
           dsl: x.nested.anotherString
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1611 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80a830", Frameless: true}]
+              Type: 1612 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString}'
@@ -3319,11 +3319,11 @@ Probes:
           dsl: x.notAMember
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1612 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80a830", Frameless: true}]
+              Type: 1613 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -3344,11 +3344,11 @@ Probes:
           dsl: x.nested
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 157}
+        - subprogram: {subprogram: 158}
           events:
             - Kind: Entry
-              Type: 1613 EventRootType Probe[main.testNestedPointer]
-              InjectionPoints: [{PC: "0x80a830", Frameless: true}]
+              Type: 1614 EventRootType Probe[main.testNestedPointer]
+              InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x.nested}'
@@ -3398,11 +3398,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 140}
+        - subprogram: {subprogram: 141}
           events:
             - Kind: Entry
-              Type: 1587 EventRootType Probe[main.testNilSlice]
-              InjectionPoints: [{PC: "0x80a1f0", Frameless: true}]
+              Type: 1588 EventRootType Probe[main.testNilSlice]
+              InjectionPoints: [{PC: "0x80a450", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -3425,11 +3425,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 137}
+        - subprogram: {subprogram: 138}
           events:
             - Kind: Entry
-              Type: 1584 EventRootType Probe[main.testNilSliceOfStructs]
-              InjectionPoints: [{PC: "0x80a1c0", Frameless: true}]
+              Type: 1585 EventRootType Probe[main.testNilSliceOfStructs]
+              InjectionPoints: [{PC: "0x80a420", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -3460,11 +3460,11 @@ Probes:
           dsl: x
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 139}
+        - subprogram: {subprogram: 140}
           events:
             - Kind: Entry
-              Type: 1586 EventRootType Probe[main.testNilSliceWithOtherParams]
-              InjectionPoints: [{PC: "0x80a1e0", Frameless: true}]
+              Type: 1587 EventRootType Probe[main.testNilSliceWithOtherParams]
+              InjectionPoints: [{PC: "0x80a440", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {s}, {x}'
@@ -3492,11 +3492,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 149}
+        - subprogram: {subprogram: 150}
           events:
             - Kind: Entry
-              Type: 1600 EventRootType Probe[main.testOneStringInStructPointer]
-              InjectionPoints: [{PC: "0x80a590", Frameless: true}]
+              Type: 1601 EventRootType Probe[main.testOneStringInStructPointer]
+              InjectionPoints: [{PC: "0x80a7f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -3933,15 +3933,15 @@ Probes:
       segments: [testReturnsArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 112}
+        - subprogram: {subprogram: 113}
           events:
             - Kind: Entry
-              Type: 1539 EventRootType Probe[main.testReturnsArray]
-              InjectionPoints: [{PC: "0x808cbc", Frameless: false}]
+              Type: 1540 EventRootType Probe[main.testReturnsArray]
+              InjectionPoints: [{PC: "0x808f0c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1540 EventRootType Probe[main.testReturnsArray]Return
-              InjectionPoints: [{PC: "0x808d0c", Frameless: false}]
+              Type: 1541 EventRootType Probe[main.testReturnsArray]Return
+              InjectionPoints: [{PC: "0x808f5c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArray
@@ -3954,15 +3954,15 @@ Probes:
       segments: [testReturnsArrayOne]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 113}
+        - subprogram: {subprogram: 114}
           events:
             - Kind: Entry
-              Type: 1541 EventRootType Probe[main.testReturnsArrayOne]
-              InjectionPoints: [{PC: "0x808d48", Frameless: false}]
+              Type: 1542 EventRootType Probe[main.testReturnsArrayOne]
+              InjectionPoints: [{PC: "0x808f98", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1542 EventRootType Probe[main.testReturnsArrayOne]Return
-              InjectionPoints: [{PC: "0x808d80", Frameless: false}]
+              Type: 1543 EventRootType Probe[main.testReturnsArrayOne]Return
+              InjectionPoints: [{PC: "0x808fd0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayOne
@@ -3975,15 +3975,15 @@ Probes:
       segments: [testReturnsArrayZero]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 114}
+        - subprogram: {subprogram: 115}
           events:
             - Kind: Entry
-              Type: 1543 EventRootType Probe[main.testReturnsArrayZero]
-              InjectionPoints: [{PC: "0x808db8", Frameless: false}]
+              Type: 1544 EventRootType Probe[main.testReturnsArrayZero]
+              InjectionPoints: [{PC: "0x809008", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1544 EventRootType Probe[main.testReturnsArrayZero]Return
-              InjectionPoints: [{PC: "0x808dec", Frameless: false}]
+              Type: 1545 EventRootType Probe[main.testReturnsArrayZero]Return
+              InjectionPoints: [{PC: "0x80903c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsArrayZero
@@ -3996,15 +3996,15 @@ Probes:
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 116}
+        - subprogram: {subprogram: 117}
           events:
             - Kind: Entry
-              Type: 1547 EventRootType Probe[main.testReturnsBacktrackInt]
-              InjectionPoints: [{PC: "0x808ea8", Frameless: false}]
+              Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]
+              InjectionPoints: [{PC: "0x8090f8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1548 EventRootType Probe[main.testReturnsBacktrackInt]Return
-              InjectionPoints: [{PC: "0x808f08", Frameless: false}]
+              Type: 1549 EventRootType Probe[main.testReturnsBacktrackInt]Return
+              InjectionPoints: [{PC: "0x809158", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBacktrackInt
@@ -4017,15 +4017,15 @@ Probes:
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 122}
+        - subprogram: {subprogram: 123}
           events:
             - Kind: Entry
-              Type: 1559 EventRootType Probe[main.testReturnsBoolAndUintptr]
-              InjectionPoints: [{PC: "0x809208", Frameless: false}]
+              Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]
+              InjectionPoints: [{PC: "0x809458", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1560 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-              InjectionPoints: [{PC: "0x809244", Frameless: false}]
+              Type: 1561 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+              InjectionPoints: [{PC: "0x809494", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsBoolAndUintptr
@@ -4038,15 +4038,15 @@ Probes:
       segments: [testReturnsComplex]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 110}
+        - subprogram: {subprogram: 111}
           events:
             - Kind: Entry
-              Type: 1535 EventRootType Probe[main.testReturnsComplex]
-              InjectionPoints: [{PC: "0x808b78", Frameless: false}]
+              Type: 1536 EventRootType Probe[main.testReturnsComplex]
+              InjectionPoints: [{PC: "0x808dc8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1536 EventRootType Probe[main.testReturnsComplex]Return
-              InjectionPoints: [{PC: "0x808bc0", Frameless: false}]
+              Type: 1537 EventRootType Probe[main.testReturnsComplex]Return
+              InjectionPoints: [{PC: "0x808e10", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsComplex
@@ -4194,15 +4194,15 @@ Probes:
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 111}
+        - subprogram: {subprogram: 112}
           events:
             - Kind: Entry
-              Type: 1537 EventRootType Probe[main.testReturnsLargeStruct]
-              InjectionPoints: [{PC: "0x808c00", Frameless: false}]
+              Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]
+              InjectionPoints: [{PC: "0x808e50", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1538 EventRootType Probe[main.testReturnsLargeStruct]Return
-              InjectionPoints: [{PC: "0x808c80", Frameless: false}]
+              Type: 1539 EventRootType Probe[main.testReturnsLargeStruct]Return
+              InjectionPoints: [{PC: "0x808ed0", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsLargeStruct
@@ -4215,15 +4215,15 @@ Probes:
       segments: [testReturnsManyFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 109}
+        - subprogram: {subprogram: 110}
           events:
             - Kind: Entry
-              Type: 1533 EventRootType Probe[main.testReturnsManyFloats]
-              InjectionPoints: [{PC: "0x808ac8", Frameless: false}]
+              Type: 1534 EventRootType Probe[main.testReturnsManyFloats]
+              InjectionPoints: [{PC: "0x808d18", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1534 EventRootType Probe[main.testReturnsManyFloats]Return
-              InjectionPoints: [{PC: "0x808b48", Frameless: false}]
+              Type: 1535 EventRootType Probe[main.testReturnsManyFloats]Return
+              InjectionPoints: [{PC: "0x808d98", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsManyFloats
@@ -4236,15 +4236,15 @@ Probes:
       segments: [testReturnsMixed]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 118}
+        - subprogram: {subprogram: 119}
           events:
             - Kind: Entry
-              Type: 1551 EventRootType Probe[main.testReturnsMixed]
-              InjectionPoints: [{PC: "0x809008", Frameless: false}]
+              Type: 1552 EventRootType Probe[main.testReturnsMixed]
+              InjectionPoints: [{PC: "0x809258", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1552 EventRootType Probe[main.testReturnsMixed]Return
-              InjectionPoints: [{PC: "0x80905c", Frameless: false}]
+              Type: 1553 EventRootType Probe[main.testReturnsMixed]Return
+              InjectionPoints: [{PC: "0x8092ac", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixed
@@ -4257,15 +4257,15 @@ Probes:
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 115}
+        - subprogram: {subprogram: 116}
           events:
             - Kind: Entry
-              Type: 1545 EventRootType Probe[main.testReturnsMixedStruct]
-              InjectionPoints: [{PC: "0x808e28", Frameless: false}]
+              Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]
+              InjectionPoints: [{PC: "0x809078", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1546 EventRootType Probe[main.testReturnsMixedStruct]Return
-              InjectionPoints: [{PC: "0x808e6c", Frameless: false}]
+              Type: 1547 EventRootType Probe[main.testReturnsMixedStruct]Return
+              InjectionPoints: [{PC: "0x8090bc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMixedStruct
@@ -4278,19 +4278,43 @@ Probes:
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 121}
+        - subprogram: {subprogram: 122}
           events:
             - Kind: Entry
-              Type: 1557 EventRootType Probe[main.testReturnsMultipleFloats]
-              InjectionPoints: [{PC: "0x809198", Frameless: false}]
+              Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]
+              InjectionPoints: [{PC: "0x8093e8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1558 EventRootType Probe[main.testReturnsMultipleFloats]Return
-              InjectionPoints: [{PC: "0x8091d8", Frameless: false}]
+              Type: 1559 EventRootType Probe[main.testReturnsMultipleFloats]Return
+              InjectionPoints: [{PC: "0x809428", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsMultipleFloats
             Segments: [testReturnsMultipleFloats]
+    - id: testReturnsNamedDeferLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testReturnsNamedDeferLine
+        sourceFile: returns.go
+        lines: ["121"]
+      template: '{i}'
+      segments: [{json: {ref: i}, dsl: i}]
+      captureSnapshot: true
+      instances:
+        - subprogram: {subprogram: 108}
+          events:
+            - Kind: Line
+              Type: 1531 EventRootType Probe[main.testReturnsNamedDeferLine]Line
+              InjectionPoints: [{PC: "0x808ae4", Frameless: false}]
+              Condition: null
+          probeTemplate:
+            TemplateString: '{i}'
+            Segments:
+                - JSON: {Ref: i}
+                  DSL: i
+                  EventKind: Line
+                  EventExpressionIndex: 0
     - id: testReturnsOnlyFloat
       version: 0
       type: LOG_PROBE
@@ -4299,15 +4323,15 @@ Probes:
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 120}
+        - subprogram: {subprogram: 121}
           events:
             - Kind: Entry
-              Type: 1555 EventRootType Probe[main.testReturnsOnlyFloat]
-              InjectionPoints: [{PC: "0x809128", Frameless: false}]
+              Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]
+              InjectionPoints: [{PC: "0x809378", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1556 EventRootType Probe[main.testReturnsOnlyFloat]Return
-              InjectionPoints: [{PC: "0x809164", Frameless: false}]
+              Type: 1557 EventRootType Probe[main.testReturnsOnlyFloat]Return
+              InjectionPoints: [{PC: "0x8093b4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsOnlyFloat
@@ -4320,15 +4344,15 @@ Probes:
       segments: [testReturnsPrimitives]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 108}
+        - subprogram: {subprogram: 109}
           events:
             - Kind: Entry
-              Type: 1531 EventRootType Probe[main.testReturnsPrimitives]
-              InjectionPoints: [{PC: "0x808a38", Frameless: false}]
+              Type: 1532 EventRootType Probe[main.testReturnsPrimitives]
+              InjectionPoints: [{PC: "0x808c88", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1532 EventRootType Probe[main.testReturnsPrimitives]Return
-              InjectionPoints: [{PC: "0x808a8c", Frameless: false}]
+              Type: 1533 EventRootType Probe[main.testReturnsPrimitives]Return
+              InjectionPoints: [{PC: "0x808cdc", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsPrimitives
@@ -4341,15 +4365,15 @@ Probes:
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 119}
+        - subprogram: {subprogram: 120}
           events:
             - Kind: Entry
-              Type: 1553 EventRootType Probe[main.testReturnsStructWithArray]
-              InjectionPoints: [{PC: "0x80909c", Frameless: false}]
+              Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]
+              InjectionPoints: [{PC: "0x8092ec", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1554 EventRootType Probe[main.testReturnsStructWithArray]Return
-              InjectionPoints: [{PC: "0x8090ec", Frameless: false}]
+              Type: 1555 EventRootType Probe[main.testReturnsStructWithArray]Return
+              InjectionPoints: [{PC: "0x80933c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsStructWithArray
@@ -4362,15 +4386,15 @@ Probes:
       segments: [testReturnsWideStruct]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 117}
+        - subprogram: {subprogram: 118}
           events:
             - Kind: Entry
-              Type: 1549 EventRootType Probe[main.testReturnsWideStruct]
-              InjectionPoints: [{PC: "0x808f40", Frameless: false}]
+              Type: 1550 EventRootType Probe[main.testReturnsWideStruct]
+              InjectionPoints: [{PC: "0x809190", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1550 EventRootType Probe[main.testReturnsWideStruct]Return
-              InjectionPoints: [{PC: "0x808fd0", Frameless: false}]
+              Type: 1551 EventRootType Probe[main.testReturnsWideStruct]Return
+              InjectionPoints: [{PC: "0x809220", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: testReturnsWideStruct
@@ -4698,11 +4722,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 145}
+        - subprogram: {subprogram: 146}
           events:
             - Kind: Entry
-              Type: 1594 EventRootType Probe[main.testSingleString]
-              InjectionPoints: [{PC: "0x80a550", Frameless: true}]
+              Type: 1595 EventRootType Probe[main.testSingleString]
+              InjectionPoints: [{PC: "0x80a7b0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -4830,11 +4854,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 142}
+        - subprogram: {subprogram: 143}
           events:
             - Kind: Entry
-              Type: 1590 EventRootType Probe[main.testSliceEmptyStructs]
-              InjectionPoints: [{PC: "0x80a210", Frameless: true}]
+              Type: 1591 EventRootType Probe[main.testSliceEmptyStructs]
+              InjectionPoints: [{PC: "0x80a470", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -4852,11 +4876,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 134}
+        - subprogram: {subprogram: 135}
           events:
             - Kind: Entry
-              Type: 1581 EventRootType Probe[main.testSliceOfSlices]
-              InjectionPoints: [{PC: "0x80a190", Frameless: true}]
+              Type: 1582 EventRootType Probe[main.testSliceOfSlices]
+              InjectionPoints: [{PC: "0x80a3f0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -4920,15 +4944,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 128}
+        - subprogram: {subprogram: 129}
           events:
             - Kind: Entry
-              Type: 1571 EventRootType Probe[main.testStackArgRegReturns]
-              InjectionPoints: [{PC: "0x809a88", Frameless: false}]
+              Type: 1572 EventRootType Probe[main.testStackArgRegReturns]
+              InjectionPoints: [{PC: "0x809cd8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1572 EventRootType Probe[main.testStackArgRegReturns]Return
-              InjectionPoints: [{PC: "0x809ae4", Frameless: false}]
+              Type: 1573 EventRootType Probe[main.testStackArgRegReturns]Return
+              InjectionPoints: [{PC: "0x809d34", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -4990,11 +5014,11 @@ Probes:
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 138}
+        - subprogram: {subprogram: 139}
           events:
             - Kind: Entry
-              Type: 1585 EventRootType Probe[main.testStringSlice]
-              InjectionPoints: [{PC: "0x80a1d0", Frameless: true}]
+              Type: 1586 EventRootType Probe[main.testStringSlice]
+              InjectionPoints: [{PC: "0x80a430", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{s}'
@@ -5056,11 +5080,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 156}
+        - subprogram: {subprogram: 157}
           events:
             - Kind: Entry
-              Type: 1609 EventRootType Probe[main.testStruct]
-              InjectionPoints: [{PC: "0x80a7d0", Frameless: true}]
+              Type: 1610 EventRootType Probe[main.testStruct]
+              InjectionPoints: [{PC: "0x80aa30", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5083,11 +5107,11 @@ Probes:
           dsl: a
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 135}
+        - subprogram: {subprogram: 136}
           events:
             - Kind: Entry
-              Type: 1582 EventRootType Probe[main.testStructSlice]
-              InjectionPoints: [{PC: "0x80a1a0", Frameless: true}]
+              Type: 1583 EventRootType Probe[main.testStructSlice]
+              InjectionPoints: [{PC: "0x80a400", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}, {a}'
@@ -5131,15 +5155,15 @@ Probes:
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 130}
+        - subprogram: {subprogram: 131}
           events:
             - Kind: Entry
-              Type: 1575 EventRootType Probe[main.testStructWithArrayArg]
-              InjectionPoints: [{PC: "0x809bec", Frameless: false}]
+              Type: 1576 EventRootType Probe[main.testStructWithArrayArg]
+              InjectionPoints: [{PC: "0x809e3c", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1576 EventRootType Probe[main.testStructWithArrayArg]Return
-              InjectionPoints: [{PC: "0x809c74", Frameless: false}]
+              Type: 1577 EventRootType Probe[main.testStructWithArrayArg]Return
+              InjectionPoints: [{PC: "0x809ec4", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{arg}'
@@ -5157,11 +5181,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 155}
+        - subprogram: {subprogram: 156}
           events:
             - Kind: Entry
-              Type: 1607 EventRootType Probe[main.testStructWithCyclicMaps]
-              InjectionPoints: [{PC: "0x80a730", Frameless: true}]
+              Type: 1608 EventRootType Probe[main.testStructWithCyclicMaps]
+              InjectionPoints: [{PC: "0x80a990", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5178,11 +5202,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 154}
+        - subprogram: {subprogram: 155}
           events:
             - Kind: Entry
-              Type: 1606 EventRootType Probe[main.testStructWithCyclicSlices]
-              InjectionPoints: [{PC: "0x80a720", Frameless: true}]
+              Type: 1607 EventRootType Probe[main.testStructWithCyclicSlices]
+              InjectionPoints: [{PC: "0x80a980", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5237,11 +5261,11 @@ Probes:
           dsl: cs
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 143}
+        - subprogram: {subprogram: 144}
           events:
             - Kind: Entry
-              Type: 1591 EventRootType Probe[main.testSubslices]
-              InjectionPoints: [{PC: "0x80a220", Frameless: true}]
+              Type: 1592 EventRootType Probe[main.testSubslices]
+              InjectionPoints: [{PC: "0x80a480", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{as}, {bs}, {cs}'
@@ -5277,11 +5301,11 @@ Probes:
           dsl: c
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 153}
+        - subprogram: {subprogram: 154}
           events:
             - Kind: Entry
-              Type: 1605 EventRootType Probe[main.testSubstrings]
-              InjectionPoints: [{PC: "0x80a5d0", Frameless: true}]
+              Type: 1606 EventRootType Probe[main.testSubstrings]
+              InjectionPoints: [{PC: "0x80a830", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}, {c}'
@@ -5395,11 +5419,11 @@ Probes:
           dsl: z
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 146}
+        - subprogram: {subprogram: 147}
           events:
             - Kind: Entry
-              Type: 1595 EventRootType Probe[main.testThreeStrings]
-              InjectionPoints: [{PC: "0x80a560", Frameless: true}]
+              Type: 1596 EventRootType Probe[main.testThreeStrings]
+              InjectionPoints: [{PC: "0x80a7c0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}, {y}, {z}'
@@ -5427,11 +5451,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1596 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80a570", Frameless: true}]
+              Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x80a7d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5457,11 +5481,11 @@ Probes:
           dsl: t.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 147}
+        - subprogram: {subprogram: 148}
           events:
             - Kind: Entry
-              Type: 1597 EventRootType Probe[main.testThreeStringsInStruct]
-              InjectionPoints: [{PC: "0x80a570", Frameless: true}]
+              Type: 1598 EventRootType Probe[main.testThreeStringsInStruct]
+              InjectionPoints: [{PC: "0x80a7d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5489,11 +5513,11 @@ Probes:
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1598 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80a580", Frameless: true}]
+              Type: 1599 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x80a7e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}'
@@ -5519,11 +5543,11 @@ Probes:
           dsl: a.c
       captureSnapshot: false
       instances:
-        - subprogram: {subprogram: 148}
+        - subprogram: {subprogram: 149}
           events:
             - Kind: Entry
-              Type: 1599 EventRootType Probe[main.testThreeStringsInStructPointer]
-              InjectionPoints: [{PC: "0x80a580", Frameless: true}]
+              Type: 1600 EventRootType Probe[main.testThreeStringsInStructPointer]
+              InjectionPoints: [{PC: "0x80a7e0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{a.a} {a.b} {a.c}'
@@ -5705,11 +5729,11 @@ Probes:
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 132}
+        - subprogram: {subprogram: 133}
           events:
             - Kind: Entry
-              Type: 1579 EventRootType Probe[main.testUintSlice]
-              InjectionPoints: [{PC: "0x80a170", Frameless: true}]
+              Type: 1580 EventRootType Probe[main.testUintSlice]
+              InjectionPoints: [{PC: "0x80a3d0", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{u}'
@@ -5727,11 +5751,11 @@ Probes:
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 151}
+        - subprogram: {subprogram: 152}
           events:
             - Kind: Entry
-              Type: 1603 EventRootType Probe[main.testUnitializedString]
-              InjectionPoints: [{PC: "0x80a5b0", Frameless: true}]
+              Type: 1604 EventRootType Probe[main.testUnitializedString]
+              InjectionPoints: [{PC: "0x80a810", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{x}'
@@ -5793,11 +5817,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1588 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80a200", Frameless: true}]
+              Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x80a460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5815,11 +5839,11 @@ Probes:
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 141}
+        - subprogram: {subprogram: 142}
           events:
             - Kind: Entry
-              Type: 1589 EventRootType Probe[main.testVeryLargeSlice]
-              InjectionPoints: [{PC: "0x80a200", Frameless: true}]
+              Type: 1590 EventRootType Probe[main.testVeryLargeSlice]
+              InjectionPoints: [{PC: "0x80a460", Frameless: true}]
               Condition: null
           probeTemplate:
             TemplateString: '{xs}'
@@ -5837,18 +5861,18 @@ Probes:
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 191}
+        - subprogram: {subprogram: 192}
           events:
             - Kind: Entry
-              Type: 1681 EventRootType Probe[main.firstBehavior.DoSomething]
+              Type: 1682 EventRootType Probe[main.firstBehavior.DoSomething]
               InjectionPoints:
                 - PC: "0x805bb8"
                   Frameless: false
-                - PC: "0x80c900"
+                - PC: "0x80cb60"
                   Frameless: false
               Condition: null
             - Kind: Return
-              Type: 1682 EventRootType Probe[main.firstBehavior.DoSomething]Return
+              Type: 1683 EventRootType Probe[main.firstBehavior.DoSomething]Return
               InjectionPoints: [{PC: "0x805be0", Frameless: false}]
               Condition: null
           probeTemplate:
@@ -5867,15 +5891,15 @@ Probes:
           dsl: b
       captureSnapshot: true
       instances:
-        - subprogram: {subprogram: 131}
+        - subprogram: {subprogram: 132}
           events:
             - Kind: Entry
-              Type: 1577 EventRootType Probe[main.testZeroSizeArgAndReturn]
-              InjectionPoints: [{PC: "0x809ca8", Frameless: false}]
+              Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]
+              InjectionPoints: [{PC: "0x809ef8", Frameless: false}]
               Condition: null
             - Kind: Return
-              Type: 1578 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-              InjectionPoints: [{PC: "0x809d0c", Frameless: false}]
+              Type: 1579 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+              InjectionPoints: [{PC: "0x809f5c", Frameless: false}]
               Condition: null
           probeTemplate:
             TemplateString: '{a}, {b}'
@@ -8070,223 +8094,252 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 108
+      Name: main.testReturnsNamedDeferLine
+      OutOfLinePCRanges: [0x808a20..0x808bb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x808a20..0x808a80
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x808a80..0x808bb0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x808a4c..0x808bb0
+              Pieces: [{Size: 16, Op: {CfaOffset: -120}}]
+          Role: Return
+          DictIndex: -1
+        - Name: b
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x808a50..0x808bb0
+              Pieces: [{Size: 16, Op: {CfaOffset: -136}}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 109
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x808a20..0x808ab0]
+      OutOfLinePCRanges: [0x808c70..0x808d00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x808a20..0x808a8c
+            - Range: 0x808c70..0x808cdc
               Pieces: []
-            - Range: 0x808a8c..0x808a8d
+            - Range: 0x808cdc..0x808cdd
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808a8d..0x808ab0
+            - Range: 0x808cdd..0x808d00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 102 BaseType int16
           Locations:
-            - Range: 0x808a20..0x808a8c
+            - Range: 0x808c70..0x808cdc
               Pieces: []
-            - Range: 0x808a8c..0x808a8d
+            - Range: 0x808cdc..0x808cdd
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x808a8d..0x808ab0
+            - Range: 0x808cdd..0x808d00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x808a20..0x808a8c
+            - Range: 0x808c70..0x808cdc
               Pieces: []
-            - Range: 0x808a8c..0x808a8d
+            - Range: 0x808cdc..0x808cdd
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x808a8d..0x808ab0
+            - Range: 0x808cdd..0x808d00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x808a20..0x808a8c
+            - Range: 0x808c70..0x808cdc
               Pieces: []
-            - Range: 0x808a8c..0x808a8d
+            - Range: 0x808cdc..0x808cdd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x808a8d..0x808ab0
+            - Range: 0x808cdd..0x808d00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x808a20..0x808a8c
+            - Range: 0x808c70..0x808cdc
               Pieces: []
-            - Range: 0x808a8c..0x808a8d
+            - Range: 0x808cdc..0x808cdd
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x808a8d..0x808ab0
+            - Range: 0x808cdd..0x808d00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x808a20..0x808a8c
+            - Range: 0x808c70..0x808cdc
               Pieces: []
-            - Range: 0x808a8c..0x808a8d
+            - Range: 0x808cdc..0x808cdd
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x808a8d..0x808ab0
+            - Range: 0x808cdd..0x808d00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x808a20..0x808a8c
+            - Range: 0x808c70..0x808cdc
               Pieces: []
-            - Range: 0x808a8c..0x808a8d
+            - Range: 0x808cdc..0x808cdd
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x808a8d..0x808ab0
+            - Range: 0x808cdd..0x808d00
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x808a20..0x808a8c
+            - Range: 0x808c70..0x808cdc
               Pieces: []
-            - Range: 0x808a8c..0x808a8d
+            - Range: 0x808cdc..0x808cdd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x808a8d..0x808ab0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 109
-      Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x808ab0..0x808b60]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r5
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r6
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r7
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r8
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r9
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r10
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r11
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r12
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r13
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r14
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: onlyOnAmd64_16
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ab0..0x808b60, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: bothArmAndAmd64
-          Type: 14 BaseType float64
-          Locations:
-            - Range: 0x808ab0..0x808b48
-              Pieces: []
-            - Range: 0x808b48..0x808b49
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x808b49..0x808b60
+            - Range: 0x808cdd..0x808d00
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 110
-      Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x808b60..0x808be0]
+      Name: main.testReturnsManyFloats
+      OutOfLinePCRanges: [0x808d00..0x808db0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 103 BaseType complex64
-          Locations: [{Range: 0x808b60..0x808be0, Pieces: []}]
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
           Role: Return
           DictIndex: -1
         - Name: ~r1
-          Type: 18 BaseType complex128
-          Locations: [{Range: 0x808b60..0x808be0, Pieces: []}]
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r5
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r6
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r7
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r8
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r9
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r10
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r11
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r12
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r13
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r14
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: onlyOnAmd64_16
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x808d00..0x808db0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: bothArmAndAmd64
+          Type: 14 BaseType float64
+          Locations:
+            - Range: 0x808d00..0x808d98
+              Pieces: []
+            - Range: 0x808d98..0x808d99
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x808d99..0x808db0
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 111
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0x808db0..0x808e30]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 103 BaseType complex64
+          Locations: [{Range: 0x808db0..0x808e30, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 18 BaseType complex128
+          Locations: [{Range: 0x808db0..0x808e30, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 112
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x808be0..0x808ca0]
+      OutOfLinePCRanges: [0x808e30..0x808ef0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x808be0..0x808c80
+            - Range: 0x808e30..0x808ed0
               Pieces: []
-            - Range: 0x808c80..0x808c81
+            - Range: 0x808ed0..0x808ed1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8308,193 +8361,193 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x808c81..0x808ca0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 112
-      Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x808ca0..0x808d30]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 257 ArrayType [3]int
-          Locations:
-            - Range: 0x808ca0..0x808d0c
-              Pieces: []
-            - Range: 0x808d0c..0x808d0d
-              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x808d0d..0x808d30
+            - Range: 0x808ed1..0x808ef0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 113
-      Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x808d30..0x808da0]
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0x808ef0..0x808f80]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 258 ArrayType [1]int
+          Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x808d30..0x808d80
+            - Range: 0x808ef0..0x808f5c
               Pieces: []
-            - Range: 0x808d80..0x808d81
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808d81..0x808da0
+            - Range: 0x808f5c..0x808f5d
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x808f5d..0x808f80
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 114
-      Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x808da0..0x808e10]
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0x808f80..0x808ff0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 259 ArrayType [0]int
+          Type: 258 ArrayType [1]int
           Locations:
-            - Range: 0x808da0..0x808dec
+            - Range: 0x808f80..0x808fd0
               Pieces: []
-            - Range: 0x808dec..0x808ded
-              Pieces: []
-            - Range: 0x808ded..0x808e10
+            - Range: 0x808fd0..0x808fd1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x808fd1..0x808ff0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 115
-      Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x808e10..0x808e90]
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0x808ff0..0x809060]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 260 StructureType main.mixedStruct
-          Locations: [{Range: 0x808e10..0x808e90, Pieces: []}]
+          Type: 259 ArrayType [0]int
+          Locations:
+            - Range: 0x808ff0..0x80903c
+              Pieces: []
+            - Range: 0x80903c..0x80903d
+              Pieces: []
+            - Range: 0x80903d..0x809060
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 116
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0x809060..0x8090e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 260 StructureType main.mixedStruct
+          Locations: [{Range: 0x809060..0x8090e0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 117
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x808e90..0x808f20]
+      OutOfLinePCRanges: [0x8090e0..0x809170]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808e90..0x808f08
+            - Range: 0x8090e0..0x809158
               Pieces: []
-            - Range: 0x808f08..0x808f09
+            - Range: 0x809158..0x809159
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808f09..0x808f20
+            - Range: 0x809159..0x809170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808e90..0x808f08
+            - Range: 0x8090e0..0x809158
               Pieces: []
-            - Range: 0x808f08..0x808f09
+            - Range: 0x809158..0x809159
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x808f09..0x808f20
+            - Range: 0x809159..0x809170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808e90..0x808f08
+            - Range: 0x8090e0..0x809158
               Pieces: []
-            - Range: 0x808f08..0x808f09
+            - Range: 0x809158..0x809159
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x808f09..0x808f20
+            - Range: 0x809159..0x809170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808e90..0x808f08
+            - Range: 0x8090e0..0x809158
               Pieces: []
-            - Range: 0x808f08..0x808f09
+            - Range: 0x809158..0x809159
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x808f09..0x808f20
+            - Range: 0x809159..0x809170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808e90..0x808f08
+            - Range: 0x8090e0..0x809158
               Pieces: []
-            - Range: 0x808f08..0x808f09
+            - Range: 0x809158..0x809159
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x808f09..0x808f20
+            - Range: 0x809159..0x809170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808e90..0x808f08
+            - Range: 0x8090e0..0x809158
               Pieces: []
-            - Range: 0x808f08..0x808f09
+            - Range: 0x809158..0x809159
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x808f09..0x808f20
+            - Range: 0x809159..0x809170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808e90..0x808f08
+            - Range: 0x8090e0..0x809158
               Pieces: []
-            - Range: 0x808f08..0x808f09
+            - Range: 0x809158..0x809159
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x808f09..0x808f20
+            - Range: 0x809159..0x809170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808e90..0x808f08
+            - Range: 0x8090e0..0x809158
               Pieces: []
-            - Range: 0x808f08..0x808f09
+            - Range: 0x809158..0x809159
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x808f09..0x808f20
+            - Range: 0x809159..0x809170
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808e90..0x808f08
+            - Range: 0x8090e0..0x809158
               Pieces: []
-            - Range: 0x808f08..0x808f09
+            - Range: 0x809158..0x809159
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x808f09..0x808f20
+            - Range: 0x809159..0x809170
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x808f20..0x808ff0]
+      OutOfLinePCRanges: [0x809170..0x809240]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.wideStruct
           Locations:
-            - Range: 0x808f20..0x808fd0
+            - Range: 0x809170..0x809220
               Pieces: []
-            - Range: 0x808fd0..0x808fd1
+            - Range: 0x809220..0x809221
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8518,145 +8571,145 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x808fd1..0x808ff0
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-      DictRegister: null
-    - ID: 118
-      Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x808ff0..0x809080]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x808ff0..0x80905c
-              Pieces: []
-            - Range: 0x80905c..0x80905d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80905d..0x809080
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ff0..0x809080, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x808ff0..0x80905c
-              Pieces: []
-            - Range: 0x80905c..0x80905d
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80905d..0x809080
-              Pieces: []
-          Role: Return
-          DictIndex: -1
-        - Name: ~r3
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x808ff0..0x809080, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r4
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x808ff0..0x80905c
-              Pieces: []
-            - Range: 0x80905c..0x80905d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80905d..0x809080
+            - Range: 0x809221..0x809240
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 119
-      Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x809080..0x809110]
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0x809240..0x8092d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 262 StructureType main.structWithArray
+          Type: 7 BaseType int
           Locations:
-            - Range: 0x809080..0x8090ec
+            - Range: 0x809240..0x8092ac
               Pieces: []
-            - Range: 0x8090ec..0x8090ed
-              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8090ed..0x809110
+            - Range: 0x8092ac..0x8092ad
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8092ad..0x8092d0
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x809240..0x8092d0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x809240..0x8092ac
+              Pieces: []
+            - Range: 0x8092ac..0x8092ad
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x8092ad..0x8092d0
+              Pieces: []
+          Role: Return
+          DictIndex: -1
+        - Name: ~r3
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x809240..0x8092d0, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r4
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x809240..0x8092ac
+              Pieces: []
+            - Range: 0x8092ac..0x8092ad
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x8092ad..0x8092d0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 120
-      Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x809110..0x809180]
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0x8092d0..0x809360]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 14 BaseType float64
-          Locations: [{Range: 0x809110..0x809180, Pieces: []}]
+          Type: 262 StructureType main.structWithArray
+          Locations:
+            - Range: 0x8092d0..0x80933c
+              Pieces: []
+            - Range: 0x80933c..0x80933d
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x80933d..0x809360
+              Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 121
-      Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x809180..0x8091f0]
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0x809360..0x8093d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 17 BaseType float32
-          Locations: [{Range: 0x809180..0x8091f0, Pieces: []}]
-          Role: Return
-          DictIndex: -1
-        - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x809180..0x8091f0, Pieces: []}]
+          Locations: [{Range: 0x809360..0x8093d0, Pieces: []}]
           Role: Return
           DictIndex: -1
       DictRegister: null
     - ID: 122
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0x8093d0..0x809440]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 17 BaseType float32
+          Locations: [{Range: 0x8093d0..0x809440, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+        - Name: ~r1
+          Type: 14 BaseType float64
+          Locations: [{Range: 0x8093d0..0x809440, Pieces: []}]
+          Role: Return
+          DictIndex: -1
+      DictRegister: null
+    - ID: 123
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x8091f0..0x809260]
+      OutOfLinePCRanges: [0x809440..0x8094b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8091f0..0x809244
+            - Range: 0x809440..0x809494
               Pieces: []
-            - Range: 0x809244..0x809245
+            - Range: 0x809494..0x809495
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809245..0x809260
+            - Range: 0x809495..0x8094b0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x8091f0..0x809244
+            - Range: 0x809440..0x809494
               Pieces: []
-            - Range: 0x809244..0x809245
+            - Range: 0x809494..0x809495
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809245..0x809260
+            - Range: 0x809495..0x8094b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 123
+    - ID: 124
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x809260..0x8093f0]
+      OutOfLinePCRanges: [0x8094b0..0x809640]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x809260..0x809294
+            - Range: 0x8094b0..0x8094e4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8678,7 +8731,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809294..0x8092c4
+            - Range: 0x8094e4..0x809514
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8700,7 +8753,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8092c4..0x8092cc
+            - Range: 0x809514..0x80951c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8722,7 +8775,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8092cc..0x8092d0
+            - Range: 0x80951c..0x809520
               Pieces:
                 - Size: 8
                   Op: null
@@ -8749,9 +8802,9 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x809260..0x8093b0
+            - Range: 0x8094b0..0x809600
               Pieces: []
-            - Range: 0x8093b0..0x8093b1
+            - Range: 0x809600..0x809601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8773,44 +8826,44 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8093b1..0x8093f0
+            - Range: 0x809601..0x809640
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 124
+    - ID: 125
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x8093f0..0x8094c0]
+      OutOfLinePCRanges: [0x809640..0x809710]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x8093f0..0x8094c0
+            - Range: 0x809640..0x809710
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x8093f0..0x8094a0
+            - Range: 0x809640..0x8096f0
               Pieces: []
-            - Range: 0x8094a0..0x8094a1
+            - Range: 0x8096f0..0x8096f1
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x8094a1..0x8094c0
+            - Range: 0x8096f1..0x809710
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x8094c0..0x8096d0]
+      OutOfLinePCRanges: [0x809710..0x809920]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x8094c0..0x8094f4
+            - Range: 0x809710..0x809744
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8832,7 +8885,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8094f4..0x809528
+            - Range: 0x809744..0x809778
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8854,7 +8907,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809528..0x809530
+            - Range: 0x809778..0x809780
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8876,7 +8929,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809530..0x809534
+            - Range: 0x809780..0x809784
               Pieces:
                 - Size: 8
                   Op: null
@@ -8903,16 +8956,16 @@ Subprograms:
         - Name: s2
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x8094c0..0x8096d0
+            - Range: 0x809710..0x809920
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x8094c0..0x809688
+            - Range: 0x809710..0x8098d8
               Pieces: []
-            - Range: 0x809688..0x809689
+            - Range: 0x8098d8..0x8098d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -8934,196 +8987,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809689..0x8096d0
+            - Range: 0x8098d9..0x809920
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 126
+    - ID: 127
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x8096d0..0x809880]
+      OutOfLinePCRanges: [0x809920..0x809ad0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8096d0..0x809758
+            - Range: 0x809920..0x8099a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809758..0x809880
+            - Range: 0x8099a8..0x809ad0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8096d0..0x809718
+            - Range: 0x809920..0x809968
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809718..0x809880
+            - Range: 0x809968..0x809ad0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8096d0..0x809750
+            - Range: 0x809920..0x8099a0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x809750..0x809880
+            - Range: 0x8099a0..0x809ad0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8096d0..0x809758
+            - Range: 0x809920..0x8099a8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x809758..0x809880
+            - Range: 0x8099a8..0x809ad0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8096d0..0x809758
+            - Range: 0x809920..0x8099a8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x809758..0x809880
+            - Range: 0x8099a8..0x809ad0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8096d0..0x809758
+            - Range: 0x809920..0x8099a8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x809758..0x809880
+            - Range: 0x8099a8..0x809ad0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8096d0..0x809758
+            - Range: 0x809920..0x8099a8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x809758..0x809880
+            - Range: 0x8099a8..0x809ad0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8096d0..0x809758
+            - Range: 0x809920..0x8099a8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x809758..0x809880
+            - Range: 0x8099a8..0x809ad0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
           DictIndex: -1
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8096d0..0x809758
+            - Range: 0x809920..0x8099a8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x809758..0x809880
+            - Range: 0x8099a8..0x809ad0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x8096d0..0x809840
+            - Range: 0x809920..0x809a90
               Pieces: []
-            - Range: 0x809840..0x809841
+            - Range: 0x809a90..0x809a91
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x809841..0x809880
+            - Range: 0x809a91..0x809ad0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 127
+    - ID: 128
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x809880..0x809a70]
+      OutOfLinePCRanges: [0x809ad0..0x809cc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809880..0x809908
+            - Range: 0x809ad0..0x809b58
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809908..0x809a70
+            - Range: 0x809b58..0x809cc0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809880..0x8098cc
+            - Range: 0x809ad0..0x809b1c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8098cc..0x809a70
+            - Range: 0x809b1c..0x809cc0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809880..0x809900
+            - Range: 0x809ad0..0x809b50
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x809900..0x809a70
+            - Range: 0x809b50..0x809cc0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809880..0x809908
+            - Range: 0x809ad0..0x809b58
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x809908..0x809a70
+            - Range: 0x809b58..0x809cc0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
           DictIndex: -1
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809880..0x809908
+            - Range: 0x809ad0..0x809b58
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x809908..0x809a70
+            - Range: 0x809b58..0x809cc0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: -1
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809880..0x809908
+            - Range: 0x809ad0..0x809b58
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x809908..0x809a70
+            - Range: 0x809b58..0x809cc0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
           DictIndex: -1
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809880..0x809908
+            - Range: 0x809ad0..0x809b58
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x809908..0x809a70
+            - Range: 0x809b58..0x809cc0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
           DictIndex: -1
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809880..0x809908
+            - Range: 0x809ad0..0x809b58
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x809908..0x809a70
+            - Range: 0x809b58..0x809cc0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809880..0x809908
+            - Range: 0x809ad0..0x809b58
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809908..0x809a70
+            - Range: 0x809b58..0x809cc0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -9134,9 +9187,9 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x809880..0x809a2c
+            - Range: 0x809ad0..0x809c7c
               Pieces: []
-            - Range: 0x809a2c..0x809a2d
+            - Range: 0x809c7c..0x809c7d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9158,215 +9211,196 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x809a2d..0x809a70
+            - Range: 0x809c7d..0x809cc0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 128
+    - ID: 129
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x809a70..0x809b00]
+      OutOfLinePCRanges: [0x809cc0..0x809d50]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0x809a70..0x809b00
+            - Range: 0x809cc0..0x809d50
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809a70..0x809ae4
+            - Range: 0x809cc0..0x809d34
               Pieces: []
-            - Range: 0x809ae4..0x809ae5
+            - Range: 0x809d34..0x809d35
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809ae5..0x809b00
+            - Range: 0x809d35..0x809d50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809a70..0x809ae4
+            - Range: 0x809cc0..0x809d34
               Pieces: []
-            - Range: 0x809ae4..0x809ae5
+            - Range: 0x809d34..0x809d35
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x809ae5..0x809b00
+            - Range: 0x809d35..0x809d50
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809a70..0x809ae4
+            - Range: 0x809cc0..0x809d34
               Pieces: []
-            - Range: 0x809ae4..0x809ae5
+            - Range: 0x809d34..0x809d35
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x809ae5..0x809b00
+            - Range: 0x809d35..0x809d50
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 129
+    - ID: 130
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x809b00..0x809bd0]
+      OutOfLinePCRanges: [0x809d50..0x809e20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x809b00..0x809bd0
+            - Range: 0x809d50..0x809e20
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x809b00..0x809bd0
+            - Range: 0x809d50..0x809e20
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809b00..0x809bb8
+            - Range: 0x809d50..0x809e08
               Pieces: []
-            - Range: 0x809bb8..0x809bb9
+            - Range: 0x809e08..0x809e09
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809bb9..0x809bd0
+            - Range: 0x809e09..0x809e20
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x809b00..0x809bb8
+            - Range: 0x809d50..0x809e08
               Pieces: []
-            - Range: 0x809bb8..0x809bb9
+            - Range: 0x809e08..0x809e09
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x809bb9..0x809bd0
+            - Range: 0x809e09..0x809e20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 130
+    - ID: 131
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x809bd0..0x809c90]
+      OutOfLinePCRanges: [0x809e20..0x809ee0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x809bd0..0x809c90
+            - Range: 0x809e20..0x809ee0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809bd0..0x809c74
+            - Range: 0x809e20..0x809ec4
               Pieces: []
-            - Range: 0x809c74..0x809c75
+            - Range: 0x809ec4..0x809ec5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809c75..0x809c90
+            - Range: 0x809ec5..0x809ee0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x809bd0..0x809c74
+            - Range: 0x809e20..0x809ec4
               Pieces: []
-            - Range: 0x809c74..0x809c75
+            - Range: 0x809ec4..0x809ec5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x809c75..0x809c90
+            - Range: 0x809ec5..0x809ee0
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809c50..0x809c90
+            - Range: 0x809ea0..0x809ee0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
       DictRegister: null
-    - ID: 131
+    - ID: 132
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x809c90..0x809d30]
+      OutOfLinePCRanges: [0x809ee0..0x809f80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 ArrayType [0]int
-          Locations: [{Range: 0x809c90..0x809d30, Pieces: []}]
+          Locations: [{Range: 0x809ee0..0x809f80, Pieces: []}]
           Role: Parameter
           DictIndex: -1
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809c90..0x809cd0
+            - Range: 0x809ee0..0x809f20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809cd0..0x809ce8
+            - Range: 0x809f20..0x809f38
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x809ce8..0x809cf0
+            - Range: 0x809f38..0x809f40
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x809cf0..0x809d30
+            - Range: 0x809f40..0x809f80
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
           DictIndex: -1
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809c90..0x809d0c
+            - Range: 0x809ee0..0x809f5c
               Pieces: []
-            - Range: 0x809d0c..0x809d0d
+            - Range: 0x809f5c..0x809f5d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809d0d..0x809d30
+            - Range: 0x809f5d..0x809f80
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: ~r1
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0x809c90..0x809d0c
+            - Range: 0x809ee0..0x809f5c
               Pieces: []
-            - Range: 0x809d0c..0x809d0d
+            - Range: 0x809f5c..0x809f5d
               Pieces: []
-            - Range: 0x809d0d..0x809d30
+            - Range: 0x809f5d..0x809f80
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 132
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80a170..0x80a180]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80a170..0x80a180
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
     - ID: 133
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80a180..0x80a190]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x80a3d0..0x80a3e0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a180..0x80a190
+            - Range: 0x80a3d0..0x80a3e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9378,14 +9412,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 134
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x80a190..0x80a1a0]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x80a3e0..0x80a3f0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 264 GoSliceHeaderType [][]uint
+          Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a190..0x80a1a0
+            - Range: 0x80a3e0..0x80a3f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9397,14 +9431,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 135
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x80a1a0..0x80a1b0]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x80a3f0..0x80a400]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 264 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x80a1a0..0x80a1b0
+            - Range: 0x80a3f0..0x80a400
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9412,25 +9446,18 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80a1a0..0x80a1b0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 136
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x80a1b0..0x80a1c0]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x80a400..0x80a410]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 266 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80a1b0..0x80a1c0
+            - Range: 0x80a400..0x80a410
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9443,20 +9470,20 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a1b0..0x80a1c0
+            - Range: 0x80a400..0x80a410
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 137
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x80a1c0..0x80a1d0]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x80a410..0x80a420]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 266 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80a1c0..0x80a1d0
+            - Range: 0x80a410..0x80a420
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9469,20 +9496,46 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a1c0..0x80a1d0
+            - Range: 0x80a410..0x80a420
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 138
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x80a420..0x80a430]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x80a420..0x80a430
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80a420..0x80a430
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 139
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80a1d0..0x80a1e0]
+      OutOfLinePCRanges: [0x80a430..0x80a440]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 269 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80a1d0..0x80a1e0
+            - Range: 0x80a430..0x80a440
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9493,22 +9546,22 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 139
+    - ID: 140
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80a1e0..0x80a1f0]
+      OutOfLinePCRanges: [0x80a440..0x80a450]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x80a1e0..0x80a1f0
+            - Range: 0x80a440..0x80a450
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
         - Name: s
           Type: 270 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80a1e0..0x80a1f0
+            - Range: 0x80a440..0x80a450
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -9521,39 +9574,20 @@ Subprograms:
         - Name: x
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x80a1e0..0x80a1f0
+            - Range: 0x80a440..0x80a450
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 140
+    - ID: 141
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80a1f0..0x80a200]
+      OutOfLinePCRanges: [0x80a450..0x80a460]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x80a1f0..0x80a200
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 141
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x80a200..0x80a210]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80a200..0x80a210
+            - Range: 0x80a450..0x80a460
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9565,14 +9599,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 142
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x80a210..0x80a220]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x80a460..0x80a470]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 272 GoSliceHeaderType []struct {}
+          Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a210..0x80a220
+            - Range: 0x80a460..0x80a470
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9584,14 +9618,33 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 143
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x80a470..0x80a480]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 272 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x80a470..0x80a480
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 144
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80a220..0x80a230]
+      OutOfLinePCRanges: [0x80a480..0x80a490]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a220..0x80a230
+            - Range: 0x80a480..0x80a490
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9604,7 +9657,7 @@ Subprograms:
         - Name: bs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a220..0x80a230
+            - Range: 0x80a480..0x80a490
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -9617,7 +9670,7 @@ Subprograms:
         - Name: cs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a220..0x80a230
+            - Range: 0x80a480..0x80a490
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -9628,36 +9681,36 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 144
+    - ID: 145
       Name: main.stackC
-      OutOfLinePCRanges: [0x80a4f0..0x80a550]
+      OutOfLinePCRanges: [0x80a750..0x80a7b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a4f0..0x80a538
+            - Range: 0x80a750..0x80a798
               Pieces: []
-            - Range: 0x80a538..0x80a539
+            - Range: 0x80a798..0x80a799
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a539..0x80a550
+            - Range: 0x80a799..0x80a7b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 145
+    - ID: 146
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80a550..0x80a560]
+      OutOfLinePCRanges: [0x80a7b0..0x80a7c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a550..0x80a560
+            - Range: 0x80a7b0..0x80a7c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9666,15 +9719,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 146
+    - ID: 147
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80a560..0x80a570]
+      OutOfLinePCRanges: [0x80a7c0..0x80a7d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a560..0x80a570
+            - Range: 0x80a7c0..0x80a7d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9685,7 +9738,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a560..0x80a570
+            - Range: 0x80a7c0..0x80a7d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9696,7 +9749,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a560..0x80a570
+            - Range: 0x80a7c0..0x80a7d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9705,15 +9758,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 147
+    - ID: 148
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80a570..0x80a580]
+      OutOfLinePCRanges: [0x80a7d0..0x80a7e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80a570..0x80a580
+            - Range: 0x80a7d0..0x80a7e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9730,58 +9783,41 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 148
+    - ID: 149
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80a580..0x80a590]
+      OutOfLinePCRanges: [0x80a7e0..0x80a7f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 275 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80a580..0x80a590
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-          DictIndex: -1
-      DictRegister: null
-    - ID: 149
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80a590..0x80a5a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 276 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0x80a590..0x80a5a0
+            - Range: 0x80a7e0..0x80a7f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 150
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80a5a0..0x80a5b0]
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x80a7f0..0x80a800]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 276 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80a5a0..0x80a5b0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a7f0..0x80a800
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
     - ID: 151
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80a5b0..0x80a5c0]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x80a800..0x80a810]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a5b0..0x80a5c0
+            - Range: 0x80a800..0x80a810
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9791,14 +9827,14 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 152
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80a5c0..0x80a5d0]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x80a810..0x80a820]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a5c0..0x80a5d0
+            - Range: 0x80a810..0x80a820
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9808,14 +9844,31 @@ Subprograms:
           DictIndex: -1
       DictRegister: null
     - ID: 153
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x80a820..0x80a830]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80a820..0x80a830
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+          DictIndex: -1
+      DictRegister: null
+    - ID: 154
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x80a5d0..0x80a5e0]
+      OutOfLinePCRanges: [0x80a830..0x80a840]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a5d0..0x80a5e0
+            - Range: 0x80a830..0x80a840
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9826,7 +9879,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a5d0..0x80a5e0
+            - Range: 0x80a830..0x80a840
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -9837,7 +9890,7 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a5d0..0x80a5e0
+            - Range: 0x80a830..0x80a840
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -9846,28 +9899,28 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 154
+    - ID: 155
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80a720..0x80a730]
+      OutOfLinePCRanges: [0x80a980..0x80a990]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80a720..0x80a730
+            - Range: 0x80a980..0x80a990
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 155
+    - ID: 156
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80a730..0x80a740]
+      OutOfLinePCRanges: [0x80a990..0x80a9a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 291 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80a730..0x80a740
+            - Range: 0x80a990..0x80a9a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -9884,15 +9937,15 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 156
+    - ID: 157
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80a7d0..0x80a7e0]
+      OutOfLinePCRanges: [0x80aa30..0x80aa40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 322 StructureType main.aStruct
           Locations:
-            - Range: 0x80a7d0..0x80a7e0
+            - Range: 0x80aa30..0x80aa40
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -9911,157 +9964,157 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 157
+    - ID: 158
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80a830..0x80a840]
+      OutOfLinePCRanges: [0x80aa90..0x80aaa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80a830..0x80a840
+            - Range: 0x80aa90..0x80aaa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 158
+    - ID: 159
       Name: main.testTenStrings
-      OutOfLinePCRanges: [0x80a840..0x80a850]
+      OutOfLinePCRanges: [0x80aaa0..0x80aab0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 325 StructureType main.tenStrings
           Locations:
-            - Range: 0x80a840..0x80a850
+            - Range: 0x80aaa0..0x80aab0
               Pieces: [{Size: 160, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 159
+    - ID: 160
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80a870..0x80a880]
+      OutOfLinePCRanges: [0x80aad0..0x80aae0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 326 StructureType main.emptyStruct
-          Locations: [{Range: 0x80a870..0x80a880, Pieces: []}]
+          Locations: [{Range: 0x80aad0..0x80aae0, Pieces: []}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 160
+    - ID: 161
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80a880..0x80a890]
+      OutOfLinePCRanges: [0x80aae0..0x80aaf0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 327 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80a880..0x80a890
+            - Range: 0x80aae0..0x80aaf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 161
+    - ID: 162
       Name: main.wrapBox[go.shape.int]
-      OutOfLinePCRanges: [0x80be80..0x80be90]
+      OutOfLinePCRanges: [0x80c0e0..0x80c0f0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80be80..0x80be90
+            - Range: 0x80c0e0..0x80c0f0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80be80..0x80be84
+            - Range: 0x80c0e0..0x80c0e4
               Pieces: []
-            - Range: 0x80be84..0x80be85
+            - Range: 0x80c0e4..0x80c0e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80be85..0x80be90
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
-    - ID: 162
-      Name: main.wrapBox[go.shape.string]
-      OutOfLinePCRanges: [0x80be90..0x80bea0]
-      InlinePCRanges: []
-      Variables:
-        - Name: val
-          Type: 330 GoStringHeaderType go.shape.string
-          Locations:
-            - Range: 0x80be90..0x80be9c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80be9c..0x80bea0
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
-          Locations:
-            - Range: 0x80be90..0x80be9c
-              Pieces: []
-            - Range: 0x80be9c..0x80be9d
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80be9d..0x80bea0
+            - Range: 0x80c0e5..0x80c0f0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 163
+      Name: main.wrapBox[go.shape.string]
+      OutOfLinePCRanges: [0x80c0f0..0x80c100]
+      InlinePCRanges: []
+      Variables:
+        - Name: val
+          Type: 330 GoStringHeaderType go.shape.string
+          Locations:
+            - Range: 0x80c0f0..0x80c0fc
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x80c0fc..0x80c100
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
+          Locations:
+            - Range: 0x80c0f0..0x80c0fc
+              Pieces: []
+            - Range: 0x80c0fc..0x80c0fd
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80c0fd..0x80c100
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 164
       Name: main.nestedGeneric[go.shape.int]
-      OutOfLinePCRanges: [0x80bea0..0x80beb0]
+      OutOfLinePCRanges: [0x80c100..0x80c110]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80bea0..0x80beb0
+            - Range: 0x80c100..0x80c110
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80bea0..0x80bea4
+            - Range: 0x80c100..0x80c104
               Pieces: []
-            - Range: 0x80bea4..0x80bea5
+            - Range: 0x80c104..0x80c105
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bea5..0x80beb0
+            - Range: 0x80c105..0x80c110
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 164
+    - ID: 165
       Name: main.nestedGeneric[go.shape.string]
-      OutOfLinePCRanges: [0x80beb0..0x80bec0]
+      OutOfLinePCRanges: [0x80c110..0x80c120]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80beb0..0x80bebc
+            - Range: 0x80c110..0x80c11c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80bebc..0x80bec0
+            - Range: 0x80c11c..0x80c120
               Pieces:
                 - Size: 8
                   Op: null
@@ -10072,28 +10125,28 @@ Subprograms:
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80beb0..0x80bebc
+            - Range: 0x80c110..0x80c11c
               Pieces: []
-            - Range: 0x80bebc..0x80bebd
+            - Range: 0x80c11c..0x80c11d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80bebd..0x80bec0
+            - Range: 0x80c11d..0x80c120
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 165
+    - ID: 166
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]
-      OutOfLinePCRanges: [0x80bf20..0x80c0c0]
+      OutOfLinePCRanges: [0x80c180..0x80c320]
       InlinePCRanges: []
       Variables:
         - Name: items
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80bf20..0x80bf50
+            - Range: 0x80c180..0x80c1b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10101,7 +10154,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80bf50..0x80bf64
+            - Range: 0x80c1b0..0x80c1c4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10109,7 +10162,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: null
-            - Range: 0x80bf64..0x80c0c0
+            - Range: 0x80c1c4..0x80c320
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -10122,18 +10175,18 @@ Subprograms:
         - Name: pred
           Type: 334 GoSubroutineType func(go.shape.int) bool
           Locations:
-            - Range: 0x80bf20..0x80bf64
+            - Range: 0x80c180..0x80c1c4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80bf64..0x80c0c0
+            - Range: 0x80c1c4..0x80c320
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80bf20..0x80c088
+            - Range: 0x80c180..0x80c2e8
               Pieces: []
-            - Range: 0x80c088..0x80c089
+            - Range: 0x80c2e8..0x80c2e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10141,14 +10194,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c089..0x80c0c0
+            - Range: 0x80c2e9..0x80c320
               Pieces: []
           Role: Return
           DictIndex: 2
         - Name: result
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80bf50..0x80bf64
+            - Range: 0x80c1b0..0x80c1c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10156,7 +10209,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80bf64..0x80bf84
+            - Range: 0x80c1c4..0x80c1e4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10164,7 +10217,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80bf84..0x80bf88
+            - Range: 0x80c1e4..0x80c1e8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10172,7 +10225,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80bf88..0x80bf88
+            - Range: 0x80c1e8..0x80c1e8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10180,7 +10233,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80bf88..0x80bfb8
+            - Range: 0x80c1e8..0x80c218
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10188,7 +10241,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80bfb8..0x80c048
+            - Range: 0x80c218..0x80c2a8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -16}
@@ -10196,7 +10249,7 @@ Subprograms:
                   Op: {CfaOffset: -80}
                 - Size: 8
                   Op: {CfaOffset: -72}
-            - Range: 0x80c048..0x80c05c
+            - Range: 0x80c2a8..0x80c2bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -10204,7 +10257,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80c05c..0x80c070
+            - Range: 0x80c2bc..0x80c2d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10212,7 +10265,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 7, Shift: 0}
-            - Range: 0x80c070..0x80c07c
+            - Range: 0x80c2d0..0x80c2dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10220,7 +10273,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: null
-            - Range: 0x80c07c..0x80c0c0
+            - Range: 0x80c2dc..0x80c320
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10233,215 +10286,215 @@ Subprograms:
         - Name: item
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80bfa8..0x80bfb8
+            - Range: 0x80c208..0x80c218
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bfb8..0x80c048
+            - Range: 0x80c218..0x80c2a8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 166
+    - ID: 167
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80c0c0..0x80c110]
+      OutOfLinePCRanges: [0x80c320..0x80c370]
       InlinePCRanges: []
       Variables:
         - Name: box
           Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
           Locations:
-            - Range: 0x80c0c0..0x80c0e8
+            - Range: 0x80c320..0x80c348
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: f
           Type: 335 GoSubroutineType func(go.shape.int) go.shape.string
           Locations:
-            - Range: 0x80c0c0..0x80c0e8
+            - Range: 0x80c320..0x80c348
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
           Locations:
-            - Range: 0x80c0c0..0x80c0e8
+            - Range: 0x80c320..0x80c348
               Pieces: []
-            - Range: 0x80c0e8..0x80c0e9
+            - Range: 0x80c348..0x80c349
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c0e9..0x80c110
+            - Range: 0x80c349..0x80c370
               Pieces: []
           Role: Return
           DictIndex: 2
       DictRegister: 0
-    - ID: 167
-      Name: main.genericPtrIdentity[go.shape.int]
-      OutOfLinePCRanges: [0x80c300..0x80c310]
-      InlinePCRanges: []
-      Variables:
-        - Name: p
-          Type: 333 PointerType *go.shape.int
-          Locations:
-            - Range: 0x80c300..0x80c310
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          Role: Parameter
-          DictIndex: 0
-        - Name: ~r0
-          Type: 333 PointerType *go.shape.int
-          Locations:
-            - Range: 0x80c300..0x80c304
-              Pieces: []
-            - Range: 0x80c304..0x80c305
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c305..0x80c310
-              Pieces: []
-          Role: Return
-          DictIndex: 1
-      DictRegister: 0
     - ID: 168
-      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
-      OutOfLinePCRanges: [0x80c310..0x80c320]
+      Name: main.genericPtrIdentity[go.shape.int]
+      OutOfLinePCRanges: [0x80c560..0x80c570]
       InlinePCRanges: []
       Variables:
         - Name: p
-          Type: 336 PointerType *go.shape.struct { Name string }
+          Type: 333 PointerType *go.shape.int
           Locations:
-            - Range: 0x80c310..0x80c320
+            - Range: 0x80c560..0x80c570
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
-          Type: 336 PointerType *go.shape.struct { Name string }
+          Type: 333 PointerType *go.shape.int
           Locations:
-            - Range: 0x80c310..0x80c314
+            - Range: 0x80c560..0x80c564
               Pieces: []
-            - Range: 0x80c314..0x80c315
+            - Range: 0x80c564..0x80c565
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c315..0x80c320
+            - Range: 0x80c565..0x80c570
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
     - ID: 169
+      Name: main.genericPtrIdentity[go.shape.struct { Name string }]
+      OutOfLinePCRanges: [0x80c570..0x80c580]
+      InlinePCRanges: []
+      Variables:
+        - Name: p
+          Type: 336 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x80c570..0x80c580
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          Role: Parameter
+          DictIndex: 0
+        - Name: ~r0
+          Type: 336 PointerType *go.shape.struct { Name string }
+          Locations:
+            - Range: 0x80c570..0x80c574
+              Pieces: []
+            - Range: 0x80c574..0x80c575
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80c575..0x80c580
+              Pieces: []
+          Role: Return
+          DictIndex: 1
+      DictRegister: 0
+    - ID: 170
       Name: main.genericPtrIdentity[go.shape.struct { X int; Y int }]
-      OutOfLinePCRanges: [0x80c320..0x80c330]
+      OutOfLinePCRanges: [0x80c580..0x80c590]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 338 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x80c320..0x80c330
+            - Range: 0x80c580..0x80c590
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 338 PointerType *go.shape.struct { X int; Y int }
           Locations:
-            - Range: 0x80c320..0x80c324
+            - Range: 0x80c580..0x80c584
               Pieces: []
-            - Range: 0x80c324..0x80c325
+            - Range: 0x80c584..0x80c585
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c325..0x80c330
+            - Range: 0x80c585..0x80c590
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 170
+    - ID: 171
       Name: main.largeGenericType[go.shape.string].LargeGet
-      OutOfLinePCRanges: [0x80c330..0x80c340]
+      OutOfLinePCRanges: [0x80c590..0x80c5a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 340 StructureType main.largeGenericType[go.shape.string]
           Locations:
-            - Range: 0x80c330..0x80c340
+            - Range: 0x80c590..0x80c5a0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c330..0x80c334
+            - Range: 0x80c590..0x80c594
               Pieces: []
-            - Range: 0x80c334..0x80c335
+            - Range: 0x80c594..0x80c595
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c335..0x80c340
+            - Range: 0x80c595..0x80c5a0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 171
+    - ID: 172
       Name: main.largeGenericType[go.shape.int].LargeGet
-      OutOfLinePCRanges: [0x80c3b0..0x80c3c0]
+      OutOfLinePCRanges: [0x80c610..0x80c620]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 342 StructureType main.largeGenericType[go.shape.int]
           Locations:
-            - Range: 0x80c3b0..0x80c3c0
+            - Range: 0x80c610..0x80c620
               Pieces: [{Size: 136, Op: {CfaOffset: 8}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c3b0..0x80c3b4
+            - Range: 0x80c610..0x80c614
               Pieces: []
-            - Range: 0x80c3b4..0x80c3b5
+            - Range: 0x80c614..0x80c615
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c3b5..0x80c3c0
+            - Range: 0x80c615..0x80c620
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 172
+    - ID: 173
       Name: main.(*Pair[go.shape.int,go.shape.bool]).SetValue
-      OutOfLinePCRanges: [0x80c430..0x80c440]
+      OutOfLinePCRanges: [0x80c690..0x80c6a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 343 PointerType *main.Pair[go.shape.int,go.shape.bool]
           Locations:
-            - Range: 0x80c430..0x80c440
+            - Range: 0x80c690..0x80c6a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c430..0x80c440
+            - Range: 0x80c690..0x80c6a0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: v
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0x80c430..0x80c440
+            - Range: 0x80c690..0x80c6a0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 173
+    - ID: 174
       Name: main.(*Pair[go.shape.string,go.shape.int]).SetValue
-      OutOfLinePCRanges: [0x80c4a0..0x80c510]
+      OutOfLinePCRanges: [0x80c700..0x80c770]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 346 PointerType *main.Pair[go.shape.string,go.shape.int]
           Locations:
-            - Range: 0x80c4a0..0x80c510
+            - Range: 0x80c700..0x80c770
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: k
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c4a0..0x80c510
+            - Range: 0x80c700..0x80c770
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -10452,20 +10505,20 @@ Subprograms:
         - Name: v
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c4a0..0x80c510
+            - Range: 0x80c700..0x80c770
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 2
       DictRegister: 1
-    - ID: 174
+    - ID: 175
       Name: main.genericSwap[go.shape.string,go.shape.bool]
-      OutOfLinePCRanges: [0x80c570..0x80c580]
+      OutOfLinePCRanges: [0x80c7d0..0x80c7e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c570..0x80c580
+            - Range: 0x80c7d0..0x80c7e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10476,59 +10529,59 @@ Subprograms:
         - Name: b
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0x80c570..0x80c580
+            - Range: 0x80c7d0..0x80c7e0
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 345 BaseType go.shape.bool
           Locations:
-            - Range: 0x80c570..0x80c578
+            - Range: 0x80c7d0..0x80c7d8
               Pieces: []
-            - Range: 0x80c578..0x80c579
+            - Range: 0x80c7d8..0x80c7d9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c579..0x80c580
+            - Range: 0x80c7d9..0x80c7e0
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c570..0x80c578
+            - Range: 0x80c7d0..0x80c7d8
               Pieces: []
-            - Range: 0x80c578..0x80c579
+            - Range: 0x80c7d8..0x80c7d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c579..0x80c580
+            - Range: 0x80c7d9..0x80c7e0
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 175
+    - ID: 176
       Name: main.genericSwap[go.shape.int,go.shape.string]
-      OutOfLinePCRanges: [0x80c580..0x80c5a0]
+      OutOfLinePCRanges: [0x80c7e0..0x80c800]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c580..0x80c590
+            - Range: 0x80c7e0..0x80c7f0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: b
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c580..0x80c58c
+            - Range: 0x80c7e0..0x80c7ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c58c..0x80c5a0
+            - Range: 0x80c7ec..0x80c800
               Pieces:
                 - Size: 8
                   Op: null
@@ -10539,73 +10592,73 @@ Subprograms:
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c580..0x80c590
+            - Range: 0x80c7e0..0x80c7f0
               Pieces: []
-            - Range: 0x80c590..0x80c591
+            - Range: 0x80c7f0..0x80c7f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c591..0x80c5a0
+            - Range: 0x80c7f1..0x80c800
               Pieces: []
           Role: Return
           DictIndex: 1
         - Name: ~r1
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c580..0x80c590
+            - Range: 0x80c7e0..0x80c7f0
               Pieces: []
-            - Range: 0x80c590..0x80c591
+            - Range: 0x80c7f0..0x80c7f1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80c591..0x80c5a0
+            - Range: 0x80c7f1..0x80c800
               Pieces: []
           Role: Return
           DictIndex: 0
       DictRegister: 0
-    - ID: 176
+    - ID: 177
       Name: main.genericDo[go.shape.struct { main.i int }]
-      OutOfLinePCRanges: [0x80c5a0..0x80c5f0]
+      OutOfLinePCRanges: [0x80c800..0x80c850]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 348 StructureType go.shape.struct { main.i int }
           Locations:
-            - Range: 0x80c5a0..0x80c5c8
+            - Range: 0x80c800..0x80c828
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c5a0..0x80c5c8
+            - Range: 0x80c800..0x80c828
               Pieces: []
-            - Range: 0x80c5c8..0x80c5c9
+            - Range: 0x80c828..0x80c829
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c5c9..0x80c5f0
+            - Range: 0x80c829..0x80c850
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 177
+    - ID: 178
       Name: main.genericDo[go.shape.struct { main.s string }]
-      OutOfLinePCRanges: [0x80c5f0..0x80c650]
+      OutOfLinePCRanges: [0x80c850..0x80c8b0]
       InlinePCRanges: []
       Variables:
         - Name: val
           Type: 349 StructureType go.shape.struct { main.s string }
           Locations:
-            - Range: 0x80c5f0..0x80c61c
+            - Range: 0x80c850..0x80c87c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x80c61c..0x80c620
+            - Range: 0x80c87c..0x80c880
               Pieces:
                 - Size: 8
                   Op: null
@@ -10616,65 +10669,65 @@ Subprograms:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c5f0..0x80c620
+            - Range: 0x80c850..0x80c880
               Pieces: []
-            - Range: 0x80c620..0x80c621
+            - Range: 0x80c880..0x80c881
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c621..0x80c650
+            - Range: 0x80c881..0x80c8b0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 0
-    - ID: 178
+    - ID: 179
       Name: main.genericDeref[go.shape.string]
-      OutOfLinePCRanges: [0x80c650..0x80c660]
+      OutOfLinePCRanges: [0x80c8b0..0x80c8c0]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 350 PointerType *go.shape.string
           Locations:
-            - Range: 0x80c650..0x80c654
+            - Range: 0x80c8b0..0x80c8b4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c650..0x80c654
+            - Range: 0x80c8b0..0x80c8b4
               Pieces: []
-            - Range: 0x80c654..0x80c655
+            - Range: 0x80c8b4..0x80c8b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c655..0x80c660
+            - Range: 0x80c8b5..0x80c8c0
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 179
+    - ID: 180
       Name: main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]
-      OutOfLinePCRanges: [0x80c660..0x80c6b0]
+      OutOfLinePCRanges: [0x80c8c0..0x80c910]
       InlinePCRanges: []
       Variables:
         - Name: p
           Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80c660..0x80c6a0
+            - Range: 0x80c8c0..0x80c900
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: ~r0
           Type: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
           Locations:
-            - Range: 0x80c660..0x80c6a4
+            - Range: 0x80c8c0..0x80c904
               Pieces: []
-            - Range: 0x80c6a4..0x80c6a5
+            - Range: 0x80c904..0x80c905
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10688,20 +10741,20 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80c6a5..0x80c6b0
+            - Range: 0x80c905..0x80c910
               Pieces: []
           Role: Return
           DictIndex: 1
       DictRegister: 0
-    - ID: 180
+    - ID: 181
       Name: main.genericContains[go.shape.int]
-      OutOfLinePCRanges: [0x80c6b0..0x80c6f0]
+      OutOfLinePCRanges: [0x80c910..0x80c950]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 332 GoSliceHeaderType []go.shape.int
           Locations:
-            - Range: 0x80c6b0..0x80c6bc
+            - Range: 0x80c910..0x80c91c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10709,7 +10762,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c6bc..0x80c6f0
+            - Range: 0x80c91c..0x80c950
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10722,42 +10775,42 @@ Subprograms:
         - Name: needle
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c6b0..0x80c6f0
+            - Range: 0x80c910..0x80c950
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80c6b0..0x80c6d8
+            - Range: 0x80c910..0x80c938
               Pieces: []
-            - Range: 0x80c6d8..0x80c6d9
+            - Range: 0x80c938..0x80c939
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c6d9..0x80c6e0
+            - Range: 0x80c939..0x80c940
               Pieces: []
-            - Range: 0x80c6e0..0x80c6e1
+            - Range: 0x80c940..0x80c941
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c6e1..0x80c6f0
+            - Range: 0x80c941..0x80c950
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c6cc..0x80c6dc
+            - Range: 0x80c92c..0x80c93c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 181
+    - ID: 182
       Name: main.genericContains[go.shape.string]
-      OutOfLinePCRanges: [0x80c6f0..0x80c7b0]
+      OutOfLinePCRanges: [0x80c950..0x80ca10]
       InlinePCRanges: []
       Variables:
         - Name: haystack
           Type: 353 GoSliceHeaderType []go.shape.string
           Locations:
-            - Range: 0x80c6f0..0x80c714
+            - Range: 0x80c950..0x80c974
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -10765,7 +10818,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80c714..0x80c718
+            - Range: 0x80c974..0x80c978
               Pieces:
                 - Size: 8
                   Op: null
@@ -10778,13 +10831,13 @@ Subprograms:
         - Name: needle
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c6f0..0x80c74c
+            - Range: 0x80c950..0x80c9ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x80c74c..0x80c7b0
+            - Range: 0x80c9ac..0x80ca10
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 40}
@@ -10795,22 +10848,22 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80c6f0..0x80c768
+            - Range: 0x80c950..0x80c9c8
               Pieces: []
-            - Range: 0x80c768..0x80c769
+            - Range: 0x80c9c8..0x80c9c9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c769..0x80c778
+            - Range: 0x80c9c9..0x80c9d8
               Pieces: []
-            - Range: 0x80c778..0x80c779
+            - Range: 0x80c9d8..0x80c9d9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c779..0x80c7b0
+            - Range: 0x80c9d9..0x80ca10
               Pieces: []
           Role: Return
           DictIndex: -1
         - Name: v
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c734..0x80c74c
+            - Range: 0x80c994..0x80c9ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10819,58 +10872,58 @@ Subprograms:
           Role: Local
           DictIndex: 1
       DictRegister: 0
-    - ID: 182
+    - ID: 183
       Name: main.typeWithGenerics[go.shape.int].Guess
-      OutOfLinePCRanges: [0x80c7b0..0x80c7c0]
+      OutOfLinePCRanges: [0x80ca10..0x80ca20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 354 StructureType main.typeWithGenerics[go.shape.int]
           Locations:
-            - Range: 0x80c7b0..0x80c7b8
+            - Range: 0x80ca10..0x80ca18
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
           DictIndex: 0
         - Name: value
           Type: 328 BaseType go.shape.int
           Locations:
-            - Range: 0x80c7b0..0x80c7c0
+            - Range: 0x80ca10..0x80ca20
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
           DictIndex: 1
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80c7b0..0x80c7b8
+            - Range: 0x80ca10..0x80ca18
               Pieces: []
-            - Range: 0x80c7b8..0x80c7b9
+            - Range: 0x80ca18..0x80ca19
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c7b9..0x80c7c0
+            - Range: 0x80ca19..0x80ca20
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 1
-    - ID: 183
+    - ID: 184
       Name: main.typeWithGenerics[go.shape.string].Guess
-      OutOfLinePCRanges: [0x80c810..0x80c880]
+      OutOfLinePCRanges: [0x80ca70..0x80cae0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 355 StructureType main.typeWithGenerics[go.shape.string]
           Locations:
-            - Range: 0x80c810..0x80c83c
+            - Range: 0x80ca70..0x80ca9c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c83c..0x80c848
+            - Range: 0x80ca9c..0x80caa8
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c848..0x80c84c
+            - Range: 0x80caa8..0x80caac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -10881,7 +10934,7 @@ Subprograms:
         - Name: value
           Type: 330 GoStringHeaderType go.shape.string
           Locations:
-            - Range: 0x80c810..0x80c84c
+            - Range: 0x80ca70..0x80caac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -10892,16 +10945,16 @@ Subprograms:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80c810..0x80c84c
+            - Range: 0x80ca70..0x80caac
               Pieces: []
-            - Range: 0x80c84c..0x80c84d
+            - Range: 0x80caac..0x80caad
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80c84d..0x80c880
+            - Range: 0x80caad..0x80cae0
               Pieces: []
           Role: Return
           DictIndex: -1
       DictRegister: 2
-    - ID: 184
+    - ID: 185
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]
       OutOfLinePCRanges: [0x139ab0..0x139c50]
       InlinePCRanges: []
@@ -11056,7 +11109,7 @@ Subprograms:
           Role: Local
           DictIndex: 4
       DictRegister: 0
-    - ID: 185
+    - ID: 186
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x8055a0..0x805610]
       InlinePCRanges:
@@ -11087,7 +11140,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 186
+    - ID: 187
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11095,7 +11148,7 @@ Subprograms:
           RootRanges: [0x8057c0..0x805880]
       Variables: []
       DictRegister: null
-    - ID: 187
+    - ID: 188
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11103,7 +11156,7 @@ Subprograms:
           RootRanges: [0x8058f0..0x805a00]
       Variables: []
       DictRegister: null
-    - ID: 188
+    - ID: 189
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11111,7 +11164,7 @@ Subprograms:
           RootRanges: [0x8058f0..0x805a00]
       Variables: []
       DictRegister: null
-    - ID: 189
+    - ID: 190
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11126,7 +11179,7 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 190
+    - ID: 191
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11145,12 +11198,12 @@ Subprograms:
           Role: Parameter
           DictIndex: -1
       DictRegister: null
-    - ID: 191
+    - ID: 192
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x805ba0..0x805c00]
       InlinePCRanges:
-        - Ranges: [0x80c900..0x80c924]
-          RootRanges: [0x80c8e0..0x80c950]
+        - Ranges: [0x80cb60..0x80cb84]
+          RootRanges: [0x80cb40..0x80cbb0]
       Variables:
         - Name: b
           Type: 360 StructureType main.firstBehavior
@@ -11179,7 +11232,7 @@ Subprograms:
           Role: Return
           DictIndex: -1
       DictRegister: null
-    - ID: 192
+    - ID: 193
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -14594,7 +14647,7 @@ Types:
       GoKind: 22
       Pointee: 867 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1627
+      ID: 1628
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14613,7 +14666,7 @@ Types:
             Type: 356 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14624,7 +14677,7 @@ Types:
             Type: 356 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 0, name: items}
+                  Variable: {subprogram: 185, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14635,12 +14688,12 @@ Types:
             Type: 359 GoSubroutineType func(go.shape.float64) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 1, name: pred}
+                  Variable: {subprogram: 185, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1628
+      ID: 1629
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.float64]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14653,12 +14706,12 @@ Types:
             Type: 356 GoSliceHeaderType []go.shape.float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 184, index: 2, name: ~r0}
+                  Variable: {subprogram: 185, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1625
+      ID: 1626
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14677,7 +14730,7 @@ Types:
             Type: 332 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14688,7 +14741,7 @@ Types:
             Type: 332 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 0, name: items}
+                  Variable: {subprogram: 166, index: 0, name: items}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14699,12 +14752,12 @@ Types:
             Type: 334 GoSubroutineType func(go.shape.int) bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 1, name: pred}
+                  Variable: {subprogram: 166, index: 1, name: pred}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1626
+      ID: 1627
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Filter[go.shape.int]]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -14717,15 +14770,15 @@ Types:
             Type: 332 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 165, index: 2, name: ~r0}
+                  Variable: {subprogram: 166, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1683
+      ID: 1684
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1629
+      ID: 1630
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -14744,7 +14797,7 @@ Types:
             Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14755,7 +14808,7 @@ Types:
             Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 0, name: box}
+                  Variable: {subprogram: 167, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14766,12 +14819,12 @@ Types:
             Type: 335 GoSubroutineType func(go.shape.int) go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 1, name: f}
+                  Variable: {subprogram: 167, index: 1, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1630
+      ID: 1631
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Map[go.shape.int,go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -14784,12 +14837,12 @@ Types:
             Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 166, index: 2, name: ~r0}
+                  Variable: {subprogram: 167, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1641
+      ID: 1642
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -14811,7 +14864,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14822,7 +14875,7 @@ Types:
             Type: 343 PointerType *main.Pair[go.shape.int,go.shape.bool]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 0, name: x}
+                  Variable: {subprogram: 173, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14833,7 +14886,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 1, name: k}
+                  Variable: {subprogram: 173, index: 1, name: k}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14844,15 +14897,15 @@ Types:
             Type: 345 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 172, index: 2, name: v}
+                  Variable: {subprogram: 173, index: 2, name: v}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1642
+      ID: 1643
       Name: Probe[main.(*Pair[go.shape.int,go.shape.bool]).SetValue]Return
     - __kind: EventRootType
-      ID: 1643
+      ID: 1644
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -14874,7 +14927,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14885,7 +14938,7 @@ Types:
             Type: 346 PointerType *main.Pair[go.shape.string,go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 0, name: x}
+                  Variable: {subprogram: 174, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -14896,7 +14949,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 1, name: k}
+                  Variable: {subprogram: 174, index: 1, name: k}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -14907,15 +14960,15 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 173, index: 2, name: v}
+                  Variable: {subprogram: 174, index: 2, name: v}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 2
     - __kind: EventRootType
-      ID: 1644
+      ID: 1645
       Name: Probe[main.(*Pair[go.shape.string,go.shape.int]).SetValue]Return
     - __kind: EventRootType
-      ID: 1681
+      ID: 1682
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14927,12 +14980,12 @@ Types:
             Type: 360 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 0, name: b}
+                  Variable: {subprogram: 192, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1682
+      ID: 1683
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -14944,12 +14997,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 191, index: 1, name: ~r0}
+                  Variable: {subprogram: 192, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1657
+      ID: 1658
       Name: Probe[main.genericContains[go.shape.int]]
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -14968,7 +15021,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -14979,7 +15032,7 @@ Types:
             Type: 332 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -14990,14 +15043,14 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1661
+      ID: 1662
       Name: Probe[main.genericContains[go.shape.int]]Line
-      ByteSize: 50
+      ByteSize: 49
       ExprStatusArraySize: 1
       DictEntries:
         - DictIndex: 0
@@ -15014,7 +15067,7 @@ Types:
             Type: 332 GoSliceHeaderType []go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 0, name: haystack}
+                  Variable: {subprogram: 181, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -15025,23 +15078,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 1, name: needle}
+                  Variable: {subprogram: 181, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
-        - Name: '@return'
-          Offset: 49
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1658
+      ID: 1659
       Name: Probe[main.genericContains[go.shape.int]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15053,12 +15095,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 180, index: 2, name: ~r0}
+                  Variable: {subprogram: 181, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1659
+      ID: 1660
       Name: Probe[main.genericContains[go.shape.string]]
       ByteSize: 73
       ExprStatusArraySize: 1
@@ -15077,7 +15119,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -15088,7 +15130,7 @@ Types:
             Type: 353 GoSliceHeaderType []go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 0, name: haystack}
+                  Variable: {subprogram: 182, index: 0, name: haystack}
                   Offset: 0
                   ByteSize: 24
           DictIndex: 0
@@ -15099,14 +15141,14 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1662
+      ID: 1663
       Name: Probe[main.genericContains[go.shape.string]]Line
-      ByteSize: 26
+      ByteSize: 25
       ExprStatusArraySize: 1
       DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
       Expressions:
@@ -15117,23 +15159,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 1, name: needle}
+                  Variable: {subprogram: 182, index: 1, name: needle}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
-        - Name: '@return'
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-          DictIndex: -1
     - __kind: EventRootType
-      ID: 1660
+      ID: 1661
       Name: Probe[main.genericContains[go.shape.string]]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -15145,12 +15176,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 181, index: 2, name: ~r0}
+                  Variable: {subprogram: 182, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1653
+      ID: 1654
       Name: Probe[main.genericDeref[go.shape.string]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15163,7 +15194,7 @@ Types:
             Type: 350 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15174,12 +15205,12 @@ Types:
             Type: 350 PointerType *go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 0, name: p}
+                  Variable: {subprogram: 179, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1654
+      ID: 1655
       Name: Probe[main.genericDeref[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15192,12 +15223,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Variable: {subprogram: 179, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1655
+      ID: 1656
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15210,7 +15241,7 @@ Types:
             Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15221,12 +15252,12 @@ Types:
             Type: 351 PointerType *go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 0, name: p}
+                  Variable: {subprogram: 180, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1656
+      ID: 1657
       Name: Probe[main.genericDeref[go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }]]Return
       ByteSize: 57
       ExprStatusArraySize: 1
@@ -15239,12 +15270,12 @@ Types:
             Type: 352 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 179, index: 1, name: ~r0}
+                  Variable: {subprogram: 180, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 48
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1649
+      ID: 1650
       Name: Probe[main.genericDo[go.shape.struct { main.i int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15257,7 +15288,7 @@ Types:
             Type: 348 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -15268,59 +15299,13 @@ Types:
             Type: 348 StructureType go.shape.struct { main.i int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 0, name: val}
+                  Variable: {subprogram: 177, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1650
-      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
-      ByteSize: 17
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: '@return'
-          Offset: 1
-          Kind: return
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 176, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1651
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
-      ByteSize: 41
-      ExprStatusArraySize: 1
-      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
-      Expressions:
-        - Name: val
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 349 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-        - Name: val
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 349 StructureType go.shape.struct { main.s string }
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 177, index: 0, name: val}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: 1
-    - __kind: EventRootType
-      ID: 1652
-      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      Name: Probe[main.genericDo[go.shape.struct { main.i int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
       Expressions:
@@ -15336,7 +15321,53 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1631
+      ID: 1652
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]
+      ByteSize: 41
+      ExprStatusArraySize: 1
+      DictEntries: [{DictIndex: 1, DictRegister: 0, Offset: 1}]
+      Expressions:
+        - Name: val
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 349 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+        - Name: val
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 349 StructureType go.shape.struct { main.s string }
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 0, name: val}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: 1
+    - __kind: EventRootType
+      ID: 1653
+      Name: Probe[main.genericDo[go.shape.struct { main.s string }]]Return
+      ByteSize: 17
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: '@return'
+          Offset: 1
+          Kind: return
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 178, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1632
       Name: Probe[main.genericPtrIdentity[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15349,7 +15380,7 @@ Types:
             Type: 333 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15360,12 +15391,12 @@ Types:
             Type: 333 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 0, name: p}
+                  Variable: {subprogram: 168, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1632
+      ID: 1633
       Name: Probe[main.genericPtrIdentity[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15378,12 +15409,12 @@ Types:
             Type: 333 PointerType *go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 167, index: 1, name: ~r0}
+                  Variable: {subprogram: 168, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1633
+      ID: 1634
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15396,7 +15427,7 @@ Types:
             Type: 336 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15407,12 +15438,12 @@ Types:
             Type: 336 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 0, name: p}
+                  Variable: {subprogram: 169, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1634
+      ID: 1635
       Name: Probe[main.genericPtrIdentity[go.shape.struct { Name string }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15425,12 +15456,12 @@ Types:
             Type: 336 PointerType *go.shape.struct { Name string }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 168, index: 1, name: ~r0}
+                  Variable: {subprogram: 169, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1635
+      ID: 1636
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15443,7 +15474,7 @@ Types:
             Type: 338 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15454,12 +15485,12 @@ Types:
             Type: 338 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 0, name: p}
+                  Variable: {subprogram: 170, index: 0, name: p}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1636
+      ID: 1637
       Name: Probe[main.genericPtrIdentity[go.shape.struct { X int; Y int }]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15472,12 +15503,12 @@ Types:
             Type: 338 PointerType *go.shape.struct { X int; Y int }
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 169, index: 1, name: ~r0}
+                  Variable: {subprogram: 170, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1647
+      ID: 1648
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15496,7 +15527,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15507,7 +15538,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 0, name: a}
+                  Variable: {subprogram: 176, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15518,12 +15549,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 1, name: b}
+                  Variable: {subprogram: 176, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1648
+      ID: 1649
       Name: Probe[main.genericSwap[go.shape.int,go.shape.string]]Return
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15542,7 +15573,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 2, name: ~r0}
+                  Variable: {subprogram: 176, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -15553,12 +15584,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 175, index: 3, name: ~r1}
+                  Variable: {subprogram: 176, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1645
+      ID: 1646
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]
       ByteSize: 50
       ExprStatusArraySize: 1
@@ -15577,7 +15608,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15588,7 +15619,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 0, name: a}
+                  Variable: {subprogram: 175, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15599,12 +15630,12 @@ Types:
             Type: 345 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 1, name: b}
+                  Variable: {subprogram: 175, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1646
+      ID: 1647
       Name: Probe[main.genericSwap[go.shape.string,go.shape.bool]]Return
       ByteSize: 34
       ExprStatusArraySize: 1
@@ -15623,7 +15654,7 @@ Types:
             Type: 345 BaseType go.shape.bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 2, name: ~r0}
+                  Variable: {subprogram: 175, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: 1
@@ -15634,12 +15665,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 174, index: 3, name: ~r1}
+                  Variable: {subprogram: 175, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1639
+      ID: 1640
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]
       ByteSize: 281
       ExprStatusArraySize: 1
@@ -15652,7 +15683,7 @@ Types:
             Type: 342 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
@@ -15663,12 +15694,12 @@ Types:
             Type: 342 StructureType main.largeGenericType[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 0, name: x}
+                  Variable: {subprogram: 172, index: 0, name: x}
                   Offset: 0
                   ByteSize: 136
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1640
+      ID: 1641
       Name: Probe[main.largeGenericType[go.shape.int].LargeGet]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15681,12 +15712,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 171, index: 1, name: ~r0}
+                  Variable: {subprogram: 172, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1637
+      ID: 1638
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]
       ByteSize: 297
       ExprStatusArraySize: 1
@@ -15699,7 +15730,7 @@ Types:
             Type: 340 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
@@ -15710,12 +15741,12 @@ Types:
             Type: 340 StructureType main.largeGenericType[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 0, name: x}
+                  Variable: {subprogram: 171, index: 0, name: x}
                   Offset: 0
                   ByteSize: 144
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1638
+      ID: 1639
       Name: Probe[main.largeGenericType[go.shape.string].LargeGet]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15728,12 +15759,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 170, index: 1, name: ~r0}
+                  Variable: {subprogram: 171, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1621
+      ID: 1622
       Name: Probe[main.nestedGeneric[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15746,7 +15777,7 @@ Types:
             Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -15757,12 +15788,12 @@ Types:
             Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: box}
+                  Variable: {subprogram: 164, index: 0, name: box}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1622
+      ID: 1623
       Name: Probe[main.nestedGeneric[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15775,12 +15806,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1623
+      ID: 1624
       Name: Probe[main.nestedGeneric[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -15793,7 +15824,7 @@ Types:
             Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -15804,12 +15835,12 @@ Types:
             Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 0, name: box}
+                  Variable: {subprogram: 165, index: 0, name: box}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1624
+      ID: 1625
       Name: Probe[main.nestedGeneric[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15822,15 +15853,15 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 164, index: 1, name: ~r0}
+                  Variable: {subprogram: 165, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1592
+      ID: 1593
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1593
+      ID: 1594
       Name: Probe[main.stackC]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -15842,7 +15873,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: ~r0}
+                  Variable: {subprogram: 145, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -15937,7 +15968,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1563
+      ID: 1564
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -15949,7 +15980,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -15960,12 +15991,12 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1564
+      ID: 1565
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -15977,7 +16008,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16676,7 +16707,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1583
+      ID: 1584
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -16688,7 +16719,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16699,7 +16730,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16710,7 +16741,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16721,12 +16752,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: a}
+                  Variable: {subprogram: 137, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1580
+      ID: 1581
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -16738,7 +16769,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -16749,12 +16780,12 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: u}
+                  Variable: {subprogram: 134, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1604
+      ID: 1605
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -16766,7 +16797,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -16777,12 +16808,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1616
+      ID: 1617
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -16794,7 +16825,7 @@ Types:
             Type: 327 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -16805,12 +16836,12 @@ Types:
             Type: 327 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: e}
+                  Variable: {subprogram: 161, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1615
+      ID: 1616
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -16822,7 +16853,7 @@ Types:
             Type: 326 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -16833,18 +16864,18 @@ Types:
             Type: 326 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 159, index: 0, name: e}
+                  Variable: {subprogram: 160, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
       ID: 1402
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 58
-      ExprStatusArraySize: 2
+      ByteSize: 49
+      ExprStatusArraySize: 1
       Expressions:
         - Name: x
-          Offset: 2
+          Offset: 1
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -16855,7 +16886,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 10
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 15 GoInterfaceType error
@@ -16865,19 +16896,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
-        - Name: '@return'
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
         - Name: x
-          Offset: 34
+          Offset: 25
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16888,7 +16908,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
         - Name: err
-          Offset: 42
+          Offset: 33
           Kind: local
           Expression:
             Type: 15 GoInterfaceType error
@@ -17019,7 +17039,7 @@ Types:
     - __kind: EventRootType
       ID: 1430
       Name: Probe[main.testFramelessArray]Line
-      ByteSize: 89
+      ByteSize: 81
       ExprStatusArraySize: 1
       Expressions:
         - Name: a
@@ -17043,17 +17063,6 @@ Types:
                   Variable: {subprogram: 55, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-          DictIndex: -1
-        - Name: '@return'
-          Offset: 81
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1429
@@ -17180,7 +17189,7 @@ Types:
       ID: 1423
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1673
+      ID: 1674
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1420
@@ -17236,16 +17245,16 @@ Types:
       ID: 1421
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1674
+      ID: 1675
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1675
+      ID: 1676
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1676
+      ID: 1677
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1677
+      ID: 1678
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1424
@@ -17254,7 +17263,7 @@ Types:
       ID: 1425
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1670
+      ID: 1671
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17266,7 +17275,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17277,24 +17286,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-          DictIndex: -1
-    - __kind: EventRootType
-      ID: 1667
-      Name: Probe[main.testInlinedPrint]Line
-      ByteSize: 9
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x_val
-          Offset: 1
-          Kind: capture_expression
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17311,12 +17303,29 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
       ID: 1669
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 186, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1670
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17328,7 +17337,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17339,12 +17348,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1672
+      ID: 1673
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17356,7 +17365,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17367,15 +17376,15 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 185, index: 0, name: x}
+                  Variable: {subprogram: 186, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1671
+      ID: 1672
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1678
+      ID: 1679
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17387,7 +17396,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17398,12 +17407,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1679
+      ID: 1680
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17415,7 +17424,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17426,12 +17435,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 189, index: 0, name: x}
+                  Variable: {subprogram: 190, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1680
+      ID: 1681
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17443,7 +17452,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17454,7 +17463,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 190, index: 0, name: a}
+                  Variable: {subprogram: 191, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -17627,7 +17636,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1561
+      ID: 1562
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -17639,7 +17648,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17650,12 +17659,12 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: arg}
+                  Variable: {subprogram: 124, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1562
+      ID: 1563
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -17667,7 +17676,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: ~r0}
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -17781,7 +17790,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1567
+      ID: 1568
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 149
       ExprStatusArraySize: 5
@@ -17793,7 +17802,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17804,7 +17813,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17815,7 +17824,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17826,7 +17835,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17837,7 +17846,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17848,7 +17857,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17859,7 +17868,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17870,7 +17879,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17881,7 +17890,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17892,7 +17901,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17903,7 +17912,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17914,7 +17923,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 127, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17925,7 +17934,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 127, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17936,7 +17945,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
+                  Variable: {subprogram: 127, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17947,7 +17956,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
+                  Variable: {subprogram: 127, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17958,7 +17967,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
+                  Variable: {subprogram: 127, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17969,7 +17978,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
+                  Variable: {subprogram: 127, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -17980,12 +17989,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 8, name: i}
+                  Variable: {subprogram: 127, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1568
+      ID: 1569
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -17997,7 +18006,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 9, name: ~r0}
+                  Variable: {subprogram: 127, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18562,34 +18571,6 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1601
-      Name: Probe[main.testMassiveString]
-      ByteSize: 33
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-        - Name: x
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1602
       Name: Probe[main.testMassiveString]
       ByteSize: 33
@@ -18602,7 +18583,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18613,12 +18594,40 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: x}
+                  Variable: {subprogram: 151, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1569
+      ID: 1603
+      Name: Probe[main.testMassiveString]
+      ByteSize: 33
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 151, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1570
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 165
       ExprStatusArraySize: 5
@@ -18630,7 +18639,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18641,7 +18650,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18652,7 +18661,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18663,7 +18672,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18674,7 +18683,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18685,7 +18694,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18696,7 +18705,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18707,7 +18716,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18718,7 +18727,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18729,7 +18738,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18740,7 +18749,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18751,7 +18760,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: c}
+                  Variable: {subprogram: 128, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18762,7 +18771,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: d}
+                  Variable: {subprogram: 128, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18773,7 +18782,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 4, name: e}
+                  Variable: {subprogram: 128, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18784,7 +18793,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 5, name: f}
+                  Variable: {subprogram: 128, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18795,7 +18804,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 6, name: g}
+                  Variable: {subprogram: 128, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18806,7 +18815,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 7, name: h}
+                  Variable: {subprogram: 128, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18817,12 +18826,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 8, name: s}
+                  Variable: {subprogram: 128, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1570
+      ID: 1571
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18834,12 +18843,12 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 9, name: ~r0}
+                  Variable: {subprogram: 128, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1573
+      ID: 1574
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18851,7 +18860,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18862,7 +18871,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -18873,7 +18882,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: a}
+                  Variable: {subprogram: 130, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -18884,12 +18893,12 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 1, name: b}
+                  Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1574
+      ID: 1575
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -18901,7 +18910,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 2, name: ~r0}
+                  Variable: {subprogram: 130, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -18912,12 +18921,12 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 3, name: ~r1}
+                  Variable: {subprogram: 130, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1565
+      ID: 1566
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       ExprStatusArraySize: 1
@@ -18929,7 +18938,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18940,7 +18949,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18951,7 +18960,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: s1}
+                  Variable: {subprogram: 126, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -18962,12 +18971,12 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: s2}
+                  Variable: {subprogram: 126, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1566
+      ID: 1567
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -18979,7 +18988,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
@@ -19632,7 +19641,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1610
+      ID: 1611
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19644,7 +19653,7 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19655,12 +19664,12 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1611
+      ID: 1612
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19672,7 +19681,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19683,10 +19692,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1612
+      ID: 1613
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1613
+      ID: 1614
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -19698,7 +19707,7 @@ Types:
             Type: 129 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -19759,7 +19768,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1584
+      ID: 1585
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -19771,7 +19780,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19782,7 +19791,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19793,7 +19802,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19804,12 +19813,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 1, name: a}
+                  Variable: {subprogram: 138, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1586
+      ID: 1587
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 68
       ExprStatusArraySize: 2
@@ -19821,7 +19830,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19832,7 +19841,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19843,7 +19852,7 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19854,7 +19863,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: a}
+                  Variable: {subprogram: 140, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -19865,7 +19874,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: s}
+                  Variable: {subprogram: 140, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19876,12 +19885,12 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: x}
+                  Variable: {subprogram: 140, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1587
+      ID: 1588
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -19893,7 +19902,7 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -19904,12 +19913,12 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: xs}
+                  Variable: {subprogram: 141, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1600
+      ID: 1601
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -19921,7 +19930,7 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -19932,7 +19941,7 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20144,10 +20153,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1541
+      ID: 1542
       Name: Probe[main.testReturnsArrayOne]
     - __kind: EventRootType
-      ID: 1542
+      ID: 1543
       Name: Probe[main.testReturnsArrayOne]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -20159,15 +20168,15 @@ Types:
             Type: 258 ArrayType [1]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1543
+      ID: 1544
       Name: Probe[main.testReturnsArrayZero]
     - __kind: EventRootType
-      ID: 1544
+      ID: 1545
       Name: Probe[main.testReturnsArrayZero]Return
       ByteSize: 1
       ExprStatusArraySize: 1
@@ -20179,15 +20188,15 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1539
+      ID: 1540
       Name: Probe[main.testReturnsArray]
     - __kind: EventRootType
-      ID: 1540
+      ID: 1541
       Name: Probe[main.testReturnsArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20199,15 +20208,15 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1547
+      ID: 1548
       Name: Probe[main.testReturnsBacktrackInt]
     - __kind: EventRootType
-      ID: 1548
+      ID: 1549
       Name: Probe[main.testReturnsBacktrackInt]Return
       ByteSize: 83
       ExprStatusArraySize: 3
@@ -20219,7 +20228,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20230,7 +20239,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 1, name: ~r1}
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20241,7 +20250,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 2, name: ~r2}
+                  Variable: {subprogram: 117, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20252,7 +20261,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 3, name: ~r3}
+                  Variable: {subprogram: 117, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20263,7 +20272,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 4, name: ~r4}
+                  Variable: {subprogram: 117, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20274,7 +20283,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 5, name: ~r5}
+                  Variable: {subprogram: 117, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20285,7 +20294,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 6, name: ~r6}
+                  Variable: {subprogram: 117, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20296,7 +20305,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 7, name: ~r7}
+                  Variable: {subprogram: 117, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20307,15 +20316,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 8, name: ~r8}
+                  Variable: {subprogram: 117, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1559
+      ID: 1560
       Name: Probe[main.testReturnsBoolAndUintptr]
     - __kind: EventRootType
-      ID: 1560
+      ID: 1561
       Name: Probe[main.testReturnsBoolAndUintptr]Return
       ByteSize: 10
       ExprStatusArraySize: 1
@@ -20327,7 +20336,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: ~r0}
+                  Variable: {subprogram: 123, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -20338,15 +20347,15 @@ Types:
             Type: 1 BaseType uintptr
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: ~r1}
+                  Variable: {subprogram: 123, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1535
+      ID: 1536
       Name: Probe[main.testReturnsComplex]
     - __kind: EventRootType
-      ID: 1536
+      ID: 1537
       Name: Probe[main.testReturnsComplex]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -20358,7 +20367,7 @@ Types:
             Type: 103 BaseType complex64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20369,7 +20378,7 @@ Types:
             Type: 18 BaseType complex128
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: ~r1}
+                  Variable: {subprogram: 111, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -20832,10 +20841,10 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1537
+      ID: 1538
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1538
+      ID: 1539
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -20847,15 +20856,15 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1533
+      ID: 1534
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1534
+      ID: 1535
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 141
       ExprStatusArraySize: 5
@@ -20867,7 +20876,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20878,7 +20887,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: ~r1}
+                  Variable: {subprogram: 110, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20889,7 +20898,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 2, name: ~r2}
+                  Variable: {subprogram: 110, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20900,7 +20909,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 3, name: ~r3}
+                  Variable: {subprogram: 110, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20911,7 +20920,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 4, name: ~r4}
+                  Variable: {subprogram: 110, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20922,7 +20931,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 5, name: ~r5}
+                  Variable: {subprogram: 110, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20933,7 +20942,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 6, name: ~r6}
+                  Variable: {subprogram: 110, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20944,7 +20953,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 7, name: ~r7}
+                  Variable: {subprogram: 110, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20955,7 +20964,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 8, name: ~r8}
+                  Variable: {subprogram: 110, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20966,7 +20975,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 9, name: ~r9}
+                  Variable: {subprogram: 110, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20977,7 +20986,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 10, name: ~r10}
+                  Variable: {subprogram: 110, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20988,7 +20997,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 11, name: ~r11}
+                  Variable: {subprogram: 110, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -20999,7 +21008,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 12, name: ~r12}
+                  Variable: {subprogram: 110, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21010,7 +21019,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 13, name: ~r13}
+                  Variable: {subprogram: 110, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21021,7 +21030,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 14, name: ~r14}
+                  Variable: {subprogram: 110, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21032,7 +21041,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 110, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21043,15 +21052,15 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 110, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1545
+      ID: 1546
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1546
+      ID: 1547
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21063,15 +21072,15 @@ Types:
             Type: 260 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1551
+      ID: 1552
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1553
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 50
       ExprStatusArraySize: 2
@@ -21083,7 +21092,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21094,7 +21103,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21105,7 +21114,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 2, name: ~r2}
+                  Variable: {subprogram: 119, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21116,7 +21125,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 3, name: ~r3}
+                  Variable: {subprogram: 119, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21127,15 +21136,15 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 4, name: ~r4}
+                  Variable: {subprogram: 119, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1557
+      ID: 1558
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1558
+      ID: 1559
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       ExprStatusArraySize: 1
@@ -21147,7 +21156,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: ~r0}
+                  Variable: {subprogram: 122, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -21158,15 +21167,65 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r1}
+                  Variable: {subprogram: 122, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1555
-      Name: Probe[main.testReturnsOnlyFloat]
+      ID: 1531
+      Name: Probe[main.testReturnsNamedDeferLine]Line
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: i
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+          DictIndex: -1
+        - Name: a
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
+        - Name: b
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 16
+          DictIndex: -1
     - __kind: EventRootType
       ID: 1556
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1557
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -21178,15 +21237,15 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Variable: {subprogram: 121, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1531
+      ID: 1532
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1532
+      ID: 1533
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 32
       ExprStatusArraySize: 2
@@ -21198,7 +21257,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -21209,7 +21268,7 @@ Types:
             Type: 102 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Variable: {subprogram: 109, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -21220,7 +21279,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 2, name: ~r2}
+                  Variable: {subprogram: 109, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -21231,7 +21290,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 3, name: ~r3}
+                  Variable: {subprogram: 109, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -21242,7 +21301,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 4, name: ~r4}
+                  Variable: {subprogram: 109, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
@@ -21253,7 +21312,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 5, name: ~r5}
+                  Variable: {subprogram: 109, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
           DictIndex: -1
@@ -21264,7 +21323,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 6, name: ~r6}
+                  Variable: {subprogram: 109, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
           DictIndex: -1
@@ -21275,15 +21334,15 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 7, name: ~r7}
+                  Variable: {subprogram: 109, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1553
+      ID: 1554
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1554
+      ID: 1555
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -21295,15 +21354,15 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1550
+      ID: 1551
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       ExprStatusArraySize: 1
@@ -21315,7 +21374,7 @@ Types:
             Type: 261 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
           DictIndex: -1
@@ -21600,7 +21659,7 @@ Types:
                   ByteSize: 4
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1594
+      ID: 1595
       Name: Probe[main.testSingleString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -21612,7 +21671,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21623,7 +21682,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -21768,7 +21827,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1590
+      ID: 1591
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21780,7 +21839,7 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21791,12 +21850,12 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Variable: {subprogram: 143, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1581
+      ID: 1582
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -21808,7 +21867,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -21819,7 +21878,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: u}
+                  Variable: {subprogram: 135, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22073,7 +22132,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1571
+      ID: 1572
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       ExprStatusArraySize: 1
@@ -22085,7 +22144,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
@@ -22096,12 +22155,12 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: arg}
+                  Variable: {subprogram: 129, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1572
+      ID: 1573
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -22113,7 +22172,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: ~r0}
+                  Variable: {subprogram: 129, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22124,7 +22183,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r1}
+                  Variable: {subprogram: 129, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22135,7 +22194,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r2}
+                  Variable: {subprogram: 129, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22196,7 +22255,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1585
+      ID: 1586
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22208,7 +22267,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22219,7 +22278,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: s}
+                  Variable: {subprogram: 139, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22280,7 +22339,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1582
+      ID: 1583
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -22292,7 +22351,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22303,7 +22362,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22314,7 +22373,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22325,7 +22384,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: a}
+                  Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22358,7 +22417,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1575
+      ID: 1576
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22370,7 +22429,7 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22381,12 +22440,12 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: arg}
+                  Variable: {subprogram: 131, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1576
+      ID: 1577
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -22398,7 +22457,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 1, name: ~r0}
+                  Variable: {subprogram: 131, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22409,12 +22468,12 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 2, name: ~r1}
+                  Variable: {subprogram: 131, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1607
+      ID: 1608
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22426,7 +22485,7 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22437,12 +22496,12 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: a}
+                  Variable: {subprogram: 156, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1606
+      ID: 1607
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       ExprStatusArraySize: 1
@@ -22454,7 +22513,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22465,7 +22524,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: a}
+                  Variable: {subprogram: 155, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
           DictIndex: -1
@@ -22498,7 +22557,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1608
+      ID: 1609
       Name: Probe[main.testStruct]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22510,12 +22569,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 8
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1609
+      ID: 1610
       Name: Probe[main.testStruct]
       ByteSize: 113
       ExprStatusArraySize: 1
@@ -22527,7 +22586,7 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
@@ -22538,12 +22597,12 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1591
+      ID: 1592
       Name: Probe[main.testSubslices]
       ByteSize: 146
       ExprStatusArraySize: 2
@@ -22555,7 +22614,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22566,7 +22625,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22577,7 +22636,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22588,7 +22647,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: as}
+                  Variable: {subprogram: 144, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22599,7 +22658,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: bs}
+                  Variable: {subprogram: 144, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -22610,12 +22669,12 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: cs}
+                  Variable: {subprogram: 144, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1605
+      ID: 1606
       Name: Probe[main.testSubstrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22627,7 +22686,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22638,7 +22697,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22649,7 +22708,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22660,7 +22719,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: a}
+                  Variable: {subprogram: 154, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22671,7 +22730,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 1, name: b}
+                  Variable: {subprogram: 154, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22682,12 +22741,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 2, name: c}
+                  Variable: {subprogram: 154, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1614
+      ID: 1615
       Name: Probe[main.testTenStrings]
       ByteSize: 161
       ExprStatusArraySize: 1
@@ -22699,12 +22758,12 @@ Types:
             Type: 325 StructureType main.tenStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 158, index: 0, name: x}
+                  Variable: {subprogram: 159, index: 0, name: x}
                   Offset: 0
                   ByteSize: 160
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1598
+      ID: 1599
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -22716,7 +22775,7 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -22727,12 +22786,12 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1599
+      ID: 1600
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22744,7 +22803,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22758,7 +22817,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22772,7 +22831,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -22780,7 +22839,7 @@ Types:
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1596
+      ID: 1597
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       ExprStatusArraySize: 1
@@ -22792,7 +22851,7 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
@@ -22803,12 +22862,12 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1597
+      ID: 1598
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -22820,7 +22879,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22831,7 +22890,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
           DictIndex: -1
@@ -22842,12 +22901,12 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1595
+      ID: 1596
       Name: Probe[main.testThreeStrings]
       ByteSize: 98
       ExprStatusArraySize: 2
@@ -22859,7 +22918,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22870,7 +22929,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22881,7 +22940,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22892,7 +22951,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22903,7 +22962,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 1, name: y}
+                  Variable: {subprogram: 147, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -22914,7 +22973,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 2, name: z}
+                  Variable: {subprogram: 147, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -23115,7 +23174,7 @@ Types:
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1579
+      ID: 1580
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       ExprStatusArraySize: 1
@@ -23127,7 +23186,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -23138,12 +23197,12 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: u}
+                  Variable: {subprogram: 133, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1603
+      ID: 1604
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       ExprStatusArraySize: 1
@@ -23155,7 +23214,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -23166,7 +23225,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: x}
+                  Variable: {subprogram: 152, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: -1
@@ -23227,34 +23286,6 @@ Types:
                   ByteSize: 800
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1588
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 49
-      ExprStatusArraySize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-        - Name: xs
-          Offset: 25
-          Kind: argument
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-          DictIndex: -1
-    - __kind: EventRootType
       ID: 1589
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
@@ -23267,7 +23298,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
@@ -23278,12 +23309,40 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: xs}
+                  Variable: {subprogram: 142, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1577
+      ID: 1590
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 49
+      ExprStatusArraySize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+        - Name: xs
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+          DictIndex: -1
+    - __kind: EventRootType
+      ID: 1578
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23295,7 +23354,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -23306,7 +23365,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -23317,7 +23376,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: a}
+                  Variable: {subprogram: 132, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
@@ -23328,12 +23387,12 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: b}
+                  Variable: {subprogram: 132, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1578
+      ID: 1579
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       ExprStatusArraySize: 1
@@ -23345,7 +23404,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 2, name: ~r0}
+                  Variable: {subprogram: 132, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: -1
@@ -23356,12 +23415,12 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 3, name: ~r1}
+                  Variable: {subprogram: 132, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1663
+      ID: 1664
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23380,7 +23439,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
@@ -23391,7 +23450,7 @@ Types:
             Type: 354 StructureType main.typeWithGenerics[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 0, name: x}
+                  Variable: {subprogram: 183, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23402,12 +23461,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 1, name: value}
+                  Variable: {subprogram: 183, index: 1, name: value}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1664
+      ID: 1665
       Name: Probe[main.typeWithGenerics[go.shape.int].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23419,12 +23478,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 182, index: 2, name: ~r0}
+                  Variable: {subprogram: 183, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1665
+      ID: 1666
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]
       ByteSize: 65
       ExprStatusArraySize: 1
@@ -23443,7 +23502,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -23454,7 +23513,7 @@ Types:
             Type: 355 StructureType main.typeWithGenerics[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 0, name: x}
+                  Variable: {subprogram: 184, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23465,12 +23524,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 1, name: value}
+                  Variable: {subprogram: 184, index: 1, name: value}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1666
+      ID: 1667
       Name: Probe[main.typeWithGenerics[go.shape.string].Guess]Return
       ByteSize: 2
       ExprStatusArraySize: 1
@@ -23482,12 +23541,12 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 183, index: 2, name: ~r0}
+                  Variable: {subprogram: 184, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 1
           DictIndex: -1
     - __kind: EventRootType
-      ID: 1617
+      ID: 1618
       Name: Probe[main.wrapBox[go.shape.int]]
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23500,7 +23559,7 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
@@ -23511,12 +23570,12 @@ Types:
             Type: 328 BaseType go.shape.int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: val}
+                  Variable: {subprogram: 162, index: 0, name: val}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1618
+      ID: 1619
       Name: Probe[main.wrapBox[go.shape.int]]Return
       ByteSize: 17
       ExprStatusArraySize: 1
@@ -23529,12 +23588,12 @@ Types:
             Type: 329 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.int]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 1, name: ~r0}
+                  Variable: {subprogram: 162, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
           DictIndex: 1
     - __kind: EventRootType
-      ID: 1619
+      ID: 1620
       Name: Probe[main.wrapBox[go.shape.string]]
       ByteSize: 41
       ExprStatusArraySize: 1
@@ -23547,7 +23606,7 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
@@ -23558,12 +23617,12 @@ Types:
             Type: 330 GoStringHeaderType go.shape.string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: val}
+                  Variable: {subprogram: 163, index: 0, name: val}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 0
     - __kind: EventRootType
-      ID: 1620
+      ID: 1621
       Name: Probe[main.wrapBox[go.shape.string]]Return
       ByteSize: 25
       ExprStatusArraySize: 1
@@ -23576,7 +23635,7 @@ Types:
             Type: 331 StructureType github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Box[go.shape.string]
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 1, name: ~r0}
+                  Variable: {subprogram: 163, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
           DictIndex: 1
@@ -32581,7 +32640,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 1.00736e+06
       GoKind: 5
-MaxTypeID: 1683
+MaxTypeID: 1684
 Issues:
     - probe_definition:
         id: testReturnCondBadField

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -140,10 +140,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [380:437] injectible: [380-387], [389-393], [395-397], [399-402], [405-419], [425-427], [431-437]
-		Var: &v: *main.firstBehavior (declared at line 389, available: [380-437])
-		Var: &fortyTwo: *int (declared at line 392, available: [393-393])
-		Var: .autotmp_8: [0]int (declared at line 436, available: [380-437])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
+		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
+		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
+		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
 		Var: originalSlice: []int (declared at line 77, available: )
 		Var: s: []uint (declared at line 86, available: )
@@ -283,9 +283,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [286:291] injectible: [286-291]
-		Arg: arg: [3]int (declared at line 286, available: [286-291])
-		Arg: ~r0: [3]int (declared at line 286, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
+		Arg: arg: [3]int (declared at line 297, available: [297-302])
+		Arg: ~r0: [3]int (declared at line 297, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -464,9 +464,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:280] injectible: [270-280]
-		Arg: arg: main.largeStruct (declared at line 270, available: [270-280])
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
+		Arg: arg: main.largeStruct (declared at line 281, available: [281-291])
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
@@ -475,17 +475,17 @@ Package: main
 		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [317:319] injectible: [317-319]
-		Arg: a: int (declared at line 317, available: [317-319])
-		Arg: b: int (declared at line 317, available: [317-319])
-		Arg: c: int (declared at line 317, available: [317-319])
-		Arg: d: int (declared at line 317, available: [317-319])
-		Arg: e: int (declared at line 317, available: [317-319])
-		Arg: f: int (declared at line 317, available: [317-319])
-		Arg: g: int (declared at line 317, available: [317-319])
-		Arg: h: int (declared at line 317, available: [317-319])
-		Arg: i: int (declared at line 317, available: [317-319])
-		Arg: ~r0: [2]int (declared at line 317, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
+		Arg: a: int (declared at line 328, available: [328-330])
+		Arg: b: int (declared at line 328, available: [328-330])
+		Arg: c: int (declared at line 328, available: [328-330])
+		Arg: d: int (declared at line 328, available: [328-330])
+		Arg: e: int (declared at line 328, available: [328-330])
+		Arg: f: int (declared at line 328, available: [328-330])
+		Arg: g: int (declared at line 328, available: [328-330])
+		Arg: h: int (declared at line 328, available: [328-330])
+		Arg: i: int (declared at line 328, available: [328-330])
+		Arg: ~r0: [2]int (declared at line 328, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -526,30 +526,30 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [326:338] injectible: [326-338]
-		Arg: a: int (declared at line 326, available: [326-338])
-		Arg: b: int (declared at line 326, available: [326-338])
-		Arg: c: int (declared at line 326, available: [326-338])
-		Arg: d: int (declared at line 326, available: [326-338])
-		Arg: e: int (declared at line 326, available: [326-338])
-		Arg: f: int (declared at line 326, available: [326-338])
-		Arg: g: int (declared at line 326, available: [326-338])
-		Arg: h: int (declared at line 326, available: [326-338])
-		Arg: s: string (declared at line 326, available: [326-338])
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [353:355] injectible: [353-355]
-		Arg: a: [2]int (declared at line 353, available: [353-355])
-		Arg: b: [3]int (declared at line 353, available: [353-355])
-		Arg: ~r0: int (declared at line 353, available: )
-		Arg: ~r1: [2]int (declared at line 353, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
+		Arg: a: int (declared at line 337, available: [337-349])
+		Arg: b: int (declared at line 337, available: [337-349])
+		Arg: c: int (declared at line 337, available: [337-349])
+		Arg: d: int (declared at line 337, available: [337-349])
+		Arg: e: int (declared at line 337, available: [337-349])
+		Arg: f: int (declared at line 337, available: [337-349])
+		Arg: g: int (declared at line 337, available: [337-349])
+		Arg: h: int (declared at line 337, available: [337-349])
+		Arg: s: string (declared at line 337, available: [337-349])
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
+		Arg: a: [2]int (declared at line 364, available: [364-366])
+		Arg: b: [3]int (declared at line 364, available: [364-366])
+		Arg: ~r0: int (declared at line 364, available: )
+		Arg: ~r1: [2]int (declared at line 364, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:309] injectible: [297-309]
-		Arg: s1: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: s2: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
+		Arg: s1: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -667,28 +667,28 @@ Package: main
 			Var: val: string (declared at line 52, available: [53-53])
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-53])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [163:165] injectible: [163-165]
-		Arg: ~r0: [3]int (declared at line 163, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [171:173] injectible: [171-173]
-		Arg: ~r0: [1]int (declared at line 171, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [179:181] injectible: [179-181]
-		Arg: ~r0: [0]int (declared at line 179, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [202:204] injectible: [202-204]
-		Arg: ~r0: int (declared at line 202, available: )
-		Arg: ~r1: int (declared at line 202, available: )
-		Arg: ~r2: int (declared at line 202, available: )
-		Arg: ~r3: int (declared at line 202, available: )
-		Arg: ~r4: int (declared at line 202, available: )
-		Arg: ~r5: int (declared at line 202, available: )
-		Arg: ~r6: int (declared at line 202, available: )
-		Arg: ~r7: int (declared at line 202, available: )
-		Arg: ~r8: string (declared at line 202, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [259:261] injectible: [259-261]
-		Arg: ~r0: bool (declared at line 259, available: )
-		Arg: ~r1: uintptr (declared at line 259, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [144:146] injectible: [144-146]
-		Arg: ~r0: complex64 (declared at line 144, available: )
-		Arg: ~r1: complex128 (declared at line 144, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [174:176] injectible: [174-176]
+		Arg: ~r0: [3]int (declared at line 174, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [182:184] injectible: [182-184]
+		Arg: ~r0: [1]int (declared at line 182, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [190:192] injectible: [190-192]
+		Arg: ~r0: [0]int (declared at line 190, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [213:215] injectible: [213-215]
+		Arg: ~r0: int (declared at line 213, available: )
+		Arg: ~r1: int (declared at line 213, available: )
+		Arg: ~r2: int (declared at line 213, available: )
+		Arg: ~r3: int (declared at line 213, available: )
+		Arg: ~r4: int (declared at line 213, available: )
+		Arg: ~r5: int (declared at line 213, available: )
+		Arg: ~r6: int (declared at line 213, available: )
+		Arg: ~r7: int (declared at line 213, available: )
+		Arg: ~r8: string (declared at line 213, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:272] injectible: [270-272]
+		Arg: ~r0: bool (declared at line 270, available: )
+		Arg: ~r1: uintptr (declared at line 270, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
+		Arg: ~r0: complex64 (declared at line 155, available: )
+		Arg: ~r1: complex128 (declared at line 155, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -710,52 +710,59 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-78])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [126:138] injectible: [126-126], [136-138]
-		Arg: ~r0: float64 (declared at line 127, available: )
-		Arg: ~r1: float64 (declared at line 127, available: )
-		Arg: ~r2: float64 (declared at line 127, available: )
-		Arg: ~r3: float64 (declared at line 127, available: )
-		Arg: ~r4: float64 (declared at line 127, available: )
-		Arg: ~r5: float64 (declared at line 127, available: )
-		Arg: ~r6: float64 (declared at line 127, available: )
-		Arg: ~r7: float64 (declared at line 128, available: )
-		Arg: ~r8: float64 (declared at line 128, available: )
-		Arg: ~r9: float64 (declared at line 128, available: )
-		Arg: ~r10: float64 (declared at line 128, available: )
-		Arg: ~r11: float64 (declared at line 128, available: )
-		Arg: ~r12: float64 (declared at line 128, available: )
-		Arg: ~r13: float64 (declared at line 128, available: )
-		Arg: ~r14: float64 (declared at line 129, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 132, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 134, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [222:224] injectible: [222-224]
-		Arg: ~r0: int (declared at line 222, available: )
-		Arg: ~r1: float64 (declared at line 222, available: )
-		Arg: ~r2: int (declared at line 222, available: )
-		Arg: ~r3: float64 (declared at line 222, available: )
-		Arg: ~r4: string (declared at line 222, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [192:194] injectible: [192-194]
-		Arg: ~r0: main.mixedStruct (declared at line 192, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [251:253] injectible: [251-253]
-		Arg: ~r0: float32 (declared at line 251, available: )
-		Arg: ~r1: float64 (declared at line 251, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [243:245] injectible: [243-245]
-		Arg: ~r0: float64 (declared at line 243, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:119] injectible: [117-119]
-		Arg: ~r0: int8 (declared at line 117, available: )
-		Arg: ~r1: int16 (declared at line 117, available: )
-		Arg: ~r2: int32 (declared at line 117, available: )
-		Arg: ~r3: int64 (declared at line 117, available: )
-		Arg: ~r4: uint8 (declared at line 117, available: )
-		Arg: ~r5: uint16 (declared at line 117, available: )
-		Arg: ~r6: uint32 (declared at line 117, available: )
-		Arg: ~r7: uint64 (declared at line 117, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [234:236] injectible: [234-236]
-		Arg: ~r0: main.structWithArray (declared at line 234, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [214:216] injectible: [214-216]
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [166:168] injectible: [166-168]
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [137:149] injectible: [137-137], [147-149]
+		Arg: ~r0: float64 (declared at line 138, available: )
+		Arg: ~r1: float64 (declared at line 138, available: )
+		Arg: ~r2: float64 (declared at line 138, available: )
+		Arg: ~r3: float64 (declared at line 138, available: )
+		Arg: ~r4: float64 (declared at line 138, available: )
+		Arg: ~r5: float64 (declared at line 138, available: )
+		Arg: ~r6: float64 (declared at line 138, available: )
+		Arg: ~r7: float64 (declared at line 139, available: )
+		Arg: ~r8: float64 (declared at line 139, available: )
+		Arg: ~r9: float64 (declared at line 139, available: )
+		Arg: ~r10: float64 (declared at line 139, available: )
+		Arg: ~r11: float64 (declared at line 139, available: )
+		Arg: ~r12: float64 (declared at line 139, available: )
+		Arg: ~r13: float64 (declared at line 139, available: )
+		Arg: ~r14: float64 (declared at line 140, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 143, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 145, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [233:235] injectible: [233-235]
+		Arg: ~r0: int (declared at line 233, available: )
+		Arg: ~r1: float64 (declared at line 233, available: )
+		Arg: ~r2: int (declared at line 233, available: )
+		Arg: ~r3: float64 (declared at line 233, available: )
+		Arg: ~r4: string (declared at line 233, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [203:205] injectible: [203-205]
+		Arg: ~r0: main.mixedStruct (declared at line 203, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [262:264] injectible: [262-264]
+		Arg: ~r0: float32 (declared at line 262, available: )
+		Arg: ~r1: float64 (declared at line 262, available: )
+	Function: testReturnsNamedDeferLine (main.testReturnsNamedDeferLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:122] injectible: [117-122]
+		Arg: i: int (declared at line 117, available: [117-122])
+		Arg: a: string (declared at line 117, available: [117-122])
+		Arg: b: string (declared at line 117, available: [117-122])
+	Function: testReturnsNamedDeferLine.func1 (main.testReturnsNamedDeferLine.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [118:118] injectible: [118-118]
+		Var: &a: *string (declared at line 118, available: )
+		Var: &b: *string (declared at line 118, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [254:256] injectible: [254-256]
+		Arg: ~r0: float64 (declared at line 254, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:130] injectible: [128-130]
+		Arg: ~r0: int8 (declared at line 128, available: )
+		Arg: ~r1: int16 (declared at line 128, available: )
+		Arg: ~r2: int32 (declared at line 128, available: )
+		Arg: ~r3: int64 (declared at line 128, available: )
+		Arg: ~r4: uint8 (declared at line 128, available: )
+		Arg: ~r5: uint16 (declared at line 128, available: )
+		Arg: ~r6: uint32 (declared at line 128, available: )
+		Arg: ~r7: uint64 (declared at line 128, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: main.structWithArray (declared at line 245, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -801,11 +808,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [345:347] injectible: [345-347]
-		Arg: arg: [5]int (declared at line 345, available: [345-347])
-		Arg: ~r0: int (declared at line 345, available: )
-		Arg: ~r1: int (declared at line 345, available: )
-		Arg: ~r2: int (declared at line 345, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [356:358] injectible: [356-358]
+		Arg: arg: [5]int (declared at line 356, available: [356-358])
+		Arg: ~r0: int (declared at line 356, available: )
+		Arg: ~r1: int (declared at line 356, available: )
+		Arg: ~r2: int (declared at line 356, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -840,11 +847,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [361:368] injectible: [361-363], [365-366], [368-368]
-		Arg: arg: main.structWithArray (declared at line 361, available: [361-368])
-		Arg: ~r0: int (declared at line 361, available: )
-		Arg: ~r1: main.structWithArray (declared at line 361, available: )
-		Var: x: int (declared at line 363, available: [361-368])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
+		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
+		Arg: ~r0: int (declared at line 372, available: )
+		Arg: ~r1: main.structWithArray (declared at line 372, available: )
+		Var: x: int (declared at line 374, available: [372-379])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -905,11 +912,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:377] injectible: [374-377]
-		Arg: a: [0]int (declared at line 374, available: )
-		Arg: b: int (declared at line 374, available: [374-377])
-		Arg: ~r0: int (declared at line 374, available: )
-		Arg: ~r1: [0]int (declared at line 374, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
+		Arg: a: [0]int (declared at line 385, available: )
+		Arg: b: int (declared at line 385, available: [385-388])
+		Arg: ~r0: int (declared at line 385, available: )
+		Arg: ~r1: [0]int (declared at line 385, available: )
 	Function: useCrossPackageGenerics (main.useCrossPackageGenerics) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [358:368] injectible: [358-363], [365-365], [367-368]
 		Var: set: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[string] (declared at line 359, available: [360-367])
 		Scope: 360-367

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -129,10 +129,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [380:437] injectible: [380-387], [389-393], [395-397], [399-402], [405-419], [425-427], [431-437]
-		Var: &v: *main.firstBehavior (declared at line 389, available: [380-437])
-		Var: &fortyTwo: *int (declared at line 392, available: [393-393])
-		Var: .autotmp_8: [0]int (declared at line 436, available: [380-437])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
+		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
+		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
+		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
 		Var: originalSlice: []int (declared at line 77, available: )
 		Var: s: []uint (declared at line 86, available: )
@@ -272,9 +272,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [286:291] injectible: [286-291]
-		Arg: arg: [3]int (declared at line 286, available: [286-291])
-		Arg: ~r0: [3]int (declared at line 286, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
+		Arg: arg: [3]int (declared at line 297, available: [297-302])
+		Arg: ~r0: [3]int (declared at line 297, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -453,9 +453,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:280] injectible: [270-280]
-		Arg: arg: main.largeStruct (declared at line 270, available: [270-280])
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
+		Arg: arg: main.largeStruct (declared at line 281, available: [281-291])
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
@@ -464,17 +464,17 @@ Package: main
 		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [317:319] injectible: [317-319]
-		Arg: a: int (declared at line 317, available: [317-319])
-		Arg: b: int (declared at line 317, available: [317-319])
-		Arg: c: int (declared at line 317, available: [317-319])
-		Arg: d: int (declared at line 317, available: [317-319])
-		Arg: e: int (declared at line 317, available: [317-319])
-		Arg: f: int (declared at line 317, available: [317-319])
-		Arg: g: int (declared at line 317, available: [317-319])
-		Arg: h: int (declared at line 317, available: [317-319])
-		Arg: i: int (declared at line 317, available: [317-319])
-		Arg: ~r0: [2]int (declared at line 317, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
+		Arg: a: int (declared at line 328, available: [328-330])
+		Arg: b: int (declared at line 328, available: [328-330])
+		Arg: c: int (declared at line 328, available: [328-330])
+		Arg: d: int (declared at line 328, available: [328-330])
+		Arg: e: int (declared at line 328, available: [328-330])
+		Arg: f: int (declared at line 328, available: [328-330])
+		Arg: g: int (declared at line 328, available: [328-330])
+		Arg: h: int (declared at line 328, available: [328-330])
+		Arg: i: int (declared at line 328, available: [328-330])
+		Arg: ~r0: [2]int (declared at line 328, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -515,30 +515,30 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [326:338] injectible: [326-338]
-		Arg: a: int (declared at line 326, available: [326-338])
-		Arg: b: int (declared at line 326, available: [326-338])
-		Arg: c: int (declared at line 326, available: [326-338])
-		Arg: d: int (declared at line 326, available: [326-338])
-		Arg: e: int (declared at line 326, available: [326-338])
-		Arg: f: int (declared at line 326, available: [326-338])
-		Arg: g: int (declared at line 326, available: [326-338])
-		Arg: h: int (declared at line 326, available: [326-338])
-		Arg: s: string (declared at line 326, available: [326-338])
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [353:355] injectible: [353-355]
-		Arg: a: [2]int (declared at line 353, available: [353-355])
-		Arg: b: [3]int (declared at line 353, available: [353-355])
-		Arg: ~r0: int (declared at line 353, available: )
-		Arg: ~r1: [2]int (declared at line 353, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
+		Arg: a: int (declared at line 337, available: [337-349])
+		Arg: b: int (declared at line 337, available: [337-349])
+		Arg: c: int (declared at line 337, available: [337-349])
+		Arg: d: int (declared at line 337, available: [337-349])
+		Arg: e: int (declared at line 337, available: [337-349])
+		Arg: f: int (declared at line 337, available: [337-349])
+		Arg: g: int (declared at line 337, available: [337-349])
+		Arg: h: int (declared at line 337, available: [337-349])
+		Arg: s: string (declared at line 337, available: [337-349])
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
+		Arg: a: [2]int (declared at line 364, available: [364-366])
+		Arg: b: [3]int (declared at line 364, available: [364-366])
+		Arg: ~r0: int (declared at line 364, available: )
+		Arg: ~r1: [2]int (declared at line 364, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:309] injectible: [297-309]
-		Arg: s1: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: s2: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
+		Arg: s1: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -656,28 +656,28 @@ Package: main
 			Var: val: string (declared at line 52, available: [53-53])
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [163:165] injectible: [163-165]
-		Arg: ~r0: [3]int (declared at line 163, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [171:173] injectible: [171-173]
-		Arg: ~r0: [1]int (declared at line 171, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [179:181] injectible: [179-181]
-		Arg: ~r0: [0]int (declared at line 179, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [202:204] injectible: [202-204]
-		Arg: ~r0: int (declared at line 202, available: )
-		Arg: ~r1: int (declared at line 202, available: )
-		Arg: ~r2: int (declared at line 202, available: )
-		Arg: ~r3: int (declared at line 202, available: )
-		Arg: ~r4: int (declared at line 202, available: )
-		Arg: ~r5: int (declared at line 202, available: )
-		Arg: ~r6: int (declared at line 202, available: )
-		Arg: ~r7: int (declared at line 202, available: )
-		Arg: ~r8: string (declared at line 202, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [259:261] injectible: [259-261]
-		Arg: ~r0: bool (declared at line 259, available: )
-		Arg: ~r1: uintptr (declared at line 259, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [144:146] injectible: [144-146]
-		Arg: ~r0: complex64 (declared at line 144, available: )
-		Arg: ~r1: complex128 (declared at line 144, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [174:176] injectible: [174-176]
+		Arg: ~r0: [3]int (declared at line 174, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [182:184] injectible: [182-184]
+		Arg: ~r0: [1]int (declared at line 182, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [190:192] injectible: [190-192]
+		Arg: ~r0: [0]int (declared at line 190, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [213:215] injectible: [213-215]
+		Arg: ~r0: int (declared at line 213, available: )
+		Arg: ~r1: int (declared at line 213, available: )
+		Arg: ~r2: int (declared at line 213, available: )
+		Arg: ~r3: int (declared at line 213, available: )
+		Arg: ~r4: int (declared at line 213, available: )
+		Arg: ~r5: int (declared at line 213, available: )
+		Arg: ~r6: int (declared at line 213, available: )
+		Arg: ~r7: int (declared at line 213, available: )
+		Arg: ~r8: string (declared at line 213, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:272] injectible: [270-272]
+		Arg: ~r0: bool (declared at line 270, available: )
+		Arg: ~r1: uintptr (declared at line 270, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
+		Arg: ~r0: complex64 (declared at line 155, available: )
+		Arg: ~r1: complex128 (declared at line 155, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -699,52 +699,59 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-78])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [126:138] injectible: [126-126], [136-138]
-		Arg: ~r0: float64 (declared at line 127, available: )
-		Arg: ~r1: float64 (declared at line 127, available: )
-		Arg: ~r2: float64 (declared at line 127, available: )
-		Arg: ~r3: float64 (declared at line 127, available: )
-		Arg: ~r4: float64 (declared at line 127, available: )
-		Arg: ~r5: float64 (declared at line 127, available: )
-		Arg: ~r6: float64 (declared at line 127, available: )
-		Arg: ~r7: float64 (declared at line 128, available: )
-		Arg: ~r8: float64 (declared at line 128, available: )
-		Arg: ~r9: float64 (declared at line 128, available: )
-		Arg: ~r10: float64 (declared at line 128, available: )
-		Arg: ~r11: float64 (declared at line 128, available: )
-		Arg: ~r12: float64 (declared at line 128, available: )
-		Arg: ~r13: float64 (declared at line 128, available: )
-		Arg: ~r14: float64 (declared at line 129, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 132, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 134, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [222:224] injectible: [222-224]
-		Arg: ~r0: int (declared at line 222, available: )
-		Arg: ~r1: float64 (declared at line 222, available: )
-		Arg: ~r2: int (declared at line 222, available: )
-		Arg: ~r3: float64 (declared at line 222, available: )
-		Arg: ~r4: string (declared at line 222, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [192:194] injectible: [192-194]
-		Arg: ~r0: main.mixedStruct (declared at line 192, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [251:253] injectible: [251-253]
-		Arg: ~r0: float32 (declared at line 251, available: )
-		Arg: ~r1: float64 (declared at line 251, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [243:245] injectible: [243-245]
-		Arg: ~r0: float64 (declared at line 243, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:119] injectible: [117-119]
-		Arg: ~r0: int8 (declared at line 117, available: )
-		Arg: ~r1: int16 (declared at line 117, available: )
-		Arg: ~r2: int32 (declared at line 117, available: )
-		Arg: ~r3: int64 (declared at line 117, available: )
-		Arg: ~r4: uint8 (declared at line 117, available: )
-		Arg: ~r5: uint16 (declared at line 117, available: )
-		Arg: ~r6: uint32 (declared at line 117, available: )
-		Arg: ~r7: uint64 (declared at line 117, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [234:236] injectible: [234-236]
-		Arg: ~r0: main.structWithArray (declared at line 234, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [214:216] injectible: [214-216]
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [166:168] injectible: [166-168]
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [137:149] injectible: [137-137], [147-149]
+		Arg: ~r0: float64 (declared at line 138, available: )
+		Arg: ~r1: float64 (declared at line 138, available: )
+		Arg: ~r2: float64 (declared at line 138, available: )
+		Arg: ~r3: float64 (declared at line 138, available: )
+		Arg: ~r4: float64 (declared at line 138, available: )
+		Arg: ~r5: float64 (declared at line 138, available: )
+		Arg: ~r6: float64 (declared at line 138, available: )
+		Arg: ~r7: float64 (declared at line 139, available: )
+		Arg: ~r8: float64 (declared at line 139, available: )
+		Arg: ~r9: float64 (declared at line 139, available: )
+		Arg: ~r10: float64 (declared at line 139, available: )
+		Arg: ~r11: float64 (declared at line 139, available: )
+		Arg: ~r12: float64 (declared at line 139, available: )
+		Arg: ~r13: float64 (declared at line 139, available: )
+		Arg: ~r14: float64 (declared at line 140, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 143, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 145, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [233:235] injectible: [233-235]
+		Arg: ~r0: int (declared at line 233, available: )
+		Arg: ~r1: float64 (declared at line 233, available: )
+		Arg: ~r2: int (declared at line 233, available: )
+		Arg: ~r3: float64 (declared at line 233, available: )
+		Arg: ~r4: string (declared at line 233, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [203:205] injectible: [203-205]
+		Arg: ~r0: main.mixedStruct (declared at line 203, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [262:264] injectible: [262-264]
+		Arg: ~r0: float32 (declared at line 262, available: )
+		Arg: ~r1: float64 (declared at line 262, available: )
+	Function: testReturnsNamedDeferLine (main.testReturnsNamedDeferLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:122] injectible: [117-122]
+		Arg: i: int (declared at line 117, available: [117-122])
+		Arg: a: string (declared at line 117, available: [117-122])
+		Arg: b: string (declared at line 117, available: [117-122])
+	Function: testReturnsNamedDeferLine.func1 (main.testReturnsNamedDeferLine.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [118:118] injectible: [118-118]
+		Var: &a: *string (declared at line 118, available: )
+		Var: &b: *string (declared at line 118, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [254:256] injectible: [254-256]
+		Arg: ~r0: float64 (declared at line 254, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:130] injectible: [128-130]
+		Arg: ~r0: int8 (declared at line 128, available: )
+		Arg: ~r1: int16 (declared at line 128, available: )
+		Arg: ~r2: int32 (declared at line 128, available: )
+		Arg: ~r3: int64 (declared at line 128, available: )
+		Arg: ~r4: uint8 (declared at line 128, available: )
+		Arg: ~r5: uint16 (declared at line 128, available: )
+		Arg: ~r6: uint32 (declared at line 128, available: )
+		Arg: ~r7: uint64 (declared at line 128, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: main.structWithArray (declared at line 245, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -790,11 +797,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [345:347] injectible: [345-347]
-		Arg: arg: [5]int (declared at line 345, available: [345-347])
-		Arg: ~r0: int (declared at line 345, available: )
-		Arg: ~r1: int (declared at line 345, available: )
-		Arg: ~r2: int (declared at line 345, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [356:358] injectible: [356-358]
+		Arg: arg: [5]int (declared at line 356, available: [356-358])
+		Arg: ~r0: int (declared at line 356, available: )
+		Arg: ~r1: int (declared at line 356, available: )
+		Arg: ~r2: int (declared at line 356, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -829,11 +836,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [361:368] injectible: [361-363], [365-366], [368-368]
-		Arg: arg: main.structWithArray (declared at line 361, available: [361-368])
-		Arg: ~r0: int (declared at line 361, available: )
-		Arg: ~r1: main.structWithArray (declared at line 361, available: )
-		Var: x: int (declared at line 363, available: [361-368])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
+		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
+		Arg: ~r0: int (declared at line 372, available: )
+		Arg: ~r1: main.structWithArray (declared at line 372, available: )
+		Var: x: int (declared at line 374, available: [372-379])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -894,11 +901,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:377] injectible: [374-377]
-		Arg: a: [0]int (declared at line 374, available: )
-		Arg: b: int (declared at line 374, available: [374-377])
-		Arg: ~r0: int (declared at line 374, available: )
-		Arg: ~r1: [0]int (declared at line 374, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
+		Arg: a: [0]int (declared at line 385, available: )
+		Arg: b: int (declared at line 385, available: [385-388])
+		Arg: ~r0: int (declared at line 385, available: )
+		Arg: ~r1: [0]int (declared at line 385, available: )
 	Function: useCrossPackageGenerics (main.useCrossPackageGenerics) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [358:368] injectible: [358-363], [365-365], [367-368]
 		Var: set: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[string] (declared at line 359, available: [360-367])
 		Scope: 360-365

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -126,10 +126,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [380:437] injectible: [380-387], [389-393], [395-397], [399-402], [405-419], [425-427], [431-437]
-		Var: &v: *main.firstBehavior (declared at line 389, available: [380-437])
-		Var: &fortyTwo: *int (declared at line 392, available: [393-393])
-		Var: .autotmp_8: [0]int (declared at line 436, available: [380-437])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
+		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
+		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
+		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
 		Var: originalSlice: []int (declared at line 77, available: )
 		Var: s: []uint (declared at line 86, available: )
@@ -269,9 +269,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [286:291] injectible: [286-291]
-		Arg: arg: [3]int (declared at line 286, available: [286-291])
-		Arg: ~r0: [3]int (declared at line 286, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
+		Arg: arg: [3]int (declared at line 297, available: [297-302])
+		Arg: ~r0: [3]int (declared at line 297, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -450,9 +450,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:280] injectible: [270-280]
-		Arg: arg: main.largeStruct (declared at line 270, available: [270-280])
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
+		Arg: arg: main.largeStruct (declared at line 281, available: [281-291])
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
@@ -461,17 +461,17 @@ Package: main
 		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [317:319] injectible: [317-319]
-		Arg: a: int (declared at line 317, available: [317-319])
-		Arg: b: int (declared at line 317, available: [317-319])
-		Arg: c: int (declared at line 317, available: [317-319])
-		Arg: d: int (declared at line 317, available: [317-319])
-		Arg: e: int (declared at line 317, available: [317-319])
-		Arg: f: int (declared at line 317, available: [317-319])
-		Arg: g: int (declared at line 317, available: [317-319])
-		Arg: h: int (declared at line 317, available: [317-319])
-		Arg: i: int (declared at line 317, available: [317-319])
-		Arg: ~r0: [2]int (declared at line 317, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
+		Arg: a: int (declared at line 328, available: [328-330])
+		Arg: b: int (declared at line 328, available: [328-330])
+		Arg: c: int (declared at line 328, available: [328-330])
+		Arg: d: int (declared at line 328, available: [328-330])
+		Arg: e: int (declared at line 328, available: [328-330])
+		Arg: f: int (declared at line 328, available: [328-330])
+		Arg: g: int (declared at line 328, available: [328-330])
+		Arg: h: int (declared at line 328, available: [328-330])
+		Arg: i: int (declared at line 328, available: [328-330])
+		Arg: ~r0: [2]int (declared at line 328, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -512,30 +512,30 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [326:338] injectible: [326-338]
-		Arg: a: int (declared at line 326, available: [326-338])
-		Arg: b: int (declared at line 326, available: [326-338])
-		Arg: c: int (declared at line 326, available: [326-338])
-		Arg: d: int (declared at line 326, available: [326-338])
-		Arg: e: int (declared at line 326, available: [326-338])
-		Arg: f: int (declared at line 326, available: [326-338])
-		Arg: g: int (declared at line 326, available: [326-338])
-		Arg: h: int (declared at line 326, available: [326-338])
-		Arg: s: string (declared at line 326, available: [326-338])
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [353:355] injectible: [353-355]
-		Arg: a: [2]int (declared at line 353, available: [353-355])
-		Arg: b: [3]int (declared at line 353, available: [353-355])
-		Arg: ~r0: int (declared at line 353, available: )
-		Arg: ~r1: [2]int (declared at line 353, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
+		Arg: a: int (declared at line 337, available: [337-349])
+		Arg: b: int (declared at line 337, available: [337-349])
+		Arg: c: int (declared at line 337, available: [337-349])
+		Arg: d: int (declared at line 337, available: [337-349])
+		Arg: e: int (declared at line 337, available: [337-349])
+		Arg: f: int (declared at line 337, available: [337-349])
+		Arg: g: int (declared at line 337, available: [337-349])
+		Arg: h: int (declared at line 337, available: [337-349])
+		Arg: s: string (declared at line 337, available: [337-349])
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
+		Arg: a: [2]int (declared at line 364, available: [364-366])
+		Arg: b: [3]int (declared at line 364, available: [364-366])
+		Arg: ~r0: int (declared at line 364, available: )
+		Arg: ~r1: [2]int (declared at line 364, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:309] injectible: [297-309]
-		Arg: s1: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: s2: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
+		Arg: s1: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -653,28 +653,28 @@ Package: main
 			Var: val: string (declared at line 52, available: [53-53])
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [163:165] injectible: [163-165]
-		Arg: ~r0: [3]int (declared at line 163, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [171:173] injectible: [171-173]
-		Arg: ~r0: [1]int (declared at line 171, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [179:181] injectible: [179-181]
-		Arg: ~r0: [0]int (declared at line 179, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [202:204] injectible: [202-204]
-		Arg: ~r0: int (declared at line 202, available: )
-		Arg: ~r1: int (declared at line 202, available: )
-		Arg: ~r2: int (declared at line 202, available: )
-		Arg: ~r3: int (declared at line 202, available: )
-		Arg: ~r4: int (declared at line 202, available: )
-		Arg: ~r5: int (declared at line 202, available: )
-		Arg: ~r6: int (declared at line 202, available: )
-		Arg: ~r7: int (declared at line 202, available: )
-		Arg: ~r8: string (declared at line 202, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [259:261] injectible: [259-261]
-		Arg: ~r0: bool (declared at line 259, available: )
-		Arg: ~r1: uintptr (declared at line 259, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [144:146] injectible: [144-146]
-		Arg: ~r0: complex64 (declared at line 144, available: )
-		Arg: ~r1: complex128 (declared at line 144, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [174:176] injectible: [174-176]
+		Arg: ~r0: [3]int (declared at line 174, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [182:184] injectible: [182-184]
+		Arg: ~r0: [1]int (declared at line 182, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [190:192] injectible: [190-192]
+		Arg: ~r0: [0]int (declared at line 190, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [213:215] injectible: [213-215]
+		Arg: ~r0: int (declared at line 213, available: )
+		Arg: ~r1: int (declared at line 213, available: )
+		Arg: ~r2: int (declared at line 213, available: )
+		Arg: ~r3: int (declared at line 213, available: )
+		Arg: ~r4: int (declared at line 213, available: )
+		Arg: ~r5: int (declared at line 213, available: )
+		Arg: ~r6: int (declared at line 213, available: )
+		Arg: ~r7: int (declared at line 213, available: )
+		Arg: ~r8: string (declared at line 213, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:272] injectible: [270-272]
+		Arg: ~r0: bool (declared at line 270, available: )
+		Arg: ~r1: uintptr (declared at line 270, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
+		Arg: ~r0: complex64 (declared at line 155, available: )
+		Arg: ~r1: complex128 (declared at line 155, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -696,52 +696,59 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-78])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [126:138] injectible: [126-126], [136-138]
-		Arg: ~r0: float64 (declared at line 127, available: )
-		Arg: ~r1: float64 (declared at line 127, available: )
-		Arg: ~r2: float64 (declared at line 127, available: )
-		Arg: ~r3: float64 (declared at line 127, available: )
-		Arg: ~r4: float64 (declared at line 127, available: )
-		Arg: ~r5: float64 (declared at line 127, available: )
-		Arg: ~r6: float64 (declared at line 127, available: )
-		Arg: ~r7: float64 (declared at line 128, available: )
-		Arg: ~r8: float64 (declared at line 128, available: )
-		Arg: ~r9: float64 (declared at line 128, available: )
-		Arg: ~r10: float64 (declared at line 128, available: )
-		Arg: ~r11: float64 (declared at line 128, available: )
-		Arg: ~r12: float64 (declared at line 128, available: )
-		Arg: ~r13: float64 (declared at line 128, available: )
-		Arg: ~r14: float64 (declared at line 129, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 132, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 134, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [222:224] injectible: [222-224]
-		Arg: ~r0: int (declared at line 222, available: )
-		Arg: ~r1: float64 (declared at line 222, available: )
-		Arg: ~r2: int (declared at line 222, available: )
-		Arg: ~r3: float64 (declared at line 222, available: )
-		Arg: ~r4: string (declared at line 222, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [192:194] injectible: [192-194]
-		Arg: ~r0: main.mixedStruct (declared at line 192, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [251:253] injectible: [251-253]
-		Arg: ~r0: float32 (declared at line 251, available: )
-		Arg: ~r1: float64 (declared at line 251, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [243:245] injectible: [243-245]
-		Arg: ~r0: float64 (declared at line 243, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:119] injectible: [117-119]
-		Arg: ~r0: int8 (declared at line 117, available: )
-		Arg: ~r1: int16 (declared at line 117, available: )
-		Arg: ~r2: int32 (declared at line 117, available: )
-		Arg: ~r3: int64 (declared at line 117, available: )
-		Arg: ~r4: uint8 (declared at line 117, available: )
-		Arg: ~r5: uint16 (declared at line 117, available: )
-		Arg: ~r6: uint32 (declared at line 117, available: )
-		Arg: ~r7: uint64 (declared at line 117, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [234:236] injectible: [234-236]
-		Arg: ~r0: main.structWithArray (declared at line 234, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [214:216] injectible: [214-216]
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [166:168] injectible: [166-168]
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [137:149] injectible: [137-137], [147-149]
+		Arg: ~r0: float64 (declared at line 138, available: )
+		Arg: ~r1: float64 (declared at line 138, available: )
+		Arg: ~r2: float64 (declared at line 138, available: )
+		Arg: ~r3: float64 (declared at line 138, available: )
+		Arg: ~r4: float64 (declared at line 138, available: )
+		Arg: ~r5: float64 (declared at line 138, available: )
+		Arg: ~r6: float64 (declared at line 138, available: )
+		Arg: ~r7: float64 (declared at line 139, available: )
+		Arg: ~r8: float64 (declared at line 139, available: )
+		Arg: ~r9: float64 (declared at line 139, available: )
+		Arg: ~r10: float64 (declared at line 139, available: )
+		Arg: ~r11: float64 (declared at line 139, available: )
+		Arg: ~r12: float64 (declared at line 139, available: )
+		Arg: ~r13: float64 (declared at line 139, available: )
+		Arg: ~r14: float64 (declared at line 140, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 143, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 145, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [233:235] injectible: [233-235]
+		Arg: ~r0: int (declared at line 233, available: )
+		Arg: ~r1: float64 (declared at line 233, available: )
+		Arg: ~r2: int (declared at line 233, available: )
+		Arg: ~r3: float64 (declared at line 233, available: )
+		Arg: ~r4: string (declared at line 233, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [203:205] injectible: [203-205]
+		Arg: ~r0: main.mixedStruct (declared at line 203, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [262:264] injectible: [262-264]
+		Arg: ~r0: float32 (declared at line 262, available: )
+		Arg: ~r1: float64 (declared at line 262, available: )
+	Function: testReturnsNamedDeferLine (main.testReturnsNamedDeferLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:122] injectible: [117-122]
+		Arg: i: int (declared at line 117, available: [117-122])
+		Arg: a: string (declared at line 117, available: [117-122])
+		Arg: b: string (declared at line 117, available: [117-122])
+	Function: testReturnsNamedDeferLine.func1 (main.testReturnsNamedDeferLine.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [118:118] injectible: [118-118]
+		Var: &a: *string (declared at line 118, available: )
+		Var: &b: *string (declared at line 118, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [254:256] injectible: [254-256]
+		Arg: ~r0: float64 (declared at line 254, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:130] injectible: [128-130]
+		Arg: ~r0: int8 (declared at line 128, available: )
+		Arg: ~r1: int16 (declared at line 128, available: )
+		Arg: ~r2: int32 (declared at line 128, available: )
+		Arg: ~r3: int64 (declared at line 128, available: )
+		Arg: ~r4: uint8 (declared at line 128, available: )
+		Arg: ~r5: uint16 (declared at line 128, available: )
+		Arg: ~r6: uint32 (declared at line 128, available: )
+		Arg: ~r7: uint64 (declared at line 128, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: main.structWithArray (declared at line 245, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -787,11 +794,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [345:347] injectible: [345-347]
-		Arg: arg: [5]int (declared at line 345, available: [345-347])
-		Arg: ~r0: int (declared at line 345, available: )
-		Arg: ~r1: int (declared at line 345, available: )
-		Arg: ~r2: int (declared at line 345, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [356:358] injectible: [356-358]
+		Arg: arg: [5]int (declared at line 356, available: [356-358])
+		Arg: ~r0: int (declared at line 356, available: )
+		Arg: ~r1: int (declared at line 356, available: )
+		Arg: ~r2: int (declared at line 356, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -826,11 +833,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [361:368] injectible: [361-363], [365-366], [368-368]
-		Arg: arg: main.structWithArray (declared at line 361, available: [361-368])
-		Arg: ~r0: int (declared at line 361, available: )
-		Arg: ~r1: main.structWithArray (declared at line 361, available: )
-		Var: x: int (declared at line 363, available: [361-368])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
+		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
+		Arg: ~r0: int (declared at line 372, available: )
+		Arg: ~r1: main.structWithArray (declared at line 372, available: )
+		Var: x: int (declared at line 374, available: [372-379])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -891,11 +898,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:377] injectible: [374-377]
-		Arg: a: [0]int (declared at line 374, available: )
-		Arg: b: int (declared at line 374, available: [374-377])
-		Arg: ~r0: int (declared at line 374, available: )
-		Arg: ~r1: [0]int (declared at line 374, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
+		Arg: a: [0]int (declared at line 385, available: )
+		Arg: b: int (declared at line 385, available: [385-388])
+		Arg: ~r0: int (declared at line 385, available: )
+		Arg: ~r1: [0]int (declared at line 385, available: )
 	Function: useCrossPackageGenerics (main.useCrossPackageGenerics) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [358:368] injectible: [358-363], [365-365], [367-368]
 		Var: set: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[string] (declared at line 359, available: [360-367])
 		Scope: 360-365

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -126,10 +126,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [380:437] injectible: [380-387], [389-393], [395-397], [399-402], [405-419], [425-427], [431-437]
-		Var: &v: *main.firstBehavior (declared at line 389, available: [380-437])
-		Var: &fortyTwo: *int (declared at line 392, available: [393-393])
-		Var: .autotmp_8: [0]int (declared at line 436, available: [380-437])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
+		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
+		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
+		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
 		Var: originalSlice: []int (declared at line 77, available: )
 		Var: s: []uint (declared at line 86, available: )
@@ -269,9 +269,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [286:291] injectible: [286-291]
-		Arg: arg: [3]int (declared at line 286, available: [286-291])
-		Arg: ~r0: [3]int (declared at line 286, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
+		Arg: arg: [3]int (declared at line 297, available: [297-302])
+		Arg: ~r0: [3]int (declared at line 297, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -450,9 +450,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:280] injectible: [270-280]
-		Arg: arg: main.largeStruct (declared at line 270, available: [270-280])
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
+		Arg: arg: main.largeStruct (declared at line 281, available: [281-291])
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
@@ -461,17 +461,17 @@ Package: main
 		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [317:319] injectible: [317-319]
-		Arg: a: int (declared at line 317, available: [317-319])
-		Arg: b: int (declared at line 317, available: [317-319])
-		Arg: c: int (declared at line 317, available: [317-319])
-		Arg: d: int (declared at line 317, available: [317-319])
-		Arg: e: int (declared at line 317, available: [317-319])
-		Arg: f: int (declared at line 317, available: [317-319])
-		Arg: g: int (declared at line 317, available: [317-319])
-		Arg: h: int (declared at line 317, available: [317-319])
-		Arg: i: int (declared at line 317, available: [317-319])
-		Arg: ~r0: [2]int (declared at line 317, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
+		Arg: a: int (declared at line 328, available: [328-330])
+		Arg: b: int (declared at line 328, available: [328-330])
+		Arg: c: int (declared at line 328, available: [328-330])
+		Arg: d: int (declared at line 328, available: [328-330])
+		Arg: e: int (declared at line 328, available: [328-330])
+		Arg: f: int (declared at line 328, available: [328-330])
+		Arg: g: int (declared at line 328, available: [328-330])
+		Arg: h: int (declared at line 328, available: [328-330])
+		Arg: i: int (declared at line 328, available: [328-330])
+		Arg: ~r0: [2]int (declared at line 328, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -512,30 +512,30 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [326:338] injectible: [326-338]
-		Arg: a: int (declared at line 326, available: [326-338])
-		Arg: b: int (declared at line 326, available: [326-338])
-		Arg: c: int (declared at line 326, available: [326-338])
-		Arg: d: int (declared at line 326, available: [326-338])
-		Arg: e: int (declared at line 326, available: [326-338])
-		Arg: f: int (declared at line 326, available: [326-338])
-		Arg: g: int (declared at line 326, available: [326-338])
-		Arg: h: int (declared at line 326, available: [326-338])
-		Arg: s: string (declared at line 326, available: [326-338])
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [353:355] injectible: [353-355]
-		Arg: a: [2]int (declared at line 353, available: [353-355])
-		Arg: b: [3]int (declared at line 353, available: [353-355])
-		Arg: ~r0: int (declared at line 353, available: )
-		Arg: ~r1: [2]int (declared at line 353, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
+		Arg: a: int (declared at line 337, available: [337-349])
+		Arg: b: int (declared at line 337, available: [337-349])
+		Arg: c: int (declared at line 337, available: [337-349])
+		Arg: d: int (declared at line 337, available: [337-349])
+		Arg: e: int (declared at line 337, available: [337-349])
+		Arg: f: int (declared at line 337, available: [337-349])
+		Arg: g: int (declared at line 337, available: [337-349])
+		Arg: h: int (declared at line 337, available: [337-349])
+		Arg: s: string (declared at line 337, available: [337-349])
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
+		Arg: a: [2]int (declared at line 364, available: [364-366])
+		Arg: b: [3]int (declared at line 364, available: [364-366])
+		Arg: ~r0: int (declared at line 364, available: )
+		Arg: ~r1: [2]int (declared at line 364, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:309] injectible: [297-309]
-		Arg: s1: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: s2: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
+		Arg: s1: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -653,28 +653,28 @@ Package: main
 			Var: val: string (declared at line 52, available: [53-53])
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [163:165] injectible: [163-165]
-		Arg: ~r0: [3]int (declared at line 163, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [171:173] injectible: [171-173]
-		Arg: ~r0: [1]int (declared at line 171, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [179:181] injectible: [179-181]
-		Arg: ~r0: [0]int (declared at line 179, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [202:204] injectible: [202-204]
-		Arg: ~r0: int (declared at line 202, available: )
-		Arg: ~r1: int (declared at line 202, available: )
-		Arg: ~r2: int (declared at line 202, available: )
-		Arg: ~r3: int (declared at line 202, available: )
-		Arg: ~r4: int (declared at line 202, available: )
-		Arg: ~r5: int (declared at line 202, available: )
-		Arg: ~r6: int (declared at line 202, available: )
-		Arg: ~r7: int (declared at line 202, available: )
-		Arg: ~r8: string (declared at line 202, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [259:261] injectible: [259-261]
-		Arg: ~r0: bool (declared at line 259, available: )
-		Arg: ~r1: uintptr (declared at line 259, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [144:146] injectible: [144-146]
-		Arg: ~r0: complex64 (declared at line 144, available: )
-		Arg: ~r1: complex128 (declared at line 144, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [174:176] injectible: [174-176]
+		Arg: ~r0: [3]int (declared at line 174, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [182:184] injectible: [182-184]
+		Arg: ~r0: [1]int (declared at line 182, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [190:192] injectible: [190-192]
+		Arg: ~r0: [0]int (declared at line 190, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [213:215] injectible: [213-215]
+		Arg: ~r0: int (declared at line 213, available: )
+		Arg: ~r1: int (declared at line 213, available: )
+		Arg: ~r2: int (declared at line 213, available: )
+		Arg: ~r3: int (declared at line 213, available: )
+		Arg: ~r4: int (declared at line 213, available: )
+		Arg: ~r5: int (declared at line 213, available: )
+		Arg: ~r6: int (declared at line 213, available: )
+		Arg: ~r7: int (declared at line 213, available: )
+		Arg: ~r8: string (declared at line 213, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:272] injectible: [270-272]
+		Arg: ~r0: bool (declared at line 270, available: )
+		Arg: ~r1: uintptr (declared at line 270, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
+		Arg: ~r0: complex64 (declared at line 155, available: )
+		Arg: ~r1: complex128 (declared at line 155, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -696,52 +696,59 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-78])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [126:138] injectible: [126-126], [136-138]
-		Arg: ~r0: float64 (declared at line 127, available: )
-		Arg: ~r1: float64 (declared at line 127, available: )
-		Arg: ~r2: float64 (declared at line 127, available: )
-		Arg: ~r3: float64 (declared at line 127, available: )
-		Arg: ~r4: float64 (declared at line 127, available: )
-		Arg: ~r5: float64 (declared at line 127, available: )
-		Arg: ~r6: float64 (declared at line 127, available: )
-		Arg: ~r7: float64 (declared at line 128, available: )
-		Arg: ~r8: float64 (declared at line 128, available: )
-		Arg: ~r9: float64 (declared at line 128, available: )
-		Arg: ~r10: float64 (declared at line 128, available: )
-		Arg: ~r11: float64 (declared at line 128, available: )
-		Arg: ~r12: float64 (declared at line 128, available: )
-		Arg: ~r13: float64 (declared at line 128, available: )
-		Arg: ~r14: float64 (declared at line 129, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 132, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 134, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [222:224] injectible: [222-224]
-		Arg: ~r0: int (declared at line 222, available: )
-		Arg: ~r1: float64 (declared at line 222, available: )
-		Arg: ~r2: int (declared at line 222, available: )
-		Arg: ~r3: float64 (declared at line 222, available: )
-		Arg: ~r4: string (declared at line 222, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [192:194] injectible: [192-194]
-		Arg: ~r0: main.mixedStruct (declared at line 192, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [251:253] injectible: [251-253]
-		Arg: ~r0: float32 (declared at line 251, available: )
-		Arg: ~r1: float64 (declared at line 251, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [243:245] injectible: [243-245]
-		Arg: ~r0: float64 (declared at line 243, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:119] injectible: [117-119]
-		Arg: ~r0: int8 (declared at line 117, available: )
-		Arg: ~r1: int16 (declared at line 117, available: )
-		Arg: ~r2: int32 (declared at line 117, available: )
-		Arg: ~r3: int64 (declared at line 117, available: )
-		Arg: ~r4: uint8 (declared at line 117, available: )
-		Arg: ~r5: uint16 (declared at line 117, available: )
-		Arg: ~r6: uint32 (declared at line 117, available: )
-		Arg: ~r7: uint64 (declared at line 117, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [234:236] injectible: [234-236]
-		Arg: ~r0: main.structWithArray (declared at line 234, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [214:216] injectible: [214-216]
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [166:168] injectible: [166-168]
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [137:149] injectible: [137-137], [147-149]
+		Arg: ~r0: float64 (declared at line 138, available: )
+		Arg: ~r1: float64 (declared at line 138, available: )
+		Arg: ~r2: float64 (declared at line 138, available: )
+		Arg: ~r3: float64 (declared at line 138, available: )
+		Arg: ~r4: float64 (declared at line 138, available: )
+		Arg: ~r5: float64 (declared at line 138, available: )
+		Arg: ~r6: float64 (declared at line 138, available: )
+		Arg: ~r7: float64 (declared at line 139, available: )
+		Arg: ~r8: float64 (declared at line 139, available: )
+		Arg: ~r9: float64 (declared at line 139, available: )
+		Arg: ~r10: float64 (declared at line 139, available: )
+		Arg: ~r11: float64 (declared at line 139, available: )
+		Arg: ~r12: float64 (declared at line 139, available: )
+		Arg: ~r13: float64 (declared at line 139, available: )
+		Arg: ~r14: float64 (declared at line 140, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 143, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 145, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [233:235] injectible: [233-235]
+		Arg: ~r0: int (declared at line 233, available: )
+		Arg: ~r1: float64 (declared at line 233, available: )
+		Arg: ~r2: int (declared at line 233, available: )
+		Arg: ~r3: float64 (declared at line 233, available: )
+		Arg: ~r4: string (declared at line 233, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [203:205] injectible: [203-205]
+		Arg: ~r0: main.mixedStruct (declared at line 203, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [262:264] injectible: [262-264]
+		Arg: ~r0: float32 (declared at line 262, available: )
+		Arg: ~r1: float64 (declared at line 262, available: )
+	Function: testReturnsNamedDeferLine (main.testReturnsNamedDeferLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:122] injectible: [117-122]
+		Arg: i: int (declared at line 117, available: [117-122])
+		Arg: a: string (declared at line 117, available: [117-122])
+		Arg: b: string (declared at line 117, available: [117-122])
+	Function: testReturnsNamedDeferLine.func1 (main.testReturnsNamedDeferLine.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [118:118] injectible: [118-118]
+		Var: &a: *string (declared at line 118, available: )
+		Var: &b: *string (declared at line 118, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [254:256] injectible: [254-256]
+		Arg: ~r0: float64 (declared at line 254, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:130] injectible: [128-130]
+		Arg: ~r0: int8 (declared at line 128, available: )
+		Arg: ~r1: int16 (declared at line 128, available: )
+		Arg: ~r2: int32 (declared at line 128, available: )
+		Arg: ~r3: int64 (declared at line 128, available: )
+		Arg: ~r4: uint8 (declared at line 128, available: )
+		Arg: ~r5: uint16 (declared at line 128, available: )
+		Arg: ~r6: uint32 (declared at line 128, available: )
+		Arg: ~r7: uint64 (declared at line 128, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: main.structWithArray (declared at line 245, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -787,11 +794,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [345:347] injectible: [345-347]
-		Arg: arg: [5]int (declared at line 345, available: [345-347])
-		Arg: ~r0: int (declared at line 345, available: )
-		Arg: ~r1: int (declared at line 345, available: )
-		Arg: ~r2: int (declared at line 345, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [356:358] injectible: [356-358]
+		Arg: arg: [5]int (declared at line 356, available: [356-358])
+		Arg: ~r0: int (declared at line 356, available: )
+		Arg: ~r1: int (declared at line 356, available: )
+		Arg: ~r2: int (declared at line 356, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -826,11 +833,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [361:368] injectible: [361-363], [365-366], [368-368]
-		Arg: arg: main.structWithArray (declared at line 361, available: [361-368])
-		Arg: ~r0: int (declared at line 361, available: )
-		Arg: ~r1: main.structWithArray (declared at line 361, available: )
-		Var: x: int (declared at line 363, available: [361-368])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
+		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
+		Arg: ~r0: int (declared at line 372, available: )
+		Arg: ~r1: main.structWithArray (declared at line 372, available: )
+		Var: x: int (declared at line 374, available: [372-379])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -891,11 +898,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:377] injectible: [374-377]
-		Arg: a: [0]int (declared at line 374, available: )
-		Arg: b: int (declared at line 374, available: [374-377])
-		Arg: ~r0: int (declared at line 374, available: )
-		Arg: ~r1: [0]int (declared at line 374, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
+		Arg: a: [0]int (declared at line 385, available: )
+		Arg: b: int (declared at line 385, available: [385-388])
+		Arg: ~r0: int (declared at line 385, available: )
+		Arg: ~r1: [0]int (declared at line 385, available: )
 	Function: useCrossPackageGenerics (main.useCrossPackageGenerics) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [358:368] injectible: [358-363], [365-365], [367-368]
 		Var: set: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[string] (declared at line 359, available: [360-367])
 		Scope: 360-365

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -140,10 +140,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [380:437] injectible: [380-387], [389-393], [395-397], [399-402], [405-419], [425-427], [431-437]
-		Var: &v: *main.firstBehavior (declared at line 389, available: [380-437])
-		Var: &fortyTwo: *int (declared at line 392, available: [393-393])
-		Var: .autotmp_8: [0]int (declared at line 436, available: [380-437])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
+		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
+		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
+		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
 		Var: originalSlice: []int (declared at line 77, available: )
 		Var: s: []uint (declared at line 86, available: )
@@ -285,9 +285,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [286:291] injectible: [286-291]
-		Arg: arg: [3]int (declared at line 286, available: [286-291])
-		Arg: ~r0: [3]int (declared at line 286, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
+		Arg: arg: [3]int (declared at line 297, available: [297-302])
+		Arg: ~r0: [3]int (declared at line 297, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -466,10 +466,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:280] injectible: [270-280]
-		Arg: arg: main.largeStruct (declared at line 270, available: [270-271])
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
+		Arg: arg: main.largeStruct (declared at line 281, available: [281-282])
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
@@ -478,17 +478,17 @@ Package: main
 		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [317:319] injectible: [317-319]
-		Arg: a: int (declared at line 317, available: [317-319])
-		Arg: b: int (declared at line 317, available: [317-319])
-		Arg: c: int (declared at line 317, available: [317-319])
-		Arg: d: int (declared at line 317, available: [317-319])
-		Arg: e: int (declared at line 317, available: [317-319])
-		Arg: f: int (declared at line 317, available: [317-319])
-		Arg: g: int (declared at line 317, available: [317-319])
-		Arg: h: int (declared at line 317, available: [317-319])
-		Arg: i: int (declared at line 317, available: [317-319])
-		Arg: ~r0: [2]int (declared at line 317, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
+		Arg: a: int (declared at line 328, available: [328-330])
+		Arg: b: int (declared at line 328, available: [328-330])
+		Arg: c: int (declared at line 328, available: [328-330])
+		Arg: d: int (declared at line 328, available: [328-330])
+		Arg: e: int (declared at line 328, available: [328-330])
+		Arg: f: int (declared at line 328, available: [328-330])
+		Arg: g: int (declared at line 328, available: [328-330])
+		Arg: h: int (declared at line 328, available: [328-330])
+		Arg: i: int (declared at line 328, available: [328-330])
+		Arg: ~r0: [2]int (declared at line 328, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -529,32 +529,32 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [326:338] injectible: [326-338]
-		Arg: a: int (declared at line 326, available: [326-338])
-		Arg: b: int (declared at line 326, available: [326-338])
-		Arg: c: int (declared at line 326, available: [326-338])
-		Arg: d: int (declared at line 326, available: [326-338])
-		Arg: e: int (declared at line 326, available: [326-338])
-		Arg: f: int (declared at line 326, available: [326-338])
-		Arg: g: int (declared at line 326, available: [326-338])
-		Arg: h: int (declared at line 326, available: [326-338])
-		Arg: s: string (declared at line 326, available: [326-338])
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [353:355] injectible: [353-355]
-		Arg: a: [2]int (declared at line 353, available: [353-355])
-		Arg: b: [3]int (declared at line 353, available: [353-355])
-		Arg: ~r0: int (declared at line 353, available: )
-		Arg: ~r1: [2]int (declared at line 353, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
+		Arg: a: int (declared at line 337, available: [337-349])
+		Arg: b: int (declared at line 337, available: [337-349])
+		Arg: c: int (declared at line 337, available: [337-349])
+		Arg: d: int (declared at line 337, available: [337-349])
+		Arg: e: int (declared at line 337, available: [337-349])
+		Arg: f: int (declared at line 337, available: [337-349])
+		Arg: g: int (declared at line 337, available: [337-349])
+		Arg: h: int (declared at line 337, available: [337-349])
+		Arg: s: string (declared at line 337, available: [337-349])
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
+		Arg: a: [2]int (declared at line 364, available: [364-366])
+		Arg: b: [3]int (declared at line 364, available: [364-366])
+		Arg: ~r0: int (declared at line 364, available: )
+		Arg: ~r1: [2]int (declared at line 364, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:309] injectible: [297-309]
-		Arg: s1: main.largeStruct (declared at line 297, available: [297-298])
-		Arg: s2: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
+		Arg: s1: main.largeStruct (declared at line 308, available: [308-309])
+		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -672,28 +672,28 @@ Package: main
 			Var: val: string (declared at line 52, available: [53-53])
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-53])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [163:165] injectible: [163-165]
-		Arg: ~r0: [3]int (declared at line 163, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [171:173] injectible: [171-173]
-		Arg: ~r0: [1]int (declared at line 171, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [179:181] injectible: [179-181]
-		Arg: ~r0: [0]int (declared at line 179, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [202:204] injectible: [202-204]
-		Arg: ~r0: int (declared at line 202, available: )
-		Arg: ~r1: int (declared at line 202, available: )
-		Arg: ~r2: int (declared at line 202, available: )
-		Arg: ~r3: int (declared at line 202, available: )
-		Arg: ~r4: int (declared at line 202, available: )
-		Arg: ~r5: int (declared at line 202, available: )
-		Arg: ~r6: int (declared at line 202, available: )
-		Arg: ~r7: int (declared at line 202, available: )
-		Arg: ~r8: string (declared at line 202, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [259:261] injectible: [259-261]
-		Arg: ~r0: bool (declared at line 259, available: )
-		Arg: ~r1: uintptr (declared at line 259, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [144:146] injectible: [144-146]
-		Arg: ~r0: complex64 (declared at line 144, available: )
-		Arg: ~r1: complex128 (declared at line 144, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [174:176] injectible: [174-176]
+		Arg: ~r0: [3]int (declared at line 174, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [182:184] injectible: [182-184]
+		Arg: ~r0: [1]int (declared at line 182, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [190:192] injectible: [190-192]
+		Arg: ~r0: [0]int (declared at line 190, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [213:215] injectible: [213-215]
+		Arg: ~r0: int (declared at line 213, available: )
+		Arg: ~r1: int (declared at line 213, available: )
+		Arg: ~r2: int (declared at line 213, available: )
+		Arg: ~r3: int (declared at line 213, available: )
+		Arg: ~r4: int (declared at line 213, available: )
+		Arg: ~r5: int (declared at line 213, available: )
+		Arg: ~r6: int (declared at line 213, available: )
+		Arg: ~r7: int (declared at line 213, available: )
+		Arg: ~r8: string (declared at line 213, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:272] injectible: [270-272]
+		Arg: ~r0: bool (declared at line 270, available: )
+		Arg: ~r1: uintptr (declared at line 270, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
+		Arg: ~r0: complex64 (declared at line 155, available: )
+		Arg: ~r1: complex128 (declared at line 155, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -715,54 +715,61 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-79])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [126:138] injectible: [126-126], [136-138]
-		Arg: ~r0: float64 (declared at line 127, available: )
-		Arg: ~r1: float64 (declared at line 127, available: )
-		Arg: ~r2: float64 (declared at line 127, available: )
-		Arg: ~r3: float64 (declared at line 127, available: )
-		Arg: ~r4: float64 (declared at line 127, available: )
-		Arg: ~r5: float64 (declared at line 127, available: )
-		Arg: ~r6: float64 (declared at line 127, available: )
-		Arg: ~r7: float64 (declared at line 128, available: )
-		Arg: ~r8: float64 (declared at line 128, available: )
-		Arg: ~r9: float64 (declared at line 128, available: )
-		Arg: ~r10: float64 (declared at line 128, available: )
-		Arg: ~r11: float64 (declared at line 128, available: )
-		Arg: ~r12: float64 (declared at line 128, available: )
-		Arg: ~r13: float64 (declared at line 128, available: )
-		Arg: ~r14: float64 (declared at line 129, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 132, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 134, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [222:224] injectible: [222-224]
-		Arg: ~r0: int (declared at line 222, available: )
-		Arg: ~r1: float64 (declared at line 222, available: )
-		Arg: ~r2: int (declared at line 222, available: )
-		Arg: ~r3: float64 (declared at line 222, available: )
-		Arg: ~r4: string (declared at line 222, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [192:194] injectible: [192-194]
-		Arg: ~r0: main.mixedStruct (declared at line 192, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [251:253] injectible: [251-253]
-		Arg: ~r0: float32 (declared at line 251, available: )
-		Arg: ~r1: float64 (declared at line 251, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [243:245] injectible: [243-245]
-		Arg: ~r0: float64 (declared at line 243, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:119] injectible: [117-119]
-		Arg: ~r0: int8 (declared at line 117, available: )
-		Arg: ~r1: int16 (declared at line 117, available: )
-		Arg: ~r2: int32 (declared at line 117, available: )
-		Arg: ~r3: int64 (declared at line 117, available: )
-		Arg: ~r4: uint8 (declared at line 117, available: )
-		Arg: ~r5: uint16 (declared at line 117, available: )
-		Arg: ~r6: uint32 (declared at line 117, available: )
-		Arg: ~r7: uint64 (declared at line 117, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [234:236] injectible: [234-236]
-		Arg: ~r0: main.structWithArray (declared at line 234, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [214:216] injectible: [214-216]
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [166:168] injectible: [166-168]
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [137:149] injectible: [137-137], [147-149]
+		Arg: ~r0: float64 (declared at line 138, available: )
+		Arg: ~r1: float64 (declared at line 138, available: )
+		Arg: ~r2: float64 (declared at line 138, available: )
+		Arg: ~r3: float64 (declared at line 138, available: )
+		Arg: ~r4: float64 (declared at line 138, available: )
+		Arg: ~r5: float64 (declared at line 138, available: )
+		Arg: ~r6: float64 (declared at line 138, available: )
+		Arg: ~r7: float64 (declared at line 139, available: )
+		Arg: ~r8: float64 (declared at line 139, available: )
+		Arg: ~r9: float64 (declared at line 139, available: )
+		Arg: ~r10: float64 (declared at line 139, available: )
+		Arg: ~r11: float64 (declared at line 139, available: )
+		Arg: ~r12: float64 (declared at line 139, available: )
+		Arg: ~r13: float64 (declared at line 139, available: )
+		Arg: ~r14: float64 (declared at line 140, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 143, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 145, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [233:235] injectible: [233-235]
+		Arg: ~r0: int (declared at line 233, available: )
+		Arg: ~r1: float64 (declared at line 233, available: )
+		Arg: ~r2: int (declared at line 233, available: )
+		Arg: ~r3: float64 (declared at line 233, available: )
+		Arg: ~r4: string (declared at line 233, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [203:205] injectible: [203-205]
+		Arg: ~r0: main.mixedStruct (declared at line 203, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [262:264] injectible: [262-264]
+		Arg: ~r0: float32 (declared at line 262, available: )
+		Arg: ~r1: float64 (declared at line 262, available: )
+	Function: testReturnsNamedDeferLine (main.testReturnsNamedDeferLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:122] injectible: [117-122]
+		Arg: i: int (declared at line 117, available: [117-122])
+		Arg: a: string (declared at line 117, available: [117-122])
+		Arg: b: string (declared at line 117, available: [117-122])
+	Function: testReturnsNamedDeferLine.func1 (main.testReturnsNamedDeferLine.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [118:118] injectible: [118-118]
+		Var: &a: *string (declared at line 118, available: )
+		Var: &b: *string (declared at line 118, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [254:256] injectible: [254-256]
+		Arg: ~r0: float64 (declared at line 254, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:130] injectible: [128-130]
+		Arg: ~r0: int8 (declared at line 128, available: )
+		Arg: ~r1: int16 (declared at line 128, available: )
+		Arg: ~r2: int32 (declared at line 128, available: )
+		Arg: ~r3: int64 (declared at line 128, available: )
+		Arg: ~r4: uint8 (declared at line 128, available: )
+		Arg: ~r5: uint16 (declared at line 128, available: )
+		Arg: ~r6: uint32 (declared at line 128, available: )
+		Arg: ~r7: uint64 (declared at line 128, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: main.structWithArray (declared at line 245, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -808,11 +815,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [345:347] injectible: [345-347]
-		Arg: arg: [5]int (declared at line 345, available: [345-347])
-		Arg: ~r0: int (declared at line 345, available: )
-		Arg: ~r1: int (declared at line 345, available: )
-		Arg: ~r2: int (declared at line 345, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [356:358] injectible: [356-358]
+		Arg: arg: [5]int (declared at line 356, available: [356-358])
+		Arg: ~r0: int (declared at line 356, available: )
+		Arg: ~r1: int (declared at line 356, available: )
+		Arg: ~r2: int (declared at line 356, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -847,11 +854,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [361:368] injectible: [361-363], [365-366], [368-368]
-		Arg: arg: main.structWithArray (declared at line 361, available: [361-368])
-		Arg: ~r0: int (declared at line 361, available: )
-		Arg: ~r1: main.structWithArray (declared at line 361, available: )
-		Var: x: int (declared at line 363, available: [361-368])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
+		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
+		Arg: ~r0: int (declared at line 372, available: )
+		Arg: ~r1: main.structWithArray (declared at line 372, available: )
+		Var: x: int (declared at line 374, available: [372-379])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -912,11 +919,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:377] injectible: [374-377]
-		Arg: a: [0]int (declared at line 374, available: )
-		Arg: b: int (declared at line 374, available: [374-377])
-		Arg: ~r0: int (declared at line 374, available: )
-		Arg: ~r1: [0]int (declared at line 374, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
+		Arg: a: [0]int (declared at line 385, available: )
+		Arg: b: int (declared at line 385, available: [385-388])
+		Arg: ~r0: int (declared at line 385, available: )
+		Arg: ~r1: [0]int (declared at line 385, available: )
 	Function: useCrossPackageGenerics (main.useCrossPackageGenerics) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [358:368] injectible: [358-363], [365-365], [367-368]
 		Var: set: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[string] (declared at line 359, available: [360-368])
 		Scope: 360-367

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -129,10 +129,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [380:437] injectible: [380-387], [389-393], [395-397], [399-402], [405-419], [425-427], [431-437]
-		Var: &v: *main.firstBehavior (declared at line 389, available: [380-437])
-		Var: &fortyTwo: *int (declared at line 392, available: [393-393])
-		Var: .autotmp_8: [0]int (declared at line 436, available: [380-437])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
+		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
+		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
+		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
 		Var: originalSlice: []int (declared at line 77, available: )
 		Var: s: []uint (declared at line 86, available: )
@@ -274,9 +274,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [286:291] injectible: [286-291]
-		Arg: arg: [3]int (declared at line 286, available: [286-291])
-		Arg: ~r0: [3]int (declared at line 286, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
+		Arg: arg: [3]int (declared at line 297, available: [297-302])
+		Arg: ~r0: [3]int (declared at line 297, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -455,10 +455,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:280] injectible: [270-280]
-		Arg: arg: main.largeStruct (declared at line 270, available: [270-271])
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
+		Arg: arg: main.largeStruct (declared at line 281, available: [281-282])
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
@@ -467,17 +467,17 @@ Package: main
 		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [317:319] injectible: [317-319]
-		Arg: a: int (declared at line 317, available: [317-319])
-		Arg: b: int (declared at line 317, available: [317-319])
-		Arg: c: int (declared at line 317, available: [317-319])
-		Arg: d: int (declared at line 317, available: [317-319])
-		Arg: e: int (declared at line 317, available: [317-319])
-		Arg: f: int (declared at line 317, available: [317-319])
-		Arg: g: int (declared at line 317, available: [317-319])
-		Arg: h: int (declared at line 317, available: [317-319])
-		Arg: i: int (declared at line 317, available: [317-319])
-		Arg: ~r0: [2]int (declared at line 317, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
+		Arg: a: int (declared at line 328, available: [328-330])
+		Arg: b: int (declared at line 328, available: [328-330])
+		Arg: c: int (declared at line 328, available: [328-330])
+		Arg: d: int (declared at line 328, available: [328-330])
+		Arg: e: int (declared at line 328, available: [328-330])
+		Arg: f: int (declared at line 328, available: [328-330])
+		Arg: g: int (declared at line 328, available: [328-330])
+		Arg: h: int (declared at line 328, available: [328-330])
+		Arg: i: int (declared at line 328, available: [328-330])
+		Arg: ~r0: [2]int (declared at line 328, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -518,32 +518,32 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [326:338] injectible: [326-338]
-		Arg: a: int (declared at line 326, available: [326-338])
-		Arg: b: int (declared at line 326, available: [326-338])
-		Arg: c: int (declared at line 326, available: [326-338])
-		Arg: d: int (declared at line 326, available: [326-338])
-		Arg: e: int (declared at line 326, available: [326-338])
-		Arg: f: int (declared at line 326, available: [326-338])
-		Arg: g: int (declared at line 326, available: [326-338])
-		Arg: h: int (declared at line 326, available: [326-338])
-		Arg: s: string (declared at line 326, available: [326-338])
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [353:355] injectible: [353-355]
-		Arg: a: [2]int (declared at line 353, available: [353-355])
-		Arg: b: [3]int (declared at line 353, available: [353-355])
-		Arg: ~r0: int (declared at line 353, available: )
-		Arg: ~r1: [2]int (declared at line 353, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-349]
+		Arg: a: int (declared at line 337, available: [337-349])
+		Arg: b: int (declared at line 337, available: [337-349])
+		Arg: c: int (declared at line 337, available: [337-349])
+		Arg: d: int (declared at line 337, available: [337-349])
+		Arg: e: int (declared at line 337, available: [337-349])
+		Arg: f: int (declared at line 337, available: [337-349])
+		Arg: g: int (declared at line 337, available: [337-349])
+		Arg: h: int (declared at line 337, available: [337-349])
+		Arg: s: string (declared at line 337, available: [337-349])
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
+		Arg: a: [2]int (declared at line 364, available: [364-366])
+		Arg: b: [3]int (declared at line 364, available: [364-366])
+		Arg: ~r0: int (declared at line 364, available: )
+		Arg: ~r1: [2]int (declared at line 364, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:309] injectible: [297-309]
-		Arg: s1: main.largeStruct (declared at line 297, available: [297-298])
-		Arg: s2: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
+		Arg: s1: main.largeStruct (declared at line 308, available: [308-309])
+		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -661,28 +661,28 @@ Package: main
 			Var: val: string (declared at line 52, available: [53-53])
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [163:165] injectible: [163-165]
-		Arg: ~r0: [3]int (declared at line 163, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [171:173] injectible: [171-173]
-		Arg: ~r0: [1]int (declared at line 171, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [179:181] injectible: [179-181]
-		Arg: ~r0: [0]int (declared at line 179, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [202:204] injectible: [202-204]
-		Arg: ~r0: int (declared at line 202, available: )
-		Arg: ~r1: int (declared at line 202, available: )
-		Arg: ~r2: int (declared at line 202, available: )
-		Arg: ~r3: int (declared at line 202, available: )
-		Arg: ~r4: int (declared at line 202, available: )
-		Arg: ~r5: int (declared at line 202, available: )
-		Arg: ~r6: int (declared at line 202, available: )
-		Arg: ~r7: int (declared at line 202, available: )
-		Arg: ~r8: string (declared at line 202, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [259:261] injectible: [259-261]
-		Arg: ~r0: bool (declared at line 259, available: )
-		Arg: ~r1: uintptr (declared at line 259, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [144:146] injectible: [144-146]
-		Arg: ~r0: complex64 (declared at line 144, available: )
-		Arg: ~r1: complex128 (declared at line 144, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [174:176] injectible: [174-176]
+		Arg: ~r0: [3]int (declared at line 174, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [182:184] injectible: [182-184]
+		Arg: ~r0: [1]int (declared at line 182, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [190:192] injectible: [190-192]
+		Arg: ~r0: [0]int (declared at line 190, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [213:215] injectible: [213-215]
+		Arg: ~r0: int (declared at line 213, available: )
+		Arg: ~r1: int (declared at line 213, available: )
+		Arg: ~r2: int (declared at line 213, available: )
+		Arg: ~r3: int (declared at line 213, available: )
+		Arg: ~r4: int (declared at line 213, available: )
+		Arg: ~r5: int (declared at line 213, available: )
+		Arg: ~r6: int (declared at line 213, available: )
+		Arg: ~r7: int (declared at line 213, available: )
+		Arg: ~r8: string (declared at line 213, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:272] injectible: [270-272]
+		Arg: ~r0: bool (declared at line 270, available: )
+		Arg: ~r1: uintptr (declared at line 270, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
+		Arg: ~r0: complex64 (declared at line 155, available: )
+		Arg: ~r1: complex128 (declared at line 155, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -704,54 +704,61 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-79])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [126:138] injectible: [126-126], [136-138]
-		Arg: ~r0: float64 (declared at line 127, available: )
-		Arg: ~r1: float64 (declared at line 127, available: )
-		Arg: ~r2: float64 (declared at line 127, available: )
-		Arg: ~r3: float64 (declared at line 127, available: )
-		Arg: ~r4: float64 (declared at line 127, available: )
-		Arg: ~r5: float64 (declared at line 127, available: )
-		Arg: ~r6: float64 (declared at line 127, available: )
-		Arg: ~r7: float64 (declared at line 128, available: )
-		Arg: ~r8: float64 (declared at line 128, available: )
-		Arg: ~r9: float64 (declared at line 128, available: )
-		Arg: ~r10: float64 (declared at line 128, available: )
-		Arg: ~r11: float64 (declared at line 128, available: )
-		Arg: ~r12: float64 (declared at line 128, available: )
-		Arg: ~r13: float64 (declared at line 128, available: )
-		Arg: ~r14: float64 (declared at line 129, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 132, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 134, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [222:224] injectible: [222-224]
-		Arg: ~r0: int (declared at line 222, available: )
-		Arg: ~r1: float64 (declared at line 222, available: )
-		Arg: ~r2: int (declared at line 222, available: )
-		Arg: ~r3: float64 (declared at line 222, available: )
-		Arg: ~r4: string (declared at line 222, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [192:194] injectible: [192-194]
-		Arg: ~r0: main.mixedStruct (declared at line 192, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [251:253] injectible: [251-253]
-		Arg: ~r0: float32 (declared at line 251, available: )
-		Arg: ~r1: float64 (declared at line 251, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [243:245] injectible: [243-245]
-		Arg: ~r0: float64 (declared at line 243, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:119] injectible: [117-119]
-		Arg: ~r0: int8 (declared at line 117, available: )
-		Arg: ~r1: int16 (declared at line 117, available: )
-		Arg: ~r2: int32 (declared at line 117, available: )
-		Arg: ~r3: int64 (declared at line 117, available: )
-		Arg: ~r4: uint8 (declared at line 117, available: )
-		Arg: ~r5: uint16 (declared at line 117, available: )
-		Arg: ~r6: uint32 (declared at line 117, available: )
-		Arg: ~r7: uint64 (declared at line 117, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [234:236] injectible: [234-236]
-		Arg: ~r0: main.structWithArray (declared at line 234, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [214:216] injectible: [214-216]
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [166:168] injectible: [166-168]
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [137:149] injectible: [137-137], [147-149]
+		Arg: ~r0: float64 (declared at line 138, available: )
+		Arg: ~r1: float64 (declared at line 138, available: )
+		Arg: ~r2: float64 (declared at line 138, available: )
+		Arg: ~r3: float64 (declared at line 138, available: )
+		Arg: ~r4: float64 (declared at line 138, available: )
+		Arg: ~r5: float64 (declared at line 138, available: )
+		Arg: ~r6: float64 (declared at line 138, available: )
+		Arg: ~r7: float64 (declared at line 139, available: )
+		Arg: ~r8: float64 (declared at line 139, available: )
+		Arg: ~r9: float64 (declared at line 139, available: )
+		Arg: ~r10: float64 (declared at line 139, available: )
+		Arg: ~r11: float64 (declared at line 139, available: )
+		Arg: ~r12: float64 (declared at line 139, available: )
+		Arg: ~r13: float64 (declared at line 139, available: )
+		Arg: ~r14: float64 (declared at line 140, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 143, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 145, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [233:235] injectible: [233-235]
+		Arg: ~r0: int (declared at line 233, available: )
+		Arg: ~r1: float64 (declared at line 233, available: )
+		Arg: ~r2: int (declared at line 233, available: )
+		Arg: ~r3: float64 (declared at line 233, available: )
+		Arg: ~r4: string (declared at line 233, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [203:205] injectible: [203-205]
+		Arg: ~r0: main.mixedStruct (declared at line 203, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [262:264] injectible: [262-264]
+		Arg: ~r0: float32 (declared at line 262, available: )
+		Arg: ~r1: float64 (declared at line 262, available: )
+	Function: testReturnsNamedDeferLine (main.testReturnsNamedDeferLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:122] injectible: [117-122]
+		Arg: i: int (declared at line 117, available: [117-122])
+		Arg: a: string (declared at line 117, available: [117-122])
+		Arg: b: string (declared at line 117, available: [117-122])
+	Function: testReturnsNamedDeferLine.func1 (main.testReturnsNamedDeferLine.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [118:118] injectible: [118-118]
+		Var: &a: *string (declared at line 118, available: )
+		Var: &b: *string (declared at line 118, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [254:256] injectible: [254-256]
+		Arg: ~r0: float64 (declared at line 254, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:130] injectible: [128-130]
+		Arg: ~r0: int8 (declared at line 128, available: )
+		Arg: ~r1: int16 (declared at line 128, available: )
+		Arg: ~r2: int32 (declared at line 128, available: )
+		Arg: ~r3: int64 (declared at line 128, available: )
+		Arg: ~r4: uint8 (declared at line 128, available: )
+		Arg: ~r5: uint16 (declared at line 128, available: )
+		Arg: ~r6: uint32 (declared at line 128, available: )
+		Arg: ~r7: uint64 (declared at line 128, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: main.structWithArray (declared at line 245, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -797,11 +804,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [345:347] injectible: [345-347]
-		Arg: arg: [5]int (declared at line 345, available: [345-347])
-		Arg: ~r0: int (declared at line 345, available: )
-		Arg: ~r1: int (declared at line 345, available: )
-		Arg: ~r2: int (declared at line 345, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [356:358] injectible: [356-358]
+		Arg: arg: [5]int (declared at line 356, available: [356-358])
+		Arg: ~r0: int (declared at line 356, available: )
+		Arg: ~r1: int (declared at line 356, available: )
+		Arg: ~r2: int (declared at line 356, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -836,11 +843,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [361:368] injectible: [361-363], [365-366], [368-368]
-		Arg: arg: main.structWithArray (declared at line 361, available: [361-368])
-		Arg: ~r0: int (declared at line 361, available: )
-		Arg: ~r1: main.structWithArray (declared at line 361, available: )
-		Var: x: int (declared at line 363, available: [361-368])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
+		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
+		Arg: ~r0: int (declared at line 372, available: )
+		Arg: ~r1: main.structWithArray (declared at line 372, available: )
+		Var: x: int (declared at line 374, available: [372-379])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -901,11 +908,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:377] injectible: [374-377]
-		Arg: a: [0]int (declared at line 374, available: )
-		Arg: b: int (declared at line 374, available: [374-377])
-		Arg: ~r0: int (declared at line 374, available: )
-		Arg: ~r1: [0]int (declared at line 374, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
+		Arg: a: [0]int (declared at line 385, available: )
+		Arg: b: int (declared at line 385, available: [385-388])
+		Arg: ~r0: int (declared at line 385, available: )
+		Arg: ~r1: [0]int (declared at line 385, available: )
 	Function: useCrossPackageGenerics (main.useCrossPackageGenerics) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [358:368] injectible: [358-363], [365-365], [367-368]
 		Var: set: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[string] (declared at line 359, available: [360-368])
 		Scope: 360-365

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -126,10 +126,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [380:437] injectible: [380-387], [389-393], [395-397], [399-402], [405-419], [425-427], [431-437]
-		Var: &v: *main.firstBehavior (declared at line 389, available: [380-437])
-		Var: &fortyTwo: *int (declared at line 392, available: [393-393])
-		Var: .autotmp_8: [0]int (declared at line 436, available: [380-437])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
+		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
+		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
+		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
 		Var: originalSlice: []int (declared at line 77, available: )
 		Var: s: []uint (declared at line 86, available: )
@@ -271,9 +271,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [286:291] injectible: [286-291]
-		Arg: arg: [3]int (declared at line 286, available: [286-291])
-		Arg: ~r0: [3]int (declared at line 286, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
+		Arg: arg: [3]int (declared at line 297, available: [297-302])
+		Arg: ~r0: [3]int (declared at line 297, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -452,10 +452,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:280] injectible: [270-280]
-		Arg: arg: main.largeStruct (declared at line 270, available: [270-271])
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
+		Arg: arg: main.largeStruct (declared at line 281, available: [281-282])
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
@@ -464,17 +464,17 @@ Package: main
 		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [317:319] injectible: [317-319]
-		Arg: a: int (declared at line 317, available: [317-319])
-		Arg: b: int (declared at line 317, available: [317-319])
-		Arg: c: int (declared at line 317, available: [317-319])
-		Arg: d: int (declared at line 317, available: [317-319])
-		Arg: e: int (declared at line 317, available: [317-319])
-		Arg: f: int (declared at line 317, available: [317-319])
-		Arg: g: int (declared at line 317, available: [317-319])
-		Arg: h: int (declared at line 317, available: [317-319])
-		Arg: i: int (declared at line 317, available: [317-319])
-		Arg: ~r0: [2]int (declared at line 317, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
+		Arg: a: int (declared at line 328, available: [328-330])
+		Arg: b: int (declared at line 328, available: [328-330])
+		Arg: c: int (declared at line 328, available: [328-330])
+		Arg: d: int (declared at line 328, available: [328-330])
+		Arg: e: int (declared at line 328, available: [328-330])
+		Arg: f: int (declared at line 328, available: [328-330])
+		Arg: g: int (declared at line 328, available: [328-330])
+		Arg: h: int (declared at line 328, available: [328-330])
+		Arg: i: int (declared at line 328, available: [328-330])
+		Arg: ~r0: [2]int (declared at line 328, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -515,32 +515,32 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [326:338] injectible: [326-336], [338-338]
-		Arg: a: int (declared at line 326, available: [326-338])
-		Arg: b: int (declared at line 326, available: [326-338])
-		Arg: c: int (declared at line 326, available: [326-338])
-		Arg: d: int (declared at line 326, available: [326-338])
-		Arg: e: int (declared at line 326, available: [326-338])
-		Arg: f: int (declared at line 326, available: [326-338])
-		Arg: g: int (declared at line 326, available: [326-338])
-		Arg: h: int (declared at line 326, available: [326-338])
-		Arg: s: string (declared at line 326, available: [326-338])
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [353:355] injectible: [353-355]
-		Arg: a: [2]int (declared at line 353, available: [353-355])
-		Arg: b: [3]int (declared at line 353, available: [353-355])
-		Arg: ~r0: int (declared at line 353, available: )
-		Arg: ~r1: [2]int (declared at line 353, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-347], [349-349]
+		Arg: a: int (declared at line 337, available: [337-349])
+		Arg: b: int (declared at line 337, available: [337-349])
+		Arg: c: int (declared at line 337, available: [337-349])
+		Arg: d: int (declared at line 337, available: [337-349])
+		Arg: e: int (declared at line 337, available: [337-349])
+		Arg: f: int (declared at line 337, available: [337-349])
+		Arg: g: int (declared at line 337, available: [337-349])
+		Arg: h: int (declared at line 337, available: [337-349])
+		Arg: s: string (declared at line 337, available: [337-349])
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
+		Arg: a: [2]int (declared at line 364, available: [364-366])
+		Arg: b: [3]int (declared at line 364, available: [364-366])
+		Arg: ~r0: int (declared at line 364, available: )
+		Arg: ~r1: [2]int (declared at line 364, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:309] injectible: [297-309]
-		Arg: s1: main.largeStruct (declared at line 297, available: [297-298])
-		Arg: s2: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
+		Arg: s1: main.largeStruct (declared at line 308, available: [308-309])
+		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -658,28 +658,28 @@ Package: main
 			Var: val: string (declared at line 52, available: )
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [163:165] injectible: [163-165]
-		Arg: ~r0: [3]int (declared at line 163, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [171:173] injectible: [171-173]
-		Arg: ~r0: [1]int (declared at line 171, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [179:181] injectible: [179-181]
-		Arg: ~r0: [0]int (declared at line 179, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [202:204] injectible: [202-204]
-		Arg: ~r0: int (declared at line 202, available: )
-		Arg: ~r1: int (declared at line 202, available: )
-		Arg: ~r2: int (declared at line 202, available: )
-		Arg: ~r3: int (declared at line 202, available: )
-		Arg: ~r4: int (declared at line 202, available: )
-		Arg: ~r5: int (declared at line 202, available: )
-		Arg: ~r6: int (declared at line 202, available: )
-		Arg: ~r7: int (declared at line 202, available: )
-		Arg: ~r8: string (declared at line 202, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [259:261] injectible: [259-261]
-		Arg: ~r0: bool (declared at line 259, available: )
-		Arg: ~r1: uintptr (declared at line 259, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [144:146] injectible: [144-146]
-		Arg: ~r0: complex64 (declared at line 144, available: )
-		Arg: ~r1: complex128 (declared at line 144, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [174:176] injectible: [174-176]
+		Arg: ~r0: [3]int (declared at line 174, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [182:184] injectible: [182-184]
+		Arg: ~r0: [1]int (declared at line 182, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [190:192] injectible: [190-192]
+		Arg: ~r0: [0]int (declared at line 190, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [213:215] injectible: [213-215]
+		Arg: ~r0: int (declared at line 213, available: )
+		Arg: ~r1: int (declared at line 213, available: )
+		Arg: ~r2: int (declared at line 213, available: )
+		Arg: ~r3: int (declared at line 213, available: )
+		Arg: ~r4: int (declared at line 213, available: )
+		Arg: ~r5: int (declared at line 213, available: )
+		Arg: ~r6: int (declared at line 213, available: )
+		Arg: ~r7: int (declared at line 213, available: )
+		Arg: ~r8: string (declared at line 213, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:272] injectible: [270-272]
+		Arg: ~r0: bool (declared at line 270, available: )
+		Arg: ~r1: uintptr (declared at line 270, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
+		Arg: ~r0: complex64 (declared at line 155, available: )
+		Arg: ~r1: complex128 (declared at line 155, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -701,54 +701,61 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-79])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [126:138] injectible: [126-126], [136-138]
-		Arg: ~r0: float64 (declared at line 127, available: )
-		Arg: ~r1: float64 (declared at line 127, available: )
-		Arg: ~r2: float64 (declared at line 127, available: )
-		Arg: ~r3: float64 (declared at line 127, available: )
-		Arg: ~r4: float64 (declared at line 127, available: )
-		Arg: ~r5: float64 (declared at line 127, available: )
-		Arg: ~r6: float64 (declared at line 127, available: )
-		Arg: ~r7: float64 (declared at line 128, available: )
-		Arg: ~r8: float64 (declared at line 128, available: )
-		Arg: ~r9: float64 (declared at line 128, available: )
-		Arg: ~r10: float64 (declared at line 128, available: )
-		Arg: ~r11: float64 (declared at line 128, available: )
-		Arg: ~r12: float64 (declared at line 128, available: )
-		Arg: ~r13: float64 (declared at line 128, available: )
-		Arg: ~r14: float64 (declared at line 129, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 132, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 134, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [222:224] injectible: [222-224]
-		Arg: ~r0: int (declared at line 222, available: )
-		Arg: ~r1: float64 (declared at line 222, available: )
-		Arg: ~r2: int (declared at line 222, available: )
-		Arg: ~r3: float64 (declared at line 222, available: )
-		Arg: ~r4: string (declared at line 222, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [192:194] injectible: [192-194]
-		Arg: ~r0: main.mixedStruct (declared at line 192, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [251:253] injectible: [251-253]
-		Arg: ~r0: float32 (declared at line 251, available: )
-		Arg: ~r1: float64 (declared at line 251, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [243:245] injectible: [243-245]
-		Arg: ~r0: float64 (declared at line 243, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:119] injectible: [117-119]
-		Arg: ~r0: int8 (declared at line 117, available: )
-		Arg: ~r1: int16 (declared at line 117, available: )
-		Arg: ~r2: int32 (declared at line 117, available: )
-		Arg: ~r3: int64 (declared at line 117, available: )
-		Arg: ~r4: uint8 (declared at line 117, available: )
-		Arg: ~r5: uint16 (declared at line 117, available: )
-		Arg: ~r6: uint32 (declared at line 117, available: )
-		Arg: ~r7: uint64 (declared at line 117, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [234:236] injectible: [234-236]
-		Arg: ~r0: main.structWithArray (declared at line 234, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [214:216] injectible: [214-216]
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [166:168] injectible: [166-168]
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [137:149] injectible: [137-137], [147-149]
+		Arg: ~r0: float64 (declared at line 138, available: )
+		Arg: ~r1: float64 (declared at line 138, available: )
+		Arg: ~r2: float64 (declared at line 138, available: )
+		Arg: ~r3: float64 (declared at line 138, available: )
+		Arg: ~r4: float64 (declared at line 138, available: )
+		Arg: ~r5: float64 (declared at line 138, available: )
+		Arg: ~r6: float64 (declared at line 138, available: )
+		Arg: ~r7: float64 (declared at line 139, available: )
+		Arg: ~r8: float64 (declared at line 139, available: )
+		Arg: ~r9: float64 (declared at line 139, available: )
+		Arg: ~r10: float64 (declared at line 139, available: )
+		Arg: ~r11: float64 (declared at line 139, available: )
+		Arg: ~r12: float64 (declared at line 139, available: )
+		Arg: ~r13: float64 (declared at line 139, available: )
+		Arg: ~r14: float64 (declared at line 140, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 143, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 145, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [233:235] injectible: [233-235]
+		Arg: ~r0: int (declared at line 233, available: )
+		Arg: ~r1: float64 (declared at line 233, available: )
+		Arg: ~r2: int (declared at line 233, available: )
+		Arg: ~r3: float64 (declared at line 233, available: )
+		Arg: ~r4: string (declared at line 233, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [203:205] injectible: [203-205]
+		Arg: ~r0: main.mixedStruct (declared at line 203, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [262:264] injectible: [262-264]
+		Arg: ~r0: float32 (declared at line 262, available: )
+		Arg: ~r1: float64 (declared at line 262, available: )
+	Function: testReturnsNamedDeferLine (main.testReturnsNamedDeferLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:122] injectible: [117-122]
+		Arg: i: int (declared at line 117, available: [117-122])
+		Arg: a: string (declared at line 117, available: [117-122])
+		Arg: b: string (declared at line 117, available: [117-122])
+	Function: testReturnsNamedDeferLine.func1 (main.testReturnsNamedDeferLine.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [118:118] injectible: [118-118]
+		Var: &a: *string (declared at line 118, available: )
+		Var: &b: *string (declared at line 118, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [254:256] injectible: [254-256]
+		Arg: ~r0: float64 (declared at line 254, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:130] injectible: [128-130]
+		Arg: ~r0: int8 (declared at line 128, available: )
+		Arg: ~r1: int16 (declared at line 128, available: )
+		Arg: ~r2: int32 (declared at line 128, available: )
+		Arg: ~r3: int64 (declared at line 128, available: )
+		Arg: ~r4: uint8 (declared at line 128, available: )
+		Arg: ~r5: uint16 (declared at line 128, available: )
+		Arg: ~r6: uint32 (declared at line 128, available: )
+		Arg: ~r7: uint64 (declared at line 128, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: main.structWithArray (declared at line 245, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -794,11 +801,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [345:347] injectible: [345-347]
-		Arg: arg: [5]int (declared at line 345, available: [345-347])
-		Arg: ~r0: int (declared at line 345, available: )
-		Arg: ~r1: int (declared at line 345, available: )
-		Arg: ~r2: int (declared at line 345, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [356:358] injectible: [356-358]
+		Arg: arg: [5]int (declared at line 356, available: [356-358])
+		Arg: ~r0: int (declared at line 356, available: )
+		Arg: ~r1: int (declared at line 356, available: )
+		Arg: ~r2: int (declared at line 356, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -833,11 +840,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [361:368] injectible: [361-363], [365-366], [368-368]
-		Arg: arg: main.structWithArray (declared at line 361, available: [361-368])
-		Arg: ~r0: int (declared at line 361, available: )
-		Arg: ~r1: main.structWithArray (declared at line 361, available: )
-		Var: x: int (declared at line 363, available: [361-368])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
+		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
+		Arg: ~r0: int (declared at line 372, available: )
+		Arg: ~r1: main.structWithArray (declared at line 372, available: )
+		Var: x: int (declared at line 374, available: [372-379])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -898,11 +905,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:377] injectible: [374-377]
-		Arg: a: [0]int (declared at line 374, available: )
-		Arg: b: int (declared at line 374, available: [374-377])
-		Arg: ~r0: int (declared at line 374, available: )
-		Arg: ~r1: [0]int (declared at line 374, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
+		Arg: a: [0]int (declared at line 385, available: )
+		Arg: b: int (declared at line 385, available: [385-388])
+		Arg: ~r0: int (declared at line 385, available: )
+		Arg: ~r1: [0]int (declared at line 385, available: )
 	Function: useCrossPackageGenerics (main.useCrossPackageGenerics) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [358:368] injectible: [358-363], [365-365], [367-368]
 		Var: set: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[string] (declared at line 359, available: [360-368])
 		Scope: 360-365

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -126,10 +126,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [380:437] injectible: [380-387], [389-393], [395-397], [399-402], [405-419], [425-427], [431-437]
-		Var: &v: *main.firstBehavior (declared at line 389, available: [380-437])
-		Var: &fortyTwo: *int (declared at line 392, available: [393-393])
-		Var: .autotmp_8: [0]int (declared at line 436, available: [380-437])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [391:449] injectible: [391-398], [400-404], [406-408], [410-414], [417-431], [437-439], [443-449]
+		Var: &v: *main.firstBehavior (declared at line 400, available: [391-449])
+		Var: &fortyTwo: *int (declared at line 403, available: [404-404])
+		Var: .autotmp_8: [0]int (declared at line 448, available: [391-449])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [76:105] injectible: [76-79], [81-88], [90-94], [96-96], [98-100], [103-105]
 		Var: originalSlice: []int (declared at line 77, available: )
 		Var: s: []uint (declared at line 86, available: )
@@ -271,9 +271,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
-	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [286:291] injectible: [286-291]
-		Arg: arg: [3]int (declared at line 286, available: [286-291])
-		Arg: ~r0: [3]int (declared at line 286, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:302] injectible: [297-302]
+		Arg: arg: [3]int (declared at line 297, available: [297-302])
+		Arg: ~r0: [3]int (declared at line 297, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -452,10 +452,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
-	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:280] injectible: [270-280]
-		Arg: arg: main.largeStruct (declared at line 270, available: [270-270])
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
-		Arg: ~r0: main.largeStruct (declared at line 270, available: )
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [281:291] injectible: [281-291]
+		Arg: arg: main.largeStruct (declared at line 281, available: [281-281])
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
+		Arg: ~r0: main.largeStruct (declared at line 281, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [223:243] injectible: [223-223], [230-230], [233-234], [236-239], [241-243]
@@ -464,17 +464,17 @@ Package: main
 		Var: b: int (declared at line 229, available: [223-243])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
-	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [317:319] injectible: [317-319]
-		Arg: a: int (declared at line 317, available: [317-319])
-		Arg: b: int (declared at line 317, available: [317-319])
-		Arg: c: int (declared at line 317, available: [317-319])
-		Arg: d: int (declared at line 317, available: [317-319])
-		Arg: e: int (declared at line 317, available: [317-319])
-		Arg: f: int (declared at line 317, available: [317-319])
-		Arg: g: int (declared at line 317, available: [317-319])
-		Arg: h: int (declared at line 317, available: [317-319])
-		Arg: i: int (declared at line 317, available: [317-319])
-		Arg: ~r0: [2]int (declared at line 317, available: )
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [328:330] injectible: [328-330]
+		Arg: a: int (declared at line 328, available: [328-330])
+		Arg: b: int (declared at line 328, available: [328-330])
+		Arg: c: int (declared at line 328, available: [328-330])
+		Arg: d: int (declared at line 328, available: [328-330])
+		Arg: e: int (declared at line 328, available: [328-330])
+		Arg: f: int (declared at line 328, available: [328-330])
+		Arg: g: int (declared at line 328, available: [328-330])
+		Arg: h: int (declared at line 328, available: [328-330])
+		Arg: i: int (declared at line 328, available: [328-330])
+		Arg: ~r0: [2]int (declared at line 328, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -515,32 +515,32 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [326:338] injectible: [326-336], [338-338]
-		Arg: a: int (declared at line 326, available: [326-338])
-		Arg: b: int (declared at line 326, available: [326-338])
-		Arg: c: int (declared at line 326, available: [326-338])
-		Arg: d: int (declared at line 326, available: [326-338])
-		Arg: e: int (declared at line 326, available: [326-338])
-		Arg: f: int (declared at line 326, available: [326-338])
-		Arg: g: int (declared at line 326, available: [326-338])
-		Arg: h: int (declared at line 326, available: [326-338])
-		Arg: s: string (declared at line 326, available: [326-338])
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-		Arg: ~r0: main.largeStruct (declared at line 326, available: )
-	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [353:355] injectible: [353-355]
-		Arg: a: [2]int (declared at line 353, available: [353-355])
-		Arg: b: [3]int (declared at line 353, available: [353-355])
-		Arg: ~r0: int (declared at line 353, available: )
-		Arg: ~r1: [2]int (declared at line 353, available: )
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [337:349] injectible: [337-347], [349-349]
+		Arg: a: int (declared at line 337, available: [337-349])
+		Arg: b: int (declared at line 337, available: [337-349])
+		Arg: c: int (declared at line 337, available: [337-349])
+		Arg: d: int (declared at line 337, available: [337-349])
+		Arg: e: int (declared at line 337, available: [337-349])
+		Arg: f: int (declared at line 337, available: [337-349])
+		Arg: g: int (declared at line 337, available: [337-349])
+		Arg: h: int (declared at line 337, available: [337-349])
+		Arg: s: string (declared at line 337, available: [337-349])
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+		Arg: ~r0: main.largeStruct (declared at line 337, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [364:366] injectible: [364-366]
+		Arg: a: [2]int (declared at line 364, available: [364-366])
+		Arg: b: [3]int (declared at line 364, available: [364-366])
+		Arg: ~r0: int (declared at line 364, available: )
+		Arg: ~r1: [2]int (declared at line 364, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [297:309] injectible: [297-309]
-		Arg: s1: main.largeStruct (declared at line 297, available: [297-297])
-		Arg: s2: main.largeStruct (declared at line 297, available: [297-309])
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
-		Arg: ~r0: main.largeStruct (declared at line 297, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [308:320] injectible: [308-320]
+		Arg: s1: main.largeStruct (declared at line 308, available: [308-308])
+		Arg: s2: main.largeStruct (declared at line 308, available: [308-320])
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
+		Arg: ~r0: main.largeStruct (declared at line 308, available: )
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
 		Arg: i: int (declared at line 95, available: [95-98])
 		Arg: result: int (declared at line 95, available: )
@@ -658,28 +658,28 @@ Package: main
 			Var: val: string (declared at line 52, available: )
 		Scope: 55-55
 			Var: val: interface {} (declared at line 54, available: [44-51])
-	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [163:165] injectible: [163-165]
-		Arg: ~r0: [3]int (declared at line 163, available: )
-	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [171:173] injectible: [171-173]
-		Arg: ~r0: [1]int (declared at line 171, available: )
-	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [179:181] injectible: [179-181]
-		Arg: ~r0: [0]int (declared at line 179, available: )
-	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [202:204] injectible: [202-204]
-		Arg: ~r0: int (declared at line 202, available: )
-		Arg: ~r1: int (declared at line 202, available: )
-		Arg: ~r2: int (declared at line 202, available: )
-		Arg: ~r3: int (declared at line 202, available: )
-		Arg: ~r4: int (declared at line 202, available: )
-		Arg: ~r5: int (declared at line 202, available: )
-		Arg: ~r6: int (declared at line 202, available: )
-		Arg: ~r7: int (declared at line 202, available: )
-		Arg: ~r8: string (declared at line 202, available: )
-	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [259:261] injectible: [259-261]
-		Arg: ~r0: bool (declared at line 259, available: )
-		Arg: ~r1: uintptr (declared at line 259, available: )
-	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [144:146] injectible: [144-146]
-		Arg: ~r0: complex64 (declared at line 144, available: )
-		Arg: ~r1: complex128 (declared at line 144, available: )
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [174:176] injectible: [174-176]
+		Arg: ~r0: [3]int (declared at line 174, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [182:184] injectible: [182-184]
+		Arg: ~r0: [1]int (declared at line 182, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [190:192] injectible: [190-192]
+		Arg: ~r0: [0]int (declared at line 190, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [213:215] injectible: [213-215]
+		Arg: ~r0: int (declared at line 213, available: )
+		Arg: ~r1: int (declared at line 213, available: )
+		Arg: ~r2: int (declared at line 213, available: )
+		Arg: ~r3: int (declared at line 213, available: )
+		Arg: ~r4: int (declared at line 213, available: )
+		Arg: ~r5: int (declared at line 213, available: )
+		Arg: ~r6: int (declared at line 213, available: )
+		Arg: ~r7: int (declared at line 213, available: )
+		Arg: ~r8: string (declared at line 213, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [270:272] injectible: [270-272]
+		Arg: ~r0: bool (declared at line 270, available: )
+		Arg: ~r1: uintptr (declared at line 270, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
+		Arg: ~r0: complex64 (declared at line 155, available: )
+		Arg: ~r1: complex128 (declared at line 155, available: )
 	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
 		Arg: failed: bool (declared at line 36, available: [36-37])
 		Arg: ~r0: error (declared at line 36, available: )
@@ -701,54 +701,61 @@ Package: main
 		Arg: v: interface {} (declared at line 77, available: [77-79])
 		Arg: ~r0: main.behavior (declared at line 77, available: )
 		Var: b: main.behavior (declared at line 78, available: [78-84])
-	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [155:157] injectible: [155-157]
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-		Arg: ~r0: main.largeStruct (declared at line 155, available: )
-	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [126:138] injectible: [126-126], [136-138]
-		Arg: ~r0: float64 (declared at line 127, available: )
-		Arg: ~r1: float64 (declared at line 127, available: )
-		Arg: ~r2: float64 (declared at line 127, available: )
-		Arg: ~r3: float64 (declared at line 127, available: )
-		Arg: ~r4: float64 (declared at line 127, available: )
-		Arg: ~r5: float64 (declared at line 127, available: )
-		Arg: ~r6: float64 (declared at line 127, available: )
-		Arg: ~r7: float64 (declared at line 128, available: )
-		Arg: ~r8: float64 (declared at line 128, available: )
-		Arg: ~r9: float64 (declared at line 128, available: )
-		Arg: ~r10: float64 (declared at line 128, available: )
-		Arg: ~r11: float64 (declared at line 128, available: )
-		Arg: ~r12: float64 (declared at line 128, available: )
-		Arg: ~r13: float64 (declared at line 128, available: )
-		Arg: ~r14: float64 (declared at line 129, available: )
-		Arg: onlyOnAmd64_16: float64 (declared at line 132, available: )
-		Arg: bothArmAndAmd64: float64 (declared at line 134, available: )
-	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [222:224] injectible: [222-224]
-		Arg: ~r0: int (declared at line 222, available: )
-		Arg: ~r1: float64 (declared at line 222, available: )
-		Arg: ~r2: int (declared at line 222, available: )
-		Arg: ~r3: float64 (declared at line 222, available: )
-		Arg: ~r4: string (declared at line 222, available: )
-	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [192:194] injectible: [192-194]
-		Arg: ~r0: main.mixedStruct (declared at line 192, available: )
-	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [251:253] injectible: [251-253]
-		Arg: ~r0: float32 (declared at line 251, available: )
-		Arg: ~r1: float64 (declared at line 251, available: )
-	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [243:245] injectible: [243-245]
-		Arg: ~r0: float64 (declared at line 243, available: )
-	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:119] injectible: [117-119]
-		Arg: ~r0: int8 (declared at line 117, available: )
-		Arg: ~r1: int16 (declared at line 117, available: )
-		Arg: ~r2: int32 (declared at line 117, available: )
-		Arg: ~r3: int64 (declared at line 117, available: )
-		Arg: ~r4: uint8 (declared at line 117, available: )
-		Arg: ~r5: uint16 (declared at line 117, available: )
-		Arg: ~r6: uint32 (declared at line 117, available: )
-		Arg: ~r7: uint64 (declared at line 117, available: )
-	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [234:236] injectible: [234-236]
-		Arg: ~r0: main.structWithArray (declared at line 234, available: )
-	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [214:216] injectible: [214-216]
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
-		Arg: ~r0: main.wideStruct (declared at line 214, available: )
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [166:168] injectible: [166-168]
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+		Arg: ~r0: main.largeStruct (declared at line 166, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [137:149] injectible: [137-137], [147-149]
+		Arg: ~r0: float64 (declared at line 138, available: )
+		Arg: ~r1: float64 (declared at line 138, available: )
+		Arg: ~r2: float64 (declared at line 138, available: )
+		Arg: ~r3: float64 (declared at line 138, available: )
+		Arg: ~r4: float64 (declared at line 138, available: )
+		Arg: ~r5: float64 (declared at line 138, available: )
+		Arg: ~r6: float64 (declared at line 138, available: )
+		Arg: ~r7: float64 (declared at line 139, available: )
+		Arg: ~r8: float64 (declared at line 139, available: )
+		Arg: ~r9: float64 (declared at line 139, available: )
+		Arg: ~r10: float64 (declared at line 139, available: )
+		Arg: ~r11: float64 (declared at line 139, available: )
+		Arg: ~r12: float64 (declared at line 139, available: )
+		Arg: ~r13: float64 (declared at line 139, available: )
+		Arg: ~r14: float64 (declared at line 140, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 143, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 145, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [233:235] injectible: [233-235]
+		Arg: ~r0: int (declared at line 233, available: )
+		Arg: ~r1: float64 (declared at line 233, available: )
+		Arg: ~r2: int (declared at line 233, available: )
+		Arg: ~r3: float64 (declared at line 233, available: )
+		Arg: ~r4: string (declared at line 233, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [203:205] injectible: [203-205]
+		Arg: ~r0: main.mixedStruct (declared at line 203, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [262:264] injectible: [262-264]
+		Arg: ~r0: float32 (declared at line 262, available: )
+		Arg: ~r1: float64 (declared at line 262, available: )
+	Function: testReturnsNamedDeferLine (main.testReturnsNamedDeferLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [117:122] injectible: [117-122]
+		Arg: i: int (declared at line 117, available: [117-122])
+		Arg: a: string (declared at line 117, available: [117-122])
+		Arg: b: string (declared at line 117, available: [117-122])
+	Function: testReturnsNamedDeferLine.func1 (main.testReturnsNamedDeferLine.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [118:118] injectible: [118-118]
+		Var: &a: *string (declared at line 118, available: )
+		Var: &b: *string (declared at line 118, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [254:256] injectible: [254-256]
+		Arg: ~r0: float64 (declared at line 254, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [128:130] injectible: [128-130]
+		Arg: ~r0: int8 (declared at line 128, available: )
+		Arg: ~r1: int16 (declared at line 128, available: )
+		Arg: ~r2: int32 (declared at line 128, available: )
+		Arg: ~r3: int64 (declared at line 128, available: )
+		Arg: ~r4: uint8 (declared at line 128, available: )
+		Arg: ~r5: uint16 (declared at line 128, available: )
+		Arg: ~r6: uint32 (declared at line 128, available: )
+		Arg: ~r7: uint64 (declared at line 128, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: main.structWithArray (declared at line 245, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [225:227] injectible: [225-227]
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
+		Arg: ~r0: main.wideStruct (declared at line 225, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -794,11 +801,11 @@ Package: main
 		Arg: ~r0: int (declared at line 103, available: )
 		Arg: result2: int (declared at line 103, available: )
 		Arg: ~r2: int (declared at line 103, available: )
-	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [345:347] injectible: [345-347]
-		Arg: arg: [5]int (declared at line 345, available: [345-347])
-		Arg: ~r0: int (declared at line 345, available: )
-		Arg: ~r1: int (declared at line 345, available: )
-		Arg: ~r2: int (declared at line 345, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [356:358] injectible: [356-358]
+		Arg: arg: [5]int (declared at line 356, available: [356-358])
+		Arg: ~r0: int (declared at line 356, available: )
+		Arg: ~r1: int (declared at line 356, available: )
+		Arg: ~r2: int (declared at line 356, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -833,11 +840,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
-	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [361:368] injectible: [361-363], [365-366], [368-368]
-		Arg: arg: main.structWithArray (declared at line 361, available: [361-368])
-		Arg: ~r0: int (declared at line 361, available: )
-		Arg: ~r1: main.structWithArray (declared at line 361, available: )
-		Var: x: int (declared at line 363, available: [361-368])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [372:379] injectible: [372-374], [376-377], [379-379]
+		Arg: arg: main.structWithArray (declared at line 372, available: [372-379])
+		Arg: ~r0: int (declared at line 372, available: )
+		Arg: ~r1: main.structWithArray (declared at line 372, available: )
+		Var: x: int (declared at line 374, available: [372-379])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -898,11 +905,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
-	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:377] injectible: [374-377]
-		Arg: a: [0]int (declared at line 374, available: )
-		Arg: b: int (declared at line 374, available: [374-377])
-		Arg: ~r0: int (declared at line 374, available: )
-		Arg: ~r1: [0]int (declared at line 374, available: )
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [385:388] injectible: [385-388]
+		Arg: a: [0]int (declared at line 385, available: )
+		Arg: b: int (declared at line 385, available: [385-388])
+		Arg: ~r0: int (declared at line 385, available: )
+		Arg: ~r1: [0]int (declared at line 385, available: )
 	Function: useCrossPackageGenerics (main.useCrossPackageGenerics) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [358:368] injectible: [358-363], [365-365], [367-368]
 		Var: set: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.ImmutableSet[string] (declared at line 359, available: [360-368])
 		Scope: 360-365

--- a/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testArrayArgAndReturn",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 291
+            "lineNumber": 302
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 426
+            "lineNumber": 438
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testConflictingReturn.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 402
+            "lineNumber": 413
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testErrorAtLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testErrorAtLine.json
@@ -53,10 +53,6 @@
           "lines": {
             "108": {
               "locals": {
-                "@return": {
-                  "type": "int",
-                  "notCapturedReason": "unavailable"
-                },
                 "x": {
                   "type": "int",
                   "notCapturedReason": "unavailable"

--- a/pkg/dyninst/testdata/decoded/sample/testErrorAtLine_config_arch=amd64,toolchain=go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testErrorAtLine_config_arch=amd64,toolchain=go1.26rc1.json
@@ -53,10 +53,6 @@
           "lines": {
             "108": {
               "locals": {
-                "@return": {
-                  "type": "int",
-                  "notCapturedReason": "unavailable"
-                },
                 "x": {
                   "type": "int",
                   "notCapturedReason": "unavailable"

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
@@ -78,10 +78,6 @@
                       "value": "5"
                     }
                   ]
-                },
-                "@return": {
-                  "type": "int",
-                  "notCapturedReason": "unavailable"
                 }
               }
             }

--- a/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testGenericFuncContainsLine.json
@@ -56,10 +56,6 @@
                 "needle": {
                   "type": "go.shape.string",
                   "value": "b"
-                },
-                "@return": {
-                  "type": "bool",
-                  "notCapturedReason": "unavailable"
                 }
               }
             }
@@ -147,10 +143,6 @@
                 "needle": {
                   "type": "int",
                   "value": "2"
-                },
-                "@return": {
-                  "type": "bool",
-                  "notCapturedReason": "unavailable"
                 }
               }
             }
@@ -238,10 +230,6 @@
                 "needle": {
                   "type": "main.namedInt",
                   "value": "2"
-                },
-                "@return": {
-                  "type": "bool",
-                  "notCapturedReason": "unavailable"
                 }
               }
             }
@@ -329,10 +317,6 @@
                 "needle": {
                   "type": "main.score",
                   "value": "20"
-                },
-                "@return": {
-                  "type": "bool",
-                  "notCapturedReason": "unavailable"
                 }
               }
             }
@@ -416,10 +400,6 @@
                 "needle": {
                   "type": "main.celsius",
                   "value": "100"
-                },
-                "@return": {
-                  "type": "bool",
-                  "notCapturedReason": "unavailable"
                 }
               }
             }

--- a/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testLargeArgAndReturn",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 280
+            "lineNumber": 291
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 425
+            "lineNumber": 437
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testManyArgsArrayReturn",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 319
+            "lineNumber": 330
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 431
+            "lineNumber": 443
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testMixedArgsStackReturn",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 328
+            "lineNumber": 339
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 432
+            "lineNumber": 444
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testMultipleArrayArgs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 355
+            "lineNumber": 366
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 434
+            "lineNumber": 446
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testMultipleLargeArgs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 299
+            "lineNumber": 310
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 427
+            "lineNumber": 439
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 400
+            "lineNumber": 411
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 399
+            "lineNumber": 410
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameCaptureExpr.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 399
+            "lineNumber": 410
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameMultiCaptureExpr.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 400
+            "lineNumber": 411
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnByNameTemplate.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 400
+            "lineNumber": 411
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturnWithTemplate.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 399
+            "lineNumber": 410
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCaptureExpr.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 381
+            "lineNumber": 392
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondMultiFloat.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 383
+            "lineNumber": 394
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondSingle.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 381
+            "lineNumber": 392
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnCondUnavailableFloat.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 383
+            "lineNumber": 394
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiCaptureExpr.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 401
+            "lineNumber": 412
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnMultiTemplate.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 401
+            "lineNumber": 412
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnTemplate.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 381
+            "lineNumber": 392
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 390
+            "lineNumber": 401
           },
           {
             "function": "main.main",
@@ -97,7 +97,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 391
+            "lineNumber": 402
           },
           {
             "function": "main.main",
@@ -181,7 +181,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 404
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 386
+            "lineNumber": 397
           },
           {
             "function": "main.main",
@@ -125,7 +125,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 387
+            "lineNumber": 398
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 165
+            "lineNumber": 176
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 409
+            "lineNumber": 421
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsArrayOne",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 173
+            "lineNumber": 184
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 410
+            "lineNumber": 422
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsArrayZero",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 181
+            "lineNumber": 192
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 411
+            "lineNumber": 423
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsBacktrackInt",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 204
+            "lineNumber": 215
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 413
+            "lineNumber": 425
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsBoolAndUintptr",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 261
+            "lineNumber": 272
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 419
+            "lineNumber": 431
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsComplex",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 146
+            "lineNumber": 157
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 407
+            "lineNumber": 419
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 384
+            "lineNumber": 395
           },
           {
             "function": "main.main",
@@ -108,7 +108,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 385
+            "lineNumber": 396
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 381
+            "lineNumber": 392
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 383
+            "lineNumber": 394
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 382
+            "lineNumber": 393
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 395
+            "lineNumber": 406
           },
           {
             "function": "main.main",
@@ -102,7 +102,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 396
+            "lineNumber": 407
           },
           {
             "function": "main.main",
@@ -196,7 +196,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 397
+            "lineNumber": 408
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsLargeStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 157
+            "lineNumber": 168
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 408
+            "lineNumber": 420
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsManyFloats",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 138
+            "lineNumber": 149
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 406
+            "lineNumber": 418
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsMixed",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 224
+            "lineNumber": 235
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 415
+            "lineNumber": 427
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsMixedStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 194
+            "lineNumber": 205
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 412
+            "lineNumber": 424
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsMultipleFloats",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 253
+            "lineNumber": 264
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 418
+            "lineNumber": 430
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsNamedDeferLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsNamedDeferLine.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testSomeNamedReturn",
+      "method": "main.testReturnsNamedDeferLine",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testSomeNamedReturn",
+            "function": "main.testReturnsNamedDeferLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 105
+            "lineNumber": 121
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 412
+            "lineNumber": 414
           },
           {
             "function": "main.main",
@@ -42,36 +42,28 @@
           }
         ],
         "probe": {
-          "id": "testReturnCondMulti",
+          "id": "testReturnsNamedDeferLine",
           "location": {
-            "method": "main.testSomeNamedReturn"
+            "method": "main.testReturnsNamedDeferLine",
+            "file": "returns.go",
+            "line": 121
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "42"
-              }
-            }
-          },
-          "return": {
-            "locals": {
-              "@return": {
-                "fields": {
-                  "r0": {
-                    "type": "int",
-                    "value": "420"
-                  },
-                  "result2": {
-                    "type": "int",
-                    "value": "840"
-                  },
-                  "r2": {
-                    "type": "int",
-                    "value": "1260"
-                  }
+          "lines": {
+            "121": {
+              "locals": {
+                "i": {
+                  "type": "int",
+                  "value": "43"
+                },
+                "a": {
+                  "type": "string",
+                  "value": "a43"
+                },
+                "b": {
+                  "type": "string",
+                  "value": "b43"
                 }
               }
             }
@@ -81,8 +73,7 @@
       "type": "snapshot"
     },
     "timestamp": "[ts]",
-    "duration": "[duration]",
-    "message": "r0=420",
+    "message": "43",
     "process_tags": "entrypoint.name:sample,svc.user:sample"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsOnlyFloat",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 245
+            "lineNumber": 256
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 417
+            "lineNumber": 429
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsPrimitives",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 119
+            "lineNumber": 130
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 405
+            "lineNumber": 417
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsStructWithArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 236
+            "lineNumber": 247
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 416
+            "lineNumber": 428
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsWideStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 216
+            "lineNumber": 227
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 414
+            "lineNumber": 426
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSegmentsForParamsAndReturnsOutOfOrder.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 400
+            "lineNumber": 411
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 401
+            "lineNumber": 412
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStackArgRegReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 347
+            "lineNumber": 358
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 433
+            "lineNumber": 445
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStructWithArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 368
+            "lineNumber": 379
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 435
+            "lineNumber": 447
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithNonexistantVariableName.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 400
+            "lineNumber": 411
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedExpression.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 400
+            "lineNumber": 411
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTemplateWithUnsupportedVariable.json
@@ -23,7 +23,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 400
+            "lineNumber": 411
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testWhollyInlinedSubroutine.json
@@ -112,7 +112,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 396
+            "lineNumber": 407
           },
           {
             "function": "main.main",
@@ -188,7 +188,7 @@
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 397
+            "lineNumber": 408
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testZeroSizeArgAndReturn",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 377
+            "lineNumber": 388
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 436
+            "lineNumber": 448
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testprogs/progs/sample/returns.go
+++ b/pkg/dyninst/testprogs/progs/sample/returns.go
@@ -111,6 +111,17 @@ func testConflictingReturn(i int) (_ int, r0 string) {
 	return i * 10, fmt.Sprintf("s%d", i)
 }
 
+// The defer keeps both named returns live on the stack for the line probe.
+//
+//go:noinline
+func testReturnsNamedDeferLine(i int) (a string, b string) {
+	defer func() { a, b = a+"!", b+"!" }()
+	a = fmt.Sprintf("a%d", i)
+	b = fmt.Sprintf("b%d", i)
+	fmt.Println("testReturnsNamedDeferLine", a, b)
+	return
+}
+
 // Primitive types - exercise all basic types.
 //
 //go:noinline
@@ -400,6 +411,7 @@ func executeReturns() {
 	testMultipleNamedReturn(41)
 	testSomeNamedReturn(42)
 	testConflictingReturn(42)
+	testReturnsNamedDeferLine(43)
 
 	// New ABI test cases - return values only.
 	testReturnsPrimitives()

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -1872,6 +1872,20 @@ probes:
           ref: "i"
         dsl: "i"
     captureSnapshot: true
+  # Tests multiple named returns in scope at a line probe.
+  - id: testReturnsNamedDeferLine
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsNamedDeferLine
+      sourceFile: returns.go
+      lines:
+        - "121"
+    template: "{i}"
+    segments:
+      - json:
+          ref: "i"
+        dsl: "i"
+    captureSnapshot: true
   - id: testReturnTemplate
     type: LOG_PROBE
     where:


### PR DESCRIPTION
### What does this PR do?

Fixes a bug introduced by #49144 where a line probe placed inside a function with multiple return-role variables that are live at the probe PC produces duplicate `"@return"` keys under `locals`, causing the decoder to reject the probe with `DecodeFailed: duplicate object member name "@return"`.

The underlying issue in `pkg/dyninst/irgen/irgen.go`: the snapshot-emission branch unconditionally gave every `VariableRoleReturn` variable the display name `"@return"` whenever `returnDisplayNames` was nil, and `returnDisplayNames` was only populated for probes with a Return event. So for a line probe with N live return-role vars, all N collided on the same key.

The fix adopts a stricter semantic model rather than extending the `@return` wrapper into line probes: `@return` is a return-point concept that only has meaning at a Return event. At line probes:

- Unnamed return slots (`~r0`, `~r1`, ...) are filtered out entirely. They
  carry no user-facing value before the function returns; exposing them as
  `@return` / `@return.r0` would either be a lie or a placeholder. This is
  also what drops the misleading `"@return": {"notCapturedReason":
  "unavailable"}` entry from existing line-probe snapshots like
  `testErrorAtLine`.
- Named returns (`result`, `v`, ...) are treated as plain locals under
  their original DWARF name. From the user's perspective at that line they
  are just pre-declared local variables; calling them `@return.v` would
  falsely suggest the function had returned. The name the user wrote in
  source is the name they see in the snapshot.

Return-event behavior is unchanged: single returns still emit as bare
`"@return"`, multi-returns still emit as `"@return": {"fields": {...}}`.

### Motivation

Reported by a customer: logpoint at `writer.go:258` was rejected with
`duplicate object member name "@return" within /debugger/snapshot/captures/lines/258/locals`. The target function has multiple named returns modified by a `defer`, which forces the compiler to stack-allocate them with DWARF live ranges covering the probe line, so the line probe ends up capturing all of them.

### Describe how you validated your changes

- Added `testReturnsNamedDeferLine` to the `sample` testprog
- Added a matching line probe in `sample.yaml` at `returns.go:126`. Under
  the new model its snapshot shows `a` and `b` as locals alongside `i`,
  not as `@return.{fields: {a, b}}`.

### Additional Notes

https://datadoghq.atlassian.net/browse/DEBUG-5482