### PR TITLE
[AGENTRUN-1237] [AIX] Add /usr/sbin to PATH and preserve parent PATH in service wrappers

### DIFF
--- a/packaging/aix/package-scripts/postinst
+++ b/packaging/aix/package-scripts/postinst
@@ -39,7 +39,7 @@ LIBPATH_VAL=${LIBPATH_VAL}:/opt/freeware/lib64:/opt/freeware/lib
 
 printf '#!/bin/sh\n'                                                          > "$WRAPPER"
 printf 'export LIBPATH=%s\n' "$LIBPATH_VAL"                                  >> "$WRAPPER"
-printf 'export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/bin:/bin\n' >> "$WRAPPER"
+printf 'export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:${PATH}\n' >> "$WRAPPER"
 printf 'exec /opt/datadog-agent/bin/agent "$@"\n'                            >> "$WRAPPER"
 chmod 755 "$WRAPPER"
 
@@ -47,7 +47,7 @@ chmod 755 "$WRAPPER"
 TRACE_WRAPPER=/opt/datadog-agent/bin/trace-agent-svc
 printf '#!/bin/sh\n'                                                              > "$TRACE_WRAPPER"
 printf 'export LIBPATH=%s\n' "$LIBPATH_VAL"                                      >> "$TRACE_WRAPPER"
-printf 'export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/bin:/bin\n' >> "$TRACE_WRAPPER"
+printf 'export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:${PATH}\n' >> "$TRACE_WRAPPER"
 printf 'exec /opt/datadog-agent/bin/trace-agent run --config /etc/datadog-agent/datadog.yaml\n' >> "$TRACE_WRAPPER"
 chmod 755 "$TRACE_WRAPPER"
 


### PR DESCRIPTION
### What does this PR do?

The SRC service wrappers (`agent-svc`, `trace-agent-svc`) generated by the postinst script previously replaced `PATH` entirely with a hardcoded list that excluded `/usr/sbin`. This caused the agent to fail when calling AIX system utilities such as `/usr/sbin/bootinfo`, which the agent uses to retrieve kernel architecture and host UUID information.

Two changes:
- Add `/usr/sbin` explicitly, so system utilities like `bootinfo` are found.
- Preserve `${PATH}` at the end of the exported value, so any additional paths set in the environment before `startsrc` is called remain accessible.

### Motivation

Without this fix, the agent logs repeated errors like:
```
failed to retrieve host info: getting kernel architecture: exec: "bootinfo": executable file not found in $PATH
```
and the `Host Info` section of `agent status` is empty.

### Describe how you validated your changes

Tested on AIX 7.3 TL2. Before the fix the errors appeared on every startup; after the fix `/usr/sbin/bootinfo` is found by the agent process.

### Additional Notes

Note: `/usr/sbin/bootinfo` also requires group `bin` membership to execute (permissions `-r-xr-x---`). The `dd-agent` user is not in that group, so even with the PATH fix the call still fails with permission denied. A separate fix (replacing the `bootinfo` call with `getconf`, which is world-executable) will be addressed in a follow-up.