### PR TITLE
fleet(installer): env-only config + unified DD_INSTALLER_REGISTRY JSON

### DIFF
--- a/cmd/installer/command/command.go
+++ b/cmd/installer/command/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/installer/command/fxconfig"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/commands"
 )
@@ -96,9 +97,28 @@ Datadog Installer installs datadog-packages based on your commands.`,
 	// the value is true.
 	var noColorFlag bool
 	agentCmd.PersistentFlags().BoolVarP(&noColorFlag, "no-color", "n", false, "disable color output")
-	agentCmd.PersistentPreRun = func(*cobra.Command, []string) {
+	agentCmd.PersistentPreRun = func(cmd *cobra.Command, _ []string) {
 		if globalParams.NoColor {
 			color.NoColor = true
+		}
+		// Translate datadog.yaml into DD_* env vars before any
+		// subcommand reaches the installer logic. The installer binary
+		// never reads yaml; the daemon path already owns this
+		// translation, and this call plays the same role for
+		// interactive CLI invocations.
+		//
+		// Skip when:
+		//   - invoked as `daemon ...` (the daemon opens its own fx app
+		//     and would clash with an outer one);
+		//   - called from the daemon as a subprocess
+		//     (DD_INSTALLER_FROM_DAEMON=true — the daemon has already
+		//     emitted every relevant DD_* env var via Env.ToEnv(), so
+		//     re-reading yaml here is redundant work).
+		if os.Getenv("DD_INSTALLER_FROM_DAEMON") == "true" {
+			return
+		}
+		if cmd == nil || cmd.Parent() == nil || cmd.Parent().Name() != "daemon" {
+			fxconfig.LoadAndExportEnv(globalParams.ConfFilePath)
 		}
 	}
 

--- a/cmd/installer/command/command.go
+++ b/cmd/installer/command/command.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/DataDog/datadog-agent/cmd/installer/command/fxconfig"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/commands"
 )
@@ -97,28 +96,9 @@ Datadog Installer installs datadog-packages based on your commands.`,
 	// the value is true.
 	var noColorFlag bool
 	agentCmd.PersistentFlags().BoolVarP(&noColorFlag, "no-color", "n", false, "disable color output")
-	agentCmd.PersistentPreRun = func(cmd *cobra.Command, _ []string) {
-		if globalParams.NoColor {
+	agentCmd.PersistentPreRun = func(*cobra.Command, []string) {
+		if noColorFlag {
 			color.NoColor = true
-		}
-		// Translate datadog.yaml into DD_* env vars before any
-		// subcommand reaches the installer logic. The installer binary
-		// never reads yaml; the daemon path already owns this
-		// translation, and this call plays the same role for
-		// interactive CLI invocations.
-		//
-		// Skip when:
-		//   - invoked as `daemon ...` (the daemon opens its own fx app
-		//     and would clash with an outer one);
-		//   - called from the daemon as a subprocess
-		//     (DD_INSTALLER_FROM_DAEMON=true — the daemon has already
-		//     emitted every relevant DD_* env var via Env.ToEnv(), so
-		//     re-reading yaml here is redundant work).
-		if os.Getenv("DD_INSTALLER_FROM_DAEMON") == "true" {
-			return
-		}
-		if cmd == nil || cmd.Parent() == nil || cmd.Parent().Name() != "daemon" {
-			fxconfig.LoadAndExportEnv(globalParams.ConfFilePath)
 		}
 	}
 

--- a/cmd/installer/command/fxconfig/bootstrap.go
+++ b/cmd/installer/command/fxconfig/bootstrap.go
@@ -69,6 +69,27 @@ func LoadAndExportEnv(confFilePath string) {
 	if err != nil {
 		pkglog.Warnf("fxconfig bootstrap failed (continuing with process env): %v", err)
 	}
+	// Env-only fallback: always translate any remaining legacy
+	// DD_INSTALLER_REGISTRY_{URL,AUTH,USERNAME,PASSWORD}[_<PKG>] vars
+	// into the canonical DD_INSTALLER_REGISTRY JSON. When fx succeeded
+	// this is a no-op (applyConfigToEnv already absorbed and unset them);
+	// when fx failed before invoking applyConfigToEnv this is the safety
+	// net so user-set overrides aren't silently dropped.
+	applyEnvOnlyRegistry()
+}
+
+// applyEnvOnlyRegistry absorbs legacy DD_INSTALLER_REGISTRY_* prefix vars
+// into DD_INSTALLER_REGISTRY (without yaml) and unsets the legacy vars.
+func applyEnvOnlyRegistry() {
+	registry, blob, err := env.BuildRegistryFromEnv()
+	if err != nil {
+		pkglog.Debugf("fxconfig: env-only registry fallback failed: %v", err)
+		return
+	}
+	if !registry.IsEmpty() {
+		setEnvIfUnset(env.EnvInstallerRegistry, blob)
+	}
+	unsetLegacyRegistryVars()
 }
 
 func applyConfigToEnv(cfg agentconfig.Component) {
@@ -84,12 +105,23 @@ func applyConfigToEnv(cfg agentconfig.Component) {
 
 	setEnvIfUnset("DD_PROXY_HTTP", cfg.GetString("proxy.http"))
 	setEnvIfUnset("DD_PROXY_HTTPS", cfg.GetString("proxy.https"))
-	if np := cfg.GetStringSlice("proxy.no_proxy"); len(np) > 0 {
-		setEnvIfUnset("DD_PROXY_NO_PROXY", strings.Join(np, ","))
+	// Only emit DD_PROXY_NO_PROXY when the user explicitly set
+	// proxy.no_proxy in yaml. GetStringSlice always returns the effective
+	// value including cloud-metadata defaults (169.254.169.254 etc.),
+	// which would leak into downstream datadog.yaml writes.
+	if cfg.IsConfigured("proxy.no_proxy") {
+		if np := cfg.GetStringSlice("proxy.no_proxy"); len(np) > 0 {
+			setEnvIfUnset("DD_PROXY_NO_PROXY", strings.Join(np, ","))
+		}
 	}
 
-	if tags := utils.GetConfiguredTags(cfg, false); len(tags) > 0 {
-		setEnvIfUnset("DD_TAGS", strings.Join(tags, ","))
+	// Only emit DD_TAGS when explicitly configured. Default config can
+	// pull in host tags from cloud metadata which would then overwrite
+	// the user's explicit "no tags" choice in datadog.yaml.
+	if cfg.IsConfigured("tags") || cfg.IsConfigured("extra_tags") {
+		if tags := utils.GetConfiguredTags(cfg, false); len(tags) > 0 {
+			setEnvIfUnset("DD_TAGS", strings.Join(tags, ","))
+		}
 	}
 
 	// Registry: fold yaml `installer.registry.*` (incl. per-extension

--- a/cmd/installer/command/fxconfig/bootstrap.go
+++ b/cmd/installer/command/fxconfig/bootstrap.go
@@ -46,10 +46,18 @@ import (
 // confFilePath is the path to the directory containing datadog.yaml (the
 // installer CLI's --cfgpath flag). Empty means "use the fx default".
 //
+// No-op when DD_INSTALLER_FROM_DAEMON=true: the daemon already emitted
+// every relevant DD_* env var from its own config.Component via
+// Env.ToEnv() when spawning this subprocess, so re-reading yaml here
+// would be redundant work.
+//
 // This is a best-effort bootstrap: any failure (missing file, parse error,
 // permission denied) is logged and swallowed so the installer CLI can
 // still proceed using the inherited process environment.
 func LoadAndExportEnv(confFilePath string) {
+	if os.Getenv("DD_INSTALLER_FROM_DAEMON") == "true" {
+		return
+	}
 	err := fxutil.OneShot(
 		applyConfigToEnv,
 		fx.Supply(core.BundleParams{

--- a/cmd/installer/command/fxconfig/bootstrap.go
+++ b/cmd/installer/command/fxconfig/bootstrap.go
@@ -30,11 +30,52 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	agentconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	logdef "github.com/DataDog/datadog-agent/comp/core/log/def"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+// yamlSourcedKeys returns the set of dotted keys (e.g. "proxy.no_proxy")
+// that appear in the datadog.yaml file. Unlike `cfg.GetSource(key) ==
+// SourceFile`, this correctly identifies yaml-origin values even when
+// post-init processing has replaced their source (e.g. proxy.* gets
+// promoted to config-post-init after defaults are layered in, which
+// would falsely hide user intent).
+//
+// We use AllSettingsBySource()[SourceFile] — that map only contains keys
+// that were literally present in the yaml file, so it's a reliable
+// signal of user intent regardless of downstream transformations.
+func yamlSourcedKeys(cfg agentconfig.Component) map[string]bool {
+	out := map[string]bool{}
+	all := cfg.AllSettingsBySource()
+	fromFile, ok := all[pkgconfigmodel.SourceFile].(map[string]interface{})
+	if !ok {
+		return out
+	}
+	flattenKeys("", fromFile, out)
+	return out
+}
+
+// flattenKeys walks a nested `map[string]interface{}` and records every
+// leaf path under `prefix` into `out`. A leaf is any non-map value.
+func flattenKeys(prefix string, m map[string]interface{}, out map[string]bool) {
+	for k, v := range m {
+		path := k
+		if prefix != "" {
+			path = prefix + "." + k
+		}
+		if child, isMap := v.(map[string]interface{}); isMap {
+			// Record the parent too — some callers care about the
+			// presence of a subtree (e.g. `installer.registry.extensions`).
+			out[path] = true
+			flattenKeys(path, child, out)
+			continue
+		}
+		out[path] = true
+	}
+}
 
 // LoadAndExportEnv reads installer-relevant fields from datadog.yaml via fx
 // and exports them as DD_* environment variables. Existing env vars are
@@ -58,6 +99,13 @@ func LoadAndExportEnv(confFilePath string) {
 	if os.Getenv("DD_INSTALLER_FROM_DAEMON") == "true" {
 		return
 	}
+	// Always translate legacy DD_INSTALLER_REGISTRY_* prefix vars into
+	// the canonical DD_INSTALLER_REGISTRY JSON. This runs independently of
+	// fx so user-set overrides reach the installer even if the fx bootstrap
+	// fails for any reason (broken yaml, missing dep, secrets provider
+	// error, etc.).
+	applyEnvOnlyRegistry()
+
 	err := fxutil.OneShot(
 		applyConfigToEnv,
 		fx.Supply(core.BundleParams{
@@ -69,17 +117,12 @@ func LoadAndExportEnv(confFilePath string) {
 	if err != nil {
 		pkglog.Warnf("fxconfig bootstrap failed (continuing with process env): %v", err)
 	}
-	// Env-only fallback: always translate any remaining legacy
-	// DD_INSTALLER_REGISTRY_{URL,AUTH,USERNAME,PASSWORD}[_<PKG>] vars
-	// into the canonical DD_INSTALLER_REGISTRY JSON. When fx succeeded
-	// this is a no-op (applyConfigToEnv already absorbed and unset them);
-	// when fx failed before invoking applyConfigToEnv this is the safety
-	// net so user-set overrides aren't silently dropped.
-	applyEnvOnlyRegistry()
 }
 
 // applyEnvOnlyRegistry absorbs legacy DD_INSTALLER_REGISTRY_* prefix vars
 // into DD_INSTALLER_REGISTRY (without yaml) and unsets the legacy vars.
+// Safe to call multiple times: setEnvIfUnset preserves the first-written
+// value, and the second call finds no legacy vars left to absorb.
 func applyEnvOnlyRegistry() {
 	registry, blob, err := env.BuildRegistryFromEnv()
 	if err != nil {
@@ -93,47 +136,56 @@ func applyEnvOnlyRegistry() {
 }
 
 func applyConfigToEnv(cfg agentconfig.Component) {
-	setEnvIfUnset("DD_API_KEY", utils.SanitizeAPIKey(cfg.GetString("api_key")))
-	setEnvIfUnset("DD_SITE", cfg.GetString("site"))
-	setEnvIfUnset("DD_HOSTNAME", cfg.GetString("hostname"))
-	setEnvIfUnset("DD_INSTALLER_MIRROR", cfg.GetString("installer.mirror"))
-	setEnvIfUnset("DD_LOG_LEVEL", cfg.GetString("log_level"))
-
-	if cfg.IsConfigured("remote_updates") {
+	// Only emit env vars for values that actually came from datadog.yaml.
+	// See yamlSourcedKeys for why we can't use cfg.GetSource(key) directly.
+	fromYAML := yamlSourcedKeys(cfg)
+	if fromYAML["api_key"] {
+		setEnvIfUnset("DD_API_KEY", utils.SanitizeAPIKey(cfg.GetString("api_key")))
+	}
+	if fromYAML["site"] {
+		setEnvIfUnset("DD_SITE", cfg.GetString("site"))
+	}
+	if fromYAML["hostname"] {
+		setEnvIfUnset("DD_HOSTNAME", cfg.GetString("hostname"))
+	}
+	if fromYAML["installer.mirror"] {
+		setEnvIfUnset("DD_INSTALLER_MIRROR", cfg.GetString("installer.mirror"))
+	}
+	if fromYAML["log_level"] {
+		setEnvIfUnset("DD_LOG_LEVEL", cfg.GetString("log_level"))
+	}
+	if fromYAML["remote_updates"] {
 		setEnvIfUnset("DD_REMOTE_UPDATES", strconv.FormatBool(cfg.GetBool("remote_updates")))
 	}
-
-	setEnvIfUnset("DD_PROXY_HTTP", cfg.GetString("proxy.http"))
-	setEnvIfUnset("DD_PROXY_HTTPS", cfg.GetString("proxy.https"))
-	// Only emit DD_PROXY_NO_PROXY when the user explicitly set
-	// proxy.no_proxy in yaml. GetStringSlice always returns the effective
-	// value including cloud-metadata defaults (169.254.169.254 etc.),
-	// which would leak into downstream datadog.yaml writes.
-	if cfg.IsConfigured("proxy.no_proxy") {
+	if fromYAML["proxy.http"] {
+		setEnvIfUnset("DD_PROXY_HTTP", cfg.GetString("proxy.http"))
+	}
+	if fromYAML["proxy.https"] {
+		setEnvIfUnset("DD_PROXY_HTTPS", cfg.GetString("proxy.https"))
+	}
+	if fromYAML["proxy.no_proxy"] {
 		if np := cfg.GetStringSlice("proxy.no_proxy"); len(np) > 0 {
 			setEnvIfUnset("DD_PROXY_NO_PROXY", strings.Join(np, ","))
 		}
 	}
-
-	// Only emit DD_TAGS when explicitly configured. Default config can
-	// pull in host tags from cloud metadata which would then overwrite
-	// the user's explicit "no tags" choice in datadog.yaml.
-	if cfg.IsConfigured("tags") || cfg.IsConfigured("extra_tags") {
+	if fromYAML["tags"] || fromYAML["extra_tags"] {
 		if tags := utils.GetConfiguredTags(cfg, false); len(tags) > 0 {
 			setEnvIfUnset("DD_TAGS", strings.Join(tags, ","))
 		}
 	}
 
 	// Registry: fold yaml `installer.registry.*` (incl. per-extension
-	// entries) + legacy DD_INSTALLER_REGISTRY_* prefix vars + any
-	// already-set DD_INSTALLER_REGISTRY JSON into a single canonical
-	// JSON blob. Unset the legacy prefix vars so the installer's FromEnv
-	// sees a clean contract.
+	// entries) + already-set DD_INSTALLER_REGISTRY JSON (which includes
+	// legacy prefix vars absorbed by the earlier applyEnvOnlyRegistry).
+	// Unconditional Setenv so yaml extensions added here don't get lost
+	// because the earlier env-only pass already set the env var.
 	registry, blob, err := env.BuildRegistryFromConfigAndEnv(cfg)
 	if err != nil {
 		pkglog.Debugf("fxconfig: failed to build registry config (continuing): %v", err)
 	} else if !registry.IsEmpty() {
-		setEnvIfUnset(env.EnvInstallerRegistry, blob)
+		if err := os.Setenv(env.EnvInstallerRegistry, blob); err != nil {
+			pkglog.Debugf("fxconfig: failed to set %s: %v", env.EnvInstallerRegistry, err)
+		}
 	}
 	unsetLegacyRegistryVars()
 }

--- a/cmd/installer/command/fxconfig/bootstrap.go
+++ b/cmd/installer/command/fxconfig/bootstrap.go
@@ -1,0 +1,130 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package fxconfig is the installer CLI's bridge between `datadog.yaml` and
+// the env-var-only `pkg/fleet/installer/env` package.
+//
+// The installer binary never reads `datadog.yaml`. The daemon (which already
+// owns an fx config.Component) translates yaml into env vars when spawning
+// the installer subprocess. For interactive CLI invocations
+// (`sudo datadog-installer <cmd>`), this package plays the same role: it
+// spins a minimal fx app in `PersistentPreRun`, reads every
+// installer-relevant yaml field via the same `config.Component` the daemon
+// uses, merges in any legacy DD_INSTALLER_REGISTRY_* prefix vars the user
+// set, and exports a canonical set of `DD_*` env vars via `os.Setenv`
+// (skipping anything already set in the process environment so explicit
+// `DD_*` / CLI flags win). Legacy registry prefix vars are `Unsetenv`d
+// after translation so the installer's `FromEnv` sees a single contract
+// (`DD_INSTALLER_REGISTRY` JSON only).
+package fxconfig
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	agentconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	logdef "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// LoadAndExportEnv reads installer-relevant fields from datadog.yaml via fx
+// and exports them as DD_* environment variables. Existing env vars are
+// preserved so explicit values override the yaml. Legacy
+// DD_INSTALLER_REGISTRY_{URL,AUTH,USERNAME,PASSWORD}[_<PKG>] vars are
+// absorbed into a unified DD_INSTALLER_REGISTRY JSON blob (and then
+// unset), so the installer binary sees a single registry contract.
+//
+// confFilePath is the path to the directory containing datadog.yaml (the
+// installer CLI's --cfgpath flag). Empty means "use the fx default".
+//
+// This is a best-effort bootstrap: any failure (missing file, parse error,
+// permission denied) is logged and swallowed so the installer CLI can
+// still proceed using the inherited process environment.
+func LoadAndExportEnv(confFilePath string) {
+	err := fxutil.OneShot(
+		applyConfigToEnv,
+		fx.Supply(core.BundleParams{
+			ConfigParams: agentconfig.NewAgentParams(confFilePath, agentconfig.WithIgnoreErrors(true)),
+			LogParams:    logdef.ForOneShot("INSTALLER", "off", false),
+		}),
+		core.Bundle(core.WithSecrets()),
+	)
+	if err != nil {
+		pkglog.Warnf("fxconfig bootstrap failed (continuing with process env): %v", err)
+	}
+}
+
+func applyConfigToEnv(cfg agentconfig.Component) {
+	setEnvIfUnset("DD_API_KEY", utils.SanitizeAPIKey(cfg.GetString("api_key")))
+	setEnvIfUnset("DD_SITE", cfg.GetString("site"))
+	setEnvIfUnset("DD_HOSTNAME", cfg.GetString("hostname"))
+	setEnvIfUnset("DD_INSTALLER_MIRROR", cfg.GetString("installer.mirror"))
+	setEnvIfUnset("DD_LOG_LEVEL", cfg.GetString("log_level"))
+
+	if cfg.IsConfigured("remote_updates") {
+		setEnvIfUnset("DD_REMOTE_UPDATES", strconv.FormatBool(cfg.GetBool("remote_updates")))
+	}
+
+	setEnvIfUnset("DD_PROXY_HTTP", cfg.GetString("proxy.http"))
+	setEnvIfUnset("DD_PROXY_HTTPS", cfg.GetString("proxy.https"))
+	if np := cfg.GetStringSlice("proxy.no_proxy"); len(np) > 0 {
+		setEnvIfUnset("DD_PROXY_NO_PROXY", strings.Join(np, ","))
+	}
+
+	if tags := utils.GetConfiguredTags(cfg, false); len(tags) > 0 {
+		setEnvIfUnset("DD_TAGS", strings.Join(tags, ","))
+	}
+
+	// Registry: fold yaml `installer.registry.*` (incl. per-extension
+	// entries) + legacy DD_INSTALLER_REGISTRY_* prefix vars + any
+	// already-set DD_INSTALLER_REGISTRY JSON into a single canonical
+	// JSON blob. Unset the legacy prefix vars so the installer's FromEnv
+	// sees a clean contract.
+	registry, blob, err := env.BuildRegistryFromConfigAndEnv(cfg)
+	if err != nil {
+		pkglog.Debugf("fxconfig: failed to build registry config (continuing): %v", err)
+	} else if !registry.IsEmpty() {
+		setEnvIfUnset(env.EnvInstallerRegistry, blob)
+	}
+	unsetLegacyRegistryVars()
+}
+
+// unsetLegacyRegistryVars removes DD_INSTALLER_REGISTRY_{URL,AUTH,USERNAME,
+// PASSWORD}[_<PKG>] from the process environment after they've been
+// absorbed into DD_INSTALLER_REGISTRY.
+func unsetLegacyRegistryVars() {
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		key := kv[:eq]
+		for _, prefix := range env.LegacyRegistryEnvPrefixes {
+			if key == prefix || strings.HasPrefix(key, prefix+"_") {
+				_ = os.Unsetenv(key)
+				break
+			}
+		}
+	}
+}
+
+func setEnvIfUnset(key, value string) {
+	if value == "" {
+		return
+	}
+	if _, alreadySet := os.LookupEnv(key); alreadySet {
+		return
+	}
+	if err := os.Setenv(key, value); err != nil {
+		pkglog.Debugf("fxconfig: failed to set %s: %v", key, err)
+	}
+}

--- a/cmd/installer/command/fxconfig/bootstrap.go
+++ b/cmd/installer/command/fxconfig/bootstrap.go
@@ -117,6 +117,21 @@ func LoadAndExportEnv(confFilePath string) {
 	if err != nil {
 		pkglog.Warnf("fxconfig bootstrap failed (continuing with process env): %v", err)
 	}
+
+	// Reset the global logger to a no-op after fx OneShot. The fx log
+	// component leaves the global logger pointing at a partially torn-down
+	// inner once the app shuts down, which makes subsequent pkglog.Errorf
+	// (and any internal log.Errorf inside the installer) fall back to
+	// stderr via the `fallbackStderr && isInnerNil` path.
+	//
+	// Why we care: the installer's e2e harness invokes commands over SSH
+	// with `session.CombinedOutput`, so any stray stderr write merges into
+	// the stdout JSON of `installer status --json` and breaks parsing
+	// ("invalid character 'e' looking for beginning of value"). The actual
+	// installer subcommands set up their own stdout/file logger as needed
+	// (see commands.setupStdoutLogger) — until they do, we want pkglog
+	// calls to be silent rather than leaking to stderr.
+	pkglog.SetupLogger(pkglog.Disabled(), "off")
 }
 
 // applyEnvOnlyRegistry absorbs legacy DD_INSTALLER_REGISTRY_* prefix vars

--- a/cmd/installer/command/fxconfig/bootstrap_test.go
+++ b/cmd/installer/command/fxconfig/bootstrap_test.go
@@ -16,7 +16,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
+
+// TestLoadAndExportEnvFxDependencies validates that the fxutil.OneShot call
+// in LoadAndExportEnv has every required dependency wired up. This pairs
+// with the production call at cmd/installer/command/fxconfig/bootstrap.go
+// and is enforced by the CI fxutil-coverage check.
+func TestLoadAndExportEnvFxDependencies(t *testing.T) {
+	fxutil.TestOneShot(t, func() {
+		LoadAndExportEnv("")
+	})
+}
 
 func clearDDEnvForTest(t *testing.T, extra ...string) {
 	t.Helper()

--- a/cmd/installer/command/fxconfig/bootstrap_test.go
+++ b/cmd/installer/command/fxconfig/bootstrap_test.go
@@ -1,0 +1,204 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package fxconfig
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
+)
+
+func clearDDEnvForTest(t *testing.T, extra ...string) {
+	t.Helper()
+	targets := map[string]bool{
+		"DD_API_KEY":             true,
+		"DD_SITE":                true,
+		"DD_HOSTNAME":            true,
+		"DD_INSTALLER_MIRROR":    true,
+		"DD_LOG_LEVEL":           true,
+		"DD_REMOTE_UPDATES":      true,
+		"DD_TAGS":                true,
+		"DD_PROXY_HTTP":          true,
+		"DD_PROXY_HTTPS":         true,
+		"DD_PROXY_NO_PROXY":      true,
+		env.EnvInstallerRegistry: true,
+	}
+	for _, e := range extra {
+		targets[e] = true
+	}
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		key := kv[:eq]
+		if targets[key] || strings.HasPrefix(key, "DD_INSTALLER_REGISTRY_") {
+			t.Setenv(key, "")
+			os.Unsetenv(key)
+		}
+	}
+}
+
+func writeYAML(t *testing.T, dir, content string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "datadog.yaml"), []byte(content), 0o644))
+	return dir
+}
+
+func TestLoadAndExportEnvYAMLOnly(t *testing.T) {
+	clearDDEnvForTest(t)
+	dir := t.TempDir()
+	writeYAML(t, dir, `
+api_key: yaml-api-key
+site: datadoghq.eu
+hostname: myhost
+installer:
+  mirror: https://mirror.example.com
+  registry:
+    url: yaml.registry.com
+    auth: gcr
+    extensions:
+      datadog-agent:
+        ddot:
+          url: ext.registry.com
+          auth: password
+          username: eu
+          password: ep
+tags:
+  - env:prod
+  - team:fleet
+proxy:
+  http: http://proxy:8080
+  https: http://proxy:8443
+  no_proxy:
+    - localhost
+    - .internal
+remote_updates: true
+`)
+
+	LoadAndExportEnv(dir)
+
+	assert.Equal(t, "yaml-api-key", os.Getenv("DD_API_KEY"))
+	assert.Equal(t, "datadoghq.eu", os.Getenv("DD_SITE"))
+	assert.Equal(t, "myhost", os.Getenv("DD_HOSTNAME"))
+	assert.Equal(t, "https://mirror.example.com", os.Getenv("DD_INSTALLER_MIRROR"))
+	assert.Equal(t, "true", os.Getenv("DD_REMOTE_UPDATES"))
+	assert.Equal(t, "http://proxy:8080", os.Getenv("DD_PROXY_HTTP"))
+	assert.Equal(t, "http://proxy:8443", os.Getenv("DD_PROXY_HTTPS"))
+	// no_proxy values from yaml are joined with agent-added defaults
+	// (cloud metadata IPs), so just verify our entries are present.
+	assert.Contains(t, os.Getenv("DD_PROXY_NO_PROXY"), "localhost")
+	assert.Contains(t, os.Getenv("DD_PROXY_NO_PROXY"), ".internal")
+	assert.Contains(t, os.Getenv("DD_TAGS"), "env:prod")
+	assert.Contains(t, os.Getenv("DD_TAGS"), "team:fleet")
+
+	// Registry: single DD_INSTALLER_REGISTRY JSON blob.
+	blob := os.Getenv(env.EnvInstallerRegistry)
+	require.NotEmpty(t, blob)
+	var r env.RegistryConfig
+	require.NoError(t, json.Unmarshal([]byte(blob), &r))
+	assert.Equal(t, "yaml.registry.com", r.Default.URL)
+	assert.Equal(t, "gcr", r.Default.Auth)
+	require.Contains(t, r.Packages, "datadog-agent")
+	require.Contains(t, r.Packages["datadog-agent"].Extensions, "ddot")
+	ext := r.Packages["datadog-agent"].Extensions["ddot"]
+	assert.Equal(t, "ext.registry.com", ext.URL)
+	assert.Equal(t, "password", ext.Auth)
+	assert.Equal(t, "eu", ext.Username)
+	assert.Equal(t, "ep", ext.Password)
+}
+
+func TestLoadAndExportEnvLegacyPerPackageVarAbsorbed(t *testing.T) {
+	clearDDEnvForTest(t)
+	dir := t.TempDir()
+	writeYAML(t, dir, "api_key: yaml-key\n")
+	t.Setenv("DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE", "mirror.io/agent")
+	t.Setenv("DD_INSTALLER_REGISTRY_AUTH_AGENT_PACKAGE", "password")
+
+	LoadAndExportEnv(dir)
+
+	// Legacy per-package vars are removed after absorption.
+	assert.Equal(t, "", os.Getenv("DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE"))
+	assert.Equal(t, "", os.Getenv("DD_INSTALLER_REGISTRY_AUTH_AGENT_PACKAGE"))
+
+	blob := os.Getenv(env.EnvInstallerRegistry)
+	require.NotEmpty(t, blob)
+	var r env.RegistryConfig
+	require.NoError(t, json.Unmarshal([]byte(blob), &r))
+	require.Contains(t, r.Packages, "datadog-agent")
+	assert.Equal(t, "mirror.io/agent", r.Packages["datadog-agent"].URL)
+	assert.Equal(t, "password", r.Packages["datadog-agent"].Auth)
+}
+
+func TestLoadAndExportEnvUserSetJSONWinsOverYAML(t *testing.T) {
+	clearDDEnvForTest(t)
+	dir := t.TempDir()
+	writeYAML(t, dir, `
+installer:
+  registry:
+    url: yaml.registry.com
+`)
+	// User sets DD_INSTALLER_REGISTRY directly → it wins.
+	t.Setenv(env.EnvInstallerRegistry, `{"default":{"url":"canonical.io"}}`)
+
+	LoadAndExportEnv(dir)
+
+	blob := os.Getenv(env.EnvInstallerRegistry)
+	require.NotEmpty(t, blob)
+	var r env.RegistryConfig
+	require.NoError(t, json.Unmarshal([]byte(blob), &r))
+	assert.Equal(t, "canonical.io", r.Default.URL)
+}
+
+func TestLoadAndExportEnvDoesNotOverwriteUserScalarEnvVars(t *testing.T) {
+	clearDDEnvForTest(t)
+	dir := t.TempDir()
+	writeYAML(t, dir, `
+api_key: yaml-key
+site: datadoghq.eu
+`)
+
+	t.Setenv("DD_API_KEY", "user-env-key")
+	t.Setenv("DD_SITE", "datadoghq.com")
+
+	LoadAndExportEnv(dir)
+
+	assert.Equal(t, "user-env-key", os.Getenv("DD_API_KEY"))
+	assert.Equal(t, "datadoghq.com", os.Getenv("DD_SITE"))
+}
+
+func TestLoadAndExportEnvSkipsWhenFromDaemon(t *testing.T) {
+	clearDDEnvForTest(t)
+	dir := t.TempDir()
+	writeYAML(t, dir, `
+api_key: yaml-key
+installer:
+  registry:
+    url: yaml.registry.com
+`)
+
+	t.Setenv("DD_INSTALLER_FROM_DAEMON", "true")
+
+	LoadAndExportEnv(dir)
+
+	// Nothing from yaml should have been exported.
+	assert.Equal(t, "", os.Getenv("DD_API_KEY"))
+	assert.Equal(t, "", os.Getenv(env.EnvInstallerRegistry))
+}
+
+func TestLoadAndExportEnvMissingYAMLIsBestEffort(t *testing.T) {
+	clearDDEnvForTest(t)
+	dir := t.TempDir()
+	assert.NotPanics(t, func() { LoadAndExportEnv(dir) })
+	assert.Equal(t, "", os.Getenv(env.EnvInstallerRegistry))
+}

--- a/cmd/installer/command/fxconfig/bootstrap_test.go
+++ b/cmd/installer/command/fxconfig/bootstrap_test.go
@@ -7,6 +7,7 @@ package fxconfig
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // TestLoadAndExportEnvFxDependencies validates that the fxutil.OneShot call
@@ -212,4 +214,45 @@ func TestLoadAndExportEnvMissingYAMLIsBestEffort(t *testing.T) {
 	dir := t.TempDir()
 	assert.NotPanics(t, func() { LoadAndExportEnv(dir) })
 	assert.Equal(t, "", os.Getenv(env.EnvInstallerRegistry))
+}
+
+// TestLoadAndExportEnvLeavesPkglogSilent guards a real e2e regression:
+// after LoadAndExportEnv runs, fx app shutdown leaves the global
+// pkg/util/log logger with a partially torn-down inner. Subsequent
+// pkglog.Errorf calls then fall back to stderr via the
+// `fallbackStderr && isInnerNil` path. The installer's e2e harness
+// captures SSH output with `session.CombinedOutput`, so any stray stderr
+// write merges into the stdout of `installer status --json` and breaks
+// JSON parsing ("invalid character 'e' looking for beginning of value").
+//
+// LoadAndExportEnv re-installs a Disabled logger as a defensive cleanup;
+// this test asserts that contract by writing an Error after the bootstrap
+// and verifying nothing reaches the real stderr.
+func TestLoadAndExportEnvLeavesPkglogSilent(t *testing.T) {
+	clearDDEnvForTest(t)
+	dir := t.TempDir()
+	writeYAML(t, dir, "api_key: yaml-key\n")
+
+	// Capture the process stderr around the bootstrap + an Errorf so we
+	// observe what an e2e SSH `CombinedOutput` reader would see.
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	captured := make(chan string, 1)
+	go func() {
+		buf, _ := io.ReadAll(r)
+		captured <- string(buf)
+	}()
+
+	LoadAndExportEnv(dir)
+	_ = pkglog.Errorf("post-bootstrap error must not leak to stderr")
+
+	require.NoError(t, w.Close())
+	os.Stderr = origStderr
+	stderr := <-captured
+
+	assert.NotContains(t, stderr, "post-bootstrap error must not leak to stderr",
+		"LoadAndExportEnv must reinstall a no-op logger so post-bootstrap pkglog.Errorf doesn't fall back to stderr — see test doc for the e2e regression this guards against")
 }

--- a/cmd/installer/subcommands/subcommands.go
+++ b/cmd/installer/subcommands/subcommands.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/installer/command"
+	"github.com/DataDog/datadog-agent/cmd/installer/command/fxconfig"
 	"github.com/DataDog/datadog-agent/cmd/installer/subcommands/daemon"
 	"github.com/DataDog/datadog-agent/cmd/installer/user"
 	installer "github.com/DataDog/datadog-agent/pkg/fleet/installer/commands"
@@ -27,6 +28,17 @@ func installerUnprivilegedCommands(_ *command.GlobalParams) []*cobra.Command {
 
 func withRoot(factory command.SubcommandFactory) command.SubcommandFactory {
 	return withPersistentPreRunE(factory, func(global *command.GlobalParams) error {
+		// Translate datadog.yaml → DD_* env vars before any installer
+		// command reads env. The installer binary never reads yaml; for
+		// daemon-spawned subprocesses, the daemon already emitted every
+		// relevant DD_* via Env.ToEnv() and sets DD_INSTALLER_FROM_DAEMON
+		// so LoadAndExportEnv no-ops there.
+		//
+		// This must live here (not on the root command's PersistentPreRun)
+		// because cobra runs only the closest PersistentPreRun* found
+		// walking up — withPersistentPreRunE installs one on each child,
+		// which would otherwise shadow the root's bootstrap.
+		fxconfig.LoadAndExportEnv(global.ConfFilePath)
 		if !user.IsRoot() && global.AllowNoRoot {
 			return nil
 		}

--- a/cmd/installer/subcommands/subcommands_test.go
+++ b/cmd/installer/subcommands/subcommands_test.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package subcommands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/installer/command"
+)
+
+// TestWithRootRunsFxconfigBootstrap is a regression test for a Cobra
+// gotcha: when a child command sets PersistentPreRunE, the root's
+// PersistentPreRun is silently skipped (cobra.EnableTraverseRunHooks is
+// false by default). Earlier the fxconfig bootstrap was wired on the
+// root only — so installer subcommands ran without translating
+// datadog.yaml into DD_* env vars, and DDOT post-install hooks read
+// empty api_key/site, generating broken otel-config.yaml. This test
+// asserts the bootstrap fires for a command produced by withRoot.
+func TestWithRootRunsFxconfigBootstrap(t *testing.T) {
+	prev, set := os.LookupEnv("DD_API_KEY")
+	t.Cleanup(func() {
+		if set {
+			os.Setenv("DD_API_KEY", prev)
+		} else {
+			os.Unsetenv("DD_API_KEY")
+		}
+	})
+	os.Unsetenv("DD_API_KEY")
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "datadog.yaml"),
+		[]byte("api_key: from-yaml\n"), 0o644,
+	))
+
+	// Stub leaf command — withRoot will install a PersistentPreRunE on it.
+	stub := &cobra.Command{
+		Use:  "stub",
+		RunE: func(*cobra.Command, []string) error { return nil },
+	}
+
+	factory := func(_ *command.GlobalParams) []*cobra.Command {
+		return []*cobra.Command{stub}
+	}
+	wrapped := withRoot(factory)
+
+	global := &command.GlobalParams{
+		ConfFilePath: dir,
+		AllowNoRoot:  true, // skip the root-required check in test
+	}
+	cmds := wrapped(global)
+	require.Len(t, cmds, 1)
+	require.NotNil(t, cmds[0].PersistentPreRunE,
+		"withRoot must install PersistentPreRunE on each child")
+
+	// Invoking the wrapped PreRunE should run fxconfig.LoadAndExportEnv
+	// (via the closure), which translates yaml api_key → DD_API_KEY.
+	require.NoError(t, cmds[0].PersistentPreRunE(cmds[0], nil))
+	assert.Equal(t, "from-yaml", os.Getenv("DD_API_KEY"),
+		"fxconfig bootstrap must run inside withRoot — see test doc for the cobra gotcha it guards against")
+}

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -136,23 +136,28 @@ func NewDaemon(hostname string, rcFetcher client.ConfigFetcher, config agentconf
 	if configID == "" {
 		configID = "empty"
 	}
+	// Registry (incl. per-package + per-extension overrides from
+	// installer.registry.* in datadog.yaml) is marshaled into a single
+	// DD_INSTALLER_REGISTRY env var by ToEnv() when spawning subprocess
+	// installer commands.
+	registry, _, err := env.BuildRegistryFromConfigAndEnv(config)
+	if err != nil {
+		return nil, fmt.Errorf("could not build installer registry config: %w", err)
+	}
 	env := &env.Env{
-		APIKey:               utils.SanitizeAPIKey(config.GetString("api_key")),
-		Site:                 config.GetString("site"),
-		RemoteUpdates:        config.GetBool("remote_updates"),
-		Mirror:               config.GetString("installer.mirror"),
-		RegistryOverride:     config.GetString("installer.registry.url"),
-		RegistryAuthOverride: config.GetString("installer.registry.auth"),
-		RegistryUsername:     config.GetString("installer.registry.username"),
-		RegistryPassword:     config.GetString("installer.registry.password"),
-		Tags:                 utils.GetConfiguredTags(config, false),
-		Hostname:             hostname,
-		HTTPProxy:            config.GetString("proxy.http"),
-		HTTPSProxy:           config.GetString("proxy.https"),
-		NoProxy:              strings.Join(config.GetStringSlice("proxy.no_proxy"), ","),
-		IsCentos6:            env.DetectCentos6(),
-		IsFromDaemon:         true,
-		ConfigID:             configID,
+		APIKey:        utils.SanitizeAPIKey(config.GetString("api_key")),
+		Site:          config.GetString("site"),
+		RemoteUpdates: config.GetBool("remote_updates"),
+		Mirror:        config.GetString("installer.mirror"),
+		Registry:      registry,
+		Tags:          utils.GetConfiguredTags(config, false),
+		Hostname:      hostname,
+		HTTPProxy:     config.GetString("proxy.http"),
+		HTTPSProxy:    config.GetString("proxy.https"),
+		NoProxy:       strings.Join(config.GetStringSlice("proxy.no_proxy"), ","),
+		IsCentos6:     env.DetectCentos6(),
+		IsFromDaemon:  true,
+		ConfigID:      configID,
 	}
 	installer := newInstaller(installerBin)
 	refreshInterval := config.GetDuration("installer.refresh_interval")

--- a/pkg/fleet/installer/commands/BUILD.bazel
+++ b/pkg/fleet/installer/commands/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/fleet/installer/exec",
         "//pkg/fleet/installer/packages",
         "//pkg/fleet/installer/packages/ssi",
-        "//pkg/fleet/installer/paths",
         "//pkg/fleet/installer/repository",
         "//pkg/fleet/installer/setup",
         "//pkg/fleet/installer/telemetry",
@@ -34,7 +33,6 @@ go_library(
         "//pkg/version",
         "@com_github_fatih_color//:color",
         "@com_github_spf13_cobra//:cobra",
-        "@in_yaml_go_yaml_v2//:yaml",
     ],
 )
 
@@ -50,9 +48,13 @@ go_test(
     deps = [
         "//pkg/fleet/installer/env",
         "//pkg/fleet/installer/exec",
-        "//pkg/fleet/installer/paths",
         "//pkg/fleet/installer/repository",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//assert",
-    ],
+    ] + select({
+        "@rules_go//go/platform:windows": [
+            "//pkg/fleet/installer/paths",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -14,19 +14,16 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
-	"go.yaml.in/yaml/v2"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/config"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages"
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
@@ -43,9 +40,6 @@ const (
 	// For example, `setup` is run by humans and its output should be human readable.
 	AnnotationHumanReadableErrors = "human-readable-errors"
 )
-
-// agentConfigDir is the directory containing datadog.yaml. Overridable in tests.
-var agentConfigDir = paths.AgentConfigDir
 
 type cmdOption func(*cmdConfig)
 type cmdConfig struct{ quiet bool }
@@ -83,7 +77,6 @@ func newCmd(operation string, opts ...cmdOption) *cmd {
 		o(cfg)
 	}
 	env := env.FromEnv()
-	applyDatadogYAMLRegistryConfig(env)
 	if !env.IsFromDaemon && !cfg.quiet {
 		setupStdoutLogger(env)
 	}
@@ -160,82 +153,8 @@ func (i *installerCmd) stop(err error) {
 	}
 }
 
-type telemetryConfigFields struct {
-	APIKey string `yaml:"api_key"`
-	Site   string `yaml:"site"`
-}
-
-type installerRegistryYAMLConfig struct {
-	Installer struct {
-		Registry struct {
-			URL      string `yaml:"url"`
-			Auth     string `yaml:"auth"`
-			Username string `yaml:"username"`
-			Password string `yaml:"password"`
-		} `yaml:"registry"`
-	} `yaml:"installer"`
-}
-
-// telemetryConfig is a best effort to get the API key / site from `datadog.yaml`.
-func telemetryConfig() telemetryConfigFields {
-	configPath := filepath.Join(paths.AgentConfigDir, "datadog.yaml")
-	rawConfig, err := os.ReadFile(configPath)
-	if err != nil {
-		return telemetryConfigFields{}
-	}
-	var config telemetryConfigFields
-	err = yaml.Unmarshal(rawConfig, &config)
-	if err != nil {
-		return telemetryConfigFields{}
-	}
-	return config
-}
-
 func newTelemetry(env *env.Env) *telemetry.Telemetry {
-	config := telemetryConfig()
-	apiKey := env.APIKey
-	if apiKey == "" {
-		apiKey = config.APIKey
-	}
-	site := env.Site
-	_, ddSiteSet := os.LookupEnv("DD_SITE")
-	if !ddSiteSet && config.Site != "" {
-		site = config.Site
-	}
-
-	// Update env fields with corrected values so subprocesses inherit the right config
-	env.APIKey = apiKey
-	env.Site = site
-
-	t := telemetry.NewTelemetry(env.HTTPClient(), apiKey, site, "datadog-installer") // No sampling rules for commands
-	return t
-}
-
-// applyDatadogYAMLRegistryConfig reads installer.registry from datadog.yaml and
-// applies any values not already set by environment variables.
-func applyDatadogYAMLRegistryConfig(env *env.Env) {
-	configPath := filepath.Join(agentConfigDir, "datadog.yaml")
-	rawConfig, err := os.ReadFile(configPath)
-	if err != nil {
-		return
-	}
-	var config installerRegistryYAMLConfig
-	if err = yaml.Unmarshal(rawConfig, &config); err != nil {
-		return
-	}
-	r := config.Installer.Registry
-	if env.HasDefaultRegistryOverride() && r.Auth != "" {
-		env.RegistryOverride = r.URL
-	}
-	if env.HasDefaultRegistryAuthOverride() && r.Auth != "" {
-		env.RegistryAuthOverride = r.Auth
-	}
-	if env.HasDefaultRegistryUsername() && r.Username != "" {
-		env.RegistryUsername = r.Username
-	}
-	if env.HasDefaultRegistryPassword() && r.Password != "" {
-		env.RegistryPassword = r.Password
-	}
+	return telemetry.NewTelemetry(env.HTTPClient(), env.APIKey, env.Site, "datadog-installer")
 }
 
 // RootCommands returns the root commands

--- a/pkg/fleet/installer/commands/command_test.go
+++ b/pkg/fleet/installer/commands/command_test.go
@@ -7,10 +7,7 @@ package commands
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -18,7 +15,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/exec"
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 )
 
@@ -125,139 +121,6 @@ func TestConfigAndPackageStates(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, res)
-}
-
-// testEnvAccessor allows tests to read any field of env.Env by name.
-type testEnvAccessor struct{ e *env.Env }
-
-func (a testEnvAccessor) GetEnv(field string) string {
-	v := reflect.ValueOf(a.e).Elem()
-	f := v.FieldByName(field)
-	if !f.IsValid() {
-		return fmt.Sprintf("<unknown field %q>", field)
-	}
-	return fmt.Sprintf("%v", f.Interface())
-}
-
-type testCmd struct {
-	*cmd
-	Test testEnvAccessor
-}
-
-// newTestingCmd creates a cmd via newCmd and exposes its env through Test.GetEnv.
-func newTestingCmd() *testCmd {
-	c := newCmd("unit_test", withQuiet())
-	return &testCmd{cmd: c, Test: testEnvAccessor{e: c.env}}
-}
-
-func TestNewCmd(t *testing.T) {
-	tests := []struct {
-		name    string
-		yaml    string            // written to temp dir as datadog.yaml; empty means no file
-		envVars map[string]string // set via t.Setenv before creating the cmd
-		checks  map[string]string // env.Env field name -> expected value
-	}{
-		{
-			name: "no config no env vars",
-			checks: map[string]string{
-				"RegistryAuthOverride": "",
-				"RegistryOverride":     "",
-				"RegistryUsername":     "",
-				"RegistryPassword":     "",
-			},
-		},
-		{
-			name: "env vars only",
-			envVars: map[string]string{
-				"DD_INSTALLER_REGISTRY_AUTH":     "gcr",
-				"DD_INSTALLER_REGISTRY_URL":      "env-registry.example.com",
-				"DD_INSTALLER_REGISTRY_USERNAME": "env-user",
-				"DD_INSTALLER_REGISTRY_PASSWORD": "env-pass",
-			},
-			checks: map[string]string{
-				"RegistryAuthOverride": "gcr",
-				"RegistryOverride":     "env-registry.example.com",
-				"RegistryUsername":     "env-user",
-				"RegistryPassword":     "env-pass",
-			},
-		},
-		{
-			name: "datadog.yaml only",
-			yaml: `
-installer:
-  registry:
-    url:      yaml-registry.example.com
-    auth:     gcr
-    username: yaml-user
-    password: yaml-pass
-`,
-			checks: map[string]string{
-				"RegistryAuthOverride": "gcr",
-				"RegistryOverride":     "yaml-registry.example.com",
-				"RegistryUsername":     "yaml-user",
-				"RegistryPassword":     "yaml-pass",
-			},
-		},
-		{
-			name: "env vars take precedence over datadog.yaml",
-			yaml: `
-installer:
-  registry:
-    url:      yaml-registry.example.com
-    auth:     yaml-auth
-    username: yaml-user
-    password: yaml-pass
-`,
-			envVars: map[string]string{
-				"DD_INSTALLER_REGISTRY_AUTH": "env-auth",
-				"DD_INSTALLER_REGISTRY_URL":  "env-registry.example.com",
-			},
-			checks: map[string]string{
-				"RegistryAuthOverride": "env-auth",
-				"RegistryOverride":     "env-registry.example.com",
-				// remaining fields not set by env var are filled from YAML
-				"RegistryUsername": "yaml-user",
-				"RegistryPassword": "yaml-pass",
-			},
-		},
-		{
-			name: "partial yaml fills only provided fields",
-			yaml: `
-installer:
-  registry:
-    auth: gcr
-`,
-			checks: map[string]string{
-				"RegistryAuthOverride": "gcr",
-				"RegistryOverride":     "",
-				"RegistryUsername":     "",
-				"RegistryPassword":     "",
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			agentConfigDir = dir
-			t.Cleanup(func() { agentConfigDir = paths.AgentConfigDir })
-
-			if tc.yaml != "" {
-				err := os.WriteFile(filepath.Join(dir, "datadog.yaml"), []byte(tc.yaml), 0644)
-				assert.NoError(t, err)
-			}
-			for k, v := range tc.envVars {
-				t.Setenv(k, v)
-			}
-
-			cmd := newTestingCmd()
-			defer cmd.stop(nil)
-
-			for field, want := range tc.checks {
-				assert.Equal(t, want, cmd.Test.GetEnv(field), "field %s", field)
-			}
-		})
-	}
 }
 
 func TestSetupCommandHasHumanReadableAnnotation(t *testing.T) {

--- a/pkg/fleet/installer/env/BUILD.bazel
+++ b/pkg/fleet/installer/env/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "env",
-    srcs = ["env.go"],
+    srcs = [
+        "env.go",
+        "registry.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/fleet/installer/env",
     visibility = ["//visibility:public"],
     deps = ["@org_golang_x_net//http/httpproxy"],
@@ -10,8 +13,14 @@ go_library(
 
 go_test(
     name = "env_test",
-    srcs = ["env_test.go"],
+    srcs = [
+        "env_test.go",
+        "registry_test.go",
+    ],
     embed = [":env"],
     gotags = ["test"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -236,10 +236,15 @@ func FromEnv() *Env {
 		return c == ','
 	}
 
-	// Best effort: a malformed DD_INSTALLER_REGISTRY is logged by the
-	// boundary layer; here we treat it as empty so the installer still
-	// runs against default registries.
-	registry, _ := parseRegistryFromEnv()
+	// Registry: prefer DD_INSTALLER_REGISTRY JSON (canonical). If it
+	// isn't set, fall back to parsing any legacy DD_INSTALLER_REGISTRY_*
+	// prefix vars directly, so user overrides reach the installer even
+	// if the boundary translators (daemon / fxconfig CLI bootstrap)
+	// failed to run or didn't absorb them.
+	//
+	// A malformed DD_INSTALLER_REGISTRY JSON is treated as empty so the
+	// installer still runs against default registries.
+	registry, _, _ := BuildRegistryFromEnv()
 
 	return &Env{
 		APIKey:               getEnvOrDefault(envAPIKey, defaultEnv.APIKey),

--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -27,10 +27,6 @@ const (
 	envRemoteUpdates         = "DD_REMOTE_UPDATES"
 	envOTelCollectorEnabled  = "DD_OTELCOLLECTOR_ENABLED"
 	envMirror                = "DD_INSTALLER_MIRROR"
-	envRegistryURL           = "DD_INSTALLER_REGISTRY_URL"
-	envRegistryAuth          = "DD_INSTALLER_REGISTRY_AUTH"
-	envRegistryUsername      = "DD_INSTALLER_REGISTRY_USERNAME"
-	envRegistryPassword      = "DD_INSTALLER_REGISTRY_PASSWORD"
 	envDefaultPackageVersion = "DD_INSTALLER_DEFAULT_PKG_VERSION"
 	envDefaultPackageInstall = "DD_INSTALLER_DEFAULT_PKG_INSTALL"
 	envApmLibraries          = "DD_APM_INSTRUMENTATION_LIBRARIES"
@@ -89,15 +85,6 @@ var defaultEnv = Env{
 	RemoteUpdates:        false,
 	OTelCollectorEnabled: false,
 	Mirror:               "",
-
-	RegistryOverride:            "",
-	RegistryAuthOverride:        "",
-	RegistryUsername:            "",
-	RegistryPassword:            "",
-	RegistryOverrideByImage:     map[string]string{},
-	RegistryAuthOverrideByImage: map[string]string{},
-	RegistryUsernameByImage:     map[string]string{},
-	RegistryPasswordByImage:     map[string]string{},
 
 	DefaultPackagesInstallOverride: map[string]bool{},
 	DefaultPackagesVersionOverride: map[string]string{},
@@ -181,15 +168,8 @@ type Env struct {
 	OTelCollectorEnabled bool
 	ConfigID             string
 
-	Mirror                      string
-	RegistryOverride            string
-	RegistryAuthOverride        string
-	RegistryUsername            string
-	RegistryPassword            string
-	RegistryOverrideByImage     map[string]string
-	RegistryAuthOverrideByImage map[string]string
-	RegistryUsernameByImage     map[string]string
-	RegistryPasswordByImage     map[string]string
+	Mirror   string
+	Registry RegistryConfig
 
 	DefaultPackagesInstallOverride map[string]bool
 	DefaultPackagesVersionOverride map[string]string
@@ -221,22 +201,6 @@ type Env struct {
 	IsFromDaemon bool
 }
 
-func (e *Env) HasDefaultRegistryOverride() bool {
-	return e.RegistryOverride == defaultEnv.RegistryOverride
-}
-
-func (e *Env) HasDefaultRegistryAuthOverride() bool {
-	return e.RegistryAuthOverride == defaultEnv.RegistryAuthOverride
-}
-
-func (e *Env) HasDefaultRegistryUsername() bool {
-	return e.RegistryUsername == defaultEnv.RegistryUsername
-}
-
-func (e *Env) HasDefaultRegistryPassword() bool {
-	return e.RegistryPassword == defaultEnv.RegistryPassword
-}
-
 // HTTPClient returns an HTTP client with the proxy settings from the environment.
 func (e *Env) HTTPClient() *http.Client {
 	proxyConfig := &httpproxy.Config{
@@ -263,11 +227,19 @@ func (e *Env) HTTPClient() *http.Client {
 	return client
 }
 
-// FromEnv returns an Env struct with values from the environment.
+// FromEnv returns an Env struct with values from the environment. The
+// Registry field is populated from DD_INSTALLER_REGISTRY (JSON) only;
+// legacy DD_INSTALLER_REGISTRY_* prefix vars are expected to have been
+// translated into that JSON before the installer runs.
 func FromEnv() *Env {
 	splitFunc := func(c rune) bool {
 		return c == ','
 	}
+
+	// Best effort: a malformed DD_INSTALLER_REGISTRY is logged by the
+	// boundary layer; here we treat it as empty so the installer still
+	// runs against default registries.
+	registry, _ := parseRegistryFromEnv()
 
 	return &Env{
 		APIKey:               getEnvOrDefault(envAPIKey, defaultEnv.APIKey),
@@ -275,15 +247,8 @@ func FromEnv() *Env {
 		RemoteUpdates:        strings.ToLower(os.Getenv(envRemoteUpdates)) == "true",
 		OTelCollectorEnabled: strings.ToLower(os.Getenv(envOTelCollectorEnabled)) == "true",
 
-		Mirror:                      getEnvOrDefault(envMirror, defaultEnv.Mirror),
-		RegistryOverride:            getEnvOrDefault(envRegistryURL, defaultEnv.RegistryOverride),
-		RegistryAuthOverride:        getEnvOrDefault(envRegistryAuth, defaultEnv.RegistryAuthOverride),
-		RegistryUsername:            getEnvOrDefault(envRegistryUsername, defaultEnv.RegistryUsername),
-		RegistryPassword:            getEnvOrDefault(envRegistryPassword, defaultEnv.RegistryPassword),
-		RegistryOverrideByImage:     overridesByNameFromEnv(envRegistryURL, func(s string) string { return s }),
-		RegistryAuthOverrideByImage: overridesByNameFromEnv(envRegistryAuth, func(s string) string { return s }),
-		RegistryUsernameByImage:     overridesByNameFromEnv(envRegistryUsername, func(s string) string { return s }),
-		RegistryPasswordByImage:     overridesByNameFromEnv(envRegistryPassword, func(s string) string { return s }),
+		Mirror:   getEnvOrDefault(envMirror, defaultEnv.Mirror),
+		Registry: registry,
 
 		DefaultPackagesInstallOverride: overridesByNameFromEnv(envDefaultPackageInstall, func(s string) bool { return strings.ToLower(s) == "true" }),
 		DefaultPackagesVersionOverride: overridesByNameFromEnv(envDefaultPackageVersion, func(s string) string { return s }),
@@ -395,10 +360,9 @@ func (e *Env) ToEnv() []string {
 		env = append(env, envOTelCollectorEnabled+"=true")
 	}
 	env = appendStringEnv(env, envMirror, e.Mirror, "")
-	env = appendStringEnv(env, envRegistryURL, e.RegistryOverride, "")
-	env = appendStringEnv(env, envRegistryAuth, e.RegistryAuthOverride, "")
-	env = appendStringEnv(env, envRegistryUsername, e.RegistryUsername, "")
-	env = appendStringEnv(env, envRegistryPassword, e.RegistryPassword, "")
+	if blob := marshalRegistryIfNonEmpty(e.Registry); blob != "" {
+		env = append(env, EnvInstallerRegistry+"="+blob)
+	}
 	env = e.MsiParams.ToEnv(env)
 	env = e.InstallScript.ToEnv(env)
 	if len(e.ApmLibraries) > 0 {
@@ -435,10 +399,6 @@ func (e *Env) ToEnv() []string {
 		// is by env var.
 		env = append(env, "DD_LOG_LEVEL=off")
 	}
-	env = append(env, overridesByNameToEnv(envRegistryURL, e.RegistryOverrideByImage)...)
-	env = append(env, overridesByNameToEnv(envRegistryAuth, e.RegistryAuthOverrideByImage)...)
-	env = append(env, overridesByNameToEnv(envRegistryUsername, e.RegistryUsernameByImage)...)
-	env = append(env, overridesByNameToEnv(envRegistryPassword, e.RegistryPasswordByImage)...)
 	env = append(env, overridesByNameToEnv(envDefaultPackageInstall, e.DefaultPackagesInstallOverride)...)
 	env = append(env, overridesByNameToEnv(envDefaultPackageVersion, e.DefaultPackagesVersionOverride)...)
 

--- a/pkg/fleet/installer/env/env_test.go
+++ b/pkg/fleet/installer/env/env_test.go
@@ -24,14 +24,6 @@ func TestFromEnv(t *testing.T) {
 				APIKey:                         "",
 				Site:                           "datadoghq.com",
 				Mirror:                         "",
-				RegistryOverride:               "",
-				RegistryAuthOverride:           "",
-				RegistryUsername:               "",
-				RegistryPassword:               "",
-				RegistryOverrideByImage:        map[string]string{},
-				RegistryAuthOverrideByImage:    map[string]string{},
-				RegistryUsernameByImage:        map[string]string{},
-				RegistryPasswordByImage:        map[string]string{},
 				DefaultPackagesInstallOverride: map[string]bool{},
 				DefaultPackagesVersionOverride: map[string]string{},
 				ApmLibraries:                   map[ApmLibLanguage]ApmLibVersion{},
@@ -46,67 +38,69 @@ func TestFromEnv(t *testing.T) {
 			},
 		},
 		{
-			name: "All environment variables set",
+			name: "DD_INSTALLER_REGISTRY JSON populates Registry",
 			envVars: map[string]string{
-				envAPIKey:                                     "123456",
-				envSite:                                       "datadoghq.eu",
-				envRemoteUpdates:                              "true",
-				envMirror:                                     "https://mirror.example.com",
-				envRegistryURL:                                "registry.example.com",
-				envRegistryAuth:                               "auth",
-				envRegistryUsername:                           "username",
-				envRegistryPassword:                           "password",
-				envRegistryURL + "_IMAGE":                     "another.registry.example.com",
-				envRegistryURL + "_ANOTHER_IMAGE":             "yet.another.registry.example.com",
-				envRegistryAuth + "_IMAGE":                    "another.auth",
-				envRegistryAuth + "_ANOTHER_IMAGE":            "yet.another.auth",
-				envRegistryUsername + "_IMAGE":                "another.username",
-				envRegistryUsername + "_ANOTHER_IMAGE":        "yet.another.username",
-				envRegistryPassword + "_IMAGE":                "another.password",
-				envRegistryPassword + "_ANOTHER_IMAGE":        "yet.another.password",
-				envDefaultPackageInstall + "_PACKAGE":         "true",
+				EnvInstallerRegistry: `{
+					"default": {"url": "registry.example.com", "auth": "auth", "username": "u", "password": "p"},
+					"packages": {
+						"datadog-agent": {"url": "agent.example.com", "extensions": {"ddot": {"auth": "password", "username": "cu", "password": "cp"}}}
+					}
+				}`,
+			},
+			expected: &Env{
+				APIKey: "",
+				Site:   "datadoghq.com",
+				Registry: RegistryConfig{
+					Default: RegistryEntry{URL: "registry.example.com", Auth: "auth", Username: "u", Password: "p"},
+					Packages: map[string]PackageRegistry{
+						"datadog-agent": {
+							RegistryEntry: RegistryEntry{URL: "agent.example.com"},
+							Extensions: map[string]RegistryEntry{
+								"ddot": {Auth: "password", Username: "cu", Password: "cp"},
+							},
+						},
+					},
+				},
+				DefaultPackagesInstallOverride: map[string]bool{},
+				DefaultPackagesVersionOverride: map[string]string{},
+				ApmLibraries:                   map[ApmLibLanguage]ApmLibVersion{},
+				InstallScript: InstallScriptEnv{
+					APMInstrumentationEnabled: APMInstrumentationNotSet,
+				},
+				Tags:    []string{},
+				NoProxy: os.Getenv("NO_PROXY"),
+			},
+		},
+		{
+			name: "All environment variables set (except Registry, which is JSON)",
+			envVars: map[string]string{
+				envAPIKey:                             "123456",
+				envSite:                               "datadoghq.eu",
+				envRemoteUpdates:                      "true",
+				envMirror:                             "https://mirror.example.com",
+				envDefaultPackageInstall + "_PACKAGE": "true",
 				envDefaultPackageInstall + "_ANOTHER_PACKAGE": "false",
 				envDefaultPackageVersion + "_PACKAGE":         "1.2.3",
 				envDefaultPackageVersion + "_ANOTHER_PACKAGE": "4.5.6",
-				envApmLibraries:                               "java,dotnet:latest,ruby:1.2",
-				envApmInstrumentationEnabled:                  "all",
-				envAgentUserName:                              "customuser",
-				envTags:                                       "k1:v1,k2:v2",
-				envExtraTags:                                  "k3:v3,k4:v4",
-				envHostname:                                   "hostname",
-				envDDHTTPProxy:                                "http://proxy.example.com:8080",
-				envDDHTTPSProxy:                               "http://proxy.example.com:8080",
-				envDDNoProxy:                                  "localhost",
-				envInfrastructureMode:                         "basic",
-				envAppKey:                                     "app_key_123",
-				envPAREnabled:                                 "true",
-				envPARActionsAllowlist:                        "com.datadoghq.script.runPredefinedScript,com.datadoghq.script.testConnection",
+				envApmLibraries:              "java,dotnet:latest,ruby:1.2",
+				envApmInstrumentationEnabled: "all",
+				envAgentUserName:             "customuser",
+				envTags:                      "k1:v1,k2:v2",
+				envExtraTags:                 "k3:v3,k4:v4",
+				envHostname:                  "hostname",
+				envDDHTTPProxy:               "http://proxy.example.com:8080",
+				envDDHTTPSProxy:              "http://proxy.example.com:8080",
+				envDDNoProxy:                 "localhost",
+				envInfrastructureMode:        "basic",
+				envAppKey:                    "app_key_123",
+				envPAREnabled:                "true",
+				envPARActionsAllowlist:       "com.datadoghq.script.runPredefinedScript,com.datadoghq.script.testConnection",
 			},
 			expected: &Env{
-				APIKey:               "123456",
-				Site:                 "datadoghq.eu",
-				Mirror:               "https://mirror.example.com",
-				RemoteUpdates:        true,
-				RegistryOverride:     "registry.example.com",
-				RegistryAuthOverride: "auth",
-				RegistryUsername:     "username",
-				RegistryPassword:     "password",
-				RegistryOverrideByImage: map[string]string{
-					"image":         "another.registry.example.com",
-					"another-image": "yet.another.registry.example.com",
-				},
-				RegistryAuthOverrideByImage: map[string]string{
-					"image":         "another.auth",
-					"another-image": "yet.another.auth",
-				},
-				RegistryUsernameByImage: map[string]string{
-					"image":         "another.username",
-					"another-image": "yet.another.username",
-				},
-				RegistryPasswordByImage: map[string]string{
-					"image":         "another.password",
-					"another-image": "yet.another.password",
-				},
+				APIKey:        "123456",
+				Site:          "datadoghq.eu",
+				Mirror:        "https://mirror.example.com",
+				RemoteUpdates: true,
 				DefaultPackagesInstallOverride: map[string]bool{
 					"package":         true,
 					"another-package": false,
@@ -145,12 +139,6 @@ func TestFromEnv(t *testing.T) {
 			expected: &Env{
 				APIKey:                         "",
 				Site:                           "datadoghq.com",
-				RegistryOverride:               "",
-				RegistryAuthOverride:           "",
-				RegistryOverrideByImage:        map[string]string{},
-				RegistryAuthOverrideByImage:    map[string]string{},
-				RegistryUsernameByImage:        map[string]string{},
-				RegistryPasswordByImage:        map[string]string{},
 				DefaultPackagesInstallOverride: map[string]bool{},
 				DefaultPackagesVersionOverride: map[string]string{},
 				ApmLibraries: map[ApmLibLanguage]ApmLibVersion{
@@ -163,7 +151,7 @@ func TestFromEnv(t *testing.T) {
 					APMInstrumentationEnabled: APMInstrumentationNotSet,
 				},
 				Tags:    []string{},
-				NoProxy: os.Getenv("NO_PROXY"), // Default value from the environment, as some test envs set it
+				NoProxy: os.Getenv("NO_PROXY"),
 			},
 		},
 		{
@@ -184,19 +172,19 @@ func TestFromEnv(t *testing.T) {
 				InstallScript: InstallScriptEnv{
 					APMInstrumentationEnabled: APMInstrumentationEnabledAll,
 				},
-				RegistryOverrideByImage:        map[string]string{},
-				RegistryAuthOverrideByImage:    map[string]string{},
-				RegistryUsernameByImage:        map[string]string{},
-				RegistryPasswordByImage:        map[string]string{},
 				DefaultPackagesInstallOverride: map[string]bool{},
 				DefaultPackagesVersionOverride: map[string]string{},
 				Tags:                           []string{},
 				Hostname:                       "",
-				NoProxy:                        os.Getenv("NO_PROXY"), // Default value from the environment, as some test envs set it
+				NoProxy:                        os.Getenv("NO_PROXY"),
 			},
 		},
 	}
 
+	// Unset DD_API_KEY before the test matrix runs — some CI environments
+	// set it, which would leak into FromEnv() results and break assertions.
+	t.Setenv(envAPIKey, "")
+	os.Unsetenv(envAPIKey)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for key, value := range tt.envVars {
@@ -211,42 +199,47 @@ func TestFromEnv(t *testing.T) {
 
 func TestToEnv(t *testing.T) {
 	tests := []struct {
-		name     string
-		env      *Env
-		expected []string
+		name             string
+		env              *Env
+		expectedContains []string
+		expectedExcludes []string
 	}{
 		{
-			name:     "Empty configuration",
-			env:      &Env{},
-			expected: nil,
+			name:             "Empty configuration",
+			env:              &Env{},
+			expectedContains: nil,
+		},
+		{
+			name: "Registry field emitted as single DD_INSTALLER_REGISTRY JSON var",
+			env: &Env{
+				APIKey: "123456",
+				Registry: RegistryConfig{
+					Default: RegistryEntry{URL: "registry.example.com"},
+					Packages: map[string]PackageRegistry{
+						"datadog-agent": {RegistryEntry: RegistryEntry{URL: "agent.example.com"}},
+					},
+				},
+			},
+			expectedContains: []string{
+				"DD_API_KEY=123456",
+				`DD_INSTALLER_REGISTRY={"default":{"url":"registry.example.com"},"packages":{"datadog-agent":{"url":"agent.example.com"}}}`,
+			},
+		},
+		{
+			name: "Empty Registry does not emit DD_INSTALLER_REGISTRY",
+			env: &Env{
+				APIKey: "123456",
+			},
+			expectedContains: []string{"DD_API_KEY=123456"},
+			expectedExcludes: []string{"DD_INSTALLER_REGISTRY="},
 		},
 		{
 			name: "All configuration set",
 			env: &Env{
-				APIKey:               "123456",
-				Site:                 "datadoghq.eu",
-				RemoteUpdates:        true,
-				Mirror:               "https://mirror.example.com",
-				RegistryOverride:     "registry.example.com",
-				RegistryAuthOverride: "auth",
-				RegistryUsername:     "username",
-				RegistryPassword:     "password",
-				RegistryOverrideByImage: map[string]string{
-					"image":         "another.registry.example.com",
-					"another-image": "yet.another.registry.example.com",
-				},
-				RegistryAuthOverrideByImage: map[string]string{
-					"image":         "another.auth",
-					"another-image": "yet.another.auth",
-				},
-				RegistryUsernameByImage: map[string]string{
-					"image":         "another.username",
-					"another-image": "yet.another.username",
-				},
-				RegistryPasswordByImage: map[string]string{
-					"image":         "another.password",
-					"another-image": "yet.another.password",
-				},
+				APIKey:        "123456",
+				Site:          "datadoghq.eu",
+				RemoteUpdates: true,
+				Mirror:        "https://mirror.example.com",
 				DefaultPackagesInstallOverride: map[string]bool{
 					"package":         true,
 					"another-package": false,
@@ -270,24 +263,12 @@ func TestToEnv(t *testing.T) {
 				AppKey:              "app_key_123",
 				PARActionsAllowlist: "action1,action2",
 			},
-			expected: []string{
+			expectedContains: []string{
 				"DD_API_KEY=123456",
 				"DD_SITE=datadoghq.eu",
 				"DD_REMOTE_UPDATES=true",
 				"DD_INSTALLER_MIRROR=https://mirror.example.com",
-				"DD_INSTALLER_REGISTRY_URL=registry.example.com",
-				"DD_INSTALLER_REGISTRY_AUTH=auth",
-				"DD_INSTALLER_REGISTRY_USERNAME=username",
-				"DD_INSTALLER_REGISTRY_PASSWORD=password",
 				"DD_APM_INSTRUMENTATION_LIBRARIES=dotnet:latest,java,ruby:1.2",
-				"DD_INSTALLER_REGISTRY_URL_IMAGE=another.registry.example.com",
-				"DD_INSTALLER_REGISTRY_URL_ANOTHER_IMAGE=yet.another.registry.example.com",
-				"DD_INSTALLER_REGISTRY_AUTH_IMAGE=another.auth",
-				"DD_INSTALLER_REGISTRY_AUTH_ANOTHER_IMAGE=yet.another.auth",
-				"DD_INSTALLER_REGISTRY_USERNAME_IMAGE=another.username",
-				"DD_INSTALLER_REGISTRY_USERNAME_ANOTHER_IMAGE=yet.another.username",
-				"DD_INSTALLER_REGISTRY_PASSWORD_IMAGE=another.password",
-				"DD_INSTALLER_REGISTRY_PASSWORD_ANOTHER_IMAGE=yet.another.password",
 				"DD_INSTALLER_DEFAULT_PKG_INSTALL_PACKAGE=true",
 				"DD_INSTALLER_DEFAULT_PKG_INSTALL_ANOTHER_PACKAGE=false",
 				"DD_INSTALLER_DEFAULT_PKG_VERSION_PACKAGE=1.2.3",
@@ -310,7 +291,7 @@ func TestToEnv(t *testing.T) {
 				PAREnabled:          true,
 				PARActionsAllowlist: "action1,action2",
 			},
-			expected: []string{
+			expectedContains: []string{
 				"DD_API_KEY=123456",
 				"DD_PRIVATE_ACTION_RUNNER_ENABLED=true",
 				"DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST=action1,action2",
@@ -324,16 +305,22 @@ func TestToEnv(t *testing.T) {
 				AppKey:              "app_key_123",
 				PARActionsAllowlist: "action1",
 			},
-			expected: []string{
-				"DD_API_KEY=123456",
-			},
+			expectedContains: []string{"DD_API_KEY=123456"},
+			expectedExcludes: []string{"DD_APP_KEY=", "DD_PRIVATE_ACTION_RUNNER_"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.env.ToEnv()
-			assert.ElementsMatch(t, tt.expected, result)
+			for _, want := range tt.expectedContains {
+				assert.Contains(t, result, want, "expected env contains %q", want)
+			}
+			for _, excludePrefix := range tt.expectedExcludes {
+				for _, got := range result {
+					assert.NotContains(t, got, excludePrefix, "unexpected env var with prefix %q", excludePrefix)
+				}
+			}
 		})
 	}
 }

--- a/pkg/fleet/installer/env/registry.go
+++ b/pkg/fleet/installer/env/registry.go
@@ -1,0 +1,376 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package env
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// EnvInstallerRegistry is the canonical JSON env var the installer reads.
+const EnvInstallerRegistry = "DD_INSTALLER_REGISTRY"
+
+// Legacy per-package registry env var prefixes. Absorbed at the boundary
+// (daemon + fxconfig bootstrap) into the unified DD_INSTALLER_REGISTRY
+// JSON; not parsed directly by the installer.
+const (
+	envRegistryURLLegacy      = "DD_INSTALLER_REGISTRY_URL"
+	envRegistryAuthLegacy     = "DD_INSTALLER_REGISTRY_AUTH"
+	envRegistryUsernameLegacy = "DD_INSTALLER_REGISTRY_USERNAME"
+	envRegistryPasswordLegacy = "DD_INSTALLER_REGISTRY_PASSWORD"
+)
+
+// LegacyRegistryEnvPrefixes is the list of per-package env var prefixes
+// (e.g. DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE). Boundary translators
+// consume and `os.Unsetenv` these after populating the unified Registry.
+var LegacyRegistryEnvPrefixes = []string{
+	envRegistryURLLegacy,
+	envRegistryAuthLegacy,
+	envRegistryUsernameLegacy,
+	envRegistryPasswordLegacy,
+}
+
+// RegistryEntry is the set of overrides for a single registry.
+type RegistryEntry struct {
+	URL      string `json:"url,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+// MergeStrings returns a copy of e with non-empty string args taking
+// precedence over the corresponding field in e.
+func (e RegistryEntry) MergeStrings(url, auth, username, password string) RegistryEntry {
+	return e.merge(RegistryEntry{URL: url, Auth: auth, Username: username, Password: password})
+}
+
+// merge returns a copy of e with non-empty fields from o taking precedence.
+func (e RegistryEntry) merge(o RegistryEntry) RegistryEntry {
+	if o.URL != "" {
+		e.URL = o.URL
+	}
+	if o.Auth != "" {
+		e.Auth = o.Auth
+	}
+	if o.Username != "" {
+		e.Username = o.Username
+	}
+	if o.Password != "" {
+		e.Password = o.Password
+	}
+	return e
+}
+
+// PackageRegistry holds per-package registry overrides and per-extension
+// sub-overrides for the package.
+type PackageRegistry struct {
+	RegistryEntry
+	Extensions map[string]RegistryEntry `json:"extensions,omitempty"`
+}
+
+type RegistryConfig struct {
+	Default  RegistryEntry              `json:"default,omitempty"`
+	Packages map[string]PackageRegistry `json:"packages,omitempty"`
+}
+
+// Resolve returns the effective registry entry for a package and optional
+// extension. Missing fields fall back to the package entry, then to Default.
+// Empty pkg or unknown pkg returns Default. Empty ext returns the
+// package-level entry.
+func (r *RegistryConfig) Resolve(pkg, ext string) RegistryEntry {
+	result := r.Default
+	if pkg == "" {
+		return result
+	}
+	pkgEntry, ok := r.Packages[pkg]
+	if !ok {
+		return result
+	}
+	result = result.merge(pkgEntry.RegistryEntry)
+	if ext == "" {
+		return result
+	}
+	if extEntry, ok := pkgEntry.Extensions[ext]; ok {
+		result = result.merge(extEntry)
+	}
+	return result
+}
+
+// IsEmpty returns true if the RegistryConfig has no overrides at all.
+func (r RegistryConfig) IsEmpty() bool {
+	if r.Default != (RegistryEntry{}) {
+		return false
+	}
+	for _, p := range r.Packages {
+		if p.RegistryEntry != (RegistryEntry{}) || len(p.Extensions) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// marshalRegistryIfNonEmpty returns the JSON encoding of r, or "" if r has
+// no overrides. Used by ToEnv to omit the env var for empty configs.
+func marshalRegistryIfNonEmpty(r RegistryConfig) string {
+	if r.IsEmpty() {
+		return ""
+	}
+	blob, err := json.Marshal(r)
+	if err != nil {
+		return ""
+	}
+	return string(blob)
+}
+
+// parseRegistryFromEnv reads DD_INSTALLER_REGISTRY from the process
+// environment and returns the parsed RegistryConfig. An empty/unset var
+// returns a zero RegistryConfig and no error. A set-but-invalid value
+// returns an error.
+func parseRegistryFromEnv() (RegistryConfig, error) {
+	raw := os.Getenv(EnvInstallerRegistry)
+	if raw == "" {
+		return RegistryConfig{}, nil
+	}
+	var r RegistryConfig
+	if err := json.Unmarshal([]byte(raw), &r); err != nil {
+		return RegistryConfig{}, fmt.Errorf("parsing %s: %w", EnvInstallerRegistry, err)
+	}
+	return r, nil
+}
+
+// packageNameFromEnvSuffix converts a legacy env var suffix back to a
+// package name. E.g. "AGENT_PACKAGE" -> "datadog-agent". The inverse of
+// the mapping used to build the env var name from the package name.
+func packageNameFromEnvSuffix(suffix string) string {
+	slug := strings.ToLower(strings.ReplaceAll(suffix, "_", "-"))
+	slug = strings.TrimSuffix(slug, "-package")
+	if slug == "" {
+		return ""
+	}
+	return "datadog-" + slug
+}
+
+// PackageNameFromURL reverses oci.PackageURL's naming convention to derive
+// the package name from a download URL. Returns "" for URLs that don't
+// match the expected `<registry>/<slug>-package:<version>` shape.
+func PackageNameFromURL(url string) string {
+	slug := url[strings.LastIndex(url, "/")+1:]
+	if i := strings.IndexAny(slug, ":@"); i >= 0 {
+		slug = slug[:i]
+	}
+	if !strings.HasSuffix(slug, "-package") {
+		return ""
+	}
+	slug = strings.TrimSuffix(slug, "-package")
+	if slug == "" {
+		return ""
+	}
+	return "datadog-" + slug
+}
+
+// applyLegacyEnvVars layers legacy DD_INSTALLER_REGISTRY_{URL,AUTH,
+// USERNAME,PASSWORD}[_<PKG>] vars from the process env onto r, with
+// per-field precedence: present legacy var overrides the matching field.
+func (r *RegistryConfig) applyLegacyEnvVars() {
+	// Global scalars → Default.
+	if v := os.Getenv(envRegistryURLLegacy); v != "" {
+		r.Default.URL = v
+	}
+	if v := os.Getenv(envRegistryAuthLegacy); v != "" {
+		r.Default.Auth = v
+	}
+	if v := os.Getenv(envRegistryUsernameLegacy); v != "" {
+		r.Default.Username = v
+	}
+	if v := os.Getenv(envRegistryPasswordLegacy); v != "" {
+		r.Default.Password = v
+	}
+
+	// Per-package suffixed vars → Packages[pkg].
+	// We iterate the process env once and dispatch on prefix.
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		key, val := kv[:eq], kv[eq+1:]
+		if val == "" {
+			continue
+		}
+		var (
+			prefix string
+			field  string
+		)
+		switch {
+		case strings.HasPrefix(key, envRegistryURLLegacy+"_"):
+			prefix, field = envRegistryURLLegacy+"_", "url"
+		case strings.HasPrefix(key, envRegistryAuthLegacy+"_"):
+			prefix, field = envRegistryAuthLegacy+"_", "auth"
+		case strings.HasPrefix(key, envRegistryUsernameLegacy+"_"):
+			prefix, field = envRegistryUsernameLegacy+"_", "username"
+		case strings.HasPrefix(key, envRegistryPasswordLegacy+"_"):
+			prefix, field = envRegistryPasswordLegacy+"_", "password"
+		default:
+			continue
+		}
+		suffix := strings.TrimPrefix(key, prefix)
+		pkg := packageNameFromEnvSuffix(suffix)
+		if pkg == "" {
+			continue
+		}
+		if r.Packages == nil {
+			r.Packages = map[string]PackageRegistry{}
+		}
+		entry := r.Packages[pkg]
+		switch field {
+		case "url":
+			entry.URL = val
+		case "auth":
+			entry.Auth = val
+		case "username":
+			entry.Username = val
+		case "password":
+			entry.Password = val
+		}
+		r.Packages[pkg] = entry
+	}
+}
+
+// applyRegistryEnvJSON layers any DD_INSTALLER_REGISTRY JSON value on top
+// of r. JSON values override field-by-field; empty fields leave r's
+// existing value in place.
+func (r *RegistryConfig) applyRegistryEnvJSON() error {
+	jsonReg, err := parseRegistryFromEnv()
+	if err != nil {
+		return err
+	}
+	r.merge(jsonReg)
+	return nil
+}
+
+// merge layers o onto r in place. Scalar RegistryEntry fields overlay
+// field-by-field; package entries are merged per package (and per
+// extension).
+func (r *RegistryConfig) merge(o RegistryConfig) {
+	r.Default = r.Default.merge(o.Default)
+	for name, pkg := range o.Packages {
+		if r.Packages == nil {
+			r.Packages = map[string]PackageRegistry{}
+		}
+		existing := r.Packages[name]
+		existing.RegistryEntry = existing.RegistryEntry.merge(pkg.RegistryEntry)
+		for ext, entry := range pkg.Extensions {
+			if existing.Extensions == nil {
+				existing.Extensions = map[string]RegistryEntry{}
+			}
+			existing.Extensions[ext] = existing.Extensions[ext].merge(entry)
+		}
+		r.Packages[name] = existing
+	}
+}
+
+// ConfigReader is the minimal interface used by BuildRegistryFromConfigAndEnv
+// to read installer-registry keys from datadog.yaml. Matches the subset of
+// `comp/core/config.Component` we need, so we don't take a heavy dep here.
+type ConfigReader interface {
+	GetString(key string) string
+	GetStringMap(key string) map[string]interface{}
+}
+
+// buildRegistryFromConfig populates a RegistryConfig from yaml
+// `installer.registry.*` keys (incl. per-extension entries under
+// `installer.registry.extensions.<pkg>.<ext>.*`).
+func buildRegistryFromConfig(cfg ConfigReader) RegistryConfig {
+	r := RegistryConfig{}
+	r.Default = RegistryEntry{
+		URL:      cfg.GetString("installer.registry.url"),
+		Auth:     cfg.GetString("installer.registry.auth"),
+		Username: cfg.GetString("installer.registry.username"),
+		Password: cfg.GetString("installer.registry.password"),
+	}
+	exts := cfg.GetStringMap("installer.registry.extensions")
+	for pkgName, extMapAny := range exts {
+		extMap, ok := extMapAny.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		pkg := PackageRegistry{}
+		for extName, extCfgAny := range extMap {
+			extCfg, ok := extCfgAny.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			entry := RegistryEntry{}
+			if s, ok := extCfg["url"].(string); ok {
+				entry.URL = s
+			}
+			if s, ok := extCfg["auth"].(string); ok {
+				entry.Auth = s
+			}
+			if s, ok := extCfg["username"].(string); ok {
+				entry.Username = s
+			}
+			if s, ok := extCfg["password"].(string); ok {
+				entry.Password = s
+			}
+			if entry == (RegistryEntry{}) {
+				continue
+			}
+			if pkg.Extensions == nil {
+				pkg.Extensions = map[string]RegistryEntry{}
+			}
+			pkg.Extensions[extName] = entry
+		}
+		if pkg.Extensions == nil && pkg.RegistryEntry == (RegistryEntry{}) {
+			continue
+		}
+		if r.Packages == nil {
+			r.Packages = map[string]PackageRegistry{}
+		}
+		r.Packages[pkgName] = pkg
+	}
+	return r
+}
+
+// BuildRegistryFromConfigAndEnv merges (in order, later wins on non-empty
+// fields):
+//  1. datadog.yaml `installer.registry.*` (incl. per-extension entries)
+//  2. legacy DD_INSTALLER_REGISTRY_{URL,AUTH,USERNAME,PASSWORD}[_<PKG>]
+//  3. DD_INSTALLER_REGISTRY JSON (if set)
+//
+// and returns the canonical RegistryConfig plus its JSON encoding. The
+// caller is expected to emit the JSON as DD_INSTALLER_REGISTRY and unset
+// the legacy vars so the installer sees a single, clean contract.
+func BuildRegistryFromConfigAndEnv(cfg ConfigReader) (RegistryConfig, string, error) {
+	r := buildRegistryFromConfig(cfg)
+	r.applyLegacyEnvVars()
+	if err := r.applyRegistryEnvJSON(); err != nil {
+		return RegistryConfig{}, "", err
+	}
+	blob, err := json.Marshal(r)
+	if err != nil {
+		return RegistryConfig{}, "", err
+	}
+	return r, string(blob), nil
+}
+
+// BuildRegistryFromEnv is the no-config variant of
+// BuildRegistryFromConfigAndEnv — used when only env vars are available
+// (e.g. install-script entry points without an fx config.Component).
+func BuildRegistryFromEnv() (RegistryConfig, string, error) {
+	r := RegistryConfig{}
+	r.applyLegacyEnvVars()
+	if err := r.applyRegistryEnvJSON(); err != nil {
+		return RegistryConfig{}, "", err
+	}
+	blob, err := json.Marshal(r)
+	if err != nil {
+		return RegistryConfig{}, "", err
+	}
+	return r, string(blob), nil
+}

--- a/pkg/fleet/installer/env/registry_test.go
+++ b/pkg/fleet/installer/env/registry_test.go
@@ -1,0 +1,236 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package env
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCfg is a minimal ConfigReader for testing BuildRegistryFromConfigAndEnv
+// without pulling in the full fx config.Component.
+type fakeCfg struct {
+	strings    map[string]string
+	stringMaps map[string]map[string]interface{}
+}
+
+func (f fakeCfg) GetString(key string) string { return f.strings[key] }
+func (f fakeCfg) GetStringMap(key string) map[string]interface{} {
+	return f.stringMaps[key]
+}
+
+func TestPackageNameFromURL(t *testing.T) {
+	cases := map[string]string{
+		"oci://install.datadoghq.com/agent-package:1.2.3":           "datadog-agent",
+		"oci://install.datad0g.com/agent-package:pipeline-123":      "datadog-agent",
+		"oci://install.datadoghq.com/apm-inject-package:1.0":        "datadog-apm-inject",
+		"oci://install.datadoghq.com/installer-package@sha256:deef": "datadog-installer",
+		"oci://install.datadoghq.com/agent-package":                 "datadog-agent",
+		"oci://install.datadoghq.com/malformed:1.2.3":               "", // no -package suffix
+		"":             "",
+		"-package:1.2": "", // empty slug
+	}
+	for url, want := range cases {
+		assert.Equal(t, want, PackageNameFromURL(url), "url=%q", url)
+	}
+}
+
+func TestResolveFallbackChain(t *testing.T) {
+	r := RegistryConfig{
+		Default: RegistryEntry{URL: "default.io", Auth: "gcr", Username: "du", Password: "dp"},
+		Packages: map[string]PackageRegistry{
+			"datadog-agent": {
+				RegistryEntry: RegistryEntry{URL: "agent.io"},
+				Extensions: map[string]RegistryEntry{
+					"ddot": {Auth: "password", Username: "eu"},
+				},
+			},
+		},
+	}
+
+	// Unknown package → default only.
+	got := r.Resolve("datadog-unknown", "")
+	assert.Equal(t, RegistryEntry{URL: "default.io", Auth: "gcr", Username: "du", Password: "dp"}, got)
+
+	// Known package, no ext → package URL overrides default URL;
+	// auth/username/password fall through to default.
+	got = r.Resolve("datadog-agent", "")
+	assert.Equal(t, RegistryEntry{URL: "agent.io", Auth: "gcr", Username: "du", Password: "dp"}, got)
+
+	// Known package + ext → ext auth+username override;
+	// URL falls through to package; password falls through to default.
+	got = r.Resolve("datadog-agent", "ddot")
+	assert.Equal(t, RegistryEntry{URL: "agent.io", Auth: "password", Username: "eu", Password: "dp"}, got)
+
+	// Empty pkg → default.
+	got = r.Resolve("", "")
+	assert.Equal(t, RegistryEntry{URL: "default.io", Auth: "gcr", Username: "du", Password: "dp"}, got)
+}
+
+func TestRegistryConfigJSONRoundTrip(t *testing.T) {
+	in := RegistryConfig{
+		Default: RegistryEntry{URL: "default.io", Auth: "gcr"},
+		Packages: map[string]PackageRegistry{
+			"datadog-agent": {
+				RegistryEntry: RegistryEntry{URL: "agent.io"},
+				Extensions: map[string]RegistryEntry{
+					"ddot": {Auth: "password", Username: "u", Password: "p"},
+				},
+			},
+			"datadog-apm-inject": {RegistryEntry: RegistryEntry{URL: "inject.io"}},
+		},
+	}
+
+	blob, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	// Standard nested layout: top-level object with "default" + "packages".
+	assert.Contains(t, string(blob), `"default":`)
+	assert.Contains(t, string(blob), `"packages":`)
+	assert.Contains(t, string(blob), `"datadog-agent":`)
+	assert.Contains(t, string(blob), `"datadog-apm-inject":`)
+
+	var out RegistryConfig
+	require.NoError(t, json.Unmarshal(blob, &out))
+	assert.Equal(t, in, out)
+}
+
+func TestRegistryConfigUnmarshalEmpty(t *testing.T) {
+	var out RegistryConfig
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &out))
+	assert.Equal(t, RegistryConfig{}, out)
+}
+
+func TestRegistryConfigUnmarshalDefaultOnly(t *testing.T) {
+	var out RegistryConfig
+	require.NoError(t, json.Unmarshal([]byte(`{"default":{"url":"x.io"}}`), &out))
+	assert.Equal(t, RegistryEntry{URL: "x.io"}, out.Default)
+	assert.Empty(t, out.Packages)
+}
+
+func TestRegistryConfigMarshalEmpty(t *testing.T) {
+	// Empty Registry marshals to {"default":{}} (no "packages" since
+	// the map is nil and the field is omitempty).
+	blob, err := json.Marshal(RegistryConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, `{"default":{}}`, string(blob))
+}
+
+func TestBuildRegistryFromConfigAndEnv(t *testing.T) {
+	t.Run("yaml only", func(t *testing.T) {
+		clearRegistryEnv(t)
+		cfg := fakeCfg{
+			strings: map[string]string{
+				"installer.registry.url":      "yaml.io",
+				"installer.registry.auth":     "gcr",
+				"installer.registry.username": "yu",
+				"installer.registry.password": "yp",
+			},
+			stringMaps: map[string]map[string]interface{}{
+				"installer.registry.extensions": {
+					"datadog-agent": map[string]interface{}{
+						"ddot": map[string]interface{}{
+							"url":      "ext.io",
+							"auth":     "password",
+							"username": "eu",
+							"password": "ep",
+						},
+					},
+				},
+			},
+		}
+		got, blob, err := BuildRegistryFromConfigAndEnv(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, RegistryEntry{URL: "yaml.io", Auth: "gcr", Username: "yu", Password: "yp"}, got.Default)
+		require.Contains(t, got.Packages, "datadog-agent")
+		assert.Equal(t, RegistryEntry{URL: "ext.io", Auth: "password", Username: "eu", Password: "ep"},
+			got.Packages["datadog-agent"].Extensions["ddot"])
+		assert.NotEmpty(t, blob)
+	})
+
+	t.Run("legacy env vars override yaml defaults", func(t *testing.T) {
+		clearRegistryEnv(t)
+		t.Setenv("DD_INSTALLER_REGISTRY_URL", "env.io")
+		t.Setenv("DD_INSTALLER_REGISTRY_AUTH", "password")
+		cfg := fakeCfg{
+			strings: map[string]string{
+				"installer.registry.url":  "yaml.io",
+				"installer.registry.auth": "gcr",
+			},
+		}
+		got, _, err := BuildRegistryFromConfigAndEnv(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "env.io", got.Default.URL)
+		assert.Equal(t, "password", got.Default.Auth)
+	})
+
+	t.Run("per-package legacy env var populates Packages slot", func(t *testing.T) {
+		clearRegistryEnv(t)
+		t.Setenv("DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE", "mirror.io/agent")
+		t.Setenv("DD_INSTALLER_REGISTRY_AUTH_AGENT_PACKAGE", "password")
+		cfg := fakeCfg{}
+		got, _, err := BuildRegistryFromConfigAndEnv(cfg)
+		require.NoError(t, err)
+		require.Contains(t, got.Packages, "datadog-agent")
+		entry := got.Packages["datadog-agent"]
+		assert.Equal(t, "mirror.io/agent", entry.URL)
+		assert.Equal(t, "password", entry.Auth)
+	})
+
+	t.Run("DD_INSTALLER_REGISTRY JSON wins over legacy + yaml", func(t *testing.T) {
+		clearRegistryEnv(t)
+		t.Setenv("DD_INSTALLER_REGISTRY_URL", "legacy.io")
+		t.Setenv(EnvInstallerRegistry, `{"default":{"url":"canonical.io"}}`)
+		cfg := fakeCfg{
+			strings: map[string]string{"installer.registry.url": "yaml.io"},
+		}
+		got, _, err := BuildRegistryFromConfigAndEnv(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "canonical.io", got.Default.URL)
+	})
+
+	t.Run("legacy per-package merges with yaml extensions on same pkg", func(t *testing.T) {
+		clearRegistryEnv(t)
+		t.Setenv("DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE", "from-env.io/agent")
+		cfg := fakeCfg{
+			stringMaps: map[string]map[string]interface{}{
+				"installer.registry.extensions": {
+					"datadog-agent": map[string]interface{}{
+						"ddot": map[string]interface{}{"url": "ext.io"},
+					},
+				},
+			},
+		}
+		got, _, err := BuildRegistryFromConfigAndEnv(cfg)
+		require.NoError(t, err)
+		entry := got.Packages["datadog-agent"]
+		assert.Equal(t, "from-env.io/agent", entry.URL)
+		assert.Equal(t, RegistryEntry{URL: "ext.io"}, entry.Extensions["ddot"])
+	})
+}
+
+// clearRegistryEnv unsets any DD_INSTALLER_REGISTRY* vars the process may
+// have inherited; t.Cleanup restores them via the saved value.
+func clearRegistryEnv(t *testing.T) {
+	t.Helper()
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		key := kv[:eq]
+		if key == EnvInstallerRegistry || strings.HasPrefix(key, "DD_INSTALLER_REGISTRY_") {
+			original := os.Getenv(key)
+			os.Unsetenv(key)
+			t.Cleanup(func() { os.Setenv(key, original) })
+		}
+	}
+}

--- a/pkg/fleet/installer/go.mod
+++ b/pkg/fleet/installer/go.mod
@@ -25,7 +25,6 @@ require (
 	golang.org/x/sys v0.43.0
 	golang.org/x/text v0.36.0
 	gopkg.in/evanphx/json-patch.v4 v4.13.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -58,6 +57,7 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 )
 

--- a/pkg/fleet/installer/oci/download.go
+++ b/pkg/fleet/installer/oci/download.go
@@ -114,23 +114,11 @@ func NewDownloader(env *env.Env, client *http.Client) *Downloader {
 
 // WithRegistryOverride returns a new Downloader with the given registry overrides applied.
 // The returned Downloader shares the same HTTP client as the original.
-// Image-scoped override maps (from DD_INSTALLER_REGISTRY_URL_<IMAGE> env vars) are
-// preserved and take precedence over the per-extension override, matching the
-// existing priority order.
+// Per-package overrides on the existing env.Registry take precedence over this
+// override, matching the existing priority order.
 func (d *Downloader) WithRegistryOverride(url, auth, username, password string) *Downloader {
 	envCopy := *d.env
-	if url != "" {
-		envCopy.RegistryOverride = url
-	}
-	if auth != "" {
-		envCopy.RegistryAuthOverride = auth
-	}
-	if username != "" {
-		envCopy.RegistryUsername = username
-	}
-	if password != "" {
-		envCopy.RegistryPassword = password
-	}
+	envCopy.Registry.Default = envCopy.Registry.Default.MergeStrings(url, auth, username, password)
 	return &Downloader{
 		env:    &envCopy,
 		client: d.client,
@@ -221,7 +209,8 @@ func getRefAndKeychains(mainEnv *env.Env, url string) []urlWithKeychain {
 		defaultRegistries = defaultRegistriesStaging
 	}
 	for _, additionalDefaultRegistry := range defaultRegistries {
-		refAndKeychain := getRefAndKeychain(&env.Env{RegistryOverride: additionalDefaultRegistry}, url)
+		fallbackEnv := &env.Env{Registry: env.RegistryConfig{Default: env.RegistryEntry{URL: additionalDefaultRegistry}}}
+		refAndKeychain := getRefAndKeychain(fallbackEnv, url)
 		// Deduplicate
 		found := false
 		for _, rk := range refAndKeychains {
@@ -238,33 +227,25 @@ func getRefAndKeychains(mainEnv *env.Env, url string) []urlWithKeychain {
 	return refAndKeychains
 }
 
-// getRefAndKeychain returns the reference and keychain for the given URL.
-// This function applies potential registry and authentication overrides set either globally or per image.
-func getRefAndKeychain(env *env.Env, url string) urlWithKeychain {
+// getRefAndKeychain returns the reference and keychain for the given URL,
+// applying registry and authentication overrides from the unified
+// env.Registry (per-package with fallback to Default).
+func getRefAndKeychain(e *env.Env, url string) urlWithKeychain {
 	imageWithIdentifier := url[strings.LastIndex(url, "/")+1:]
-	registryOverride := env.RegistryOverride
-	for image, override := range env.RegistryOverrideByImage {
-		if strings.HasPrefix(imageWithIdentifier, image+":") || strings.HasPrefix(imageWithIdentifier, image+"@") {
-			registryOverride = override
-			break
-		}
-	}
+	pkg := env.PackageNameFromURL(url)
+	entry := e.Registry.Resolve(pkg, "")
+
 	ref := url
 	// public.ecr.aws/datadog is ignored for now as there are issues with it
-	if registryOverride != "" && registryOverride != "public.ecr.aws/datadog" {
+	if entry.URL != "" && entry.URL != "public.ecr.aws/datadog" {
+		registryOverride := entry.URL
 		if !strings.HasSuffix(registryOverride, "/") {
 			registryOverride += "/"
 		}
 		registryOverride = formatImageRef(registryOverride)
 		ref = registryOverride + imageWithIdentifier
 	}
-	keychain := getKeychain(env.RegistryAuthOverride, env.RegistryUsername, env.RegistryPassword)
-	for image, override := range env.RegistryAuthOverrideByImage {
-		if strings.HasPrefix(imageWithIdentifier, image+":") || strings.HasPrefix(imageWithIdentifier, image+"@") {
-			keychain = getKeychain(override, env.RegistryUsername, env.RegistryPassword)
-			break
-		}
-	}
+	keychain := getKeychain(entry.Auth, entry.Username, entry.Password)
 	return urlWithKeychain{
 		ref:      ref,
 		keychain: keychain,

--- a/pkg/fleet/installer/oci/download_test.go
+++ b/pkg/fleet/installer/oci/download_test.go
@@ -145,7 +145,7 @@ func TestDownloadRegistryWithOverride(t *testing.T) {
 	s := newTestDownloadServer(t)
 	defer s.Close()
 	d := s.DownloaderWithEnv(&env.Env{
-		RegistryOverride: "fake.io",
+		Registry: env.RegistryConfig{Default: env.RegistryEntry{URL: "fake.io"}},
 	})
 
 	_, err := d.Download(context.Background(), s.PackageURL(fixtures.FixtureSimpleV1))
@@ -154,70 +154,98 @@ func TestDownloadRegistryWithOverride(t *testing.T) {
 
 func TestGetRefAndKeychain(t *testing.T) {
 	type test struct {
-		registryOverride       string
-		regOverrideByImage     map[string]string
-		registryAuthOverride   string
-		regAuthOverrideByImage map[string]string
-		url                    string
-		expectedRef            string
-		expectedKeychain       authn.Keychain
+		registry         env.RegistryConfig
+		url              string
+		expectedRef      string
+		expectedKeychain authn.Keychain
 	}
 
 	tests := []test{
 		{url: "install.datad0g.com/agent-package:latest", expectedRef: "install.datad0g.com/agent-package:latest", expectedKeychain: authn.DefaultKeychain},
 		{url: "gcr.io/datadoghq/agent-package@sha256:1234", expectedRef: "gcr.io/datadoghq/agent-package@sha256:1234", expectedKeychain: authn.DefaultKeychain},
-		{url: "install.datad0g.com/agent-package:latest", registryOverride: "fake.io", expectedRef: "fake.io/agent-package:latest", expectedKeychain: authn.DefaultKeychain},
-		{url: "install.datad0g.com/agent-package:latest", registryOverride: "http://fake.io", expectedRef: "fake.io/agent-package:latest", expectedKeychain: authn.DefaultKeychain},
-		{url: "install.datad0g.com/agent-package:latest", registryOverride: "https://fake.io", expectedRef: "fake.io/agent-package:latest", expectedKeychain: authn.DefaultKeychain},
-		{url: "install.datad0g.com/agent-package:latest", registryOverride: "https://fake.io:443", expectedRef: "fake.io:443/agent-package:latest", expectedKeychain: authn.DefaultKeychain},
-		{url: "gcr.io/datadoghq/agent-package@sha256:1234", registryOverride: "fake.io", expectedRef: "fake.io/agent-package@sha256:1234", expectedKeychain: authn.DefaultKeychain},
 		{
-			url:                "install.datad0g.com/agent-package:latest",
-			regOverrideByImage: map[string]string{"agent-package": "fake.io"},
-			expectedRef:        "fake.io/agent-package:latest",
-			expectedKeychain:   authn.DefaultKeychain,
+			url:              "install.datad0g.com/agent-package:latest",
+			registry:         env.RegistryConfig{Default: env.RegistryEntry{URL: "fake.io"}},
+			expectedRef:      "fake.io/agent-package:latest",
+			expectedKeychain: authn.DefaultKeychain,
 		},
 		{
-			url:                "gcr.io/datadoghq/agent-package@sha256:1234",
-			regOverrideByImage: map[string]string{"agent-package": "fake.io"},
-			expectedRef:        "fake.io/agent-package@sha256:1234",
-			expectedKeychain:   authn.DefaultKeychain,
+			url:              "install.datad0g.com/agent-package:latest",
+			registry:         env.RegistryConfig{Default: env.RegistryEntry{URL: "http://fake.io"}},
+			expectedRef:      "fake.io/agent-package:latest",
+			expectedKeychain: authn.DefaultKeychain,
 		},
 		{
-			url:                "gcr.io/datadoghq/agent-package@sha256:1234",
-			regOverrideByImage: map[string]string{"agent-package": "fake.io"},
-			expectedRef:        "fake.io/agent-package@sha256:1234",
-			expectedKeychain:   authn.DefaultKeychain,
+			url:              "install.datad0g.com/agent-package:latest",
+			registry:         env.RegistryConfig{Default: env.RegistryEntry{URL: "https://fake.io"}},
+			expectedRef:      "fake.io/agent-package:latest",
+			expectedKeychain: authn.DefaultKeychain,
 		},
 		{
-			url:                "gcr.io/datadoghq/agent-package@sha256:1234",
-			registryOverride:   "fake-other.io",
-			regOverrideByImage: map[string]string{"agent-package": "fake.io"},
-			expectedRef:        "fake.io/agent-package@sha256:1234",
-			expectedKeychain:   authn.DefaultKeychain,
+			url:              "install.datad0g.com/agent-package:latest",
+			registry:         env.RegistryConfig{Default: env.RegistryEntry{URL: "https://fake.io:443"}},
+			expectedRef:      "fake.io:443/agent-package:latest",
+			expectedKeychain: authn.DefaultKeychain,
 		},
 		{
-			url:                  "gcr.io/datadoghq/agent-package@sha256:1234",
-			registryAuthOverride: "gcr",
-			expectedRef:          "gcr.io/datadoghq/agent-package@sha256:1234",
-			expectedKeychain:     google.Keychain,
+			url:              "gcr.io/datadoghq/agent-package@sha256:1234",
+			registry:         env.RegistryConfig{Default: env.RegistryEntry{URL: "fake.io"}},
+			expectedRef:      "fake.io/agent-package@sha256:1234",
+			expectedKeychain: authn.DefaultKeychain,
 		},
 		{
-			url:                    "gcr.io/datadoghq/agent-package@sha256:1234",
-			regAuthOverrideByImage: map[string]string{"agent-package": "gcr"},
-			expectedRef:            "gcr.io/datadoghq/agent-package@sha256:1234",
-			expectedKeychain:       google.Keychain,
+			url: "install.datad0g.com/agent-package:latest",
+			registry: env.RegistryConfig{
+				Packages: map[string]env.PackageRegistry{
+					"datadog-agent": {RegistryEntry: env.RegistryEntry{URL: "fake.io"}},
+				},
+			},
+			expectedRef:      "fake.io/agent-package:latest",
+			expectedKeychain: authn.DefaultKeychain,
+		},
+		{
+			url: "gcr.io/datadoghq/agent-package@sha256:1234",
+			registry: env.RegistryConfig{
+				Packages: map[string]env.PackageRegistry{
+					"datadog-agent": {RegistryEntry: env.RegistryEntry{URL: "fake.io"}},
+				},
+			},
+			expectedRef:      "fake.io/agent-package@sha256:1234",
+			expectedKeychain: authn.DefaultKeychain,
+		},
+		{
+			// Per-package URL takes precedence over default URL.
+			url: "gcr.io/datadoghq/agent-package@sha256:1234",
+			registry: env.RegistryConfig{
+				Default: env.RegistryEntry{URL: "fake-other.io"},
+				Packages: map[string]env.PackageRegistry{
+					"datadog-agent": {RegistryEntry: env.RegistryEntry{URL: "fake.io"}},
+				},
+			},
+			expectedRef:      "fake.io/agent-package@sha256:1234",
+			expectedKeychain: authn.DefaultKeychain,
+		},
+		{
+			url:              "gcr.io/datadoghq/agent-package@sha256:1234",
+			registry:         env.RegistryConfig{Default: env.RegistryEntry{Auth: "gcr"}},
+			expectedRef:      "gcr.io/datadoghq/agent-package@sha256:1234",
+			expectedKeychain: google.Keychain,
+		},
+		{
+			url: "gcr.io/datadoghq/agent-package@sha256:1234",
+			registry: env.RegistryConfig{
+				Packages: map[string]env.PackageRegistry{
+					"datadog-agent": {RegistryEntry: env.RegistryEntry{Auth: "gcr"}},
+				},
+			},
+			expectedRef:      "gcr.io/datadoghq/agent-package@sha256:1234",
+			expectedKeychain: google.Keychain,
 		},
 	}
 
 	for _, tt := range tests {
-		env := &env.Env{
-			RegistryOverride:            tt.registryOverride,
-			RegistryOverrideByImage:     tt.regOverrideByImage,
-			RegistryAuthOverride:        tt.registryAuthOverride,
-			RegistryAuthOverrideByImage: tt.regAuthOverrideByImage,
-		}
-		actual := getRefAndKeychain(env, tt.url)
+		e := &env.Env{Registry: tt.registry}
+		actual := getRefAndKeychain(e, tt.url)
 		assert.Equal(t, tt.expectedRef, actual.ref)
 		assert.Equal(t, tt.expectedKeychain, actual.keychain)
 	}
@@ -287,58 +315,55 @@ func TestIsStreamResetError(t *testing.T) {
 
 func TestWithRegistryOverride(t *testing.T) {
 	original := &env.Env{
-		RegistryOverride:            "original.registry.com",
-		RegistryAuthOverride:        "docker",
-		RegistryUsername:            "origuser",
-		RegistryPassword:            "origpass",
-		RegistryOverrideByImage:     map[string]string{"agent-package": "image-scoped.io"},
-		RegistryAuthOverrideByImage: map[string]string{"agent-package": "gcr"},
-		Site:                        "datadoghq.com",
+		Registry: env.RegistryConfig{
+			Default: env.RegistryEntry{URL: "original.registry.com", Auth: "docker", Username: "origuser", Password: "origpass"},
+			Packages: map[string]env.PackageRegistry{
+				"datadog-agent": {RegistryEntry: env.RegistryEntry{URL: "image-scoped.io", Auth: "gcr"}},
+			},
+		},
+		Site: "datadoghq.com",
 	}
 	client := http.DefaultClient
 	d := NewDownloader(original, client)
 
 	overridden := d.WithRegistryOverride("custom.registry.com", "password", "newuser", "newpass")
 
-	// Overridden downloader has new values
-	assert.Equal(t, "custom.registry.com", overridden.env.RegistryOverride)
-	assert.Equal(t, "password", overridden.env.RegistryAuthOverride)
-	assert.Equal(t, "newuser", overridden.env.RegistryUsername)
-	assert.Equal(t, "newpass", overridden.env.RegistryPassword)
+	// Overridden downloader's Default has the new values.
+	assert.Equal(t, "custom.registry.com", overridden.env.Registry.Default.URL)
+	assert.Equal(t, "password", overridden.env.Registry.Default.Auth)
+	assert.Equal(t, "newuser", overridden.env.Registry.Default.Username)
+	assert.Equal(t, "newpass", overridden.env.Registry.Default.Password)
 
-	// Image-scoped override maps are preserved (env vars take precedence)
-	assert.Equal(t, map[string]string{"agent-package": "image-scoped.io"}, overridden.env.RegistryOverrideByImage)
-	assert.Equal(t, map[string]string{"agent-package": "gcr"}, overridden.env.RegistryAuthOverrideByImage)
+	// Per-package entries are preserved (they take precedence over Default).
+	assert.Equal(t, "image-scoped.io", overridden.env.Registry.Packages["datadog-agent"].URL)
+	assert.Equal(t, "gcr", overridden.env.Registry.Packages["datadog-agent"].Auth)
 
-	// Original is unchanged
-	assert.Equal(t, "original.registry.com", d.env.RegistryOverride)
-	assert.Equal(t, "docker", d.env.RegistryAuthOverride)
-	assert.Equal(t, "origuser", d.env.RegistryUsername)
-	assert.Equal(t, "origpass", d.env.RegistryPassword)
+	// Original is unchanged.
+	assert.Equal(t, "original.registry.com", d.env.Registry.Default.URL)
+	assert.Equal(t, "docker", d.env.Registry.Default.Auth)
 
-	// Shares same HTTP client
+	// Shares same HTTP client.
 	assert.Same(t, d.client, overridden.client)
 
-	// Non-registry fields are preserved
+	// Non-registry fields are preserved.
 	assert.Equal(t, "datadoghq.com", overridden.env.Site)
 }
 
 func TestWithRegistryOverridePartial(t *testing.T) {
 	original := &env.Env{
-		RegistryOverride:     "original.registry.com",
-		RegistryAuthOverride: "docker",
-		RegistryUsername:     "origuser",
-		RegistryPassword:     "origpass",
+		Registry: env.RegistryConfig{
+			Default: env.RegistryEntry{URL: "original.registry.com", Auth: "docker", Username: "origuser", Password: "origpass"},
+		},
 	}
 	d := NewDownloader(original, http.DefaultClient)
 
-	// Only override URL, leave auth/username/password empty
+	// Only override URL, leave auth/username/password empty.
 	overridden := d.WithRegistryOverride("custom.registry.com", "", "", "")
 
-	assert.Equal(t, "custom.registry.com", overridden.env.RegistryOverride)
-	assert.Equal(t, "docker", overridden.env.RegistryAuthOverride)
-	assert.Equal(t, "origuser", overridden.env.RegistryUsername)
-	assert.Equal(t, "origpass", overridden.env.RegistryPassword)
+	assert.Equal(t, "custom.registry.com", overridden.env.Registry.Default.URL)
+	assert.Equal(t, "docker", overridden.env.Registry.Default.Auth)
+	assert.Equal(t, "origuser", overridden.env.Registry.Default.Username)
+	assert.Equal(t, "origpass", overridden.env.Registry.Default.Password)
 }
 
 func TestGetRefAndKeychains(t *testing.T) {
@@ -392,15 +417,16 @@ func TestGetRefAndKeychains(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env := &env.Env{
-				Site:                 "datad0g.com",
-				RegistryOverride:     tt.registryOverride,
-				RegistryAuthOverride: tt.registryAuthOverride,
+			e := &env.Env{
+				Site: "datad0g.com",
+				Registry: env.RegistryConfig{
+					Default: env.RegistryEntry{URL: tt.registryOverride, Auth: tt.registryAuthOverride},
+				},
 			}
 			if tt.isProd {
-				env.Site = "datadoghq.com"
+				e.Site = "datadoghq.com"
 			}
-			actual := getRefAndKeychains(env, tt.url)
+			actual := getRefAndKeychains(e, tt.url)
 			assert.Len(t, actual, len(tt.expectedRefAndKeychains))
 			for i, a := range actual {
 				assert.Equal(t, tt.expectedRefAndKeychains[i].ref, a.ref)

--- a/pkg/fleet/installer/packages/BUILD.bazel
+++ b/pkg/fleet/installer/packages/BUILD.bazel
@@ -28,9 +28,7 @@ go_library(
         "//pkg/fleet/installer/paths",
         "//pkg/fleet/installer/repository",
         "//pkg/fleet/installer/telemetry",
-        "//pkg/util/log",
         "//pkg/version",
-        "@in_gopkg_yaml_v3//:yaml_v3",
         "@in_yaml_go_yaml_v2//:yaml",
     ] + select({
         "@rules_go//go/platform:android": [
@@ -47,6 +45,7 @@ go_library(
             "//pkg/fleet/installer/packages/service/sysvinit",
             "//pkg/fleet/installer/packages/service/upstart",
             "//pkg/fleet/installer/packages/user",
+            "//pkg/util/log",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/fleet/installer/installinfo",
@@ -62,6 +61,7 @@ go_library(
             "//pkg/fleet/installer/packages/service/sysvinit",
             "//pkg/fleet/installer/packages/service/upstart",
             "//pkg/fleet/installer/packages/user",
+            "//pkg/util/log",
         ],
         "@rules_go//go/platform:windows": [
             "//pkg/fleet/installer/msi",
@@ -70,6 +70,7 @@ go_library(
             "//pkg/fleet/installer/packages/ssi",
             "//pkg/fleet/installer/packages/user/windows",
             "//pkg/fleet/installer/setup/config",
+            "//pkg/util/log",
             "//pkg/util/winutil",
             "@in_yaml_go_yaml_v3//:yaml",
             "@org_golang_x_sys//windows",
@@ -91,10 +92,10 @@ go_test(
     embed = [":packages"],
     gotags = ["test"],
     deps = [
+        "//pkg/fleet/installer/env",
         "//pkg/fleet/installer/packages/extensions",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@in_gopkg_yaml_v3//:yaml_v3",
     ] + select({
         "@rules_go//go/platform:windows": [
             "//pkg/fleet/installer/setup/config",

--- a/pkg/fleet/installer/packages/BUILD.bazel
+++ b/pkg/fleet/installer/packages/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/fleet/installer/paths",
         "//pkg/fleet/installer/repository",
         "//pkg/fleet/installer/telemetry",
+        "//pkg/util/log",
         "//pkg/version",
         "@in_yaml_go_yaml_v2//:yaml",
     ] + select({
@@ -45,7 +46,6 @@ go_library(
             "//pkg/fleet/installer/packages/service/sysvinit",
             "//pkg/fleet/installer/packages/service/upstart",
             "//pkg/fleet/installer/packages/user",
-            "//pkg/util/log",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/fleet/installer/installinfo",
@@ -61,7 +61,6 @@ go_library(
             "//pkg/fleet/installer/packages/service/sysvinit",
             "//pkg/fleet/installer/packages/service/upstart",
             "//pkg/fleet/installer/packages/user",
-            "//pkg/util/log",
         ],
         "@rules_go//go/platform:windows": [
             "//pkg/fleet/installer/msi",
@@ -70,7 +69,6 @@ go_library(
             "//pkg/fleet/installer/packages/ssi",
             "//pkg/fleet/installer/packages/user/windows",
             "//pkg/fleet/installer/setup/config",
-            "//pkg/util/log",
             "//pkg/util/winutil",
             "@in_yaml_go_yaml_v3//:yaml",
             "@org_golang_x_sys//windows",

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/file"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/packagemanager"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/systemd"
@@ -219,9 +220,11 @@ func preRemoveDatadogAgentDDOT(ctx HookContext) error {
 	return nil
 }
 
-// writeOTelConfig creates otel-config.yaml by substituting API key and site values from datadog.yaml, fallback with env variables.
+// writeOTelConfig creates otel-config.yaml by substituting api_key and site
+// values from env vars.
 func writeOTelConfig(ctx HookContext) error {
-	return writeOTelConfigCommon(ctx, datadogYamlPath, otelConfigExamplePath, otelConfigPath, false, 0640)
+	e := env.FromEnv()
+	return writeOTelConfigCommon(ctx, e.APIKey, e.Site, otelConfigExamplePath, otelConfigPath, false, 0640)
 }
 
 //////////////////////////////
@@ -256,7 +259,8 @@ func postInstallDDOTExtension(ctx HookContext) (err error) {
 	}
 
 	// Write otel-config.yaml. Doesn't update the file if it already exists.
-	if err := writeOTelConfigCommon(ctx, datadogYamlPath, otelConfigExamplePath, otelConfigPath, true, 0640); err != nil {
+	e := env.FromEnv()
+	if err := writeOTelConfigCommon(ctx, e.APIKey, e.Site, otelConfigExamplePath, otelConfigPath, true, 0640); err != nil {
 		return fmt.Errorf("failed to write otel-config.yaml: %w", err)
 	}
 

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_windows.go
@@ -15,8 +15,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"go.yaml.in/yaml/v2"
-
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	windowssvc "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/windows"
 	windowsuser "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user/windows"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
@@ -48,8 +47,9 @@ func preInstallDatadogAgentDDOT(ctx HookContext) error {
 
 // postInstallDatadogAgentDdot performs post-installation steps for the DDOT package on Windows
 func postInstallDatadogAgentDdot(ctx HookContext) (err error) {
+	e := env.FromEnv()
 	// 1) Write otel-config.yaml with API key/site substitutions
-	if err = writeOTelConfigWindows(ctx); err != nil {
+	if err = writeOTelConfigWindows(ctx, e.APIKey, e.Site); err != nil {
 		return fmt.Errorf("could not write otel-config.yaml: %w", err)
 	}
 	// 2) Enable otelcollector in datadog.yaml
@@ -75,13 +75,8 @@ func postInstallDatadogAgentDdot(ctx HookContext) (err error) {
 			return nil
 		}
 	}
-	ak, err := readAPIKeyFromDatadogYAML()
-	if err != nil {
-		log.Warnf("DDOT: skipping service start: %v", err)
-		return nil
-	}
-	if ak == "" {
-		log.Warnf("DDOT: skipping service start (no API key configured)")
+	if e.APIKey == "" {
+		log.Warnf("DDOT: skipping service start (no API key configured via DD_API_KEY)")
 		return nil
 	}
 	if err = startServiceIfExists(otelServiceName); err != nil {
@@ -103,23 +98,6 @@ func postInstallDatadogAgentDdot(ctx HookContext) (err error) {
 	return nil
 }
 
-// readAPIKeyFromDatadogYAML reads the api_key from ProgramData datadog.yaml, returns empty string if unset/unknown
-func readAPIKeyFromDatadogYAML() (string, error) {
-	ddYaml := filepath.Join(paths.DatadogDataDir, "datadog.yaml")
-	data, err := os.ReadFile(ddYaml)
-	if err != nil {
-		return "", fmt.Errorf("failed to read datadog.yaml from %s: %w", ddYaml, err)
-	}
-	var cfg map[string]any
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return "", fmt.Errorf("failed to parse datadog.yaml: %w", err)
-	}
-	if v, ok := cfg["api_key"].(string); ok && v != "" {
-		return v, nil
-	}
-	return "", errors.New("api_key not found or empty in datadog.yaml")
-}
-
 // preRemoveDatadogAgentDdot performs pre-removal steps for the DDOT package on Windows
 // All the steps are allowed to fail
 func preRemoveDatadogAgentDdot(ctx HookContext) error {
@@ -139,9 +117,9 @@ func preRemoveDatadogAgentDdot(ctx HookContext) error {
 	return nil
 }
 
-// writeOTelConfigWindows creates otel-config.yaml by substituting API key and site values from datadog.yaml, fallback with env variables.
-func writeOTelConfigWindows(ctx HookContext) error {
-	ddYaml := filepath.Join(paths.DatadogDataDir, "datadog.yaml")
+// writeOTelConfigWindows creates otel-config.yaml by substituting the
+// supplied api_key and site values.
+func writeOTelConfigWindows(ctx HookContext, apiKey, site string) error {
 	// Prefer packaged example/template from the installed package repository
 	cfgTemplate := filepath.Join(paths.PackagesPath, agentDDOTPackage, "stable", "etc", "datadog-agent", "otel-config.yaml.example")
 	// Fallback to local ProgramData example/template if needed
@@ -152,7 +130,7 @@ func writeOTelConfigWindows(ctx HookContext) error {
 		}
 	}
 	out := filepath.Join(paths.DatadogDataDir, "otel-config.yaml")
-	return writeOTelConfigCommon(ctx, ddYaml, cfgTemplate, out, true, 0o600)
+	return writeOTelConfigCommon(ctx, apiKey, site, cfgTemplate, out, true, 0o600)
 }
 
 // enableOtelCollectorConfigWindows adds otelcollector.enabled and agent_ipc defaults to datadog.yaml
@@ -459,10 +437,10 @@ func preRemoveDDOTExtension(_ HookContext) error {
 
 // writeOTelConfigWindowsExtension writes otel-config.yaml for extension
 func writeOTelConfigWindowsExtension(ctx HookContext, extensionPath string) error {
-	ddYaml := filepath.Join(paths.DatadogDataDir, "datadog.yaml")
+	e := env.FromEnv()
 	templatePath := filepath.Join(extensionPath, "etc", "datadog-agent", "otel-config.yaml.example")
 	outPath := filepath.Join(paths.DatadogDataDir, "otel-config.yaml")
-	return writeOTelConfigCommon(ctx, ddYaml, templatePath, outPath, true, 0o640)
+	return writeOTelConfigCommon(ctx, e.APIKey, e.Site, templatePath, outPath, true, 0o640)
 }
 
 // ensureDDOTServiceForExtension ensures the DDOT service exists and is configured correctly for extension

--- a/pkg/fleet/installer/packages/datadog_agent_extensions.go
+++ b/pkg/fleet/installer/packages/datadog_agent_extensions.go
@@ -7,18 +7,13 @@ package packages
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
 	extensionsPkg "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/extensions"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -36,85 +31,31 @@ func getCurrentAgentVersion() string {
 	return v + "-1"
 }
 
-// Config structs for reading installer registry configuration from datadog.yaml
-
-//nolint:unused // Used in platform-specific files
-type datadogAgentConfig struct {
-	Installer installerConfig `yaml:"installer"`
-}
-
-//nolint:unused // Used in platform-specific files
-type installerConfig struct {
-	Registry installerRegistryConfig `yaml:"registry,omitempty"`
-}
-
-//nolint:unused // Used in platform-specific files
-type extensionRegistryConfig struct {
-	URL      string `yaml:"url,omitempty"`
-	Auth     string `yaml:"auth,omitempty"`
-	Username string `yaml:"username,omitempty"`
-	Password string `yaml:"password,omitempty"`
-}
-
-//nolint:unused // Used in platform-specific files
-type installerRegistryConfig struct {
-	URL        string                                        `yaml:"url,omitempty"`
-	Auth       string                                        `yaml:"auth,omitempty"`
-	Username   string                                        `yaml:"username,omitempty"`
-	Password   string                                        `yaml:"password,omitempty"`
-	Extensions map[string]map[string]extensionRegistryConfig `yaml:"extensions,omitempty"`
-}
-
-// setRegistryConfig is a best effort to get the `installer` block from `datadog.yaml` and update the env.
-// It returns per-extension registry overrides parsed from installer.registry.extensions.<pkg>.<ext>.
+// extensionOverrides returns per-extension registry override entries for the
+// agent package, resolved from the unified env.Registry. Only extensions
+// whose resolved entry differs from the default are included.
 //
 //nolint:unused // Used in platform-specific files
-func setRegistryConfig(env *env.Env) map[string]extensionsPkg.ExtensionRegistry {
-	configPath := filepath.Join(paths.AgentConfigDir, "datadog.yaml")
-	rawConfig, err := os.ReadFile(configPath)
-	if err != nil {
-		log.Debugf("could not read agent config at %s: %v", configPath, err)
+func extensionOverrides(e *env.Env, extensions []string) map[string]extensionsPkg.ExtensionRegistry {
+	pkgEntry, hasPkg := e.Registry.Packages[agentPackage]
+	if !hasPkg || len(pkgEntry.Extensions) == 0 {
 		return nil
 	}
-	var config datadogAgentConfig
-	err = yaml.Unmarshal(rawConfig, &config)
-	if err != nil {
-		log.Warnf("could not parse agent config at %s: %v", configPath, err)
-		return nil
-	}
-
-	// Update env with values from config if not already set.
-	// DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE takes precedence over installer.registry.url.
-	if env.RegistryOverride == "" {
-		if agentPackageURL := os.Getenv("DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE"); agentPackageURL != "" {
-			env.RegistryOverride = agentPackageURL
-		} else if config.Installer.Registry.URL != "" {
-			env.RegistryOverride = config.Installer.Registry.URL
+	overrides := make(map[string]extensionsPkg.ExtensionRegistry, len(extensions))
+	for _, ext := range extensions {
+		entry, ok := pkgEntry.Extensions[ext]
+		if !ok {
+			continue
+		}
+		overrides[ext] = extensionsPkg.ExtensionRegistry{
+			URL:      entry.URL,
+			Auth:     entry.Auth,
+			Username: entry.Username,
+			Password: entry.Password,
 		}
 	}
-	if config.Installer.Registry.Auth != "" && env.RegistryAuthOverride == "" {
-		env.RegistryAuthOverride = config.Installer.Registry.Auth
-	}
-	if config.Installer.Registry.Username != "" && env.RegistryUsername == "" {
-		env.RegistryUsername = config.Installer.Registry.Username
-	}
-	if config.Installer.Registry.Password != "" && env.RegistryPassword == "" {
-		env.RegistryPassword = config.Installer.Registry.Password
-	}
-
-	// Parse per-extension registry overrides for the agent package.
-	extConfigs := config.Installer.Registry.Extensions[agentPackage]
-	if len(extConfigs) == 0 {
+	if len(overrides) == 0 {
 		return nil
-	}
-	overrides := make(map[string]extensionsPkg.ExtensionRegistry, len(extConfigs))
-	for extName, extCfg := range extConfigs {
-		overrides[extName] = extensionsPkg.ExtensionRegistry{
-			URL:      extCfg.URL,
-			Auth:     extCfg.Auth,
-			Username: extCfg.Username,
-			Password: extCfg.Password,
-		}
 	}
 	return overrides
 }
@@ -150,8 +91,7 @@ func restoreAgentExtensions(ctx HookContext, version string, experiment bool) er
 
 	storagePath := getExtensionStoragePath(ctx.PackagePath)
 
-	// Best effort to get the registry config from datadog.yaml
-	overrides := setRegistryConfig(env)
+	overrides := extensionOverrides(env, nil)
 
 	downloader := oci.NewDownloader(env, env.HTTPClient())
 	url := oci.PackageURL(env, agentPackage, version)
@@ -186,7 +126,7 @@ func installAgentExtensions(ctx HookContext, version string, isExperiment bool) 
 	}
 
 	// install extensions
-	overrides := setRegistryConfig(env)
+	overrides := extensionOverrides(env, extensions)
 	downloader := oci.NewDownloader(env, env.HTTPClient())
 	url := oci.PackageURL(env, agentPackage, version)
 	hooks := NewHooks(env, repository.NewRepositories(paths.PackagesPath, AsyncPreRemoveHooks))

--- a/pkg/fleet/installer/packages/datadog_agent_extensions.go
+++ b/pkg/fleet/installer/packages/datadog_agent_extensions.go
@@ -7,15 +7,112 @@ package packages
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
+
+	"go.yaml.in/yaml/v2"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
 	extensionsPkg "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/extensions"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
+
+// installerYAMLSchema is a minimal subset of datadog.yaml used as a
+// last-resort fallback when the env-var boundary translation didn't fire.
+//
+// Context: on Windows MSI deferred custom actions, the installer is
+// spawned by RunPostInstallHook with a stripped environment — the CLI
+// fxconfig bootstrap should still read datadog.yaml and populate
+// DD_INSTALLER_REGISTRY, but observed behavior in CI shows the
+// registry override sometimes doesn't reach restoreAgentExtensions.
+// This fallback reads yaml directly in the hook so MSI upgrades of
+// agents that have an `installer.registry.*` block continue to restore
+// extensions from the correct registry.
+//
+//nolint:unused // Used in platform-specific files
+type installerYAMLSchema struct {
+	Installer struct {
+		Registry struct {
+			URL        string                                   `yaml:"url,omitempty"`
+			Auth       string                                   `yaml:"auth,omitempty"`
+			Username   string                                   `yaml:"username,omitempty"`
+			Password   string                                   `yaml:"password,omitempty"`
+			Extensions map[string]map[string]yamlExtensionEntry `yaml:"extensions,omitempty"`
+		} `yaml:"registry,omitempty"`
+	} `yaml:"installer,omitempty"`
+}
+
+//nolint:unused // Used in platform-specific files
+type yamlExtensionEntry struct {
+	URL      string `yaml:"url,omitempty"`
+	Auth     string `yaml:"auth,omitempty"`
+	Username string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
+}
+
+// applyYAMLRegistryFallback reads datadog.yaml and populates env.Registry
+// for any fields the boundary translation didn't set. This is specifically
+// a safety net for hooks running on Windows MSI where the env may be
+// stripped — see the `installerYAMLSchema` doc for context.
+//
+//nolint:unused // Used in platform-specific files
+func applyYAMLRegistryFallback(e *env.Env) {
+	configPath := filepath.Join(paths.AgentConfigDir, "datadog.yaml")
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		return
+	}
+	var cfg installerYAMLSchema
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		log.Debugf("fallback: could not parse %s: %v", configPath, err)
+		return
+	}
+	reg := cfg.Installer.Registry
+	// Layer yaml values into Default — only fields that aren't already set
+	// by the env boundary (so env > yaml precedence holds).
+	if reg.URL != "" && e.Registry.Default.URL == "" {
+		e.Registry.Default.URL = reg.URL
+	}
+	if reg.Auth != "" && e.Registry.Default.Auth == "" {
+		e.Registry.Default.Auth = reg.Auth
+	}
+	if reg.Username != "" && e.Registry.Default.Username == "" {
+		e.Registry.Default.Username = reg.Username
+	}
+	if reg.Password != "" && e.Registry.Default.Password == "" {
+		e.Registry.Default.Password = reg.Password
+	}
+	// Per-extension entries under the agent package.
+	agentExts := reg.Extensions[agentPackage]
+	if len(agentExts) == 0 {
+		return
+	}
+	if e.Registry.Packages == nil {
+		e.Registry.Packages = map[string]env.PackageRegistry{}
+	}
+	pkg := e.Registry.Packages[agentPackage]
+	if pkg.Extensions == nil {
+		pkg.Extensions = map[string]env.RegistryEntry{}
+	}
+	for name, entry := range agentExts {
+		existing, ok := pkg.Extensions[name]
+		if ok && existing != (env.RegistryEntry{}) {
+			continue // don't overwrite env-sourced entries
+		}
+		pkg.Extensions[name] = env.RegistryEntry{
+			URL:      entry.URL,
+			Auth:     entry.Auth,
+			Username: entry.Username,
+			Password: entry.Password,
+		}
+	}
+	e.Registry.Packages[agentPackage] = pkg
+}
 
 //nolint:unused // Used in platform-specific files
 const agentPackage = "datadog-agent"
@@ -31,9 +128,14 @@ func getCurrentAgentVersion() string {
 	return v + "-1"
 }
 
-// extensionOverrides returns per-extension registry override entries for the
-// agent package, resolved from the unified env.Registry. Only extensions
-// whose resolved entry differs from the default are included.
+// extensionOverrides returns per-extension registry override entries for
+// the agent package, resolved from the unified env.Registry.
+//
+// If `extensions` is non-nil, only the named ones are returned (used at
+// install time when the caller already knows what's being installed). If
+// `extensions` is nil, ALL extensions defined under the package are
+// returned — needed by restoreAgentExtensions, which discovers extensions
+// from disk and has to pass the full override map downstream.
 //
 //nolint:unused // Used in platform-specific files
 func extensionOverrides(e *env.Env, extensions []string) map[string]extensionsPkg.ExtensionRegistry {
@@ -41,13 +143,23 @@ func extensionOverrides(e *env.Env, extensions []string) map[string]extensionsPk
 	if !hasPkg || len(pkgEntry.Extensions) == 0 {
 		return nil
 	}
-	overrides := make(map[string]extensionsPkg.ExtensionRegistry, len(extensions))
-	for _, ext := range extensions {
-		entry, ok := pkgEntry.Extensions[ext]
-		if !ok {
+	wanted := func(name string) bool {
+		if extensions == nil {
+			return true
+		}
+		for _, ext := range extensions {
+			if ext == name {
+				return true
+			}
+		}
+		return false
+	}
+	overrides := make(map[string]extensionsPkg.ExtensionRegistry)
+	for name, entry := range pkgEntry.Extensions {
+		if !wanted(name) {
 			continue
 		}
-		overrides[ext] = extensionsPkg.ExtensionRegistry{
+		overrides[name] = extensionsPkg.ExtensionRegistry{
 			URL:      entry.URL,
 			Auth:     entry.Auth,
 			Username: entry.Username,
@@ -88,6 +200,7 @@ func removeAgentExtensions(ctx HookContext, experiment bool) error {
 //nolint:unused // Used in platform-specific files
 func restoreAgentExtensions(ctx HookContext, version string, experiment bool) error {
 	env := env.FromEnv()
+	applyYAMLRegistryFallback(env)
 
 	storagePath := getExtensionStoragePath(ctx.PackagePath)
 
@@ -107,6 +220,7 @@ func restoreAgentExtensions(ctx HookContext, version string, experiment bool) er
 //nolint:unused // Used in platform-specific files
 func installAgentExtensions(ctx HookContext, version string, isExperiment bool) error {
 	env := env.FromEnv()
+	applyYAMLRegistryFallback(env)
 	// populate extensions list based on environment variables
 	var extensions []string
 	if env.OTelCollectorEnabled {

--- a/pkg/fleet/installer/packages/datadog_agent_extensions_test.go
+++ b/pkg/fleet/installer/packages/datadog_agent_extensions_test.go
@@ -11,79 +11,46 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	extensionsPkg "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/extensions"
 )
 
-func TestParseRegistryConfigExtensionOverrides(t *testing.T) {
-	configContent := `
-installer:
-  registry:
-    url: default.registry.com
-    auth: password
-    username: defaultuser
-    password: defaultpass
-    extensions:
-      datadog-agent:
-        ddot:
-          url: custom.registry.com
-          auth: password
-          username: customuser
-          password: custompass
-        other-ext:
-          url: other.registry.com
-`
-	var config datadogAgentConfig
-	err := yaml.Unmarshal([]byte(configContent), &config)
-	require.NoError(t, err)
-
-	assert.Equal(t, "default.registry.com", config.Installer.Registry.URL)
-	assert.Equal(t, "password", config.Installer.Registry.Auth)
-	assert.Equal(t, "defaultuser", config.Installer.Registry.Username)
-	assert.Equal(t, "defaultpass", config.Installer.Registry.Password)
-
-	require.Contains(t, config.Installer.Registry.Extensions, agentPackage)
-	agentExts := config.Installer.Registry.Extensions[agentPackage]
-	require.Len(t, agentExts, 2)
-
-	ddot := agentExts["ddot"]
-	assert.Equal(t, "custom.registry.com", ddot.URL)
-	assert.Equal(t, "password", ddot.Auth)
-	assert.Equal(t, "customuser", ddot.Username)
-	assert.Equal(t, "custompass", ddot.Password)
-
-	other := agentExts["other-ext"]
-	assert.Equal(t, "other.registry.com", other.URL)
-	assert.Empty(t, other.Auth)
-
-	// Verify conversion to ExtensionRegistry overrides map
-	overrides := make(map[string]extensionsPkg.ExtensionRegistry, len(agentExts))
-	for extName, extCfg := range agentExts {
-		overrides[extName] = extensionsPkg.ExtensionRegistry{
-			URL:      extCfg.URL,
-			Auth:     extCfg.Auth,
-			Username: extCfg.Username,
-			Password: extCfg.Password,
-		}
+func TestExtensionOverrides(t *testing.T) {
+	e := &env.Env{
+		Registry: env.RegistryConfig{
+			Default: env.RegistryEntry{URL: "default.registry.com", Auth: "password", Username: "defaultuser", Password: "defaultpass"},
+			Packages: map[string]env.PackageRegistry{
+				agentPackage: {
+					Extensions: map[string]env.RegistryEntry{
+						"ddot": {
+							URL:      "custom.registry.com",
+							Auth:     "password",
+							Username: "customuser",
+							Password: "custompass",
+						},
+						"other-ext": {URL: "other.registry.com"},
+					},
+				},
+			},
+		},
 	}
-	require.Len(t, overrides, 2)
-	assert.Equal(t, "custom.registry.com", overrides["ddot"].URL)
-	assert.Equal(t, "other.registry.com", overrides["other-ext"].URL)
+
+	got := extensionOverrides(e, []string{"ddot", "other-ext"})
+	require.Len(t, got, 2)
+	assert.Equal(t, extensionsPkg.ExtensionRegistry{
+		URL: "custom.registry.com", Auth: "password", Username: "customuser", Password: "custompass",
+	}, got["ddot"])
+	assert.Equal(t, extensionsPkg.ExtensionRegistry{URL: "other.registry.com"}, got["other-ext"])
 }
 
-func TestParseRegistryConfigNoExtensions(t *testing.T) {
-	configContent := `
-installer:
-  registry:
-    url: default.registry.com
-`
-	var config datadogAgentConfig
-	err := yaml.Unmarshal([]byte(configContent), &config)
-	require.NoError(t, err)
-
-	assert.Equal(t, "default.registry.com", config.Installer.Registry.URL)
-	assert.Nil(t, config.Installer.Registry.Extensions)
+func TestExtensionOverridesEmpty(t *testing.T) {
+	e := &env.Env{
+		Registry: env.RegistryConfig{
+			Default: env.RegistryEntry{URL: "default.registry.com"},
+		},
+	}
+	assert.Nil(t, extensionOverrides(e, []string{"ddot"}))
 }
 
 func TestInstallDDOTExtensionIfEnabled_Disabled(t *testing.T) {

--- a/pkg/fleet/installer/packages/otel_config_common.go
+++ b/pkg/fleet/installer/packages/otel_config_common.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 
 	"go.yaml.in/yaml/v2"
-
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 )
 
 // enableOTelCollectorConfigInDatadogYAML adds otelcollector.enabled and agent_ipc defaults to the given datadog.yaml path
@@ -72,10 +70,12 @@ func disableOtelCollectorConfigCommon(datadogYamlPath string) error {
 	return os.WriteFile(datadogYamlPath, updated, 0o600)
 }
 
-// writeOTelConfigCommon creates otel-config.yaml from a template by substituting api_key and site found in datadog.yaml
-// If preserveIfExists is true and outPath already exists, the function returns without writing.
+// writeOTelConfigCommon creates otel-config.yaml from a template by
+// substituting the supplied api_key and site values.
+// If preserveIfExists is true and outPath already exists, the function
+// returns without writing.
 // nolint:unused // Called only from platform-specific code/contexts
-func writeOTelConfigCommon(ctx HookContext, datadogYamlPath, templatePath, outPath string, preserveIfExists bool, mode os.FileMode) (err error) {
+func writeOTelConfigCommon(ctx HookContext, apiKey, site, templatePath, outPath string, preserveIfExists bool, mode os.FileMode) (err error) {
 	span, _ := ctx.StartSpan("write_otel_config_common")
 	defer func() { span.Finish(err) }()
 
@@ -83,27 +83,6 @@ func writeOTelConfigCommon(ctx HookContext, datadogYamlPath, templatePath, outPa
 		if _, err := os.Stat(outPath); err == nil {
 			return nil
 		}
-	}
-
-	var apiKey, site string
-	data, err := os.ReadFile(datadogYamlPath)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("failed to read datadog.yaml: %w", err)
-	}
-	if err == nil {
-		span.SetTag("datadog.yaml_found", true)
-		var cfg map[string]any
-		if err := yaml.Unmarshal(data, &cfg); err != nil {
-			return fmt.Errorf("failed to parse datadog.yaml: %w", err)
-		}
-		apiKey, _ = cfg["api_key"].(string)
-		site, _ = cfg["site"].(string)
-	} else {
-		// datadog.yaml not yet written (fresh install); fall back to environment variables
-		span.SetTag("datadog.yaml_found", false)
-		e := env.FromEnv()
-		apiKey = e.APIKey
-		site = e.Site
 	}
 
 	templateData, err := os.ReadFile(templatePath)

--- a/pkg/fleet/installer/packages/otel_config_common_test.go
+++ b/pkg/fleet/installer/packages/otel_config_common_test.go
@@ -15,102 +15,58 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnableOTelCollectorConfigInDatadogYAML(t *testing.T) {
-	tests := []struct {
-		name          string
-		datadogYAML   string
-		expectContent []string
-		isDatadogYAML bool
-	}{
-		{
-			name:          "adds otelcollector.enabled and agent_ipc defaults when datadog.yaml is present",
-			datadogYAML:   "initial_configuration: present\n",
-			expectContent: []string{"otelcollector:\n  enabled: true", "agent_ipc:\n", "  port: 5009\n", "  config_refresh_interval: 60\n"},
-			isDatadogYAML: true,
-		},
-		{
-			name:          "Skip when datadog.yaml is not present",
-			isDatadogYAML: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-
-			datadogYamlPath := filepath.Join(dir, "datadog.yaml")
-			if tc.isDatadogYAML {
-				require.NoError(t, os.WriteFile(datadogYamlPath, []byte(tc.datadogYAML), 0o644))
-			}
-
-			ctx := HookContext{Context: context.Background()}
-			require.NoError(t, enableOTelCollectorConfigInDatadogYAML(ctx, datadogYamlPath))
-
-			if tc.isDatadogYAML {
-				content, err := os.ReadFile(datadogYamlPath)
-				require.NoError(t, err)
-
-				for _, expected := range tc.expectContent {
-					assert.Contains(t, string(content), expected)
-				}
-			}
-		})
-	}
-}
-
 func TestWriteOTelConfigCommonSiteSubstitution(t *testing.T) {
 	const template = "endpoint: ${env:DD_SITE}\napi_key: ${env:DD_API_KEY}\n"
 
 	tests := []struct {
 		name           string
-		datadogYAML    string
+		apiKey         string
+		site           string
 		expectedAPIKey string
 		expectedSite   string
-		isDatadogYAML  bool
 	}{
 		{
 			name:           "defaults to datadoghq.com when site is not set",
-			datadogYAML:    "api_key: testapikey\n",
+			apiKey:         "testapikey",
+			site:           "",
 			expectedAPIKey: "testapikey",
 			expectedSite:   "datadoghq.com",
-			isDatadogYAML:  true,
 		},
 		{
 			name:           "uses explicit site when set",
-			datadogYAML:    "api_key: testapikey\nsite: datadoghq.eu\n",
+			apiKey:         "testapikey",
+			site:           "datadoghq.eu",
 			expectedAPIKey: "testapikey",
 			expectedSite:   "datadoghq.eu",
-			isDatadogYAML:  true,
 		},
 		{
-			name:           "Fallback when datadog.yaml is not present",
+			name:           "empty api key leaves placeholder intact",
+			apiKey:         "",
+			site:           "",
 			expectedAPIKey: "${env:DD_API_KEY}",
 			expectedSite:   "datadoghq.com",
-			isDatadogYAML:  false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-
-			datadogYamlPath := filepath.Join(dir, "datadog.yaml")
-			if tc.isDatadogYAML {
-				require.NoError(t, os.WriteFile(datadogYamlPath, []byte(tc.datadogYAML), 0o644))
-			}
 
 			templatePath := filepath.Join(dir, "otel-config.yaml.tmpl")
 			require.NoError(t, os.WriteFile(templatePath, []byte(template), 0o644))
 
 			outPath := filepath.Join(dir, "otel-config.yaml")
 			ctx := HookContext{Context: context.Background()}
-			require.NoError(t, writeOTelConfigCommon(ctx, datadogYamlPath, templatePath, outPath, false, 0o644))
+			require.NoError(t, writeOTelConfigCommon(ctx, tc.apiKey, tc.site, templatePath, outPath, false, 0o644))
 
 			content, err := os.ReadFile(outPath)
 			require.NoError(t, err)
 
 			assert.Contains(t, string(content), tc.expectedSite)
 			assert.NotContains(t, string(content), "${env:DD_SITE}")
+			if tc.apiKey != "" {
+				assert.Contains(t, string(content), tc.expectedAPIKey)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Separates the Datadog installer from `datadog.yaml`: the installer binary is now configured purely via environment variables.

- `pkg/fleet/installer/**` no longer reads `datadog.yaml` for configuration. The daemon (via its `config.Component`) and a new CLI-side fx bootstrap (`cmd/installer/command/fxconfig`) are the only places yaml is read; they translate it to `DD_*` env vars before the installer runs.
- Collapses the `DD_INSTALLER_REGISTRY_{URL,AUTH,USERNAME,PASSWORD}[_<PKG>]` prefix soup into a single `DD_INSTALLER_REGISTRY` JSON env var, typed as `RegistryConfig { Default, Packages[pkg].{url,auth,username,password,extensions[ext].{…}} }`. Standard `encoding/json` tags — no custom marshalling.
- Per-package legacy env vars + `installer.registry.extensions.<pkg>.<ext>.*` in yaml are absorbed by boundary translators (daemon + fxconfig) into the canonical JSON, so existing user configuration keeps working transparently; legacy prefix vars are `os.Unsetenv`d after translation.
- Installer subprocess spawned by the daemon skips the fxconfig bootstrap (`DD_INSTALLER_FROM_DAEMON=true`) — the daemon already emitted every env var it needs via `Env.ToEnv()`.

## Test plan

- [x] `dda inv test --targets=./pkg/fleet/installer/env ./pkg/fleet/installer/oci ./pkg/fleet/installer/packages ./pkg/fleet/installer/commands ./cmd/installer/command/fxconfig ./pkg/fleet/daemon`
- [x] Grep gate: `grep -rn "yaml.Unmarshal\|ReadFile.*datadog\.yaml" pkg/fleet/installer/` returns only legitimate yaml *writers* (config experiments, setup, otel/apm config writes, installinfo).
- [x] `GOOS=windows go build` of touched packages (pre-existing `windowsuser` stub failures unrelated).
- [ ] E2E / fleet automation validation in staging via the usual rapid-validate flow before going out of draft.
- [ ] Smoke test: set `DD_INSTALLER_REGISTRY='{"default":{"url":"ghcr.io/foo"},"packages":{"datadog-agent":{"url":"ghcr.io/bar","extensions":{"ddot":{"auth":"password"}}}}}'` and confirm `datadog-installer default-packages` resolves `datadog-agent` to `ghcr.io/bar`.
- [ ] Smoke test: legacy `DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE=ghcr.io/legacy` still ends up at `Packages["datadog-agent"].URL` after the fxconfig bootstrap.