### PR TITLE
Expand infrastructure basic mode default allowlist for Windows integrations

### DIFF
--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1198,6 +1198,7 @@ func agent(config pkgconfigmodel.Setup) {
 		"agent_telemetry",
 		"agentcrashdetect",
 		"disk",
+		"directory",
 		"file_handle",
 		"filehandles",
 		"io",
@@ -1222,6 +1223,9 @@ func agent(config pkgconfigmodel.Setup) {
 		"wincrashdetect",
 		"winkmem",
 		"winproc",
+		"wmi_check",
+		"windows_certificate",
+		"windows_registry",
 		"windows_service",
 	})
 	// Configuration for TLS for outgoing connections

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1225,6 +1225,7 @@ func agent(config pkgconfigmodel.Setup) {
 		"winproc",
 		"wmi_check",
 		"windows_certificate",
+		"windows_performance_counters",
 		"windows_registry",
 		"windows_service",
 	})

--- a/releasenotes/notes/basic-mode-windows-integrations-a9959e66764f0c49.yaml
+++ b/releasenotes/notes/basic-mode-windows-integrations-a9959e66764f0c49.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When ``infrastructure_mode`` is ``basic``, the Agent's default allowlist
+    now includes the Directory, WMI Check, Windows Certificate, and Windows
+    Registry integrations so they can run without extra
+    ``integration.additional`` configuration on Windows-oriented deployments.

--- a/releasenotes/notes/basic-mode-windows-integrations-a9959e66764f0c49.yaml
+++ b/releasenotes/notes/basic-mode-windows-integrations-a9959e66764f0c49.yaml
@@ -9,6 +9,7 @@
 enhancements:
   - |
     When ``infrastructure_mode`` is ``basic``, the Agent's default allowlist
-    now includes the Directory, WMI Check, Windows Certificate, and Windows
-    Registry integrations so they can run without extra
-    ``integration.additional`` configuration on Windows-oriented deployments.
+    now includes the Directory, WMI Check, Windows Certificate, Windows
+    Performance Counters, and Windows Registry integrations so they can run
+    without extra ``integration.additional`` configuration on
+    Windows-oriented deployments.


### PR DESCRIPTION
### What does this PR do?

Extends the default `integration.basic.allowed` list in `pkg/config/setup/common_settings.go` so that when `infrastructure_mode` is **basic**, these checks are permitted by default (without adding them to `integration.additional`):

- `directory`
- `wmi_check` (WMI integration check name used by the agent)
- `windows_certificate`
- `windows_performance_counters` (Windows Performance Counters / PDH integration)
- `windows_registry`

### Motivation

Basic mode restricts which integrations can run. On Windows, customers often rely on directory metrics, WMI, certificate and registry monitoring, and PDH-based performance counters. Allowing these in the default basic-mode allowlist avoids maintaining a custom `integration.additional` list for typical Windows host monitoring.

### Describe how you validated your changes

- Ran `dda inv test --targets=./pkg/config/setup` (all tests passed).
- Confirmed check names: `wmi_check` vs integration tile `wmi`; `windows_registry` / `windows_certificate` in agent code; `directory` and `windows_performance_counters` aligned with integrations-core package names and `pkg/metrics/metricsource.go` for the performance counters integration.

### Additional Notes

- `integration.basic.allowed` remains undocumented in the config template; the change only affects the default allowlist for **basic** mode.
- Custom checks prefixed with `custom_` are unchanged and still always allowed per existing rules.
- Release note updated to mention Windows Performance Counters alongside the other integrations.