### PR TITLE
Revert CWS Fargate e2e tests to public Ubuntu ECR image

### DIFF
--- a/test/new-e2e/tests/cws/fargate_test.go
+++ b/test/new-e2e/tests/cws/fargate_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -95,11 +94,6 @@ func TestECSFargate(t *testing.T) {
 			}
 
 			// Create task definition
-			ubuntuImage := "ubuntu:22.04"
-			if awsEnv.CommonEnvironment.ImagePullRegistry() != "" {
-				ubuntuImage = strings.SplitN(awsEnv.CommonEnvironment.ImagePullRegistry(), ",", 2)[0] + "/dockerhub/library/ubuntu:22.04"
-			}
-
 			taskDef, err := ecsx.NewFargateTaskDefinition(ctx, "cws-task", &ecsx.FargateTaskDefinitionArgs{
 				Containers: map[string]ecsx.TaskDefinitionContainerDefinitionArgs{
 					"datadog-agent": {
@@ -148,7 +142,7 @@ func TestECSFargate(t *testing.T) {
 					"ubuntu-with-tracer": {
 						Cpu:       pulumi.IntPtr(0),
 						Name:      pulumi.String("ubuntu-with-tracer"),
-						Image:     pulumi.String(ubuntuImage),
+						Image:     pulumi.String("public.ecr.aws/lts/ubuntu:22.04"),
 						Essential: pulumi.BoolPtr(false),
 						EntryPoint: pulumi.ToStringArray([]string{
 							"/cws-instrumentation-volume/cws-instrumentation",


### PR DESCRIPTION
### What does this PR do?

This PR reverts back to pulling the Ubuntu image from the public AWS registry (`public.ecr.aws/lts/ubuntu:22.04`) in the CWS Fargate e2e testsuite.

### Motivation

The changes made by #47900 to the `ecsFargateSuite` testsuite in `test/new-e2e/tests/cws/fargate_test.go` prevent the Fargate task from starting and thus cause the corresponding job to fail.

### Describe how you validated your changes

- `new-e2e-cws: [--run TestECSFargate]` CI job is passing

### Additional Notes
