### PR TITLE
[compliance] avoid panic on nil in TestMongoDBConfig_CustomConfigPath

### DIFF
--- a/pkg/compliance/dbconfig/loader_test.go
+++ b/pkg/compliance/dbconfig/loader_test.go
@@ -805,7 +805,8 @@ net:
 	defer stop()
 
 	c, ok := LoadMongoDBConfig(context.Background(), hostroot, proc)
-	assert.True(t, ok)
+	require.True(t, ok)
+	require.NotNil(t, c)
 	assert.Equal(t, customConfigPath, c.ConfigFilePath)
 
 	configData := c.ConfigData.(*mongoDBConfig)


### PR DESCRIPTION
### What does this PR do?

Replace `assert.True(t, ok)` with `require.True(t, ok)` and add `require.NotNil(t, c)` in `TestMongoDBConfig_CustomConfigPath`, so the test stops with a clean failure instead of a nil pointer dereference panic when `LoadMongoDBConfig` returns a nil result.

Related CI failure: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1624729622

### Motivation

Panics in CI (repanicked `SIGSEGV`) obscure the real failure and make triage harder. A clean `require` assertion failure surfaces the problem immediately without a stack trace.

### Describe how you validated your changes

Code inspection: the panic on the original line 809 (`c.ConfigFilePath`) can only occur when `c` is nil, which happens when `ok` is false. Using `require` stops the test at that point before any dereference occurs.

### Additional Notes

I have a monitor which triggers on panics in CI, which was triggered by this 😄 