### PR TITLE
[SNMP] Enrich device tags from resource by default

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -289,7 +289,16 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 		d.sender.ServiceCheck(serviceCheckName, servicecheck.ServiceCheckOK, tags, "")
 	}
 
-	metricTags := append(tags, "dd.internal.resource:ndm_device:"+d.GetDeviceID())
+	// When device metadata is collected, the backend enriches metrics with device tags
+	// from the metadata payload, so only the resource tag is needed on metrics.
+	// Otherwise, there is no enrichment payload and legacy device tags must be kept
+	// so existing queries/monitors keep matching.
+	var metricTags []string
+	if d.config.CollectDeviceMetadata {
+		metricTags = []string{"dd.internal.resource:ndm_device:" + d.GetDeviceID()}
+	} else {
+		metricTags = append(tags, "dd.internal.resource:ndm_device:"+d.GetDeviceID())
+	}
 	d.sender.Gauge(deviceReachableMetric, utils.BoolToFloat64(deviceReachable), metricTags)
 	d.sender.Gauge(deviceUnreachableMetric, utils.BoolToFloat64(!deviceReachable), metricTags)
 	if values != nil {

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -8,6 +8,7 @@ package devicecheck
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -101,22 +102,12 @@ profiles:
 	err = deviceCk.Run(time.Now())
 	assert.Nil(t, err)
 
-	snmpTags := []string{
-		"snmp_device:1.2.3.4",
-		"device_ip:1.2.3.4",
-		"device_id:default:1.2.3.4",
-		"snmp_profile:f5-big-ip",
-		"device_vendor:f5",
-		"snmp_host:foo_sys_name",
-		"static_tag:from_profile_root",
-		"some_tag:some_tag_value",
-		"prefix:f",
-		"suffix:oo_sys_name"}
-	telemetryTags := append(utils.CopyStrings(snmpTags), "agent_version:"+version.AgentVersion)
-	row1Tags := append(utils.CopyStrings(snmpTags), "interface:nameRow1", "interface_alias:descRow1", "table_static_tag:val")
-	row2Tags := append(utils.CopyStrings(snmpTags), "interface:nameRow2", "interface_alias:descRow2", "table_static_tag:val")
+	resourceTag := "dd.internal.resource:ndm_device:default:1.2.3.4"
+	telemetryTags := []string{resourceTag, "loader:core", "agent_version:" + version.AgentVersion}
+	row1Tags := []string{resourceTag, "interface:nameRow1", "interface_alias:descRow1", "table_static_tag:val"}
+	row2Tags := []string{resourceTag, "interface:nameRow2", "interface_alias:descRow2", "table_static_tag:val"}
 
-	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", []string{resourceTag})
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInErrors", float64(70.5), "", row1Tags)
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInErrors", float64(71), "", row2Tags)
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInDiscards", float64(131), "", row1Tags)
@@ -133,7 +124,7 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
 
 	// Should see f5-specific 'sysStatMemoryTotal' but not fake metrics
-	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", []string{resourceTag})
 	sender.AssertNotCalled(t, "Gauge", "snmp.anotherMetric", mock.Anything, mock.Anything, mock.Anything)
 	sender.AssertMetricNotTaggedWith(t, "Gauge", "snmp.sysStatMemoryTotal", []string{"unknown_symbol:100"})
 
@@ -148,16 +139,7 @@ profiles:
 	err = deviceCk.Run(time.Now())
 	assert.Nil(t, err)
 
-	snmpTags = []string{
-		"device_namespace:default",
-		"snmp_device:1.2.3.4",
-		"device_ip:1.2.3.4",
-		"device_id:default:1.2.3.4",
-		"snmp_profile:another-profile",
-		"unknown_symbol:100"}
-	telemetryTags = append(utils.CopyStrings(snmpTags), "agent_version:"+version.AgentVersion)
-
-	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", []string{resourceTag})
 
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", telemetryTags)
@@ -169,7 +151,7 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getbulk"))
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
 	// Should see fake metrics but not f5-specific 'sysStatMemoryTotal'
-	sender.AssertMetric(t, "Gauge", "snmp.anotherMetric", float64(100), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.anotherMetric", float64(100), "", []string{resourceTag})
 	sender.AssertNotCalled(t, "Gauge", "snmp.sysStatMemoryTotal", mock.Anything, mock.Anything, mock.Anything)
 	sender.AssertMetricNotTaggedWith(t, "Gauge", "snmp.anotherMetric", []string{"some_tag:some_tag_value"})
 
@@ -228,8 +210,9 @@ global_metrics:
 	err = deviceCk.Run(time.Now())
 	assert.Nil(t, err)
 
-	sender.AssertMetric(t, "Gauge", "snmp.fake.global.metric", float64(12345), "", []string{"snmp_profile:f5-big-ip"})
-	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", []string{"snmp_profile:f5-big-ip"})
+	resourceTag := "dd.internal.resource:ndm_device:default:1.2.3.4"
+	sender.AssertMetric(t, "Gauge", "snmp.fake.global.metric", float64(12345), "", []string{resourceTag})
+	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", []string{resourceTag})
 	sender.AssertNotCalled(t, "Gauge", "snmp.anotherMetric", mock.Anything, mock.Anything, mock.Anything)
 
 	// Switch device sysobjid
@@ -238,8 +221,8 @@ global_metrics:
 	err = deviceCk.Run(time.Now())
 	assert.Nil(t, err)
 
-	sender.AssertMetric(t, "Gauge", "snmp.fake.global.metric", float64(12345), "", []string{"snmp_profile:another_profile"})
-	sender.AssertMetric(t, "Gauge", "snmp.anotherMetric", float64(100), "", []string{"snmp_profile:another_profile"})
+	sender.AssertMetric(t, "Gauge", "snmp.fake.global.metric", float64(12345), "", []string{resourceTag})
+	sender.AssertMetric(t, "Gauge", "snmp.anotherMetric", float64(100), "", []string{resourceTag})
 	sender.AssertNotCalled(t, "Gauge", "snmp.sysStatMemoryTotal", mock.Anything, mock.Anything, mock.Anything)
 
 }
@@ -621,9 +604,10 @@ profiles:
 	err = deviceCk.Run(time.Now())
 	assert.Nil(t, err)
 
+	resourceTag := "dd.internal.resource:ndm_device:default:1.2.3.4"
 	sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckOK, "", snmpTags, "")
-	sender.AssertMetric(t, "Gauge", deviceReachableMetric, 1., "", snmpTags)
-	sender.AssertMetric(t, "Gauge", deviceUnreachableMetric, 0., "", snmpTags)
+	sender.AssertMetric(t, "Gauge", deviceReachableMetric, 1., "", []string{resourceTag})
+	sender.AssertMetric(t, "Gauge", deviceUnreachableMetric, 0., "", []string{resourceTag})
 
 	sender.ResetCalls()
 	sess.ConnectErr = errors.New("some error")
@@ -631,11 +615,11 @@ profiles:
 
 	assert.Error(t, err, "some error")
 	sender.Mock.AssertCalled(t, "ServiceCheck", "snmp.can_check", servicecheck.ServiceCheckCritical, "", mocksender.MatchTagsContains(snmpTags), "snmp connection error: some error")
-	sender.AssertMetric(t, "Gauge", deviceUnreachableMetric, 1., "", snmpTags)
-	sender.AssertMetric(t, "Gauge", deviceReachableMetric, 0., "", snmpTags)
+	sender.AssertMetric(t, "Gauge", deviceUnreachableMetric, 1., "", []string{resourceTag})
+	sender.AssertMetric(t, "Gauge", deviceReachableMetric, 0., "", []string{resourceTag})
 
 	// Verify that basic telemetry metrics are still sent even when session is nil
-	telemetryTagsForError := append(utils.CopyStrings(snmpTags), "agent_version:"+version.AgentVersion)
+	telemetryTagsForError := []string{resourceTag, "loader:core", "agent_version:" + version.AgentVersion}
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", telemetryTagsForError)
 	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", telemetryTagsForError)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", telemetryTagsForError)
@@ -643,6 +627,89 @@ profiles:
 
 	// Verify that session-dependent SNMP request counter metrics are NOT sent when session is nil
 	sender.AssertNotCalled(t, "Gauge", "datadog.snmp.requests", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestEnrichDeviceTagsFromResource verifies both paths for device tag handling on metrics:
+//   - When collect_device_metadata is true (default), metrics are tagged with only the
+//     ndm_device resource tag; the backend enriches them with device tags using the
+//     metadata payload.
+//   - When collect_device_metadata is false, no metadata payload is produced, so the
+//     backend cannot enrich. In that case the legacy device tags must remain on metrics.
+//
+// Service checks keep full device tags in both modes.
+func TestEnrichDeviceTagsFromResource(t *testing.T) {
+	const resourceTag = "dd.internal.resource:ndm_device:default:1.2.3.4"
+	deviceTag := "snmp_device:1.2.3.4"
+
+	// language=yaml
+	rawInitConfig := []byte(`
+profiles:
+ f5-big-ip:
+   definition_file: f5-big-ip.yaml
+`)
+
+	runCheck := func(t *testing.T, collectDeviceMetadata bool) *mocksender.MockSender {
+		profile.SetConfdPathAndCleanProfiles()
+		sess := session.CreateFakeSession()
+		sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
+			return sess, nil
+		}
+
+		sess.
+			SetStr("1.3.6.1.2.1.1.1.0", "my_desc").
+			SetObj("1.3.6.1.2.1.1.2.0", "1.3.6.1.4.1.3375.2.1.3.4.1").
+			SetTime("1.3.6.1.2.1.1.3.0", 20).
+			SetStr("1.3.6.1.2.1.1.5.0", "foo_sys_name").
+			SetInt("1.3.6.1.4.1.3375.2.1.1.2.1.44.0", 30)
+
+		// language=yaml
+		rawInstanceConfig := []byte(fmt.Sprintf(`
+ip_address: 1.2.3.4
+community_string: public
+collect_topology: false
+collect_device_metadata: %t
+metrics:
+- symbol:
+    OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
+    name: myMetric
+`, collectDeviceMetadata))
+
+		config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
+		assert.Nil(t, err)
+
+		connMgr := NewConnectionManager(config, sessionFactory)
+		deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
+		assert.Nil(t, err)
+
+		sender := mocksender.NewMockSender("123")
+		sender.SetupAcceptAll()
+		deviceCk.SetSender(report.NewMetricSender(sender, "", nil, report.MakeInterfaceBandwidthState()))
+
+		err = deviceCk.Run(time.Now())
+		assert.Nil(t, err)
+		return sender
+	}
+
+	t.Run("with device metadata: metrics carry only the resource tag", func(t *testing.T) {
+		sender := runCheck(t, true)
+
+		sender.AssertMetricTaggedWith(t, "Gauge", deviceReachableMetric, []string{resourceTag})
+		sender.AssertMetricNotTaggedWith(t, "Gauge", deviceReachableMetric, []string{deviceTag})
+		sender.AssertMetricNotTaggedWith(t, "Gauge", deviceReachableMetric, []string{"device_namespace:default"})
+
+		// Service checks still carry device tags (they are not resource-enriched).
+		sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckOK, "", []string{deviceTag}, "")
+	})
+
+	t.Run("without device metadata: legacy device tags stay on metrics", func(t *testing.T) {
+		sender := runCheck(t, false)
+
+		// Backend cannot enrich without the metadata payload, so keep the legacy tags.
+		sender.AssertMetricTaggedWith(t, "Gauge", deviceReachableMetric, []string{resourceTag})
+		sender.AssertMetricTaggedWith(t, "Gauge", deviceReachableMetric, []string{deviceTag})
+
+		sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckOK, "", []string{deviceTag}, "")
+	})
 }
 
 func TestRun_sessionCloseError(t *testing.T) {
@@ -872,22 +939,12 @@ profiles:
 	err = deviceCk.Run(time.Now())
 	assert.Nil(t, err)
 
-	snmpTags := []string{
-		"snmp_device:1.2.3.4",
-		"device_ip:1.2.3.4",
-		"device_id:default:1.2.3.4",
-		"snmp_profile:f5-big-ip",
-		"device_vendor:f5",
-		"snmp_host:foo_sys_name",
-		"static_tag:from_profile_root",
-		"some_tag:some_tag_value",
-		"prefix:f",
-		"suffix:oo_sys_name"}
-	telemetryTags := append(utils.CopyStrings(snmpTags), "agent_version:"+version.AgentVersion)
-	row1Tags := append(utils.CopyStrings(snmpTags), "interface:nameRow1", "interface_alias:descRow1", "table_static_tag:val")
-	row2Tags := append(utils.CopyStrings(snmpTags), "interface:nameRow2", "interface_alias:descRow2", "table_static_tag:val")
+	resourceTag := "dd.internal.resource:ndm_device:default:1.2.3.4"
+	telemetryTags := []string{resourceTag, "loader:core", "agent_version:" + version.AgentVersion}
+	row1Tags := []string{resourceTag, "interface:nameRow1", "interface_alias:descRow1", "table_static_tag:val"}
+	row2Tags := []string{resourceTag, "interface:nameRow2", "interface_alias:descRow2", "table_static_tag:val"}
 
-	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", []string{resourceTag})
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInErrors", float64(70.5), "", row1Tags)
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInErrors", float64(71), "", row2Tags)
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInDiscards", float64(131), "", row1Tags)
@@ -904,7 +961,7 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
 
 	// Should see f5-specific 'sysStatMemoryTotal' but not fake metrics
-	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", []string{resourceTag})
 	sender.AssertNotCalled(t, "Gauge", "snmp.anotherMetric", mock.Anything, mock.Anything, mock.Anything)
 	sender.AssertMetricNotTaggedWith(t, "Gauge", "snmp.sysStatMemoryTotal", []string{"unknown_symbol:100"})
 
@@ -919,16 +976,7 @@ profiles:
 	err = deviceCk.Run(time.Now())
 	assert.Nil(t, err)
 
-	snmpTags = []string{
-		"device_namespace:default",
-		"snmp_device:1.2.3.4",
-		"device_ip:1.2.3.4",
-		"device_id:default:1.2.3.4",
-		"snmp_profile:another-profile",
-		"unknown_symbol:100"}
-	telemetryTags = append(utils.CopyStrings(snmpTags), "agent_version:"+version.AgentVersion)
-
-	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", []string{resourceTag})
 
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", telemetryTags)
@@ -940,7 +988,7 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getbulk"))
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
 	// Should see fake metrics but not f5-specific 'sysStatMemoryTotal'
-	sender.AssertMetric(t, "Gauge", "snmp.anotherMetric", float64(100), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.anotherMetric", float64(100), "", []string{resourceTag})
 	sender.AssertNotCalled(t, "Gauge", "snmp.sysStatMemoryTotal", mock.Anything, mock.Anything, mock.Anything)
 	sender.AssertMetricNotTaggedWith(t, "Gauge", "snmp.anotherMetric", []string{"some_tag:some_tag_value"})
 
@@ -949,10 +997,10 @@ profiles:
 	assert.Len(t, deviceCk.profileCache.profile.MetricTags, 2)
 
 	// Assert Ping Metrics
-	sender.AssertMetric(t, "Gauge", pingReachableMetric, float64(1), "", snmpTags)
-	sender.AssertMetric(t, "Gauge", pingUnreachableMetric, float64(0), "", snmpTags)
-	sender.AssertMetric(t, "Gauge", pingAvgRttMetric, 4, "", snmpTags)
-	sender.AssertMetric(t, "Gauge", pingPacketLoss, 0.57, "", snmpTags)
+	sender.AssertMetric(t, "Gauge", pingReachableMetric, float64(1), "", []string{resourceTag})
+	sender.AssertMetric(t, "Gauge", pingUnreachableMetric, float64(0), "", []string{resourceTag})
+	sender.AssertMetric(t, "Gauge", pingAvgRttMetric, 4, "", []string{resourceTag})
+	sender.AssertMetric(t, "Gauge", pingPacketLoss, 0.57, "", []string{resourceTag})
 }
 
 func TestDeviceCheck_WithFailingPing(t *testing.T) {
@@ -1030,22 +1078,12 @@ profiles:
 	err = deviceCk.Run(time.Now())
 	assert.Nil(t, err)
 
-	snmpTags := []string{
-		"snmp_device:1.2.3.4",
-		"device_ip:1.2.3.4",
-		"device_id:default:1.2.3.4",
-		"snmp_profile:f5-big-ip",
-		"device_vendor:f5",
-		"snmp_host:foo_sys_name",
-		"static_tag:from_profile_root",
-		"some_tag:some_tag_value",
-		"prefix:f",
-		"suffix:oo_sys_name"}
-	telemetryTags := append(utils.CopyStrings(snmpTags), "agent_version:"+version.AgentVersion)
-	row1Tags := append(utils.CopyStrings(snmpTags), "interface:nameRow1", "interface_alias:descRow1", "table_static_tag:val")
-	row2Tags := append(utils.CopyStrings(snmpTags), "interface:nameRow2", "interface_alias:descRow2", "table_static_tag:val")
+	resourceTag := "dd.internal.resource:ndm_device:default:1.2.3.4"
+	telemetryTags := []string{resourceTag, "loader:core", "agent_version:" + version.AgentVersion}
+	row1Tags := []string{resourceTag, "interface:nameRow1", "interface_alias:descRow1", "table_static_tag:val"}
+	row2Tags := []string{resourceTag, "interface:nameRow2", "interface_alias:descRow2", "table_static_tag:val"}
 
-	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", []string{resourceTag})
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInErrors", float64(70.5), "", row1Tags)
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInErrors", float64(71), "", row2Tags)
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInDiscards", float64(131), "", row1Tags)
@@ -1062,7 +1100,7 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
 
 	// Should see f5-specific 'sysStatMemoryTotal' but not fake metrics
-	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", []string{resourceTag})
 	sender.AssertNotCalled(t, "Gauge", "snmp.anotherMetric", mock.Anything, mock.Anything, mock.Anything)
 	sender.AssertMetricNotTaggedWith(t, "Gauge", "snmp.sysStatMemoryTotal", []string{"unknown_symbol:100"})
 
@@ -1077,16 +1115,7 @@ profiles:
 	err = deviceCk.Run(time.Now())
 	assert.Nil(t, err)
 
-	snmpTags = []string{
-		"device_namespace:default",
-		"snmp_device:1.2.3.4",
-		"device_ip:1.2.3.4",
-		"device_id:default:1.2.3.4",
-		"snmp_profile:another-profile",
-		"unknown_symbol:100"}
-	telemetryTags = append(utils.CopyStrings(snmpTags), "agent_version:"+version.AgentVersion)
-
-	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", []string{resourceTag})
 
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", telemetryTags)
@@ -1098,7 +1127,7 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getbulk"))
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
 	// Should see fake metrics but not f5-specific 'sysStatMemoryTotal'
-	sender.AssertMetric(t, "Gauge", "snmp.anotherMetric", float64(100), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.anotherMetric", float64(100), "", []string{resourceTag})
 	sender.AssertNotCalled(t, "Gauge", "snmp.sysStatMemoryTotal", mock.Anything, mock.Anything, mock.Anything)
 	sender.AssertMetricNotTaggedWith(t, "Gauge", "snmp.anotherMetric", []string{"some_tag:some_tag_value"})
 
@@ -1107,8 +1136,8 @@ profiles:
 	assert.Len(t, deviceCk.profileCache.profile.MetricTags, 2)
 
 	// Assert Ping reachability metrics are sent
-	sender.AssertMetric(t, "Gauge", pingReachableMetric, float64(0), "", snmpTags)
-	sender.AssertMetric(t, "Gauge", pingUnreachableMetric, float64(1), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", pingReachableMetric, float64(0), "", []string{resourceTag})
+	sender.AssertMetric(t, "Gauge", pingUnreachableMetric, float64(1), "", []string{resourceTag})
 
 	// Assert Ping Loss and RTT metrics are not send
 	sender.AssertNotCalled(t, "Gauge", pingAvgRttMetric, mock.Anything, mock.Anything, mock.Anything)

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -346,18 +346,16 @@ tags:
 	err = chk.Run()
 	assert.Nil(t, err)
 
-	snmpTags := []string{"snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}
-	snmpGlobalTags := append(utils.CopyStrings(snmpTags), "snmp_host:foo_sys_name")
-	snmpGlobalTagsWithLoader := append(utils.CopyStrings(snmpGlobalTags), "loader:core")
-	telemetryTags := append(utils.CopyStrings(snmpGlobalTagsWithLoader), "agent_version:"+version.AgentVersion)
-	row1Tags := append(utils.CopyStrings(snmpGlobalTags), "if_index:1", "if_desc:desc1")
-	row2Tags := append(utils.CopyStrings(snmpGlobalTags), "if_index:2", "if_desc:desc2")
-	scalarTags := append(utils.CopyStrings(snmpGlobalTags), "symboltag1:1", "symboltag2:2")
+	resourceTag := "dd.internal.resource:ndm_device:default:1.2.3.4"
+	telemetryTags := []string{resourceTag, "loader:core", "agent_version:" + version.AgentVersion}
+	row1Tags := []string{resourceTag, "if_index:1", "if_desc:desc1"}
+	row2Tags := []string{resourceTag, "if_index:2", "if_desc:desc2"}
+	scalarTags := []string{resourceTag, "symboltag1:1", "symboltag2:2"}
 
-	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", snmpGlobalTags)
-	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", snmpGlobalTags)
+	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", telemetryTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", []string{resourceTag})
 	sender.AssertMetric(t, "Gauge", "snmp.ifNumber", float64(30), "", scalarTags)
-	sender.AssertMetric(t, "Gauge", "snmp.aMetricWithExtractValue", float64(22), "", snmpGlobalTags)
+	sender.AssertMetric(t, "Gauge", "snmp.aMetricWithExtractValue", float64(22), "", []string{resourceTag})
 	sender.AssertMetric(t, "Gauge", "snmp.ifInErrors", float64(141), "", row1Tags)
 	sender.AssertMetric(t, "Gauge", "snmp.ifInErrors", float64(142), "", row2Tags)
 	sender.AssertMetric(t, "Gauge", "snmp.ifOutErrors", float64(201), "", row1Tags)
@@ -873,27 +871,24 @@ profiles:
 	err = chk.Run()
 	assert.Nil(t, err)
 
+	resourceTag := "dd.internal.resource:ndm_device:default:1.2.3.4"
+	telemetryTags := []string{resourceTag, "loader:core", "agent_version:" + version.AgentVersion}
+	row1Tags := []string{resourceTag, "interface:nameRow1", "interface_alias:descRow1", "mac_address:00:00:00:00:00:01", "table_static_tag:val"}
+	row2Tags := []string{resourceTag, "interface:nameRow2", "interface_alias:descRow2", "mac_address:00:00:00:00:00:02", "table_static_tag:val"}
 	snmpTags := []string{
 		"device_namespace:default",
 		"snmp_device:1.2.3.4",
 		"device_ip:1.2.3.4",
 		"device_id:default:1.2.3.4",
-		"snmp_profile:f5-big-ip",
-		"device_vendor:f5",
-		"snmp_host:foo_sys_name",
-		"static_tag:from_profile_root",
-		"static_tag:from_base_profile",
 	}
-	row1Tags := append(utils.CopyStrings(snmpTags), "interface:nameRow1", "interface_alias:descRow1", "mac_address:00:00:00:00:00:01", "table_static_tag:val")
-	row2Tags := append(utils.CopyStrings(snmpTags), "interface:nameRow2", "interface_alias:descRow2", "mac_address:00:00:00:00:00:02", "table_static_tag:val")
 
-	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", snmpTags)
-	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", telemetryTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", []string{resourceTag})
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInErrors", float64(70.5), "", row1Tags)
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInErrors", float64(71), "", row2Tags)
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInDiscards", float64(131), "", row1Tags)
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInDiscards", float64(132), "", row2Tags)
-	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", []string{resourceTag})
 
 	// language=json
 	event := []byte(fmt.Sprintf(`
@@ -1578,10 +1573,12 @@ tags:
 	err = chk.Run()
 	assert.EqualError(t, err, "failed to autodetect profile: failed to fetch sysobjectid: cannot get sysobjectid: no value")
 
+	resourceTag := "dd.internal.resource:ndm_device:default:1.2.3.4"
+	telemetryTags := []string{resourceTag, "loader:core", "agent_version:" + version.AgentVersion}
 	snmpTags := []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}
 
-	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", snmpTags)
-	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", telemetryTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", []string{resourceTag})
 
 	// language=json
 	event := []byte(fmt.Sprintf(`
@@ -1740,9 +1737,11 @@ tags:
 	err = chk.Run()
 	assert.EqualError(t, err, expectedErrMsg)
 
+	resourceTag5 := "dd.internal.resource:ndm_device:default:1.2.3.5"
+	telemetryTags5 := []string{resourceTag5, "loader:core", "agent_version:" + version.AgentVersion}
 	snmpTags := []string{"device_namespace:default", "snmp_device:1.2.3.5", "device_ip:1.2.3.5", "device_id:default:1.2.3.5"}
 
-	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", snmpTags)
+	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", telemetryTags5)
 
 	// language=json
 	event := []byte(fmt.Sprintf(`
@@ -2057,18 +2056,17 @@ metric_tags:
 	assert.Nil(t, err)
 
 	for _, deviceData := range deviceMap {
-		snmpTags := []string{"device_namespace:default", "snmp_device:" + deviceData.ipAddress, "device_ip:" + deviceData.ipAddress, "device_id:default:" + deviceData.ipAddress, "autodiscovery_subnet:10.10.0.0/30"}
-		snmpGlobalTags := append(utils.CopyStrings(snmpTags), "snmp_host:foo_sys_name")
-		snmpGlobalTagsWithLoader := append(utils.CopyStrings(snmpGlobalTags), "loader:core")
-		scalarTags := append(utils.CopyStrings(snmpGlobalTags), "symboltag1:1", "symboltag2:2")
+		deviceResourceTag := "dd.internal.resource:ndm_device:default:" + deviceData.ipAddress
+		deviceTelemetryTags := []string{deviceResourceTag, "loader:core", "agent_version:" + version.AgentVersion}
+		scalarTags := []string{deviceResourceTag, "symboltag1:1", "symboltag2:2"}
 
-		sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", snmpGlobalTags)
-		sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", snmpGlobalTags)
+		sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", deviceTelemetryTags)
+		sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", []string{deviceResourceTag})
 		sender.AssertMetric(t, "Gauge", "snmp.ifNumber", float64(30), "", scalarTags)
 
-		sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", snmpGlobalTagsWithLoader)
-		sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", snmpGlobalTagsWithLoader)
-		sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 2, "", snmpGlobalTagsWithLoader)
+		sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", deviceTelemetryTags)
+		sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", deviceTelemetryTags)
+		sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 2, "", deviceTelemetryTags)
 
 		// language=json
 		event := []byte(fmt.Sprintf(`
@@ -2418,18 +2416,17 @@ use_device_id_as_hostname: true
 	assert.Nil(t, err)
 
 	hostname := "device:default:1.2.3.4"
-	snmpTags := []string{"snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}
-	snmpGlobalTags := utils.CopyStrings(snmpTags)
-	snmpGlobalTagsWithLoader := append(utils.CopyStrings(snmpGlobalTags), "loader:core")
-	scalarTags := append(utils.CopyStrings(snmpGlobalTags), "symboltag1:1", "symboltag2:2")
+	resourceTag := "dd.internal.resource:ndm_device:default:1.2.3.4"
+	telemetryTags := []string{resourceTag, "loader:core", "agent_version:" + version.AgentVersion}
+	scalarTags := []string{resourceTag, "symboltag1:1", "symboltag2:2"}
 
-	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), hostname, snmpGlobalTags)
-	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), hostname, snmpGlobalTags)
+	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), hostname, telemetryTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), hostname, []string{resourceTag})
 	sender.AssertMetric(t, "Gauge", "snmp.ifNumber", float64(30), hostname, scalarTags)
 
-	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", snmpGlobalTagsWithLoader)
-	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", snmpGlobalTagsWithLoader)
-	sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 2, hostname, snmpGlobalTagsWithLoader)
+	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", telemetryTags)
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", telemetryTags)
+	sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 2, hostname, telemetryTags)
 
 	// Test SetExternalTags
 	host := "device:default:1.2.3.4"
@@ -2652,18 +2649,17 @@ metrics:
 
 	for _, deviceData := range deviceMap {
 		hostname := "device:" + deviceData.deviceID
-		snmpTags := []string{"snmp_device:" + deviceData.ipAddress, "device_ip:" + deviceData.ipAddress, "device_id:default:" + deviceData.ipAddress, "autodiscovery_subnet:10.10.0.0/30", "agent_host:my-hostname"}
-		snmpGlobalTags := utils.CopyStrings(snmpTags)
-		snmpGlobalTagsWithLoader := append(utils.CopyStrings(snmpGlobalTags), "loader:core")
-		scalarTags := append(utils.CopyStrings(snmpGlobalTags), "symboltag1:1", "symboltag2:2")
+		deviceResourceTag := "dd.internal.resource:ndm_device:default:" + deviceData.ipAddress
+		deviceTelemetryTags := []string{deviceResourceTag, "loader:core", "agent_version:" + version.AgentVersion}
+		scalarTags := []string{deviceResourceTag, "symboltag1:1", "symboltag2:2"}
 
-		sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), hostname, snmpGlobalTags)
-		sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), hostname, snmpGlobalTags)
+		sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), hostname, deviceTelemetryTags)
+		sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), hostname, []string{deviceResourceTag})
 		sender.AssertMetric(t, "Gauge", "snmp.ifNumber", float64(30), hostname, scalarTags)
 
-		sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", snmpGlobalTagsWithLoader)
-		sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", snmpGlobalTagsWithLoader)
-		sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 2, hostname, snmpGlobalTagsWithLoader)
+		sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", deviceTelemetryTags)
+		sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", deviceTelemetryTags)
+		sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 2, hostname, deviceTelemetryTags)
 	}
 	networkTags := []string{"network:10.10.0.0/30", "autodiscovery_subnet:10.10.0.0/30"}
 	sender.AssertMetric(t, "Gauge", "snmp.discovered_devices_count", 4, "", networkTags)

--- a/releasenotes/notes/snmp-enrich-device-tags-from-resource-7e3f1593c7bfd8d2.yaml
+++ b/releasenotes/notes/snmp-enrich-device-tags-from-resource-7e3f1593c7bfd8d2.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    Reduce the payload size of SNMP device metrics by letting the Datadog
+    backend enrich device tags (such as ``snmp_device``, ``device_ip``, and
+    ``device_id``) from device metadata instead of attaching them to every
+    metric. Existing queries and monitors continue to work, and no action is
+    required. This only applies when ``collect_device_metadata`` is enabled
+    (the default).


### PR DESCRIPTION
Tag SNMP device metrics with only `dd.internal.resource:ndm_device:<ns>:<ip>` when `collect_device_metadata` is true, so the backend enriches device tags from the metadata payload instead of sending them on every metric. When `collect_device_metadata` is false no metadata payload is produced, so keep the legacy device tags on metrics to preserve existing queries/monitors.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
