### PR TITLE
[DO NOT MERGE] EUDM beta install script pin (agent 7.79)

### DIFF
--- a/.gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml
@@ -250,6 +250,7 @@ export_testing_public_key:
       echo "Found single DMG file: $dmg_src"
       $S3_CP_CMD --acl public-read "$dmg_src" "s3://$MACOS_S3_BUCKET/ci/datadog-agent/pipeline-$CI_PIPELINE_ID-$ARCH/datadog-agent-7-latest.dmg"
       $S3_CP_CMD --acl public-read --content-type "text/x-shellscript" "cmd/agent/macos/install_mac_os.sh" "s3://$MACOS_S3_BUCKET/ci/datadog-agent/pipeline-$CI_PIPELINE_ID-$ARCH/install_mac_os.sh"
+      $S3_CP_CMD --acl public-read --content-type "text/x-shellscript" "cmd/agent/macos/install_mac_os.sh" "s3://$MACOS_S3_BUCKET/beta/install_mac_os-7.79.0.sh"
 
 
 deploy_dmg_testing-a7_arm64:

--- a/cmd/agent/macos/install_mac_os.sh
+++ b/cmd/agent/macos/install_mac_os.sh
@@ -268,18 +268,6 @@ if [ "$infrastructure_mode" = "end_user_device" ]; then
         echo "infrastructure_mode: end_user_device" | $sudo_cmd tee -a "$datadog_yaml" > /dev/null
     fi
 
-    # Enable the wlan check
-    printf "${BLUE}\n    - Surpressing location permission prompt ...\n${NC}"
-    wlan_conf_dir="/opt/datadog-agent/etc/conf.d/wlan.d"
-    $sudo_cmd mkdir -p "$wlan_conf_dir"
-    $sudo_cmd tee "$wlan_conf_dir/conf.yaml" > /dev/null <<'WLAN_EOF'
-init_config:
-  request_location_permission: false
-
-instances:
-  - {}
-WLAN_EOF
-
     # Restart the Agent so the new configuration takes effect
     printf "${BLUE}\n    - Restarting the Agent ...\n${NC}"
     $sudo_cmd launchctl kickstart -k -s system/com.datadoghq.agent 2>/dev/null || true

--- a/cmd/agent/macos/install_mac_os.sh
+++ b/cmd/agent/macos/install_mac_os.sh
@@ -283,6 +283,10 @@ WLAN_EOF
     # Restart the Agent so the new configuration takes effect
     printf "${BLUE}\n    - Restarting the Agent ...\n${NC}"
     $sudo_cmd launchctl kickstart -k -s system/com.datadoghq.agent 2>/dev/null || true
+
+    # Restart System Probe
+    printf "${BLUE}\n    - Restarting System Probe ...\n${NC}"
+    $sudo_cmd launchctl kickstart -k -s system/com.datadoghq.sysprobe 2>/dev/null || true
 fi
 
 if $sudo_cmd launchctl print system/com.datadoghq.agent 2>/dev/null | grep -q "pid ="; then

--- a/cmd/agent/macos/install_mac_os.sh
+++ b/cmd/agent/macos/install_mac_os.sh
@@ -219,7 +219,6 @@ $sudo_cmd chmod 700 "$install_staging_dir"
     [ -n "$apikey" ] && echo "DD_API_KEY=$apikey"
     [ -n "$site" ] && echo "DD_SITE=$site"
     [ "$gui_app_menu_enabled" = true ] && echo "DD_GUI_APP_MENU_ENABLED=true"
-    [ -n "$infrastructure_mode" ] && echo "DD_INFRASTRUCTURE_MODE=$infrastructure_mode"
     echo "DD_INSTALL_METHOD=install_script_mac"
     echo "DD_INSTALL_SCRIPT_VERSION=$install_script_version"
 } | $sudo_cmd tee "$install_env_file" > /dev/null
@@ -260,6 +259,31 @@ printf "${BLUE}\n    - Unpacking and copying files (this usually takes about a m
 cd / && $sudo_cmd /usr/sbin/installer -pkg "`find "/Volumes/datadog_agent" -name \*.pkg 2>/dev/null`" -target / >/dev/null
 printf "${BLUE}\n    - Unmounting the DMG installer ...\n${NC}"
 $sudo_cmd hdiutil detach "/Volumes/datadog_agent" >/dev/null
+
+if [ "$infrastructure_mode" = "end_user_device" ]; then
+    # Configure end-user device mode
+    printf "${BLUE}\n    - Configuring infrastructure_mode ...\n${NC}"
+    datadog_yaml="/opt/datadog-agent/etc/datadog.yaml"
+    if ! $sudo_cmd grep -q '^infrastructure_mode:' "$datadog_yaml" 2>/dev/null; then
+        echo "infrastructure_mode: end_user_device" | $sudo_cmd tee -a "$datadog_yaml" > /dev/null
+    fi
+
+    # Enable the wlan check
+    printf "${BLUE}\n    - Surpressing location permission prompt ...\n${NC}"
+    wlan_conf_dir="/opt/datadog-agent/etc/conf.d/wlan.d"
+    $sudo_cmd mkdir -p "$wlan_conf_dir"
+    $sudo_cmd tee "$wlan_conf_dir/conf.yaml" > /dev/null <<'WLAN_EOF'
+init_config:
+  request_location_permission: false
+
+instances:
+  - {}
+WLAN_EOF
+
+    # Restart the Agent so the new configuration takes effect
+    printf "${BLUE}\n    - Restarting the Agent ...\n${NC}"
+    $sudo_cmd launchctl kickstart -k -s system/com.datadoghq.agent 2>/dev/null || true
+fi
 
 if $sudo_cmd launchctl print system/com.datadoghq.agent 2>/dev/null | grep -q "pid ="; then
     printf "${GREEN}


### PR DESCRIPTION
## Summary
https://datadoghq.atlassian.net/browse/WINA-2629

**This PR is not meant to be merged.** It exists to track the version of `cmd/agent/macos/install_mac_os.sh` that EUDM beta customers should use to install Agent 7.79.

Beta customers run the script as:

```bash
DD_API_KEY=... \
DD_INFRASTRUCTURE_MODE=end_user_device \
DD_AGENT_DIST_CHANNEL=beta \
DD_AGENT_MINOR_VERSION=79.0~rc.2 \
bash install_mac_os.sh
```

## Changes

- Gate the `infrastructure_mode` write, wlan check config, and post-install agent restart on `DD_INFRASTRUCTURE_MODE=end_user_device` so standard (non-EUDM) installs are unaffected.

## Test plan

- [ ] Run the command above on a clean macOS host and confirm the agent installs with `infrastructure_mode: end_user_device` in `/opt/datadog-agent/etc/datadog.yaml`, the wlan check config at `/opt/datadog-agent/etc/conf.d/wlan.d/conf.yaml`, and the agent running (`datadog-agent status`).
- [ ] Run the script without `DD_INFRASTRUCTURE_MODE` and confirm none of the EUDM-specific config is written.