### PR TITLE
ci(jobowners): refine @DataDog/multiple ownership for tests_* and new-e2e*

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -19,8 +19,7 @@ fetch_openjdk                        @DataDog/agent-metric-pipelines
 
 # Source test
 # Notifications are handled separately for more fine-grained control on go tests
-# tests_* defaults to agent-devx (owner of the `dda inv test` framework and
-# CI runners). Platform-, flavor- and feature-specific jobs override below.
+# tests_* defaults to agent-devx, with overrides below
 tests_*                                 @DataDog/agent-devx
 tests_ebpf*                             @DataDog/ebpf-platform
 tests_gpu                               @DataDog/ebpf-platform
@@ -192,10 +191,10 @@ k8s-e2e-cspm-*                    @DataDog/agent-security
 
 # New E2E
 e2e_pre_test*                     @DataDog/agent-devx
-# new-e2e* defaults to @DataDog/multiple; subcategory patterns below override
-# it. Order matters — last-matching pattern wins, so shared-ownership rules
-# at the bottom take precedence over single-owner rules earlier.
-new-e2e*                          @DataDog/multiple
+# new-e2e* defaults to @DataDog/agent-devx
+# More detailed rules are following for precise team match
+# latest match wins
+new-e2e*                          @DataDog/agent-devx
 # --- E2E framework / infra ---
 new-e2e-base*                           @DataDog/agent-devx
 new-e2e-unit-tests                      @DataDog/agent-devx

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -19,14 +19,24 @@ fetch_openjdk                        @DataDog/agent-metric-pipelines
 
 # Source test
 # Notifications are handled separately for more fine-grained control on go tests
-tests_*                                 @DataDog/multiple
+# tests_* defaults to agent-devx (owner of the `dda inv test` framework and
+# CI runners). Platform-, flavor- and feature-specific jobs override below.
+tests_*                                 @DataDog/agent-devx
 tests_ebpf*                             @DataDog/ebpf-platform
+tests_gpu                               @DataDog/ebpf-platform
+tests_windows-x64                       @DataDog/windows-products
 tests_windows_sysprobe*                 @DataDog/windows-products
+tests_windows_secagent*                 @DataDog/windows-products @DataDog/agent-security
+tests_flavor_*                          @DataDog/agent-runtimes
+tests_flavor_dogstatsd*                 @DataDog/agent-metric-pipelines
+tests_nodetreemodel                     @DataDog/agent-configuration
+tests_rtloader*                         @DataDog/agent-runtimes
+tests_serverless-init*                  @DataDog/serverless-azure-gcp
 security_go_generate_check              @DataDog/agent-security
 prepare_sysprobe_ebpf_functional_tests* @DataDog/ebpf-platform
 prepare_secagent_ebpf_functional_tests* @DataDog/agent-security
 procmgr_rust_tests                      @DataDog/agent-runtimes
-protobuf_test                           @DataDog/multiple
+protobuf_test                           @DataDog/agent-runtimes
 test_kmt_local_setup*                   @DataDog/ebpf-platform
 
 # Send count metrics about Golang dependencies
@@ -182,7 +192,62 @@ k8s-e2e-cspm-*                    @DataDog/agent-security
 
 # New E2E
 e2e_pre_test*                     @DataDog/agent-devx
+# new-e2e* defaults to @DataDog/multiple; subcategory patterns below override
+# it. Order matters — last-matching pattern wins, so shared-ownership rules
+# at the bottom take precedence over single-owner rules earlier.
 new-e2e*                          @DataDog/multiple
+# --- E2E framework / infra ---
+new-e2e-base*                           @DataDog/agent-devx
+new-e2e-unit-tests                      @DataDog/agent-devx
+new-e2e-cleanup-on-failure              @DataDog/agent-devx
+# --- Agent core ---
+new-e2e-agent-configuration*            @DataDog/agent-configuration
+new-e2e-agent-subcommands*              @DataDog/agent-configuration
+new-e2e-agent-runtimes*                 @DataDog/agent-runtimes
+new-e2e-agent-health                    @DataDog/agent-health
+new-e2e-fips-compliance-test*           @DataDog/agent-runtimes
+new-e2e-remote-config                   @DataDog/remote-config
+# --- Containers / orchestration / SSI ---
+new-e2e-containers*                     @DataDog/container-integrations
+new-e2e-orchestrator*                   @DataDog/kubernetes-experiences
+new-e2e-language-detection              @DataDog/container-experiences
+new-e2e-process*                        @DataDog/container-experiences
+new-e2e-ssi*                            @DataDog/injection-platform
+# --- Networking ---
+new-e2e-npm*                            @DataDog/cloud-network-monitoring
+new-e2e-netpath*                        @DataDog/cloud-network-monitoring
+new-e2e-ndm-netflow*                    @DataDog/ndm-integrations
+new-e2e-ndm-snmp*                       @DataDog/network-device-monitoring-core
+new-e2e-ha-agent*                       @DataDog/network-device-monitoring-core
+# --- Pipelines (metrics / logs / traces) ---
+new-e2e-amp                             @DataDog/agent-metric-pipelines
+new-e2e-alp*                            @DataDog/agent-log-pipelines
+new-e2e-apm*                            @DataDog/agent-apm
+# --- Security ---
+new-e2e-cws*                            @DataDog/agent-security
+new-e2e-sbom                            @DataDog/agent-security @DataDog/container-integrations
+new-e2e-cspm                            @DataDog/agent-cspm @DataDog/agent-security
+# --- OpenTelemetry ---
+new-e2e-otel*                           @DataDog/opentelemetry-agent
+# --- Fleet / installer (non-Windows) ---
+new-e2e-fleet*                          @DataDog/fleet
+new-e2e-installer*                      @DataDog/fleet
+# --- Agent packaging (install scripts, step-by-step, package signing) ---
+new-e2e-agent-platform-*                @DataDog/agent-delivery
+new-e2e-platform-integrations-*         @DataDog/agent-delivery
+new-e2e-package-signing-*               @DataDog/agent-delivery
+# --- GPU ---
+new-e2e-gpu*                            @DataDog/ebpf-platform
+# --- Action platform / discovery ---
+new-e2e-privateactionrunner             @DataDog/action-platform
+new-e2e-discovery                       @DataDog/agent-discovery
+# --- Windows-only jobs (single owner: windows-products) ---
+new-e2e-windows-*                       @DataDog/windows-products
+# --- Shared-ownership overrides (must come after the per-category rules above) ---
+new-e2e-installer-windows*              @DataDog/fleet @DataDog/windows-products
+new-e2e-windows-security-agent          @DataDog/windows-products @DataDog/agent-security
+new-e2e-windows-fips-compliance-test*   @DataDog/windows-products @DataDog/agent-runtimes
+new-e2e-windows-systemprobe*            @DataDog/windows-products @DataDog/ebpf-platform
 go_e2e_test_binaries              @DataDog/agent-devx
 all-artifacts                     @DataDog/agent-devx
 

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -207,14 +207,14 @@ new-e2e-agent-health                    @DataDog/agent-health
 new-e2e-fips-compliance-test*           @DataDog/agent-runtimes
 new-e2e-remote-config                   @DataDog/remote-config
 # --- Containers / orchestration / SSI ---
-new-e2e-containers*                     @DataDog/container-integrations
+new-e2e-containers*                     @DataDog/container-integrations @DataDog/container-platform
 new-e2e-orchestrator*                   @DataDog/kubernetes-experiences
 new-e2e-language-detection              @DataDog/container-experiences
 new-e2e-process*                        @DataDog/container-experiences
 new-e2e-ssi*                            @DataDog/injection-platform
 # --- Networking ---
 new-e2e-npm*                            @DataDog/cloud-network-monitoring
-new-e2e-netpath*                        @DataDog/cloud-network-monitoring
+new-e2e-netpath*                        @DataDog/network-path
 new-e2e-ndm-netflow*                    @DataDog/ndm-integrations
 new-e2e-ndm-snmp*                       @DataDog/network-device-monitoring-core
 new-e2e-ha-agent*                       @DataDog/network-device-monitoring-core
@@ -224,7 +224,7 @@ new-e2e-alp*                            @DataDog/agent-log-pipelines
 new-e2e-apm*                            @DataDog/agent-apm
 # --- Security ---
 new-e2e-cws*                            @DataDog/agent-security
-new-e2e-sbom                            @DataDog/agent-security @DataDog/container-integrations
+new-e2e-sbom*                           @DataDog/agent-security
 new-e2e-cspm                            @DataDog/agent-cspm @DataDog/agent-security
 # --- OpenTelemetry ---
 new-e2e-otel*                           @DataDog/opentelemetry-agent
@@ -232,8 +232,8 @@ new-e2e-otel*                           @DataDog/opentelemetry-agent
 new-e2e-fleet*                          @DataDog/fleet
 new-e2e-installer*                      @DataDog/fleet
 # --- Agent packaging (install scripts, step-by-step, package signing) ---
-new-e2e-agent-platform-*                @DataDog/agent-delivery
-new-e2e-platform-integrations-*         @DataDog/agent-delivery
+new-e2e-agent-platform-*                @DataDog/fleet
+new-e2e-platform-integrations-*         @DataDog/agent-runtimes
 new-e2e-package-signing-*               @DataDog/agent-delivery
 # --- GPU ---
 new-e2e-gpu*                            @DataDog/ebpf-platform


### PR DESCRIPTION
### What does this PR do?

Refines the two `@DataDog/multiple` catch-alls in `.gitlab/JOBOWNERS` (`tests_*`, `new-e2e*`) into per-team patterns, and drops `@DataDog/multiple` entirely in favor of `@DataDog/agent-devx` as the fallback for uncategorized jobs.

### Motivation

Done to better involve owning teams in CI incident resolution. Today, `@DataDog/multiple` routes hundreds of `tests_*` / `new-e2e-*` failures to no specific owner even though ownership is already knowable from the job's `TEAM:` variable — this sends incidents directly to the team that owns the code being tested. Any uncategorized job falls back to `agent-devx` (owner of the test framework, runners, and this file) rather than the nobody-owns-it `multiple` alias.

### Judgment calls (please sanity-check for your team's jobs)

- **`tests_*` fallback** → `@DataDog/agent-devx`: generic Linux/macOS unit tests exercise the whole repo; no single product team owns them.
- **`new-e2e*` fallback** → `@DataDog/agent-devx`: same rationale; agent-devx owns the e2e framework and runners.
- **`protobuf_test`** → `@DataDog/agent-runtimes`: owners of `/pkg/proto/` and the `dda inv protobuf.generate` task.
- **`tests_flavor_iot*` / `tests_flavor_heroku*`** → `@DataDog/agent-runtimes`: no dedicated CODEOWNERS entry; best guess.
- **`new-e2e-windows-systemprobe*`** → shared with `ebpf-platform` even though the job's `TEAM:` var is only `windows-products`, because the test exercises system-probe.
- **`new-e2e-windows-fips-compliance-test*`** → shared with `agent-runtimes` to mirror the non-Windows `new-e2e-fips-compliance-test*` owner.
- **`new-e2e-sbom`** (agent-security + container-integrations) and **`new-e2e-cspm`** (agent-cspm + agent-security): shared ownership mirrors CODEOWNERS.
- **`new-e2e-installer-windows*`** → shared fleet + windows-products (installer logic is fleet-owned, Windows specifics are windows-products).

### Describe how you validated your changes

`dda inv -- -e linter.full-gitlab-ci` passes (incl. `jobowners-exist`).

### Additional Notes

_None._