### PR TITLE
[AGTHEAL-60] feat(healthplatform): add JMX connection failure issue template

### DIFF
--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//comp/healthplatform/issues/admissionprobe",
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
+        "//comp/healthplatform/issues/jmxconnection",
         "//comp/healthplatform/issues/rofspermissions",
         "//comp/healthplatform/scheduler/fx",
         "//comp/healthplatform/store/def",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/jmxconnection"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"
 )
 

--- a/comp/healthplatform/issues/jmxconnection/BUILD.bazel
+++ b/comp/healthplatform/issues/jmxconnection/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "jmxconnection",
+    srcs = [
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/jmxconnection",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/jmxconnection/issue.go
+++ b/comp/healthplatform/issues/jmxconnection/issue.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package jmxconnection
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	issueName  = "jmx_connection_failure"
+	category   = "integration"
+	location   = "jmxfetch"
+	severity   = "medium"
+	source     = "jmxfetch"
+	unknownVal = "unknown"
+)
+
+// JMXConnectionIssue provides the complete issue template for JMX connection failures
+type JMXConnectionIssue struct{}
+
+// NewJMXConnectionIssue creates a new JMX connection failure issue template
+func NewJMXConnectionIssue() *JMXConnectionIssue {
+	return &JMXConnectionIssue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation for JMX connection failures
+func (t *JMXConnectionIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	checkName := context["checkName"]
+	if checkName == "" {
+		checkName = unknownVal
+	}
+
+	host := context["host"]
+	if host == "" {
+		host = unknownVal
+	}
+
+	port := context["port"]
+	if port == "" {
+		port = unknownVal
+	}
+
+	errorMsg := context["error"]
+	if errorMsg == "" {
+		errorMsg = unknownVal
+	}
+
+	description := "The JMX check " + checkName + " failed to connect to " + host + ":" + port +
+		". Error: " + errorMsg + ". JMX metrics will not be collected for this integration."
+
+	steps := []*healthplatform.RemediationStep{
+		{Order: 1, Text: "Verify the JMX endpoint is reachable: nc -zv " + host + " " + port},
+		{Order: 2, Text: "Check JMX authentication credentials in conf.yaml"},
+		{Order: 3, Text: "Ensure com.sun.management.jmxremote.authenticate=false or correct credentials are set"},
+		{Order: 4, Text: "Check firewall rules between agent and JMX port"},
+		{Order: 5, Text: "Verify the JVM has JMX remote enabled: -Dcom.sun.management.jmxremote"},
+	}
+
+	extra, err := structpb.NewStruct(map[string]any{
+		"check_name": checkName,
+		"host":       host,
+		"port":       port,
+		"error":      errorMsg,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create extra: %v", err)
+	}
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   issueName,
+		Title:       "JMX Check Cannot Connect to JMX Endpoint",
+		Description: description,
+		Category:    category,
+		Location:    location,
+		Severity:    severity,
+		DetectedAt:  "",
+		Source:      source,
+		Extra:       extra,
+		Remediation: &healthplatform.Remediation{
+			Summary: "Verify JMX endpoint reachability and authentication configuration",
+			Steps:   steps,
+		},
+		Tags: []string{"jmx", "integration", "connection"},
+	}, nil
+}

--- a/comp/healthplatform/issues/jmxconnection/module.go
+++ b/comp/healthplatform/issues/jmxconnection/module.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package jmxconnection provides an issue module for JMX connection failures.
+// This module only provides remediation (no built-in check) as JMX connection
+// failures are reported by the JMXFetch check runner.
+package jmxconnection
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for JMX connection failure issues
+	IssueID = "jmx-connection-failure"
+)
+
+// jmxConnectionModule implements issues.Module
+type jmxConnectionModule struct {
+	template *JMXConnectionIssue
+}
+
+// NewModule creates a new JMX connection failure issue module
+func NewModule(config.Component) issues.Module {
+	return &jmxConnectionModule{
+		template: NewJMXConnectionIssue(),
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *jmxConnectionModule) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *jmxConnectionModule) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns nil — JMX connection failures are reported by the JMXFetch check runner
+func (m *jmxConnectionModule) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Registers an **event-driven** issue template for JMX connection failures under the health platform. There is no built-in periodic check — when the JMXFetch check runner detects a connection failure, it emits a `storedef.IssueReport` with `IssueID = "jmx-connection-failure"` and the health platform builds the full `Issue` from this template.

The template surfaces:
- The failing check name, host, and port
- The raw connection error
- Five structured remediation steps covering endpoint reachability, authentication, JVM flags, and firewall rules

**Changes:**
- `comp/healthplatform/issues/jmxconnection/` — new issue module (template + registration, no check)
- `comp/healthplatform/bundle.go` + `BUILD.bazel` — registers the module

**Note:** Requires a follow-up PR to wire `IssueReport` emission into the JMXFetch check runner (AGTHEAL-60 follow-up).

### Motivation

JMX connection failures are one of the most common support escalations for JMX-based integrations (Kafka, Cassandra, Tomcat, etc.). Providing structured, contextual remediation guidance — surfaced directly in the health platform UI — lets operators self-serve instead of opening support tickets. Closes AGTHEAL-60.

### Describe how you validated your changes

- `go build ./comp/healthplatform/...` passes cleanly
- Template follows the event-driven pattern from `comp/healthplatform/issues/checkfailure/`
- `BuiltInHealthCheck()` returns `nil` by design

### QA Plan

#### Prerequisites

- A host running the Datadog Agent with a JMX-based integration configured (e.g. Kafka, Cassandra, Tomcat, or a custom JMX check).
- The JMXFetch runner able to emit `storedef.IssueReport` with `IssueID = "jmx-connection-failure"` (follow-up PR, AGTHEAL-60).
- For manual template testing, you can emit the report directly via the health platform store API.

#### Verify the issue template is registered

After the agent starts, confirm the `jmx-connection-failure` issue type is registered in the health platform issue registry. The template will be resolved when an `IssueReport` with that `IssueType` arrives.

#### Verify the issue is triggered (via JMXFetch follow-up)

Once the follow-up PR wires up JMXFetch:

1. Configure a JMX-based check pointing at a **non-existent or unreachable** endpoint:

   ```yaml
   # /etc/datadog-agent/conf.d/kafka.d/conf.yaml
   init_config:
     is_jmx: true

   instances:
     - host: 10.0.0.99   # unreachable host
       port: 9999
       name: kafka
   ```

2. Start the agent. When JMXFetch attempts and fails the connection, it should emit:

   ```go
   storedef.IssueReport{
     IssueID:   "jmx-connection-failure",
     IssueType: "jmx-connection-failure",
     Source:    "jmxfetch",
     Context: map[string]string{
       "checkName": "kafka",
       "host":      "10.0.0.99",
       "port":      "9999",
       "error":     "<connection error>",
     },
   }
   ```

3. Confirm the health platform store records an issue with:
   - `issue_id: "jmx-connection-failure"`
   - `severity: "medium"`
   - `category: "integration"`
   - `location: "jmxfetch"`
   - `tags: ["jmx", "integration", "connection"]`

4. The issue description should reference the check name, host, and port. The remediation should list 5 steps.

#### Verify the remediation content

The issue should surface these remediation steps:
1. **Reachability:** `nc -zv <host> <port>`
2. **Credentials:** check `conf.yaml` for JMX auth settings
3. **JVM auth flag:** `com.sun.management.jmxremote.authenticate=false`
4. **Firewall:** check rules between agent and JMX port
5. **JVM remote flag:** `-Dcom.sun.management.jmxremote`

#### Verify the issue is not reported on success

When JMXFetch successfully connects and collects metrics, no `IssueReport` is emitted for `jmx-connection-failure` and no issue appears in the store.

#### Common JMX integration config reference

```yaml
# /etc/datadog-agent/conf.d/<integration>.d/conf.yaml
init_config:
  is_jmx: true

instances:
  - host: localhost
    port: 7199              # Default Cassandra JMX port (9999 for Kafka, 7199 for Cassandra, etc.)
    name: my-service
    user: jmxuser           # Optional: JMX auth username
    password: jmxpass       # Optional: JMX auth password
```

Common JMX ports by integration:

| Integration | Default JMX port |
|---|---|
| Kafka | 9999 |
| Cassandra | 7199 |
| Tomcat | 8050 |
| JBoss/WildFly | 9990 |
| ActiveMQ | 1099 |

### Additional Notes

- No build constraints — works on all platforms.
- This module is **event-driven** (no periodic health check). The health platform scheduler does not schedule it; detection happens in the JMXFetch check runner.
- Context keys consumed by `BuildIssue`: `checkName`, `host`, `port`, `error`. Missing keys fall back to `"unknown"`.