### PR TITLE
[AGTHEAL-55] feat(healthplatform): add JMX metric limit issue template

### DIFF
--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//comp/healthplatform/issues/admissionprobe",
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
+        "//comp/healthplatform/issues/jmxmetriccap",
         "//comp/healthplatform/issues/rofspermissions",
         "//comp/healthplatform/scheduler/fx",
         "//comp/healthplatform/store/def",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/jmxmetriccap"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"
 )
 

--- a/comp/healthplatform/issues/jmxmetriccap/BUILD.bazel
+++ b/comp/healthplatform/issues/jmxmetriccap/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "jmxmetriccap",
+    srcs = [
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/jmxmetriccap",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/jmxmetriccap/issue.go
+++ b/comp/healthplatform/issues/jmxmetriccap/issue.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package jmxmetriccap
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	issueTitle    = "JMX Metric Collection Limit Reached"
+	issueCategory = "configuration"
+	issueLocation = "jmxfetch"
+	issueSeverity = "warning"
+	unknownVal    = "unknown"
+)
+
+// JMXMetricCapIssue provides complete issue template for JMX metric cap exceeded
+type JMXMetricCapIssue struct{}
+
+// NewJMXMetricCapIssue creates a new JMX metric cap issue template
+func NewJMXMetricCapIssue() *JMXMetricCapIssue {
+	return &JMXMetricCapIssue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation for JMX metric cap exceeded
+func (t *JMXMetricCapIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	checkName := context["checkName"]
+	if checkName == "" {
+		checkName = unknownVal
+	}
+
+	limit := context["limit"]
+	if limit == "" {
+		limit = unknownVal
+	}
+
+	collected := context["collected"]
+	if collected == "" {
+		collected = unknownVal
+	}
+
+	description := "The JMX check " + checkName + " has reached the maximum metric collection limit of " + limit + ". Only " + collected + " metrics were collected and some may have been silently dropped. Increase the limit or reduce the bean scope."
+
+	steps := []*healthplatform.RemediationStep{
+		{Order: 1, Text: "Increase the limit in conf.yaml: max_returned_metrics: 1000"},
+		{Order: 2, Text: "Narrow the bean scope using include_match / exclude_match filters"},
+		{Order: 3, Text: "Review which beans are contributing the most metrics"},
+	}
+
+	extra, err := structpb.NewStruct(map[string]any{
+		"check_name": checkName,
+		"limit":      limit,
+		"collected":  collected,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create extra: %v", err)
+	}
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		Title:       issueTitle,
+		Description: description,
+		Category:    issueCategory,
+		Location:    issueLocation,
+		Severity:    issueSeverity,
+		DetectedAt:  "",
+		Extra:       extra,
+		Remediation: &healthplatform.Remediation{
+			Summary: "Increase metric limit or reduce bean scope",
+			Steps:   steps,
+		},
+		Tags: []string{"jmx", "metrics", "limit"},
+	}, nil
+}

--- a/comp/healthplatform/issues/jmxmetriccap/module.go
+++ b/comp/healthplatform/issues/jmxmetriccap/module.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package jmxmetriccap provides an issue module for JMX metric collection limit exceeded.
+// This module only provides remediation (no built-in check) as JMX metric cap events
+// are reported by external integrations (JMXFetch).
+package jmxmetriccap
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for JMX metric cap issues
+	IssueID = "jmx-metric-limit-reached"
+)
+
+// jmxMetricCapModule implements issues.Module
+type jmxMetricCapModule struct {
+	template *JMXMetricCapIssue
+}
+
+// NewModule creates a new JMX metric cap issue module
+func NewModule(config.Component) issues.Module {
+	return &jmxMetricCapModule{
+		template: NewJMXMetricCapIssue(),
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *jmxMetricCapModule) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *jmxMetricCapModule) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns nil — JMX metric cap events are reported by JMXFetch
+func (m *jmxMetricCapModule) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Registers an **event-driven** issue template for JMX metric collection limit exceeded under the health platform. There is no built-in periodic check — when JMXFetch hits the 350-metric cap and silently truncates metrics, it emits a `storedef.IssueReport` with `IssueID = "jmx-metric-limit-reached"` and the health platform builds the full `Issue` from this template.

The template surfaces:
- The failing check name, the configured limit, and how many metrics were collected
- Three structured remediation steps: increase `max_returned_metrics`, narrow bean scope, review bean contributions

**Changes:**
- `comp/healthplatform/issues/jmxmetriccap/` — new issue module (template + registration, no check)
- `comp/healthplatform/bundle.go` + `BUILD.bazel` — registers the module

**Note:** Requires a follow-up PR to emit `IssueReport` from JMXFetch when the limit is reached (AGTHEAL-55 follow-up).

### Motivation

JMXFetch silently drops metrics when the 350-metric collection limit is reached — there is no warning in the agent status today. Surfacing this as a structured health platform issue (AGTHEAL-55) lets operators immediately see which check hit the cap and what to do about it. Closes AGTHEAL-55.

### Describe how you validated your changes

- `go build ./comp/healthplatform/...` passes cleanly
- Template-only change (event-driven, no built-in check)
- Pattern follows `comp/healthplatform/issues/checkfailure/` exactly

### QA Plan

#### Prerequisites

- A host running the Datadog Agent with a JMX-based integration configured (Kafka, Cassandra, Tomcat, etc.) that collects more than **350 metrics per check instance**.
- The JMXFetch runner able to emit `storedef.IssueReport` with `IssueID = "jmx-metric-limit-reached"` (follow-up PR).
- For manual testing, you can trigger the template directly via the health platform store API.

#### Verify the issue is triggered (via JMXFetch follow-up)

Once the follow-up PR wires up JMXFetch, the issue fires when a check hits the metric cap. To reproduce:

1. Configure a JMX check that collects more than the default limit (350 metrics):

   ```yaml
   # /etc/datadog-agent/conf.d/kafka.d/conf.yaml
   init_config:
     is_jmx: true
     collect_default_metrics: true

   instances:
     - host: localhost
       port: 9999
       name: kafka
       # max_returned_metrics: 350  ← default, intentionally NOT increased
   ```

2. Start the agent. When JMXFetch reaches the cap, it should emit:

   ```go
   storedef.IssueReport{
     IssueID:   "jmx-metric-limit-reached",
     IssueType: "jmx-metric-limit-reached",
     Source:    "jmxfetch",
     Context: map[string]string{
       "checkName": "kafka",
       "limit":     "350",
       "collected": "350",
     },
   }
   ```

3. Confirm the health platform store records an issue with:
   - `issue_id: "jmx-metric-limit-reached"`
   - `severity: "warning"`
   - `category: "configuration"`
   - `location: "jmxfetch"`
   - `tags: ["jmx", "metrics", "limit"]`
   - `context.checkName`: the check name (e.g. `"kafka"`)
   - `context.limit`: the configured limit (e.g. `"350"`)
   - `context.collected`: how many were collected (e.g. `"350"`)

4. The issue description should read:
   > The JMX check kafka has reached the maximum metric collection limit of 350. Only 350 metrics were collected and some may have been silently dropped. Increase the limit or reduce the bean scope.

#### Verify the remediation content

The issue should surface these remediation steps:
1. **Increase the limit:** `max_returned_metrics: 1000` in `conf.yaml`
2. **Narrow bean scope:** use `include_match` / `exclude_match` filters
3. **Review contributions:** identify which beans contribute the most metrics

#### Fix and verify resolution

Increase the limit in `conf.yaml`:

```yaml
instances:
  - host: localhost
    port: 9999
    name: kafka
    max_returned_metrics: 1000
```

Restart the agent. If the check now collects fewer metrics than the new limit, JMXFetch stops emitting the `IssueReport` and the issue resolves.

#### Config key reference

| Key | Default | Description |
|---|---|---|
| `max_returned_metrics` | `350` | Maximum metrics collected per JMX check instance |

To check the current limit in a running agent:

```bash
datadog-agent jmx list collected --checks kafka
```

#### Context keys consumed by `BuildIssue`

| Key | Description | Fallback |
|---|---|---|
| `checkName` | JMX check instance name | `"unknown"` |
| `limit` | Configured `max_returned_metrics` | `"unknown"` |
| `collected` | Actual metrics collected | `"unknown"` |

### Additional Notes

- No build constraints — works on all platforms.
- Event-driven: no periodic health check. Detection happens in JMXFetch when it truncates the metric list.
- The default limit of 350 is a long-standing JMXFetch constraint; `max_returned_metrics` can be increased per-instance in `conf.yaml`.