### PR TITLE
[AGTHEAL-47] feat(healthplatform): detect process-agent unreachable when process monitoring enabled

### DIFF
--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//comp/healthplatform/issues/admissionprobe",
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
+        "//comp/healthplatform/issues/processagentunreachable",
         "//comp/healthplatform/issues/rofspermissions",
         "//comp/healthplatform/scheduler/fx",
         "//comp/healthplatform/store/def",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/processagentunreachable"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"
 )
 

--- a/comp/healthplatform/issues/processagentunreachable/BUILD.bazel
+++ b/comp/healthplatform/issues/processagentunreachable/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "processagentunreachable",
+    srcs = [
+        "check.go",
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/processagentunreachable",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/processagentunreachable/check.go
+++ b/comp/healthplatform/issues/processagentunreachable/check.go
@@ -8,6 +8,7 @@ package processagentunreachable
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/healthplatform"
@@ -42,7 +43,7 @@ func Check(cfg config.Component) (*healthplatform.IssueReport, error) {
 	return &healthplatform.IssueReport{
 		IssueId: IssueID,
 		Context: map[string]string{
-			"port":    fmt.Sprintf("%d", port),
+			"port":    strconv.Itoa(port),
 			"enabled": "true",
 		},
 	}, nil

--- a/comp/healthplatform/issues/processagentunreachable/check.go
+++ b/comp/healthplatform/issues/processagentunreachable/check.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package processagentunreachable
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+)
+
+const (
+	defaultCmdPort = 6162
+	dialTimeout    = 2 * time.Second
+)
+
+// Check detects whether process collection is enabled but the process-agent is unreachable.
+// Returns nil if process collection is disabled or if the process-agent is reachable.
+func Check(cfg config.Component) (*healthplatform.IssueReport, error) {
+	if !cfg.GetBool("process_config.process_collection.enabled") {
+		return nil, nil
+	}
+
+	port := cfg.GetInt("process_config.cmd_port")
+	if port <= 0 {
+		port = defaultCmdPort
+	}
+
+	addr := fmt.Sprintf("localhost:%d", port)
+	conn, err := net.DialTimeout("tcp", addr, dialTimeout)
+	if err == nil {
+		conn.Close()
+		return nil, nil
+	}
+
+	return &healthplatform.IssueReport{
+		IssueId: IssueID,
+		Context: map[string]string{
+			"port":    fmt.Sprintf("%d", port),
+			"enabled": "true",
+		},
+	}, nil
+}

--- a/comp/healthplatform/issues/processagentunreachable/issue.go
+++ b/comp/healthplatform/issues/processagentunreachable/issue.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package processagentunreachable
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// ProcessAgentUnreachableIssue provides the issue template for process-agent reachability failures
+type ProcessAgentUnreachableIssue struct{}
+
+// NewProcessAgentUnreachableIssue creates a new process-agent unreachable issue template
+func NewProcessAgentUnreachableIssue() *ProcessAgentUnreachableIssue {
+	return &ProcessAgentUnreachableIssue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation steps
+func (t *ProcessAgentUnreachableIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	port := context["port"]
+	if port == "" {
+		port = fmt.Sprintf("%d", defaultCmdPort)
+	}
+
+	extra, err := structpb.NewStruct(map[string]any{
+		"port":    port,
+		"enabled": "true",
+		"impact":  "Process metrics will not be collected by the Datadog Agent.",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create issue extra: %w", err)
+	}
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   "process_agent_unreachable",
+		Title:       "Process Agent Is Not Reachable",
+		Description: fmt.Sprintf("Process collection is enabled in datadog.yaml but the process-agent is not running or not reachable on port %s. Process metrics will not be collected.", port),
+		Category:    "configuration",
+		Location:    "process-agent",
+		Severity:    "medium",
+		DetectedAt:  "", // Will be filled by health platform
+		Source:      "agent",
+		Extra:       extra,
+		Remediation: &healthplatform.Remediation{
+			Summary: "Start the process-agent service or verify the process collection configuration.",
+			Steps: []*healthplatform.RemediationStep{
+				{Order: 1, Text: "Start the process-agent (Linux): systemctl start datadog-agent-process"},
+				{Order: 2, Text: "Start the process-agent (Windows): Start-Service datadog-agent-process"},
+				{Order: 3, Text: "Check process-agent logs: /var/log/datadog/process-agent.log"},
+				{Order: 4, Text: "Verify process_config.process_collection.enabled: true is set in datadog.yaml"},
+				{Order: 5, Text: "Ensure the process-agent binary exists and is executable"},
+			},
+		},
+		Tags: []string{"process-agent", "process-collection", "configuration"},
+	}, nil
+}

--- a/comp/healthplatform/issues/processagentunreachable/issue.go
+++ b/comp/healthplatform/issues/processagentunreachable/issue.go
@@ -7,6 +7,7 @@ package processagentunreachable
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/DataDog/agent-payload/v5/healthplatform"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -24,7 +25,7 @@ func NewProcessAgentUnreachableIssue() *ProcessAgentUnreachableIssue {
 func (t *ProcessAgentUnreachableIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
 	port := context["port"]
 	if port == "" {
-		port = fmt.Sprintf("%d", defaultCmdPort)
+		port = strconv.Itoa(defaultCmdPort)
 	}
 
 	extra, err := structpb.NewStruct(map[string]any{

--- a/comp/healthplatform/issues/processagentunreachable/module.go
+++ b/comp/healthplatform/issues/processagentunreachable/module.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package processagentunreachable provides a complete issue module for detecting
+// when process collection is enabled but the process-agent is not running or reachable.
+package processagentunreachable
+
+import (
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for the process-agent unreachable issue
+	IssueID = "process-agent-unreachable"
+
+	// CheckID is the unique identifier for the built-in health check
+	CheckID = "process-agent-reachability"
+
+	// CheckName is the human-readable name for the health check
+	CheckName = "Process Agent Reachability"
+)
+
+// processAgentUnreachableModule implements issues.Module
+type processAgentUnreachableModule struct {
+	template *ProcessAgentUnreachableIssue
+	conf     config.Component
+}
+
+// NewModule creates a new process-agent unreachable issue module
+func NewModule(conf config.Component) issues.Module {
+	return &processAgentUnreachableModule{
+		template: NewProcessAgentUnreachableIssue(),
+		conf:     conf,
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *processAgentUnreachableModule) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *processAgentUnreachableModule) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns the built-in health check configuration.
+// Once is true so the check runs only once at startup.
+func (m *processAgentUnreachableModule) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return &issues.BuiltInHealthCheck{
+		ID:   CheckID,
+		Name: CheckName,
+		CheckFn: func() (*healthplatform.IssueReport, error) {
+			return Check(m.conf)
+		},
+		Once: true,
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a **startup** `BuiltInHealthCheck` (`process-agent-reachability`, `Once: true`) that detects when `process_config.process_collection.enabled` is `true` in `datadog.yaml` but the process-agent is not running or not reachable on its configured port (`process_config.cmd_port`, default `6162`).

The check runs **once at agent startup**. It performs a TCP dial to `localhost:<cmd_port>` with a 2-second timeout. If the connection fails, an issue is reported. If process collection is disabled, the check is a no-op (no false positives).

**Changes:**
- `comp/healthplatform/issues/processagentunreachable/` — startup check + issue template + module registration
- `comp/healthplatform/bundle.go` + `BUILD.bazel` — registers the module

### Motivation

Without this check, users who enable process collection (`process_config.process_collection.enabled: true`) but forget to start the process-agent get **silent data loss** — no process metrics are collected and there is no actionable signal. Closes AGTHEAL-47.

### Describe how you validated your changes

- `go build ./comp/healthplatform/...` passes cleanly
- `Check()` returns `nil` when process collection is disabled (no false positives)
- `Check()` attempts a TCP dial with a 2-second timeout and only fires when the connection fails
- `Once: true` ensures the check runs exactly once at agent startup

### QA Plan

#### Prerequisites

- A Linux or Windows host running the Datadog Agent.
- Process collection **enabled** in `datadog.yaml`:

  ```yaml
  # datadog.yaml
  process_config:
    process_collection:
      enabled: true
  ```

#### Verify the issue is detected — process-agent not running

1. Enable process collection and ensure the **process-agent is stopped**:

   ```bash
   # Linux
   sudo systemctl stop datadog-agent-process
   ```

2. Restart the core agent. At startup the `process-agent-reachability` check runs once.

3. With process-agent stopped and `cmd_port` defaulting to `6162`, the TCP dial to `localhost:6162` fails.

4. Confirm the health platform store records an issue with:
   - `issue_id: "process-agent-unreachable"`
   - `severity: "medium"`
   - `category: "configuration"`
   - `location: "process-agent"`
   - `tags: ["process-agent", "process-collection", "configuration"]`
   - `context.port`: `"6162"` (or your configured `cmd_port`)
   - `context.enabled`: `"true"`

#### Verify the issue resolves — process-agent running

1. Start the process-agent:

   ```bash
   # Linux
   sudo systemctl start datadog-agent-process

   # Windows (elevated PowerShell)
   Start-Service datadog-agent-process
   ```

2. Restart the core agent. The TCP dial to `localhost:6162` now succeeds and no issue is recorded.

#### Verify no false positives

| Scenario | Expected |
|---|---|
| `process_config.process_collection.enabled: false` (default) | No issue — check is skipped |
| Process collection not configured at all | No issue — defaults to disabled |
| Process-agent running on default port 6162 | No issue — TCP dial succeeds |
| Custom `cmd_port` set and process-agent running on that port | No issue |

#### Config key reference

| Key | Default | Description |
|---|---|---|
| `process_config.process_collection.enabled` | `false` | Enables process metric collection |
| `process_config.cmd_port` | `6162` | Port on which the process-agent listens |

To use a custom port:

```yaml
# datadog.yaml
process_config:
  process_collection:
    enabled: true
  cmd_port: 7777
```

The check automatically reads `cmd_port` and dials `localhost:7777`.

#### Check timing

The check runs **once at agent startup** (`Once: true`). To re-trigger it, restart the core agent.

#### Remediation steps surfaced in the issue

1. Start the process-agent (Linux): `systemctl start datadog-agent-process`
2. Start the process-agent (Windows): `Start-Service datadog-agent-process`
3. Check process-agent logs: `/var/log/datadog/process-agent.log`
4. Verify `process_config.process_collection.enabled: true` in `datadog.yaml`
5. Ensure the process-agent binary exists and is executable

### Additional Notes

- No build constraints — compiles on all platforms; the TCP dial safely fails on platforms where the process-agent isn't relevant.
- `dialTimeout` is 2 seconds — fast enough to not delay agent startup appreciably.
- The check does **not** re-run periodically; a process-agent that dies after startup is out of scope for this check (follow-up: periodic liveness).