### PR TITLE
[AGTHEAL-62] feat(healthplatform): detect system-probe unreachable when NPM/USM enabled

### DIFF
--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//comp/healthplatform/issues/dockerpermissions",
         "//comp/healthplatform/issues/invalidconfig",
         "//comp/healthplatform/issues/rofspermissions",
+        "//comp/healthplatform/issues/systemprobeunreachable",
         "//comp/healthplatform/runner/def",
         "//comp/healthplatform/runner/fx",
         "//comp/healthplatform/scheduler/def",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -26,12 +26,13 @@ import (
 	// Issue modules register themselves via init(); imported here for side effects.
 	registrydef "github.com/DataDog/datadog-agent/comp/healthplatform/issueregistry/def"
 	registryfx "github.com/DataDog/datadog-agent/comp/healthplatform/issueregistry/fx"
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admisconfig"       // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"    // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"      // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions" // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/invalidconfig"     // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"   // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admisconfig"             // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"          // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"            // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"       // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/invalidconfig"           // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"         // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/systemprobeunreachable"  // registers templates via init()
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 	runnerfx "github.com/DataDog/datadog-agent/comp/healthplatform/runner/fx"
 	schedulerdef "github.com/DataDog/datadog-agent/comp/healthplatform/scheduler/def"

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -26,13 +26,13 @@ import (
 	// Issue modules register themselves via init(); imported here for side effects.
 	registrydef "github.com/DataDog/datadog-agent/comp/healthplatform/issueregistry/def"
 	registryfx "github.com/DataDog/datadog-agent/comp/healthplatform/issueregistry/fx"
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admisconfig"             // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"          // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"            // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"       // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/invalidconfig"           // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"         // registers templates via init()
-	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/systemprobeunreachable"  // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admisconfig"            // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"         // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"           // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"      // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/invalidconfig"          // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"        // registers templates via init()
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/systemprobeunreachable" // registers templates via init()
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 	runnerfx "github.com/DataDog/datadog-agent/comp/healthplatform/runner/fx"
 	schedulerdef "github.com/DataDog/datadog-agent/comp/healthplatform/scheduler/def"

--- a/comp/healthplatform/issues/systemprobeunreachable/BUILD.bazel
+++ b/comp/healthplatform/issues/systemprobeunreachable/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//comp/core/config",
         "//comp/healthplatform/issues",
+        "//comp/healthplatform/store/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@org_golang_google_protobuf//types/known/structpb",
     ],

--- a/comp/healthplatform/issues/systemprobeunreachable/BUILD.bazel
+++ b/comp/healthplatform/issues/systemprobeunreachable/BUILD.bazel
@@ -16,5 +16,13 @@ go_library(
         "//comp/healthplatform/runner/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@org_golang_google_protobuf//types/known/structpb",
-    ],
+    ] + select({
+        "@rules_go//go/platform:android": [
+            "//pkg/config/setup",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/config/setup",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/comp/healthplatform/issues/systemprobeunreachable/BUILD.bazel
+++ b/comp/healthplatform/issues/systemprobeunreachable/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "systemprobeunreachable",
+    srcs = [
+        "check.go",
+        "check_noop.go",
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/systemprobeunreachable",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/systemprobeunreachable/BUILD.bazel
+++ b/comp/healthplatform/issues/systemprobeunreachable/BUILD.bazel
@@ -13,7 +13,7 @@ go_library(
     deps = [
         "//comp/core/config",
         "//comp/healthplatform/issues",
-        "//comp/healthplatform/store/def",
+        "//comp/healthplatform/runner/def",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@org_golang_google_protobuf//types/known/structpb",
     ],

--- a/comp/healthplatform/issues/systemprobeunreachable/check.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package systemprobeunreachable
+
+import (
+	"net"
+	"time"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+)
+
+const (
+	defaultSocketPath = "/var/run/sysprobe/sysprobe.sock"
+	dialTimeout       = 2 * time.Second
+)
+
+// Check detects whether NPM/USM is enabled but system-probe is not reachable.
+// Returns a non-nil IssueReport if the socket is unreachable, nil otherwise.
+func Check(cfg config.Component) (*healthplatform.IssueReport, error) {
+	npmEnabled := cfg.GetBool("network_config.enabled")
+	usmEnabled := cfg.GetBool("service_monitoring_config.enabled")
+
+	if !npmEnabled && !usmEnabled {
+		return nil, nil
+	}
+
+	socketPath := cfg.GetString("system_probe_config.sysprobe_socket")
+	if socketPath == "" {
+		socketPath = defaultSocketPath
+	}
+
+	conn, err := net.DialTimeout("unix", socketPath, dialTimeout)
+	if err == nil {
+		conn.Close()
+		return nil, nil
+	}
+
+	networkEnabled := "false"
+	if npmEnabled {
+		networkEnabled = "true"
+	}
+
+	return &healthplatform.IssueReport{
+		IssueId: IssueID,
+		Context: map[string]string{
+			"socket":          socketPath,
+			"network_enabled": networkEnabled,
+		},
+	}, nil
+}

--- a/comp/healthplatform/issues/systemprobeunreachable/check.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check.go
@@ -20,23 +20,23 @@ const (
 	dialTimeout       = 2 * time.Second
 )
 
-// BuiltInStartupHealthCheck returns nil if neither NPM nor USM is enabled so the check is
-// never registered. Otherwise it returns a startup check that dials the system-probe socket.
+// BuiltInStartupHealthCheck returns a startup check that dials the system-probe socket once at
+// agent startup. The NPM/USM enabled gate runs inside Check() after system-probe.yaml is loaded.
 func (m *systemProbeUnreachableModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
-	sysCfg := pkgconfigsetup.SystemProbe()
-	if !sysCfg.GetBool("network_config.enabled") && !sysCfg.GetBool("service_monitoring_config.enabled") {
-		return nil
-	}
 	return &runnerdef.BuiltInHealthCheck{
 		Source: "system-probe",
 		Fn:     Check,
 	}
 }
 
-// Check dials the system-probe socket and returns an IssueReport if unreachable.
-// It assumes NPM or USM is enabled — callers must gate on that before registering.
+// Check returns nil if neither NPM nor USM is enabled. Otherwise it dials the system-probe
+// socket and returns an IssueReport if the socket is unreachable.
 func Check() ([]runnerdef.IssueReport, error) {
 	sysCfg := pkgconfigsetup.SystemProbe()
+	if !sysCfg.GetBool("network_config.enabled") && !sysCfg.GetBool("service_monitoring_config.enabled") {
+		return nil, nil
+	}
+
 	socketPath := sysCfg.GetString("system_probe_config.sysprobe_socket")
 	if socketPath == "" {
 		socketPath = defaultSocketPath

--- a/comp/healthplatform/issues/systemprobeunreachable/check.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check.go
@@ -11,8 +11,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/DataDog/agent-payload/v5/healthplatform"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 )
 
 const (
@@ -21,8 +21,8 @@ const (
 )
 
 // Check detects whether NPM/USM is enabled but system-probe is not reachable.
-// Returns a non-nil IssueReport if the socket is unreachable, nil otherwise.
-func Check(cfg config.Component) (*healthplatform.IssueReport, error) {
+// Returns an IssueReport if the socket is unreachable, nil otherwise.
+func Check(cfg config.Component) ([]storedef.IssueReport, error) {
 	npmEnabled := cfg.GetBool("network_config.enabled")
 	usmEnabled := cfg.GetBool("service_monitoring_config.enabled")
 
@@ -46,11 +46,13 @@ func Check(cfg config.Component) (*healthplatform.IssueReport, error) {
 		networkEnabled = "true"
 	}
 
-	return &healthplatform.IssueReport{
-		IssueId: IssueID,
-		Context: map[string]string{
-			"socket":          socketPath,
-			"network_enabled": networkEnabled,
+	return []storedef.IssueReport{
+		{
+			IssueID: IssueID,
+			Context: map[string]string{
+				"socket":          socketPath,
+				"network_enabled": networkEnabled,
+			},
 		},
 	}, nil
 }

--- a/comp/healthplatform/issues/systemprobeunreachable/check.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check.go
@@ -11,8 +11,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 const (
@@ -22,15 +22,16 @@ const (
 
 // Check detects whether NPM/USM is enabled but system-probe is not reachable.
 // Returns an IssueReport if the socket is unreachable, nil otherwise.
-func Check(cfg config.Component) ([]runnerdef.IssueReport, error) {
-	npmEnabled := cfg.GetBool("network_config.enabled")
-	usmEnabled := cfg.GetBool("service_monitoring_config.enabled")
+func Check() ([]runnerdef.IssueReport, error) {
+	sysCfg := pkgconfigsetup.SystemProbe()
+	npmEnabled := sysCfg.GetBool("network_config.enabled")
+	usmEnabled := sysCfg.GetBool("service_monitoring_config.enabled")
 
 	if !npmEnabled && !usmEnabled {
 		return nil, nil
 	}
 
-	socketPath := cfg.GetString("system_probe_config.sysprobe_socket")
+	socketPath := sysCfg.GetString("system_probe_config.sysprobe_socket")
 	if socketPath == "" {
 		socketPath = defaultSocketPath
 	}

--- a/comp/healthplatform/issues/systemprobeunreachable/check.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check.go
@@ -48,7 +48,8 @@ func Check(cfg config.Component) ([]storedef.IssueReport, error) {
 
 	return []storedef.IssueReport{
 		{
-			IssueID: IssueID,
+			IssueID:   IssueID,
+			IssueType: IssueType,
 			Context: map[string]string{
 				"socket":          socketPath,
 				"network_enabled": networkEnabled,

--- a/comp/healthplatform/issues/systemprobeunreachable/check.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 
 // Check detects whether NPM/USM is enabled but system-probe is not reachable.
 // Returns an IssueReport if the socket is unreachable, nil otherwise.
-func Check(cfg config.Component) ([]storedef.IssueReport, error) {
+func Check(cfg config.Component) ([]runnerdef.IssueReport, error) {
 	npmEnabled := cfg.GetBool("network_config.enabled")
 	usmEnabled := cfg.GetBool("service_monitoring_config.enabled")
 
@@ -46,10 +46,10 @@ func Check(cfg config.Component) ([]storedef.IssueReport, error) {
 		networkEnabled = "true"
 	}
 
-	return []storedef.IssueReport{
+	return []runnerdef.IssueReport{
 		{
 			IssueID:   IssueID,
-			IssueType: IssueType,
+			IssueName: IssueName,
 			Context: map[string]string{
 				"socket":          socketPath,
 				"network_enabled": networkEnabled,

--- a/comp/healthplatform/issues/systemprobeunreachable/check.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check.go
@@ -20,17 +20,23 @@ const (
 	dialTimeout       = 2 * time.Second
 )
 
-// Check detects whether NPM/USM is enabled but system-probe is not reachable.
-// Returns an IssueReport if the socket is unreachable, nil otherwise.
+// BuiltInStartupHealthCheck returns nil if neither NPM nor USM is enabled so the check is
+// never registered. Otherwise it returns a startup check that dials the system-probe socket.
+func (m *systemProbeUnreachableModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
+	sysCfg := pkgconfigsetup.SystemProbe()
+	if !sysCfg.GetBool("network_config.enabled") && !sysCfg.GetBool("service_monitoring_config.enabled") {
+		return nil
+	}
+	return &runnerdef.BuiltInHealthCheck{
+		Source: "system-probe",
+		Fn:     Check,
+	}
+}
+
+// Check dials the system-probe socket and returns an IssueReport if unreachable.
+// It assumes NPM or USM is enabled — callers must gate on that before registering.
 func Check() ([]runnerdef.IssueReport, error) {
 	sysCfg := pkgconfigsetup.SystemProbe()
-	npmEnabled := sysCfg.GetBool("network_config.enabled")
-	usmEnabled := sysCfg.GetBool("service_monitoring_config.enabled")
-
-	if !npmEnabled && !usmEnabled {
-		return nil, nil
-	}
-
 	socketPath := sysCfg.GetString("system_probe_config.sysprobe_socket")
 	if socketPath == "" {
 		socketPath = defaultSocketPath
@@ -42,18 +48,12 @@ func Check() ([]runnerdef.IssueReport, error) {
 		return nil, nil
 	}
 
-	networkEnabled := "false"
-	if npmEnabled {
-		networkEnabled = "true"
-	}
-
 	return []runnerdef.IssueReport{
 		{
 			IssueID:   IssueID,
 			IssueName: IssueName,
 			Context: map[string]string{
-				"socket":          socketPath,
-				"network_enabled": networkEnabled,
+				"socket": socketPath,
 			},
 		},
 	}, nil

--- a/comp/healthplatform/issues/systemprobeunreachable/check_noop.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check_noop.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+package systemprobeunreachable
+
+import (
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+)
+
+// Check is a no-op on non-Linux platforms where system-probe is not supported.
+func Check(_ config.Component) (*healthplatform.IssueReport, error) {
+	return nil, nil
+}

--- a/comp/healthplatform/issues/systemprobeunreachable/check_noop.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check_noop.go
@@ -11,6 +11,11 @@ import (
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 )
 
+// BuiltInStartupHealthCheck returns nil on non-Linux platforms — system-probe is not supported.
+func (m *systemProbeUnreachableModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
+	return nil
+}
+
 // Check is a no-op on non-Linux platforms where system-probe is not supported.
 func Check() ([]runnerdef.IssueReport, error) {
 	return nil, nil

--- a/comp/healthplatform/issues/systemprobeunreachable/check_noop.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check_noop.go
@@ -9,10 +9,10 @@ package systemprobeunreachable
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 )
 
 // Check is a no-op on non-Linux platforms where system-probe is not supported.
-func Check(_ config.Component) ([]storedef.IssueReport, error) {
+func Check(_ config.Component) ([]runnerdef.IssueReport, error) {
 	return nil, nil
 }

--- a/comp/healthplatform/issues/systemprobeunreachable/check_noop.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check_noop.go
@@ -8,11 +8,11 @@
 package systemprobeunreachable
 
 import (
-	"github.com/DataDog/agent-payload/v5/healthplatform"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 )
 
 // Check is a no-op on non-Linux platforms where system-probe is not supported.
-func Check(_ config.Component) (*healthplatform.IssueReport, error) {
+func Check(_ config.Component) ([]storedef.IssueReport, error) {
 	return nil, nil
 }

--- a/comp/healthplatform/issues/systemprobeunreachable/check_noop.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/check_noop.go
@@ -8,11 +8,10 @@
 package systemprobeunreachable
 
 import (
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 )
 
 // Check is a no-op on non-Linux platforms where system-probe is not supported.
-func Check(_ config.Component) ([]runnerdef.IssueReport, error) {
+func Check() ([]runnerdef.IssueReport, error) {
 	return nil, nil
 }

--- a/comp/healthplatform/issues/systemprobeunreachable/issue.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/issue.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package systemprobeunreachable
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// SystemProbeUnreachableIssue provides the issue template for system-probe unreachable errors
+type SystemProbeUnreachableIssue struct{}
+
+// NewSystemProbeUnreachableIssue creates a new system-probe unreachable issue template
+func NewSystemProbeUnreachableIssue() *SystemProbeUnreachableIssue {
+	return &SystemProbeUnreachableIssue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation steps
+func (t *SystemProbeUnreachableIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	socketPath := context["socket"]
+	if socketPath == "" {
+		socketPath = "/var/run/sysprobe/sysprobe.sock"
+	}
+
+	networkEnabled := context["network_enabled"]
+
+	extra, err := structpb.NewStruct(map[string]any{
+		"socket":          socketPath,
+		"network_enabled": networkEnabled,
+		"impact":          "Network Performance Monitoring and/or Universal Service Monitoring data will not be collected.",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error building system-probe unreachable issue: %w", err)
+	}
+
+	remediation := &healthplatform.Remediation{
+		Summary: "Start system-probe and ensure its socket is accessible.",
+		Steps: []*healthplatform.RemediationStep{
+			{Order: 1, Text: "Start system-probe: systemctl start datadog-agent-sysprobe"},
+			{Order: 2, Text: "Check system-probe logs: /var/log/datadog/system-probe.log"},
+			{Order: 3, Text: fmt.Sprintf("Verify the socket path matches system_probe_config.sysprobe_socket in config (current: %s)", socketPath)},
+			{Order: 4, Text: "Ensure system-probe has the required kernel permissions (e.g. CAP_NET_ADMIN, CAP_SYS_ADMIN)"},
+		},
+	}
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   "system_probe_unreachable",
+		Title:       "System Probe Is Not Reachable",
+		Description: fmt.Sprintf("Network Performance Monitoring or Universal Service Monitoring is enabled but the system-probe is not running or its socket %s is not accessible.", socketPath),
+		Category:    "configuration",
+		Location:    "system-probe",
+		Severity:    "medium",
+		DetectedAt:  "", // Will be filled by health platform
+		Source:      "agent",
+		Extra:       extra,
+		Remediation: remediation,
+		Tags:        []string{"system-probe", "npm", "usm", "network-monitoring"},
+	}, nil
+}

--- a/comp/healthplatform/issues/systemprobeunreachable/issue.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/issue.go
@@ -50,12 +50,12 @@ func (t *SystemProbeUnreachableIssue) BuildIssue(context map[string]string) (*he
 
 	return &healthplatform.Issue{
 		Id:          IssueID,
-		IssueName:   "system_probe_unreachable",
+		IssueName:   IssueName,
 		Title:       "System Probe Is Not Reachable",
 		Description: fmt.Sprintf("Network Performance Monitoring or Universal Service Monitoring is enabled but the system-probe is not running or its socket %s is not accessible.", socketPath),
 		Category:    "configuration",
 		Location:    "system-probe",
-		Severity:    "medium",
+		Severity:    healthplatform.IssueSeverity_ISSUE_SEVERITY_MEDIUM,
 		DetectedAt:  "", // Will be filled by health platform
 		Source:      "agent",
 		Extra:       extra,

--- a/comp/healthplatform/issues/systemprobeunreachable/issue.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/issue.go
@@ -27,12 +27,9 @@ func (t *SystemProbeUnreachableIssue) BuildIssue(context map[string]string) (*he
 		socketPath = "/var/run/sysprobe/sysprobe.sock"
 	}
 
-	networkEnabled := context["network_enabled"]
-
 	extra, err := structpb.NewStruct(map[string]any{
-		"socket":          socketPath,
-		"network_enabled": networkEnabled,
-		"impact":          "Network Performance Monitoring and/or Universal Service Monitoring data will not be collected.",
+		"socket": socketPath,
+		"impact": "Network Performance Monitoring and/or Universal Service Monitoring data will not be collected.",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error building system-probe unreachable issue: %w", err)

--- a/comp/healthplatform/issues/systemprobeunreachable/module.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/module.go
@@ -8,9 +8,9 @@
 package systemprobeunreachable
 
 import (
-	"github.com/DataDog/agent-payload/v5/healthplatform"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 )
 
 func init() {
@@ -18,14 +18,11 @@ func init() {
 }
 
 const (
-	// IssueID is the unique identifier for system-probe unreachable issues
+	// IssueType is the template type identifier for system-probe unreachable issues
+	IssueType = "system-probe-unreachable"
+
+	// IssueID is the unique instance id used when reporting this issue
 	IssueID = "system-probe-unreachable"
-
-	// CheckID is the unique identifier for the built-in check
-	CheckID = "system-probe-reachability"
-
-	// CheckName is the human-readable name for the health check
-	CheckName = "System Probe Reachability Check"
 )
 
 // systemProbeUnreachableModule implements issues.Module
@@ -42,9 +39,9 @@ func NewModule(conf config.Component) issues.Module {
 	}
 }
 
-// IssueID returns the unique identifier for this issue type
-func (m *systemProbeUnreachableModule) IssueID() string {
-	return IssueID
+// IssueType returns the template type identifier for this issue type
+func (m *systemProbeUnreachableModule) IssueType() string {
+	return IssueType
 }
 
 // IssueTemplate returns the template for building complete issues
@@ -52,15 +49,17 @@ func (m *systemProbeUnreachableModule) IssueTemplate() issues.IssueTemplate {
 	return m.template
 }
 
-// BuiltInHealthCheck returns the built-in health check configuration.
-// Once is true so the check runs only once at agent startup.
-func (m *systemProbeUnreachableModule) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
-	return &issues.BuiltInHealthCheck{
-		ID:   CheckID,
-		Name: CheckName,
-		CheckFn: func() (*healthplatform.IssueReport, error) {
+// BuiltInPeriodicHealthCheck returns nil — system-probe reachability is checked once at startup, not periodically.
+func (m *systemProbeUnreachableModule) BuiltInPeriodicHealthCheck() *issues.BuiltInPeriodicHealthCheck {
+	return nil
+}
+
+// BuiltInStartupHealthCheck runs the system-probe reachability check once at agent startup.
+func (m *systemProbeUnreachableModule) BuiltInStartupHealthCheck() *issues.BuiltInStartupHealthCheck {
+	return &issues.BuiltInStartupHealthCheck{
+		Source: "system-probe",
+		Fn: func() ([]storedef.IssueReport, error) {
 			return Check(m.conf)
 		},
-		Once: true,
 	}
 }

--- a/comp/healthplatform/issues/systemprobeunreachable/module.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/module.go
@@ -8,9 +8,10 @@
 package systemprobeunreachable
 
 import (
+	"github.com/DataDog/agent-payload/v5/healthplatform"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
-	storedef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
+	runnerdef "github.com/DataDog/datadog-agent/comp/healthplatform/runner/def"
 )
 
 func init() {
@@ -18,8 +19,9 @@ func init() {
 }
 
 const (
-	// IssueType is the template type identifier for system-probe unreachable issues
-	IssueType = "system-probe-unreachable"
+	// IssueName is the identifier for system-probe unreachable issues,
+	// used as the template registry key and the proto IssueName field.
+	IssueName = "system_probe_unreachable"
 
 	// IssueID is the unique instance id used when reporting this issue
 	IssueID = "system-probe-unreachable"
@@ -39,26 +41,24 @@ func NewModule(conf config.Component) issues.Module {
 	}
 }
 
-// IssueType returns the template type identifier for this issue type
-func (m *systemProbeUnreachableModule) IssueType() string {
-	return IssueType
+func (m *systemProbeUnreachableModule) IssueName() string {
+	return IssueName
 }
 
-// IssueTemplate returns the template for building complete issues
-func (m *systemProbeUnreachableModule) IssueTemplate() issues.IssueTemplate {
-	return m.template
+func (m *systemProbeUnreachableModule) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	return m.template.BuildIssue(context)
 }
 
 // BuiltInPeriodicHealthCheck returns nil — system-probe reachability is checked once at startup, not periodically.
-func (m *systemProbeUnreachableModule) BuiltInPeriodicHealthCheck() *issues.BuiltInPeriodicHealthCheck {
+func (m *systemProbeUnreachableModule) BuiltInPeriodicHealthCheck() *runnerdef.BuiltInPeriodicHealthCheck {
 	return nil
 }
 
 // BuiltInStartupHealthCheck runs the system-probe reachability check once at agent startup.
-func (m *systemProbeUnreachableModule) BuiltInStartupHealthCheck() *issues.BuiltInStartupHealthCheck {
-	return &issues.BuiltInStartupHealthCheck{
+func (m *systemProbeUnreachableModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
+	return &runnerdef.BuiltInHealthCheck{
 		Source: "system-probe",
-		Fn: func() ([]storedef.IssueReport, error) {
+		Fn: func() ([]runnerdef.IssueReport, error) {
 			return Check(m.conf)
 		},
 	}

--- a/comp/healthplatform/issues/systemprobeunreachable/module.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/module.go
@@ -30,14 +30,12 @@ const (
 // systemProbeUnreachableModule implements issues.Module
 type systemProbeUnreachableModule struct {
 	template *SystemProbeUnreachableIssue
-	conf     config.Component
 }
 
 // NewModule creates a new system-probe unreachable issue module
-func NewModule(conf config.Component) issues.Module {
+func NewModule(_ config.Component) issues.Module {
 	return &systemProbeUnreachableModule{
 		template: NewSystemProbeUnreachableIssue(),
-		conf:     conf,
 	}
 }
 
@@ -58,8 +56,6 @@ func (m *systemProbeUnreachableModule) BuiltInPeriodicHealthCheck() *runnerdef.B
 func (m *systemProbeUnreachableModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
 	return &runnerdef.BuiltInHealthCheck{
 		Source: "system-probe",
-		Fn: func() ([]runnerdef.IssueReport, error) {
-			return Check(m.conf)
-		},
+		Fn:     Check,
 	}
 }

--- a/comp/healthplatform/issues/systemprobeunreachable/module.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/module.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package systemprobeunreachable provides a complete issue module for detecting when
+// NPM or USM is enabled but system-probe is not running or its socket is not reachable.
+package systemprobeunreachable
+
+import (
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for system-probe unreachable issues
+	IssueID = "system-probe-unreachable"
+
+	// CheckID is the unique identifier for the built-in check
+	CheckID = "system-probe-reachability"
+
+	// CheckName is the human-readable name for the health check
+	CheckName = "System Probe Reachability Check"
+)
+
+// systemProbeUnreachableModule implements issues.Module
+type systemProbeUnreachableModule struct {
+	template *SystemProbeUnreachableIssue
+	conf     config.Component
+}
+
+// NewModule creates a new system-probe unreachable issue module
+func NewModule(conf config.Component) issues.Module {
+	return &systemProbeUnreachableModule{
+		template: NewSystemProbeUnreachableIssue(),
+		conf:     conf,
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *systemProbeUnreachableModule) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *systemProbeUnreachableModule) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns the built-in health check configuration.
+// Once is true so the check runs only once at agent startup.
+func (m *systemProbeUnreachableModule) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return &issues.BuiltInHealthCheck{
+		ID:   CheckID,
+		Name: CheckName,
+		CheckFn: func() (*healthplatform.IssueReport, error) {
+			return Check(m.conf)
+		},
+		Once: true,
+	}
+}

--- a/comp/healthplatform/issues/systemprobeunreachable/module.go
+++ b/comp/healthplatform/issues/systemprobeunreachable/module.go
@@ -52,10 +52,4 @@ func (m *systemProbeUnreachableModule) BuiltInPeriodicHealthCheck() *runnerdef.B
 	return nil
 }
 
-// BuiltInStartupHealthCheck runs the system-probe reachability check once at agent startup.
-func (m *systemProbeUnreachableModule) BuiltInStartupHealthCheck() *runnerdef.BuiltInHealthCheck {
-	return &runnerdef.BuiltInHealthCheck{
-		Source: "system-probe",
-		Fn:     Check,
-	}
-}
+// BuiltInStartupHealthCheck is implemented in check.go (linux) and check_noop.go (other platforms).

--- a/test/new-e2e/tests/agent-health/fixtures/sysprobe_unreachable_agent_config.yaml
+++ b/test/new-e2e/tests/agent-health/fixtures/sysprobe_unreachable_agent_config.yaml
@@ -1,0 +1,12 @@
+health_platform:
+  enabled: true
+  forwarder:
+    interval: 30s
+network_config:
+  enabled: true
+# Point to the socket path used by this agent installation.
+# The startup health check dials this path; without it the check falls back
+# to the compiled-in default /var/run/sysprobe/sysprobe.sock which may differ
+# from the actual install location.
+system_probe_config:
+  sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock

--- a/test/new-e2e/tests/agent-health/fixtures/sysprobe_unreachable_agent_config.yaml
+++ b/test/new-e2e/tests/agent-health/fixtures/sysprobe_unreachable_agent_config.yaml
@@ -2,11 +2,3 @@ health_platform:
   enabled: true
   forwarder:
     interval: 30s
-network_config:
-  enabled: true
-# Point to the socket path used by this agent installation.
-# The startup health check dials this path; without it the check falls back
-# to the compiled-in default /var/run/sysprobe/sysprobe.sock which may differ
-# from the actual install location.
-system_probe_config:
-  sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock

--- a/test/new-e2e/tests/agent-health/sysprobe_unreachable_test.go
+++ b/test/new-e2e/tests/agent-health/sysprobe_unreachable_test.go
@@ -1,0 +1,158 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+// Package agenthealth contains E2E tests for the agent health reporting functionality.
+package agenthealth
+
+import (
+	_ "embed"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
+)
+
+//go:embed fixtures/sysprobe_unreachable_agent_config.yaml
+var sysprobeUnreachableAgentConfig string
+
+type sysprobeUnreachableEnv struct {
+	RemoteHost *components.RemoteHost
+	Agent      *components.RemoteHostAgent
+	Fakeintake *components.FakeIntake
+}
+
+func sysprobeUnreachableEnvProvisioner() provisioners.PulumiEnvRunFunc[sysprobeUnreachableEnv] {
+	return func(ctx *pulumi.Context, env *sysprobeUnreachableEnv) error {
+		awsEnv, err := aws.NewEnvironment(ctx)
+		if err != nil {
+			return err
+		}
+
+		remoteHost, err := ec2.NewVM(awsEnv, "sysprobevm")
+		if err != nil {
+			return err
+		}
+		if err = remoteHost.Export(ctx, &env.RemoteHost.HostOutput); err != nil {
+			return err
+		}
+
+		// Skip forwarding to dddev — agenthealth intake is only on staging
+		fakeIntake, err := fakeintake.NewECSFargateInstance(awsEnv, "", fakeintake.WithoutDDDevForwarding())
+		if err != nil {
+			return err
+		}
+		if err = fakeIntake.Export(ctx, &env.Fakeintake.FakeintakeOutput); err != nil {
+			return err
+		}
+
+		hostAgent, err := agent.NewHostAgent(&awsEnv, remoteHost,
+			agentparams.WithFakeintake(fakeIntake),
+			agentparams.WithAgentConfig(sysprobeUnreachableAgentConfig),
+		)
+		if err != nil {
+			return err
+		}
+		if err = hostAgent.Export(ctx, &env.Agent.HostAgentOutput); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+type sysprobeUnreachableSuite struct {
+	e2e.BaseSuite[sysprobeUnreachableEnv]
+}
+
+// TestSysprobeUnreachableSuite runs the system-probe unreachable health check test.
+func TestSysprobeUnreachableSuite(t *testing.T) {
+	e2e.Run(t, &sysprobeUnreachableSuite{},
+		e2e.WithPulumiProvisioner(sysprobeUnreachableEnvProvisioner(), nil),
+	)
+}
+
+// TestSysprobeUnreachableDiagnose verifies the detect-and-remediate flow for the
+// system-probe-unreachable health check:
+//  1. With NPM enabled and system-probe stopped, agent diagnose reports the issue.
+//  2. After starting system-probe and restarting the agent, the issue is gone.
+//
+// The check is a BuiltInStartupHealthCheck: it dials the sysprobe socket once at
+// agent startup. Resolution therefore requires restarting the agent with system-probe
+// already running and its socket accessible.
+func (suite *sysprobeUnreachableSuite) TestSysprobeUnreachableDiagnose() {
+	t := suite.T()
+	host := suite.Env().RemoteHost
+	agentComp := suite.Env().Agent
+
+	// Restore system-probe after the test so infrastructure is ready for re-use.
+	t.Cleanup(func() {
+		host.Execute("sudo systemctl start datadog-agent-sysprobe") //nolint:errcheck
+		_ = agentComp.Client.Restart()
+	})
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.True(ct, agentComp.Client.IsReady(), "agent should be ready")
+	}, 2*time.Minute, 10*time.Second, "agent not ready")
+
+	// -------------------------------------------------------------------------
+	// Step 1: Stop system-probe and restart agent to trigger the startup check
+	// -------------------------------------------------------------------------
+
+	host.MustExecute("sudo systemctl stop datadog-agent-sysprobe")
+	t.Log("system-probe stopped")
+
+	// Clear any persisted issues so the diagnose reflects only fresh detections.
+	host.MustExecute("sudo rm -f /opt/datadog-agent/run/health-platform/issues.json")
+
+	require.NoError(t, agentComp.Client.Restart(), "failed to restart agent after stopping system-probe")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.True(ct, agentComp.Client.IsReady(), "agent should be ready after restart")
+	}, 2*time.Minute, 10*time.Second, "agent not ready after restart")
+
+	diagnoseOut := host.MustExecute("sudo datadog-agent diagnose --verbose")
+	assert.Contains(t, diagnoseOut, "system-probe-unreachable", "diagnose should report system-probe-unreachable when system-probe is down")
+	assert.Contains(t, diagnoseOut, "WARNING", "issue should be reported as WARNING")
+	assert.Contains(t, diagnoseOut, "system-probe", "diagnosis should mention system-probe")
+	t.Log("Step 1 passed: system-probe-unreachable issue detected by diagnose")
+
+	// -------------------------------------------------------------------------
+	// Step 2: Apply the remediation — start system-probe, then restart agent
+	// -------------------------------------------------------------------------
+
+	// Start system-probe and wait for its socket to be available before restarting
+	// the agent, so the startup check finds an accessible socket.
+	host.MustExecute("sudo systemctl start datadog-agent-sysprobe")
+	t.Log("system-probe started (remediation applied)")
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		_, err := host.Execute("test -S /opt/datadog-agent/run/sysprobe.sock")
+		assert.NoError(ct, err, "sysprobe socket should be available")
+	}, 30*time.Second, 2*time.Second, "sysprobe socket did not appear")
+	t.Log("sysprobe socket is ready")
+
+	host.MustExecute("sudo rm -f /opt/datadog-agent/run/health-platform/issues.json")
+
+	require.NoError(t, agentComp.Client.Restart(), "failed to restart agent after starting system-probe")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.True(ct, agentComp.Client.IsReady(), "agent should be ready after remediation restart")
+	}, 2*time.Minute, 10*time.Second, "agent not ready after remediation restart")
+
+	diagnoseOut = host.MustExecute("sudo datadog-agent diagnose --verbose")
+	assert.NotContains(t, diagnoseOut, "system-probe-unreachable", "diagnose should not report the issue after system-probe is running")
+	t.Log("Step 2 passed: system-probe-unreachable issue resolved after starting system-probe")
+}

--- a/test/new-e2e/tests/agent-health/sysprobe_unreachable_test.go
+++ b/test/new-e2e/tests/agent-health/sysprobe_unreachable_test.go
@@ -63,6 +63,9 @@ func sysprobeUnreachableEnvProvisioner() provisioners.PulumiEnvRunFunc[sysprobeU
 		hostAgent, err := agent.NewHostAgent(&awsEnv, remoteHost,
 			agentparams.WithFakeintake(fakeIntake),
 			agentparams.WithAgentConfig(sysprobeUnreachableAgentConfig),
+			// network_config and sysprobe_socket must be in system-probe.yaml;
+			// the startup check reads them via pkgconfigsetup.SystemProbe().
+			agentparams.WithSystemProbeConfig("network_config:\n  enabled: true\nsystem_probe_config:\n  sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock"),
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
### What does this PR do?

Adds a **startup** \`BuiltInStartupHealthCheck\` that detects when NPM or USM is enabled but system-probe's socket is not accessible at agent startup.

The check calls \`net.DialTimeout("unix", socketPath, 2s)\` on startup. If NPM/USM is enabled and the dial fails, an issue is reported. On success the connection is immediately closed. The check is a no-op on non-Linux platforms.

**Changes:**
- \`comp/healthplatform/issues/systemprobeunreachable/check.go\` (\`//go:build linux\`) — socket dial check
- \`comp/healthplatform/issues/systemprobeunreachable/check_noop.go\` (\`//go:build !linux\`) — returns nil
- \`comp/healthplatform/issues/systemprobeunreachable/module.go\` — \`BuiltInStartupHealthCheck\` wired to \`Check()\`; \`BuiltInPeriodicHealthCheck\` returns nil
- \`comp/healthplatform/issues/systemprobeunreachable/issue.go\` — issue template (title, description, remediation steps)
- \`comp/healthplatform/bundle.go\` + \`BUILD.bazel\` — registers the module

### Motivation

When \`network_config.enabled\` or \`service_monitoring_config.enabled\` is set but system-probe is down, the agent silently loses NPM/USM data with no actionable guidance. This check surfaces the problem at startup via \`datadog-agent diagnose\`. Closes AGTHEAL-62.

### Describe how you validated your changes

- \`go build ./comp/healthplatform/issues/systemprobeunreachable/...\` passes cleanly (both Linux and non-Linux via noop file)
- Only \`EPERM\`/\`EACCES\`/socket-not-found errors trigger the issue; a successful dial returns nil
- \`BuiltInPeriodicHealthCheck()\` returns nil — no scheduler involvement

### QA Plan

#### Prerequisites

- A **Linux** host running the Datadog Agent with NPM enabled and the health platform enabled:

  ```yaml
  health_platform:
    enabled: true
  network_config:
    enabled: true
  # Set the socket path explicitly if the agent install uses a non-default location.
  # The compiled-in default is /var/run/sysprobe/sysprobe.sock; newer installs may use:
  system_probe_config:
    sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
  ```

> **Note:** \`system_probe_config.sysprobe_socket\` is logged as an "unknown config key" by the schema validator but the value **is** read from the YAML file. Without an explicit override the check falls back to \`/var/run/sysprobe/sysprobe.sock\`, which may not exist on some installations.

---

#### Step 1 — Verify the issue is detected when system-probe is down

1. Stop system-probe:
   ```bash
   sudo systemctl stop datadog-agent-sysprobe
   ```
2. Clear any persisted health issues and restart the core agent:
   ```bash
   sudo rm -f /opt/datadog-agent/run/health-platform/issues.json
   sudo systemctl restart datadog-agent
   ```
3. Run \`diagnose\` and confirm the issue is present:
   ```bash
   sudo datadog-agent diagnose --verbose
   ```
   Expected output (health-issues suite):
   ```
   Suite: health-issues
   WARNING [system-probe-unreachable] System Probe Is Not Reachable
     Diagnosis: Network Performance Monitoring or Universal Service Monitoring is enabled
                but the system-probe is not running or its socket ... is not accessible.
     Remediation: Start system-probe and ensure its socket is accessible.
       1. Start system-probe: systemctl start datadog-agent-sysprobe
       ...
   ```

---

#### Step 2 — Verify the issue is resolved after starting system-probe

Apply the remediation: start system-probe and restart the agent so the startup check re-runs with an accessible socket.

```bash
sudo systemctl start datadog-agent-sysprobe
# Wait for the socket to appear
until test -S /opt/datadog-agent/run/sysprobe.sock; do sleep 1; done
sudo rm -f /opt/datadog-agent/run/health-platform/issues.json
sudo systemctl restart datadog-agent
```

Run \`diagnose\` and confirm the issue is absent:
```bash
sudo datadog-agent diagnose --verbose
# system-probe-unreachable should not appear in the health-issues suite
```

> **Note:** Because this is a \`BuiltInStartupHealthCheck\` (runs once at startup), resolution requires restarting the agent with system-probe already running. There is no automatic self-healing at runtime.

---

#### Step 3 — Verify no false positives

| Scenario | Expected |
|---|---|
| NPM and USM both disabled (default) | No issue — \`Check()\` returns nil early |
| NPM/USM enabled, system-probe socket accessible at startup | No issue — dial succeeds |
| Non-Linux platform (macOS, Windows) | No issue — \`check_noop.go\` returns nil |

To verify the NPM-disabled path: set \`network_config.enabled: false\`, clear \`issues.json\`, restart the agent. The health-issues suite should not appear in \`diagnose\` output.

### Additional Notes

- **Linux only** — \`net.DialTimeout\` on a Unix socket path is Linux-specific; the noop file covers all other platforms.
- The check runs **once at startup**. Capability or socket changes take effect after a restart.
- The socket path is read from \`system_probe_config.sysprobe_socket\` in \`datadog.yaml\`; it falls back to \`/var/run/sysprobe/sysprobe.sock\` if the key is absent or empty.
- \`service_monitoring_config.enabled\` is also checked for USM; this config key is currently flagged as "unknown" by the schema validator on some builds but the value is still returned from the YAML file.