### PR TITLE
[AGTHEAL-57] feat(healthplatform): detect AWS EC2 hostname misconfiguration

### DIFF
--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//comp/healthplatform/forwarder/fx",
         "//comp/healthplatform/issues/admisconfig",
         "//comp/healthplatform/issues/admissionprobe",
+        "//comp/healthplatform/issues/awshostnamemismatch",
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
         "//comp/healthplatform/issues/rofspermissions",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -23,6 +23,7 @@ import (
 	// must not import other impl packages.
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admisconfig"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/awshostnamemismatch"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"

--- a/comp/healthplatform/issues/awshostnamemismatch/BUILD.bazel
+++ b/comp/healthplatform/issues/awshostnamemismatch/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "awshostnamemismatch",
+    srcs = [
+        "check.go",
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/awshostnamemismatch",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+    ],
+)

--- a/comp/healthplatform/issues/awshostnamemismatch/check.go
+++ b/comp/healthplatform/issues/awshostnamemismatch/check.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package awshostnamemismatch
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+)
+
+const (
+	imdsInstanceIDURL = "http://169.254.169.254/latest/meta-data/instance-id"
+	imdsTimeout       = 1 * time.Second
+)
+
+// Check detects whether the agent's configured hostname matches the EC2 instance ID.
+// Returns nil if the agent is not on AWS or if no manual hostname is configured.
+func Check(cfg config.Component) (*healthplatform.IssueReport, error) {
+	configuredHostname := cfg.GetString("hostname")
+	if configuredHostname == "" {
+		return nil, nil
+	}
+
+	instanceID, err := getInstanceID()
+	if err != nil {
+		// Not on AWS or IMDS unreachable — not our problem.
+		return nil, nil
+	}
+
+	if strings.Contains(configuredHostname, instanceID) {
+		return nil, nil
+	}
+
+	return &healthplatform.IssueReport{
+		IssueId: IssueID,
+		Context: map[string]string{
+			"configuredHostname": configuredHostname,
+			"ec2InstanceId":      instanceID,
+		},
+	}, nil
+}
+
+// getInstanceID fetches the EC2 instance ID from IMDS.
+func getInstanceID() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), imdsTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imdsInstanceIDURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	client := &http.Client{Timeout: imdsTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(body)), nil
+}

--- a/comp/healthplatform/issues/awshostnamemismatch/issue.go
+++ b/comp/healthplatform/issues/awshostnamemismatch/issue.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package awshostnamemismatch
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+)
+
+// AWSHostnameMismatchIssue provides the complete issue template for AWS hostname mismatch issues.
+type AWSHostnameMismatchIssue struct{}
+
+// NewAWSHostnameMismatchIssue creates a new AWS hostname mismatch issue template.
+func NewAWSHostnameMismatchIssue() *AWSHostnameMismatchIssue {
+	return &AWSHostnameMismatchIssue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation steps.
+func (t *AWSHostnameMismatchIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	configuredHostname := context["configuredHostname"]
+	ec2InstanceID := context["ec2InstanceId"]
+
+	description := fmt.Sprintf(
+		"The agent's configured hostname '%s' does not match or contain the EC2 instance ID '%s'. Metrics may be attributed to the wrong host.",
+		configuredHostname,
+		ec2InstanceID,
+	)
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   "aws_hostname_mismatch",
+		Title:       "Agent Hostname Doesn't Match EC2 Instance ID",
+		Description: description,
+		Category:    "configuration",
+		Severity:    "warning",
+		Source:      "core-agent",
+		Tags:        []string{"aws", "ec2", "hostname", "configuration"},
+		Remediation: &healthplatform.Remediation{
+			Summary: "Align the agent's configured hostname with the EC2 instance ID to ensure correct metric attribution.",
+			Steps: []*healthplatform.RemediationStep{
+				{
+					Order: 1,
+					Text:  "Remove the manual 'hostname' setting from datadog.yaml to let the agent auto-detect the EC2 instance ID as the hostname.",
+				},
+				{
+					Order: 2,
+					Text:  fmt.Sprintf("Or set 'hostname: %s' explicitly in datadog.yaml to match the EC2 instance ID.", ec2InstanceID),
+				},
+				{
+					Order: 3,
+					Text:  "On Windows, check the 'ec2_use_windows_prefix_detection' setting in datadog.yaml, which may affect how the hostname is resolved.",
+				},
+				{
+					Order: 4,
+					Text:  "Verify that the IAM role attached to the EC2 instance has the 'ec2:DescribeInstances' permission if using IMDSv2, or that IMDSv2 is not blocking metadata access.",
+				},
+			},
+		},
+	}, nil
+}

--- a/comp/healthplatform/issues/awshostnamemismatch/module.go
+++ b/comp/healthplatform/issues/awshostnamemismatch/module.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package awshostnamemismatch provides an issue module for AWS EC2 hostname mismatches.
+// It includes a startup health check that fires when the agent's configured hostname
+// does not match or contain the EC2 instance ID.
+package awshostnamemismatch
+
+import (
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for AWS hostname mismatch issues
+	IssueID = "aws-hostname-mismatch"
+
+	// CheckID is the unique identifier for the built-in health check
+	CheckID = "aws-hostname"
+
+	// CheckName is the human-readable name for the health check
+	CheckName = "AWS EC2 Hostname Check"
+)
+
+// awsHostnameMismatchModule implements issues.Module
+type awsHostnameMismatchModule struct {
+	cfg      config.Component
+	template *AWSHostnameMismatchIssue
+}
+
+// NewModule creates a new AWS hostname mismatch issue module
+func NewModule(cfg config.Component) issues.Module {
+	return &awsHostnameMismatchModule{
+		cfg:      cfg,
+		template: NewAWSHostnameMismatchIssue(),
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *awsHostnameMismatchModule) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *awsHostnameMismatchModule) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns the built-in health check configuration.
+// Once is true so it runs once at startup.
+func (m *awsHostnameMismatchModule) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	cfg := m.cfg
+	return &issues.BuiltInHealthCheck{
+		ID:   CheckID,
+		Name: CheckName,
+		CheckFn: func() (*healthplatform.IssueReport, error) {
+			return Check(cfg)
+		},
+		Once: true,
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a **startup** `BuiltInHealthCheck` (`aws-hostname`, `Once: true`) that detects when the agent's manually configured `hostname` setting does not match or contain the EC2 instance ID. When a mismatch is found, an `aws-hostname-mismatch` issue is reported to the health platform with remediation guidance.

The check:
1. Reads the `hostname` config key — **skips if empty** (no false positives when hostname is auto-detected)
2. Fetches the EC2 instance ID from `http://169.254.169.254/latest/meta-data/instance-id` with a 1-second timeout — **skips if IMDS is unreachable** (not on AWS)
3. Checks if the configured hostname contains the instance ID — reports an issue only on mismatch

**Changes:**
- `comp/healthplatform/issues/awshostnamemismatch/check.go` — IMDS fetch + hostname comparison
- `comp/healthplatform/issues/awshostnamemismatch/module.go` — module registration, `BuiltInHealthCheck` with `Once: true`
- `comp/healthplatform/issues/awshostnamemismatch/issue.go` — issue template with remediation
- `comp/healthplatform/bundle.go` + `BUILD.bazel` — registers the module

### Motivation

When a `hostname` is set explicitly in `datadog.yaml` on an EC2 host, it can diverge from the actual EC2 instance ID. This causes metrics to be attributed to the wrong host in the Datadog UI, which can be very confusing in environments with many instances. Closes AGTHEAL-57.

### Describe how you validated your changes

- `go build ./comp/healthplatform/...` passes cleanly
- `Check()` returns `nil` when `hostname` is empty (auto-detected hostname path)
- `Check()` returns `nil` when IMDS is unreachable (non-AWS host or network timeout)
- `Once: true` ensures the check runs only once at agent startup

### QA Plan

#### Prerequisites

- An **AWS EC2 instance** running the Datadog Agent.
- A **manually configured, mismatching** `hostname` in `datadog.yaml`:

  ```yaml
  # datadog.yaml — trigger the issue
  hostname: my-custom-hostname-that-does-not-match-instance-id
  ```

#### Verify IMDS is accessible (EC2 prerequisite)

```bash
curl -s --max-time 2 http://169.254.169.254/latest/meta-data/instance-id
# Expected output: i-0abc1234567890def
```

#### Verify the issue is detected

1. Set a mismatching hostname and restart the agent.
2. At startup, the `aws-hostname` check runs once.
3. IMDS returns the actual instance ID (e.g. `i-0abc1234567890def`).
4. The configured hostname `my-custom-hostname-that-does-not-match-instance-id` does not contain the instance ID.
5. Confirm the health platform store records an issue with:
   - `issue_id: "aws-hostname-mismatch"`
   - `severity: "warning"`
   - `category: "configuration"`
   - `source: "core-agent"`
   - `tags: ["aws", "ec2", "hostname", "configuration"]`
   - `context.configuredHostname`: `"my-custom-hostname-that-does-not-match-instance-id"`
   - `context.ec2InstanceId`: `"i-0abc1234567890def"`

#### Verify the issue resolves

**Option A — remove the manual hostname** (recommended):

```yaml
# datadog.yaml — remove the hostname line entirely
# hostname: my-custom-hostname  ← deleted
```

Restart the agent. The check skips because `hostname` is empty. No issue is recorded.

**Option B — set the hostname to the instance ID**:

```yaml
# datadog.yaml
hostname: i-0abc1234567890def
```

Restart. The check finds that `hostname` contains the instance ID. No issue is recorded.

#### Verify no false positives

| Scenario | Expected |
|---|---|
| `hostname` not set in `datadog.yaml` (default) | No issue — check skips |
| Hostname contains the instance ID (e.g. `my-app-i-0abc1234`) | No issue — substring match passes |
| Not on AWS / IMDS unreachable | No issue — IMDS call fails silently |
| EC2 instance with IMDSv2 that returns 401 without token | No issue — IMDS call fails silently (no false positive) |

#### Config key reference

| Key | Default | Description |
|---|---|---|
| `hostname` | `""` (auto-detected) | Manually override the agent hostname |

#### EC2 instance ID format

Instance IDs follow the format `i-<17 hex chars>`, e.g. `i-0abc1234567890def`. The check uses `strings.Contains` so any hostname that embeds the instance ID is accepted.

#### IMDSv2 note

The check uses `http.MethodGet` to the IMDSv1 endpoint. On instances with IMDSv2 required (`HttpTokens = required`), the call will return a 401 or time out, causing the check to skip silently. This is intentional — IMDSv2 connectivity issues are handled by the existing `awsimds` module.

### Additional Notes

- No build tag — the check runs on all platforms but fires only on AWS (IMDS unreachable elsewhere).
- `imdsTimeout` is 1 second — does not appreciably delay agent startup on non-AWS hosts.
- Runs **once at startup** (`Once: true`). Changes to `datadog.yaml` take effect on agent restart.