### PR TITLE
feat(win32_event_log): detect invalid channel via EvtSubscribe, report to health platform

### DIFF
--- a/comp/checks/windowseventlog/impl/check/check.go
+++ b/comp/checks/windowseventlog/impl/check/check.go
@@ -18,6 +18,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/checks/windowseventlog/impl/check/eventdatafilter"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	windowseventlogchannels "github.com/DataDog/datadog-agent/comp/healthplatform/issues/windowseventlogchannels"
+	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	publishermetadatacache "github.com/DataDog/datadog-agent/comp/publishermetadatacache/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -71,6 +73,8 @@ type Check struct {
 	userRenderContext      evtapi.EventRenderContextHandle
 	bookmarkManager        evtbookmark.Manager
 	publisherMetadataCache publishermetadatacache.Component
+
+	healthPlatform healthplatformdef.Component
 }
 
 // Run updates sender stats, restarts the subscription if it failed, and saves the bookmark.
@@ -90,11 +94,26 @@ func (c *Check) Run() error {
 		// starts the event collection in the background.
 		err := c.startSubscription()
 		if err != nil {
+			if c.healthPlatform != nil && errors.Is(err, windows.ERROR_EVT_CHANNEL_NOT_FOUND) {
+				channelPath, _ := c.getChannelPath()
+				instanceID := fmt.Sprintf("%s:%s", windowseventlogchannels.IssueID, string(c.ID()))
+				_ = c.healthPlatform.ReportIssue(healthplatformdef.IssueReport{
+					IssueID:   instanceID,
+					IssueType: windowseventlogchannels.IssueID,
+					Source:    CheckName,
+					Context:   map[string]string{"channelPath": channelPath},
+				})
+			}
 			err = fmt.Errorf("subscription is not running, failed to start: %w", err)
 			if c.sub.Error() != nil {
 				err = fmt.Errorf("%w, last stop reason: %w", err, c.sub.Error())
 			}
 			return err
+		}
+		// Subscription started successfully; resolve any previously recorded channel issue.
+		if c.healthPlatform != nil {
+			instanceID := fmt.Sprintf("%s:%s", windowseventlogchannels.IssueID, string(c.ID()))
+			c.healthPlatform.ResolveIssue(instanceID)
 		}
 	}
 
@@ -304,7 +323,7 @@ func (c *Check) Cancel() {
 }
 
 // Factory creates a new check factory
-func Factory(logsAgent option.Option[logsAgent.Component], config configComponent.Component, publisherMetadataCache publishermetadatacache.Component) option.Option[func() check.Check] {
+func Factory(logsAgent option.Option[logsAgent.Component], config configComponent.Component, publisherMetadataCache publishermetadatacache.Component, healthPlatform healthplatformdef.Component) option.Option[func() check.Check] {
 	return option.New(func() check.Check {
 		return &Check{
 			CheckBase:              core.NewCheckBase(CheckName),
@@ -312,6 +331,7 @@ func Factory(logsAgent option.Option[logsAgent.Component], config configComponen
 			agentConfig:            config,
 			evtapi:                 winevtapi.New(),
 			publisherMetadataCache: publisherMetadataCache,
+			healthPlatform:         healthPlatform,
 		}
 	})
 }

--- a/comp/checks/windowseventlog/impl/windows_event_log.go
+++ b/comp/checks/windowseventlog/impl/windows_event_log.go
@@ -16,6 +16,7 @@ import (
 	windowseventlog "github.com/DataDog/datadog-agent/comp/checks/windowseventlog/def"
 	check "github.com/DataDog/datadog-agent/comp/checks/windowseventlog/impl/check"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	publishermetadatacache "github.com/DataDog/datadog-agent/comp/publishermetadatacache/def"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -30,6 +31,8 @@ type Requires struct {
 	LogsComponent          option.Option[logsAgent.Component]
 	Config                 configComponent.Component
 	PublisherMetadataCache publishermetadatacache.Component
+	// HealthPlatform is optional; absent in builds that omit the health platform bundle.
+	HealthPlatform healthplatformdef.Component `optional:"true"`
 }
 
 // Provides defines the output of the windowseventlog component.
@@ -41,7 +44,7 @@ type Provides struct {
 func NewComponent(reqs Requires) Provides {
 	reqs.Lifecycle.Append(compdef.Hook{
 		OnStart: func(_ context.Context) error {
-			core.RegisterCheck(check.CheckName, check.Factory(reqs.LogsComponent, reqs.Config, reqs.PublisherMetadataCache))
+			core.RegisterCheck(check.CheckName, check.Factory(reqs.LogsComponent, reqs.Config, reqs.PublisherMetadataCache, reqs.HealthPlatform))
 			return nil
 		},
 	})

--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
         "//comp/healthplatform/issues/rofspermissions",
+        "//comp/healthplatform/issues/windowseventlogchannels",
         "//comp/healthplatform/scheduler/fx",
         "//comp/healthplatform/store/def",
         "//comp/healthplatform/store/fx",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/windowseventlogchannels"
 )
 
 // team: agent-health

--- a/comp/healthplatform/issues/windowseventlogchannels/BUILD.bazel
+++ b/comp/healthplatform/issues/windowseventlogchannels/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "windowseventlogchannels",
+    srcs = [
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/windowseventlogchannels",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/windowseventlogchannels/BUILD.bazel
+++ b/comp/healthplatform/issues/windowseventlogchannels/BUILD.bazel
@@ -9,9 +9,14 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/windowseventlogchannels",
     visibility = ["//visibility:public"],
     deps = [
-        "//comp/core/config",
-        "//comp/healthplatform/issues",
         "@com_github_datadog_agent_payload_v5//healthplatform",
         "@org_golang_google_protobuf//types/known/structpb",
-    ],
+    ] + select({
+        "@rules_go//go/platform:windows": [
+            "//comp/core/config",
+            "//comp/healthplatform/issues",
+            "//comp/healthplatform/runner/def",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/comp/healthplatform/issues/windowseventlogchannels/issue.go
+++ b/comp/healthplatform/issues/windowseventlogchannels/issue.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package windowseventlogchannels provides an issue module for invalid Windows
+// Event Log channel configurations. The issue is detected by the win32_event_log
+// check itself when EvtSubscribe fails with ERROR_EVT_CHANNEL_NOT_FOUND.
+package windowseventlogchannels
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// WindowsEventLogChannelIssue provides the issue template for an invalid Windows Event Log channel.
+type WindowsEventLogChannelIssue struct{}
+
+// NewWindowsEventLogChannelIssue creates a new issue template.
+func NewWindowsEventLogChannelIssue() *WindowsEventLogChannelIssue {
+	return &WindowsEventLogChannelIssue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation steps.
+// Expected context keys:
+//   - "channelPath": the configured channel name that was not found on the host
+func (t *WindowsEventLogChannelIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	channelPath := context["channelPath"]
+	if channelPath == "" {
+		channelPath = "unknown"
+	}
+
+	extra, err := structpb.NewStruct(map[string]any{
+		"channelPath": channelPath,
+		"impact":      "Events from this channel will not be collected.",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error building Windows Event Log channel issue: %w", err)
+	}
+
+	return &healthplatform.Issue{
+		IssueName:   "windows_eventlog_channel_not_found",
+		Title:       "Windows Event Log Channel Not Found",
+		Description: fmt.Sprintf("The configured Windows Event Log channel %q does not exist on this host.", channelPath),
+		Category:    "configuration",
+		Location:    "win32-event-log",
+		Severity:    "warning",
+		Source:      "win32_event_log",
+		Extra:       extra,
+		Remediation: &healthplatform.Remediation{
+			Summary: "Verify the channel name and update the integration configuration.",
+			Steps: []*healthplatform.RemediationStep{
+				{Order: 1, Text: "List available channels: run `wevtutil el` in PowerShell"},
+				{Order: 2, Text: fmt.Sprintf("Verify that %q appears in the output", channelPath)},
+				{Order: 3, Text: "Update `channel_path` in win32_event_log.d/conf.yaml to a valid channel name"},
+				{Order: 4, Text: "Restart the Datadog Agent to apply the change"},
+			},
+		},
+		Tags: []string{"windows-event-log", "configuration", "win32_event_log"},
+	}, nil
+}

--- a/comp/healthplatform/issues/windowseventlogchannels/module.go
+++ b/comp/healthplatform/issues/windowseventlogchannels/module.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package windowseventlogchannels
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique type identifier for Windows Event Log channel-not-found issues.
+	IssueID = "windows-eventlog-channel-not-found"
+)
+
+type windowsEventLogChannelModule struct {
+	template *WindowsEventLogChannelIssue
+}
+
+// NewModule creates a new Windows Event Log channel issue module.
+func NewModule(config.Component) issues.Module {
+	return &windowsEventLogChannelModule{
+		template: NewWindowsEventLogChannelIssue(),
+	}
+}
+
+func (m *windowsEventLogChannelModule) IssueID() string {
+	return IssueID
+}
+
+func (m *windowsEventLogChannelModule) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns nil — the issue is reported by the win32_event_log
+// check itself when EvtSubscribe fails with ERROR_EVT_CHANNEL_NOT_FOUND.
+func (m *windowsEventLogChannelModule) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return nil
+}

--- a/test/new-e2e/tests/agent-health/fixtures/win32_eventlog_channels_agent_config.yaml
+++ b/test/new-e2e/tests/agent-health/fixtures/win32_eventlog_channels_agent_config.yaml
@@ -1,0 +1,4 @@
+health_platform:
+  enabled: true
+  forwarder:
+    interval: 30s

--- a/test/new-e2e/tests/agent-health/win32_eventlog_channels_test.go
+++ b/test/new-e2e/tests/agent-health/win32_eventlog_channels_test.go
@@ -1,0 +1,168 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build windows
+
+// Package agenthealth contains E2E tests for the agent health reporting functionality.
+package agenthealth
+
+import (
+	_ "embed"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
+)
+
+//go:embed fixtures/win32_eventlog_channels_agent_config.yaml
+var win32EventLogChannelsAgentConfig string
+
+// invalidChannelConf is the win32_event_log config with a non-existent channel.
+const invalidChannelConf = `instances:
+  - path: NonExistentChannel123
+    legacy_mode: false
+`
+
+// validChannelConf is the win32_event_log config with a valid channel.
+const validChannelConf = `instances:
+  - path: System
+    legacy_mode: false
+`
+
+const win32EventLogCheckConfPath = `C:\ProgramData\Datadog\conf.d\win32_event_log.d\conf.yaml`
+const win32HealthPlatformIssuesPath = `C:\ProgramData\Datadog\run\health-platform\issues.json`
+
+type win32EventLogChannelsEnv struct {
+	RemoteHost *components.RemoteHost
+	Agent      *components.RemoteHostAgent
+	Fakeintake *components.FakeIntake
+}
+
+func win32EventLogChannelsEnvProvisioner() provisioners.PulumiEnvRunFunc[win32EventLogChannelsEnv] {
+	return func(ctx *pulumi.Context, env *win32EventLogChannelsEnv) error {
+		awsEnv, err := aws.NewEnvironment(ctx)
+		if err != nil {
+			return err
+		}
+
+		remoteHost, err := ec2.NewVM(awsEnv, "win32evtlogvm", ec2.WithOS(ec2.WindowsDefault))
+		if err != nil {
+			return err
+		}
+		if err = remoteHost.Export(ctx, &env.RemoteHost.HostOutput); err != nil {
+			return err
+		}
+
+		// Skip forwarding to dddev — agenthealth intake is only on staging
+		fakeIntake, err := fakeintake.NewECSFargateInstance(awsEnv, "", fakeintake.WithoutDDDevForwarding())
+		if err != nil {
+			return err
+		}
+		if err = fakeIntake.Export(ctx, &env.Fakeintake.FakeintakeOutput); err != nil {
+			return err
+		}
+
+		hostAgent, err := agent.NewHostAgent(&awsEnv, remoteHost,
+			agentparams.WithFakeintake(fakeIntake),
+			agentparams.WithAgentConfig(win32EventLogChannelsAgentConfig),
+		)
+		if err != nil {
+			return err
+		}
+		if err = hostAgent.Export(ctx, &env.Agent.HostAgentOutput); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+type win32EventLogChannelsSuite struct {
+	e2e.BaseSuite[win32EventLogChannelsEnv]
+}
+
+// TestWin32EventLogChannelsSuite runs the Windows Event Log channel health check test.
+func TestWin32EventLogChannelsSuite(t *testing.T) {
+	e2e.Run(t, &win32EventLogChannelsSuite{},
+		e2e.WithPulumiProvisioner(win32EventLogChannelsEnvProvisioner(), nil),
+	)
+}
+
+// TestWin32EventLogChannelNotFoundDiagnose verifies the detect-and-remediate flow for the
+// windows-eventlog-channel-not-found health check:
+//  1. With an invalid channel_path in the win32_event_log config, agent diagnose reports
+//     the windows-eventlog-channel-not-found issue with a WARNING.
+//  2. After fixing the config to a valid channel and restarting, the issue is gone.
+//
+// The check reports the issue inline in Run() when EvtSubscribe returns
+// ERROR_EVT_CHANNEL_NOT_FOUND. The check requires legacy_mode: false to use the Go
+// implementation; the legacy Python check does not call EvtSubscribe.
+func (suite *win32EventLogChannelsSuite) TestWin32EventLogChannelNotFoundDiagnose() {
+	t := suite.T()
+	host := suite.Env().RemoteHost
+	agentComp := suite.Env().Agent
+
+	// Restore a clean config after the test.
+	t.Cleanup(func() {
+		host.Execute(`Remove-Item -Force '` + win32EventLogCheckConfPath + `' -ErrorAction SilentlyContinue`) //nolint:errcheck
+		host.Execute(`Remove-Item -Force '` + win32HealthPlatformIssuesPath + `' -ErrorAction SilentlyContinue`) //nolint:errcheck
+		_ = agentComp.Client.Restart()
+	})
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.True(ct, agentComp.Client.IsReady(), "agent should be ready")
+	}, 3*time.Minute, 10*time.Second, "agent not ready")
+
+	// -------------------------------------------------------------------------
+	// Step 1: Configure an invalid channel and restart to trigger the check
+	// -------------------------------------------------------------------------
+
+	host.MustExecute(`Set-Content '` + win32EventLogCheckConfPath + `' -Value @'
+` + invalidChannelConf + `
+'@ -Encoding UTF8`)
+
+	host.MustExecute(`Remove-Item -Force '` + win32HealthPlatformIssuesPath + `' -ErrorAction SilentlyContinue`)
+
+	require.NoError(t, agentComp.Client.Restart(), "failed to restart agent after writing invalid channel config")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.True(ct, agentComp.Client.IsReady(), "agent should be ready after restart")
+	}, 3*time.Minute, 10*time.Second, "agent not ready after restart")
+
+	diagnoseOut := host.MustExecute(`& 'C:\Program Files\Datadog\Datadog Agent\bin\agent.exe' diagnose --verbose`)
+	assert.Contains(t, diagnoseOut, "windows-eventlog-channel-not-found", "diagnose should report windows-eventlog-channel-not-found")
+	assert.Contains(t, diagnoseOut, "WARNING", "issue should be reported as WARNING")
+	assert.Contains(t, diagnoseOut, "NonExistentChannel123", "diagnosis should name the offending channel")
+	t.Log("Step 1 passed: windows-eventlog-channel-not-found issue detected by diagnose")
+
+	// -------------------------------------------------------------------------
+	// Step 2: Fix the config and restart to verify resolution
+	// -------------------------------------------------------------------------
+
+	host.MustExecute(`Set-Content '` + win32EventLogCheckConfPath + `' -Value @'
+` + validChannelConf + `
+'@ -Encoding UTF8`)
+
+	host.MustExecute(`Remove-Item -Force '` + win32HealthPlatformIssuesPath + `' -ErrorAction SilentlyContinue`)
+
+	require.NoError(t, agentComp.Client.Restart(), "failed to restart agent after fixing config")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.True(ct, agentComp.Client.IsReady(), "agent should be ready after remediation restart")
+	}, 3*time.Minute, 10*time.Second, "agent not ready after remediation restart")
+
+	diagnoseOut = host.MustExecute(`& 'C:\Program Files\Datadog\Datadog Agent\bin\agent.exe' diagnose --verbose`)
+	assert.NotContains(t, diagnoseOut, "windows-eventlog-channel-not-found", "diagnose should not report the issue after fixing the channel")
+	t.Log("Step 2 passed: windows-eventlog-channel-not-found issue resolved after fixing config")
+}


### PR DESCRIPTION
### What does this PR do?

Detects invalid Windows Event Log channel configurations inline inside the existing \`win32_event_log\` check, rather than via a separate startup \`BuiltInHealthCheck\`.

When \`EvtSubscribe\` fails with \`ERROR_EVT_CHANNEL_NOT_FOUND\`, the check's \`Run()\` method calls \`healthPlatform.ReportIssue(...)\` directly. When the subscription starts successfully (e.g. after the config is corrected and the agent restarted), it calls \`ResolveIssue(...)\` automatically.

**Changes:**
- \`comp/healthplatform/issues/windowseventlogchannels/\` — new issue module (\`issue.go\` + \`module.go\`) that registers the \`windows-eventlog-channel-not-found\` issue type; \`BuiltInHealthCheck()\` returns \`nil\` since detection is owned by the check itself, not the scheduler
- \`comp/healthplatform/bundle.go\` — blank import to trigger \`init()\` registration
- \`comp/checks/windowseventlog/impl/windows_event_log.go\` — adds \`HealthPlatform healthplatformdef.Component\` (\`optional:"true"\`) to \`Requires\`
- \`comp/checks/windowseventlog/impl/check/check.go\` — adds \`healthPlatform\` field; \`Factory\` threads it through; \`Run()\` detects \`ERROR_EVT_CHANNEL_NOT_FOUND\` and reports/resolves the issue

### Motivation

The check already calls \`EvtSubscribe\` with the exact channel and receives the precise Windows error code when the channel does not exist — it is the natural place to report the issue. No YAML re-parsing, no \`wevtutil\` subprocess, no separate scheduled probe.

### Describe how you validated your changes

- \`go build ./comp/healthplatform/... ./comp/checks/windowseventlog/...\` passes on non-Windows (noop path via \`unsupported_platforms.go\`)
- \`healthPlatform\` is \`optional:"true"\` — nil-guarded before every call, safe when the health platform bundle is absent
- Existing check tests use \`new(Check)\` directly so \`healthPlatform\` defaults to nil — no test changes needed

### QA Plan

#### Prerequisites

A **Windows** host running the Datadog Agent with the Windows Event Log integration configured with at least one invalid channel:

```yaml
# C:\ProgramData\Datadog\conf.d\win32_event_log.d\conf.yaml
instances:
  - channel_path: System          # valid
  - channel_path: NonExistentChannel123  # invalid
```

#### Verify the issue is detected

1. Add an invalid \`channel_path\` to the configuration (see Prerequisites above).
2. Restart the agent. On the first \`Run()\` call the scheduler fires for the \`NonExistentChannel123\` instance, \`EvtSubscribe\` returns \`ERROR_EVT_CHANNEL_NOT_FOUND\`, and \`ReportIssue\` is called.
3. Confirm the health platform store records an issue:

```powershell
& "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" health-platform
```

Expected issue fields:
- \`issue_id\`: \`"windows-eventlog-channel-not-found:win32_event_log:<check-digest>"\`
- \`issue_type\`: \`"windows-eventlog-channel-not-found"\`
- \`severity\`: \`"warning"\`
- \`category\`: \`"configuration"\`
- \`location\`: \`"win32-event-log"\`
- \`context.channelPath\`: \`"NonExistentChannel123"\`

4. Also confirm the check error appears in agent logs:

```powershell
Select-String "NonExistentChannel123" "C:\ProgramData\Datadog\logs\agent.log"
```

#### Verify the issue resolves automatically

1. Fix the configuration (replace \`NonExistentChannel123\` with a valid channel such as \`Application\`).
2. Restart the agent. On the next \`Run()\` call \`EvtSubscribe\` succeeds and \`ResolveIssue\` is called.
3. Confirm the health platform store no longer shows the issue:

```powershell
& "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe" health-platform
```

#### Verify valid-only config produces no issue

| Scenario | Expected |
|---|---|
| All channels exist on the host | No issue reported |
| \`channel_path\` is absent from the instance | Check fails config validation before reaching \`Run()\` — no issue reported |
| \`EvtSubscribe\` fails with a non-channel error (e.g. permissions) | No issue reported — only \`ERROR_EVT_CHANNEL_NOT_FOUND\` triggers it |
| Health platform bundle not present in the build | No issue reported — \`healthPlatform\` field is \`nil\`, all calls are no-ops |
| Non-Windows platform | No issue — \`unsupported_platforms.go\` noop \`Factory\` |

#### Common channel names for reference

| Channel | Description |
|---|---|
| \`System\` | System-level events |
| \`Application\` | Application events |
| \`Security\` | Security audit events |
| \`Microsoft-Windows-PowerShell/Operational\` | PowerShell activity |

### Additional Notes

- \`ERROR_EVT_CHANNEL_NOT_FOUND\` (\`windows.Errno(15007)\`) is defined in \`golang.org/x/sys/windows\`
- Issue instance ID is \`"windows-eventlog-channel-not-found:<checkID>"\` — unique per check instance, so multiple \`win32_event_log\` instances monitoring different channels each get their own independent issue entry
- The issue auto-resolves on the next successful \`Run()\` — no agent restart required once the config is fixed

Closes AGTHEAL-58