### PR TITLE
[AGTHEAL-64] feat(healthplatform): add silent log pipeline issue template

### DIFF
--- a/comp/healthplatform/impl/health-platform.go
+++ b/comp/healthplatform/impl/health-platform.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/dockerpermissions"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/rofspermissions"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/silentlogpipeline"
 )
 
 // Requires defines the dependencies for the health-platform component

--- a/comp/healthplatform/impl/issues/silentlogpipeline/issue.go
+++ b/comp/healthplatform/impl/issues/silentlogpipeline/issue.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package silentlogpipeline
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	issueName     = "silent_log_pipeline"
+	category      = "configuration"
+	location      = "logs-agent"
+	severity      = "warning"
+	source        = "logs-agent"
+	unknownVal    = "unknown"
+	defaultImpact = "Logs from this source are not being collected or forwarded to Datadog"
+)
+
+// SilentLogPipelineIssue provides complete issue template for silent log pipeline issues
+type SilentLogPipelineIssue struct{}
+
+// NewSilentLogPipelineIssue creates a new silent log pipeline issue template
+func NewSilentLogPipelineIssue() *SilentLogPipelineIssue {
+	return &SilentLogPipelineIssue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation for silent log pipelines
+func (t *SilentLogPipelineIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	logSource := context["source"]
+	if logSource == "" {
+		logSource = unknownVal
+	}
+
+	configFile := context["configFile"]
+	if configFile == "" {
+		configFile = unknownVal
+	}
+
+	inactiveDuration := context["inactiveDuration"]
+	if inactiveDuration == "" {
+		inactiveDuration = unknownVal
+	}
+
+	description := fmt.Sprintf(
+		"The log source '%s' defined in '%s' has been configured for %s but no logs have been collected. "+
+			"This may indicate a misconfiguration, permission issue, or the source is genuinely quiet.",
+		logSource, configFile, inactiveDuration,
+	)
+
+	steps := []*healthplatform.RemediationStep{
+		{Order: 1, Text: "Verify the log file path exists: ls -la <path>"},
+		{Order: 2, Text: "Check the agent has read permissions: sudo -u dd-agent cat <path>"},
+		{Order: 3, Text: "Ensure logs_enabled: true in datadog.yaml"},
+		{Order: 4, Text: "Run agent diagnostics: datadog-agent logs check"},
+		{Order: 5, Text: "Check if the source is intentionally quiet (no action needed if so)"},
+	}
+
+	extra, err := structpb.NewStruct(map[string]any{
+		"source":            logSource,
+		"config_file":       configFile,
+		"inactive_duration": inactiveDuration,
+		"impact":            defaultImpact,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create extra: %v", err)
+	}
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   issueName,
+		Title:       "Log Source Configured But No Logs Received",
+		Description: description,
+		Category:    category,
+		Location:    location,
+		Severity:    severity,
+		DetectedAt:  "",
+		Source:      source,
+		Extra:       extra,
+		Remediation: &healthplatform.Remediation{
+			Summary: "Verify source path, permissions, and agent configuration",
+			Steps:   steps,
+		},
+		Tags: []string{"logs", "configuration", "collection"},
+	}, nil
+}

--- a/comp/healthplatform/impl/issues/silentlogpipeline/module.go
+++ b/comp/healthplatform/impl/issues/silentlogpipeline/module.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package silentlogpipeline provides an issue module for log sources that are
+// configured but not producing logs.
+// This module only provides remediation (no built-in check) as silent pipelines
+// are reported by external integrations (the logs agent) when a source has been
+// inactive beyond a threshold.
+package silentlogpipeline
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for silent log pipeline issues
+	IssueID = "silent-log-pipeline"
+)
+
+// silentLogPipelineModule implements issues.Module
+type silentLogPipelineModule struct {
+	template *SilentLogPipelineIssue
+}
+
+// NewModule creates a new silent log pipeline issue module
+func NewModule(config.Component) issues.Module {
+	return &silentLogPipelineModule{
+		template: NewSilentLogPipelineIssue(),
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *silentLogPipelineModule) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *silentLogPipelineModule) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInCheck returns nil - silent pipelines are reported by the logs agent
+func (m *silentLogPipelineModule) BuiltInCheck() *issues.BuiltInCheck {
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Registers an issue template for log sources that are configured but not producing logs (`silent-log-pipeline`).

The module is event-driven only — `BuiltInCheck()` returns `nil` — due to the high false-positive risk of periodic checks (many customers intentionally have quiet log sources). A follow-up PR will emit `IssueReport` from the logs agent when a source has been inactive beyond a configurable threshold.

### Motivation

Closes AGTHEAL-64.

### Describe how you validated your changes

Template-only module; no runtime behaviour to validate. The `init()` registration pattern is identical to `checkfailure` and `admisconfig`.

### Additional Notes

Requires a follow-up PR to emit `IssueReport` from the logs agent when a source is inactive beyond a threshold.