### PR TITLE
[AGTHEAL-56] feat(healthplatform): add disk check permission denied issue template

### DIFF
--- a/comp/healthplatform/impl/health-platform.go
+++ b/comp/healthplatform/impl/health-platform.go
@@ -34,6 +34,7 @@ import (
 	// Import issue modules to trigger their init() registration
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/admisconfig"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/checkfailure"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/diskcheckpermissions"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/dockerpermissions"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues/rofspermissions"
 )

--- a/comp/healthplatform/impl/issues/diskcheckpermissions/issue.go
+++ b/comp/healthplatform/impl/issues/diskcheckpermissions/issue.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package diskcheckpermissions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	issueName  = "disk_check_permission_denied"
+	category   = "permissions"
+	location   = "collector"
+	severity   = "warning"
+	source     = "disk"
+	unknownVal = "unknown"
+)
+
+// DiskCheckPermissionIssue provides complete issue template for disk check permission errors
+type DiskCheckPermissionIssue struct{}
+
+// NewDiskCheckPermissionIssue creates a new disk check permission issue template
+func NewDiskCheckPermissionIssue() *DiskCheckPermissionIssue {
+	return &DiskCheckPermissionIssue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation for disk check permission errors
+func (t *DiskCheckPermissionIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	path := context["path"]
+	if path == "" {
+		path = unknownVal
+	}
+
+	errorMsg := context["error"]
+	if errorMsg == "" {
+		errorMsg = unknownVal
+	}
+
+	description := strings.NewReplacer(
+		"{path}", path,
+		"{error}", errorMsg,
+	).Replace("The disk check cannot read disk statistics for path '{path}': {error}. Disk metrics for this mount point will not be collected.")
+
+	extra, err := structpb.NewStruct(map[string]any{
+		"path":  path,
+		"error": errorMsg,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create extra: %v", err)
+	}
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   issueName,
+		Title:       "Disk Check Lacks Read Permission",
+		Description: description,
+		Category:    category,
+		Location:    location,
+		Severity:    severity,
+		DetectedAt:  "",
+		Source:      source,
+		Extra:       extra,
+		Remediation: &healthplatform.Remediation{
+			Summary: "Grant read access to the dd-agent user or exclude the problematic path.",
+			Steps: []*healthplatform.RemediationStep{
+				{Order: 1, Text: "Grant read access to the dd-agent user: `sudo chmod o+r " + path + "` or `sudo setfacl -m u:dd-agent:r " + path + "`"},
+				{Order: 2, Text: "Check if the disk is mounted with `noexec` or restrictive options: `mount | grep " + path + "`"},
+				{Order: 3, Text: "In containerized environments, ensure the disk path is mounted into the container"},
+				{Order: 4, Text: "Exclude the problematic path with `excluded_filesystems` in disk check config if not needed"},
+			},
+		},
+		Tags: []string{"disk", "permissions", "metrics"},
+	}, nil
+}

--- a/comp/healthplatform/impl/issues/diskcheckpermissions/module.go
+++ b/comp/healthplatform/impl/issues/diskcheckpermissions/module.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package diskcheckpermissions provides an issue module for disk check permission errors.
+// This module only provides remediation (no built-in check) as disk permission errors
+// are reported by external integrations (the disk check collector).
+package diskcheckpermissions
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for disk check permission denied issues
+	IssueID = "disk-check-permission-denied"
+)
+
+// diskCheckPermissionsModule implements issues.Module
+type diskCheckPermissionsModule struct {
+	template *DiskCheckPermissionIssue
+}
+
+// NewModule creates a new disk check permission issue module
+func NewModule(config.Component) issues.Module {
+	return &diskCheckPermissionsModule{
+		template: NewDiskCheckPermissionIssue(),
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *diskCheckPermissionsModule) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *diskCheckPermissionsModule) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInCheck returns nil - disk check permission errors are reported by external integrations
+func (m *diskCheckPermissionsModule) BuiltInCheck() *issues.BuiltInCheck {
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Registers an issue module template for disk check permission errors (`EACCES`/`EPERM`) in the health platform.

### Motivation

Closes AGTHEAL-56.

Event-driven template (no built-in check): emitted when the disk check encounters a permission denied error on a configured path. Requires a follow-up PR to wire `IssueReport` emission from the disk check itself.

### Describe how you validated your changes

Template-only change; no runtime logic. The module registers via `init()` following the same pattern as `checkfailure` and other event-driven modules.

**Note:** Requires a follow-up PR to wire IssueReport emission from the disk check.

### Additional Notes

- `IssueID`: `disk-check-permission-denied`
- Context keys: `path`, `error`
- No build tag (unconditional registration)