### PR TITLE
test(par): add rshell permission-model matrix E2E tests

### DIFF
--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -164,8 +164,29 @@ func warnUnnamespacedCommands(commands []string) {
 // rshellAllowedPaths mirrors rshellAllowedCommands for the filesystem
 // allowlist. Nil means "operator unset" — the handler will pass the backend
 // list through unchanged rather than tightening to an empty intersection.
+//
+// The contract is forward-slash paths only (matching the backend's Linux-
+// style allow-list). Entries containing a backslash are logged as a warning
+// so operators who write Windows-native paths can see why their rule never
+// matches; the entries still flow through and produce an empty intersection
+// at runtime.
 func rshellAllowedPaths(config config.Component) []string {
-	return configuredStringSliceOrNil(config, setup.PARRestrictedShellAllowedPaths)
+	paths := configuredStringSliceOrNil(config, setup.PARRestrictedShellAllowedPaths)
+	warnBackslashPaths(paths)
+	return paths
+}
+
+// warnBackslashPaths emits a log warning for each entry containing a
+// backslash. The operator-side allow-list is defined as forward-slash only;
+// Windows-native paths will never match the backend's Linux-style entries
+// and would otherwise fail silently.
+func warnBackslashPaths(paths []string) {
+	for _, p := range paths {
+		if strings.ContainsRune(p, '\\') {
+			log.Warnf("%s entry %q contains a backslash; only forward-slash paths are supported and this entry will never match a backend path",
+				setup.PARRestrictedShellAllowedPaths, p)
+		}
+	}
 }
 
 // configuredStringSliceOrNil returns the configured value only when the key

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -18,10 +18,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
+
+// rshellCommandNamespace is the prefix the backend stamps onto every command
+// in its allow-list. Operator entries in datadog.yaml must use the same form
+// to intersect; otherwise they silently fail to match.
+const rshellCommandNamespace = "rshell:"
 
 func FromDDConfig(config config.Component) (*Config, error) {
 	mainEndpoint := configutils.GetMainEndpoint(config, "https://api.", "dd_url")
@@ -129,22 +135,57 @@ func makeActionsAllowlist(config config.Component) map[string]sets.Set[string] {
 
 // rshellAllowedCommands returns the operator-configured rshell command
 // allowlist, or nil when the operator did not configure one. Nil signals
-// "pass-through" so the handler forwards the backend list unchanged.
+// "pass-through" so the handler forwards the backend list unchanged; a
+// non-nil empty slice is the explicit "block everything" kill-switch.
+//
+// Entries are expected to be in the backend's namespaced form
+// ("rshell:<name>"). Operators spelling commands without the prefix are
+// warned at load time so the silent no-match failure mode is observable.
 func rshellAllowedCommands(config config.Component) []string {
-	if !config.IsConfigured(setup.PARRestrictedShellAllowedCommands) {
-		return nil
+	commands := configuredStringSliceOrNil(config, setup.PARRestrictedShellAllowedCommands)
+	warnUnnamespacedCommands(commands)
+	return commands
+}
+
+// warnUnnamespacedCommands emits a log warning for each entry missing the
+// "rshell:" prefix. These entries will never match a backend command, so an
+// operator who writes `allowed_commands: [cat]` instead of
+// `allowed_commands: [rshell:cat]` would otherwise get silent kill-switch
+// behavior with no feedback.
+func warnUnnamespacedCommands(commands []string) {
+	for _, c := range commands {
+		if !strings.HasPrefix(c, rshellCommandNamespace) {
+			log.Warnf("%s entry %q is missing the %q prefix and will never match a backend command; use %q instead",
+				setup.PARRestrictedShellAllowedCommands, c, rshellCommandNamespace, rshellCommandNamespace+c)
+		}
 	}
-	return config.GetStringSlice(setup.PARRestrictedShellAllowedCommands)
 }
 
 // rshellAllowedPaths mirrors rshellAllowedCommands for the filesystem
 // allowlist. Nil means "operator unset" — the handler will pass the backend
 // list through unchanged rather than tightening to an empty intersection.
 func rshellAllowedPaths(config config.Component) []string {
-	if !config.IsConfigured(setup.PARRestrictedShellAllowedPaths) {
+	return configuredStringSliceOrNil(config, setup.PARRestrictedShellAllowedPaths)
+}
+
+// configuredStringSliceOrNil returns the configured value only when the key
+// was explicitly set by the user (YAML file, env, or SetWithoutSource); it
+// returns nil when the key is still at its default.
+//
+// GetStringSlice returns a nil slice for an explicit YAML empty list
+// (`key: []`), which is indistinguishable at the slice level from "unset".
+// IsConfigured is the authoritative signal for "user touched this key", so we
+// gate on that and then normalize nil → non-nil empty to preserve the
+// "operator explicitly allowed nothing" semantics downstream.
+func configuredStringSliceOrNil(config config.Component, key string) []string {
+	if !config.IsConfigured(key) {
 		return nil
 	}
-	return config.GetStringSlice(setup.PARRestrictedShellAllowedPaths)
+	v := config.GetStringSlice(key)
+	if v == nil {
+		return []string{}
+	}
+	return v
 }
 
 // getDatadogHost extracts and normalizes the Datadog host from the main endpoint.

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -374,3 +374,68 @@ func TestFromDDConfigPARRestrictedShellAllowedCommandsEmpty(t *testing.T) {
 	assert.NotNil(t, cfg.RShellAllowedCommands)
 	assert.Empty(t, cfg.RShellAllowedCommands)
 }
+
+// TestFromDDConfigPARRestrictedShellAllowedPathsEmptyYAML reproduces the
+// real-world failure observed in PAR: when datadog.yaml contains
+// `allowed_paths: []` the transform must preserve the explicit-empty value so
+// the handler treats it as "block everything", not "operator unset". This
+// exercises the YAML parsing path rather than SetWithoutSource; the two can
+// differ in whether IsConfigured reports an empty slice as set.
+func TestFromDDConfigPARRestrictedShellAllowedPathsEmptyYAML(t *testing.T) {
+	yaml := `
+private_action_runner:
+  restricted_shell:
+    allowed_paths: []
+`
+	mockConfig := configmock.NewFromYAML(t, yaml)
+
+	cfg, err := FromDDConfig(mockConfig)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg.RShellAllowedPaths, "YAML [] must reach the handler as a non-nil slice so the kill-switch is honored")
+	assert.Empty(t, cfg.RShellAllowedPaths)
+}
+
+func TestFromDDConfigPARRestrictedShellAllowedCommandsEmptyYAML(t *testing.T) {
+	yaml := `
+private_action_runner:
+  restricted_shell:
+    allowed_commands: []
+`
+	mockConfig := configmock.NewFromYAML(t, yaml)
+
+	cfg, err := FromDDConfig(mockConfig)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg.RShellAllowedCommands, "YAML [] must reach the handler as a non-nil slice so the kill-switch is honored")
+	assert.Empty(t, cfg.RShellAllowedCommands)
+}
+
+func TestFromDDConfigPARRestrictedShellAllowedCommandsPassesThroughUnnamespaced(t *testing.T) {
+	// Unnamespaced entries are preserved in the returned slice so the
+	// intersection layer can surface them (as silent no-matches). The
+	// transform also emits a log warning about them, which is not asserted
+	// here — the point of this test is that unnamespaced entries do not
+	// cause config load to fail.
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource(setup.PARPrivateKey, "")
+	mockConfig.SetWithoutSource(setup.PARUrn, "")
+	mockConfig.SetWithoutSource(setup.PARRestrictedShellAllowedCommands, []string{"cat", "rshell:ls"})
+
+	cfg, err := FromDDConfig(mockConfig)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cat", "rshell:ls"}, cfg.RShellAllowedCommands)
+}
+
+func TestFromDDConfigPARRestrictedShellAllowedAbsentYAML(t *testing.T) {
+	// No restricted_shell block at all: the handler must see nil slices so
+	// it passes the backend list through unchanged.
+	yaml := `
+private_action_runner:
+  enabled: true
+`
+	mockConfig := configmock.NewFromYAML(t, yaml)
+
+	cfg, err := FromDDConfig(mockConfig)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.RShellAllowedPaths)
+	assert.Nil(t, cfg.RShellAllowedCommands)
+}

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -409,6 +409,21 @@ private_action_runner:
 	assert.Empty(t, cfg.RShellAllowedCommands)
 }
 
+func TestFromDDConfigPARRestrictedShellAllowedPathsPassesThroughBackslash(t *testing.T) {
+	// Backslash-containing entries are preserved in the returned slice so
+	// the handler still sees what the operator wrote; the transform also
+	// logs a warning so a Windows-native path configured by mistake does
+	// not silently produce an empty intersection without feedback.
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource(setup.PARPrivateKey, "")
+	mockConfig.SetWithoutSource(setup.PARUrn, "")
+	mockConfig.SetWithoutSource(setup.PARRestrictedShellAllowedPaths, []string{`C:\Data`, "/var/log"})
+
+	cfg, err := FromDDConfig(mockConfig)
+	require.NoError(t, err)
+	assert.Equal(t, []string{`C:\Data`, "/var/log"}, cfg.RShellAllowedPaths)
+}
+
 func TestFromDDConfigPARRestrictedShellAllowedCommandsPassesThroughUnnamespaced(t *testing.T) {
 	// Unnamespaced entries are preserved in the returned slice so the
 	// intersection layer can surface them (as silent no-matches). The

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -165,13 +165,14 @@ func (h *RunCommandHandler) filterAllowedPaths(backendAllowed []string) []string
 }
 
 // pathContains reports whether parent is an ancestor of (or equal to) child,
-// using the path separator as the boundary. Leading and trailing slashes
-// are normalized via path.Clean so "/var/log/" and "/var/log" compare equal.
-// Prefix-sibling strings like "/var/logger" do not count as contained in
-// "/var/log".
+// using the path separator as the boundary. Both inputs are first
+// canonicalized to forward-slash form so the comparison works identically
+// on Linux and on Windows (where PAR also runs and rshell itself uses the
+// OS-native backslash). Prefix-sibling strings like "/var/logger" do not
+// count as contained in "/var/log".
 func pathContains(parent, child string) bool {
-	parent = path.Clean(parent)
-	child = path.Clean(child)
+	parent = normalizePath(parent)
+	child = normalizePath(child)
 	if parent == child {
 		return true
 	}
@@ -182,6 +183,16 @@ func pathContains(parent, child string) bool {
 		parent += "/"
 	}
 	return strings.HasPrefix(child, parent)
+}
+
+// normalizePath rewrites backslashes to forward slashes and runs path.Clean.
+// The backslash-to-slash step is what makes containment work for
+// Windows-native paths; path.Clean alone treats "\\" as an ordinary
+// character, which would make "C:\Data\logs" look like a prefix sibling of
+// "C:\Data" instead of a sub-path. We use path (not path/filepath) so the
+// comparison behaves identically regardless of build OS.
+func normalizePath(p string) string {
+	return path.Clean(strings.ReplaceAll(p, `\`, "/"))
 }
 
 // RunCommandInputs defines the inputs for the runCommand action.

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -37,21 +37,29 @@ var statFn = os.Stat
 
 // RunCommandHandler implements the runCommand action.
 //
-// Both allow-lists follow the same pattern: the operator list is stored as a
-// set for O(1) lookup, and the filter functions do plain string-equality
-// intersection with the backend list. Nil means the operator did not
-// configure the axis (backend list passes through); an empty list means the
-// operator explicitly restricts to nothing.
+// Both allow-lists are stored as dedup-preserving slices of operator entries
+// plus a boolean that distinguishes "unset" from "empty". The filter
+// functions intersect with the backend list under two different notions of
+// equivalence:
+//
+//   - commands compare by exact string equality. The backend stamps every
+//     entry with the "rshell:" namespace (e.g. "rshell:cat"); operators must
+//     spell entries the same way in datadog.yaml for them to match;
+//   - paths compare by containment, with the narrower side winning, so that
+//     an operator entry of "/var/log/nginx" is admitted even when the
+//     backend only lists "/var/log". Prefix siblings like "/var/logger" do
+//     not match "/var/log" — boundary is a path separator.
 type RunCommandHandler struct {
 	// operatorAllowedPaths is the operator's filesystem allowlist from
 	// datadog.yaml. Populated only when filtering is enabled.
-	operatorAllowedPaths map[string]struct{}
-	// operatorPathsFilterEnabled distinguishes "unset" (nil map, no
+	operatorAllowedPaths []string
+	// operatorPathsFilterEnabled distinguishes "unset" (nil slice, no
 	// filtering) from "empty list" (operator explicitly allowed nothing).
 	operatorPathsFilterEnabled bool
-	// operatorAllowedCommands is the set of bare command names the
-	// operator has allow-listed. Populated only when filtering is enabled.
-	operatorAllowedCommands map[string]struct{}
+	// operatorAllowedCommands is the operator allow-list, stored verbatim.
+	// Entries are expected to be namespaced ("rshell:<name>") to match the
+	// backend form; anything else silently fails to intersect.
+	operatorAllowedCommands []string
 	// operatorCommandsFilterEnabled distinguishes "unset" from "empty".
 	operatorCommandsFilterEnabled bool
 }
@@ -63,25 +71,31 @@ func NewRunCommandHandler(operatorAllowedPaths []string, operatorAllowedCommands
 	h := &RunCommandHandler{}
 	if operatorAllowedPaths != nil {
 		h.operatorPathsFilterEnabled = true
-		h.operatorAllowedPaths = make(map[string]struct{}, len(operatorAllowedPaths))
-		for _, p := range operatorAllowedPaths {
-			if p == "" {
-				continue
-			}
-			h.operatorAllowedPaths[p] = struct{}{}
-		}
+		h.operatorAllowedPaths = dedupeNonEmpty(operatorAllowedPaths)
 	}
 	if operatorAllowedCommands != nil {
 		h.operatorCommandsFilterEnabled = true
-		h.operatorAllowedCommands = make(map[string]struct{}, len(operatorAllowedCommands))
-		for _, c := range operatorAllowedCommands {
-			if c == "" {
-				continue
-			}
-			h.operatorAllowedCommands[c] = struct{}{}
-		}
+		h.operatorAllowedCommands = dedupeNonEmpty(operatorAllowedCommands)
 	}
 	return h
+}
+
+// dedupeNonEmpty returns the input slice with empties removed and duplicates
+// dropped, preserving first-seen order.
+func dedupeNonEmpty(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
 }
 
 // filterAllowedCommands returns the effective command allowlist given the
@@ -90,7 +104,9 @@ func NewRunCommandHandler(operatorAllowedPaths []string, operatorAllowedCommands
 // The backend is the authoritative gate. A nil backend list (field absent)
 // produces an empty result — rshell then blocks every command. The operator
 // config can only tighten further; it cannot grant commands the backend did
-// not.
+// not. Comparison is plain string equality: operator entries in datadog.yaml
+// must be spelled in the backend's namespaced form ("rshell:<name>") to
+// match.
 func (h *RunCommandHandler) filterAllowedCommands(backendAllowed []string) []string {
 	if backendAllowed == nil {
 		return nil
@@ -98,18 +114,25 @@ func (h *RunCommandHandler) filterAllowedCommands(backendAllowed []string) []str
 	if !h.operatorCommandsFilterEnabled {
 		return backendAllowed
 	}
+	operatorSet := make(map[string]struct{}, len(h.operatorAllowedCommands))
+	for _, c := range h.operatorAllowedCommands {
+		operatorSet[c] = struct{}{}
+	}
 	filtered := make([]string, 0, len(backendAllowed))
 	for _, c := range backendAllowed {
-		if _, ok := h.operatorAllowedCommands[c]; ok {
+		if _, ok := operatorSet[c]; ok {
 			filtered = append(filtered, c)
 		}
 	}
 	return filtered
 }
 
-// filterAllowedPaths is the paths analogue of filterAllowedCommands. Both
-// do plain string-equality intersection — paths must be spelled identically
-// on the backend and in datadog.yaml to be admitted.
+// filterAllowedPaths is the paths analogue of filterAllowedCommands, but
+// with containment-aware intersection: the narrower of each matching
+// (backend, operator) pair wins. This admits an operator sub-path when the
+// backend entry is a parent directory, and vice versa. Disjoint pairs are
+// skipped. Prefix siblings do not match (boundary is a path separator), so
+// "/var/logger" does not satisfy a "/var/log" rule.
 func (h *RunCommandHandler) filterAllowedPaths(backendAllowed []string) []string {
 	if backendAllowed == nil {
 		return nil
@@ -118,12 +141,47 @@ func (h *RunCommandHandler) filterAllowedPaths(backendAllowed []string) []string
 		return backendAllowed
 	}
 	filtered := make([]string, 0, len(backendAllowed))
-	for _, p := range backendAllowed {
-		if _, ok := h.operatorAllowedPaths[p]; ok {
-			filtered = append(filtered, p)
+	seen := make(map[string]struct{})
+	admit := func(p string) {
+		if _, dup := seen[p]; dup {
+			return
+		}
+		seen[p] = struct{}{}
+		filtered = append(filtered, p)
+	}
+	for _, b := range backendAllowed {
+		for _, o := range h.operatorAllowedPaths {
+			switch {
+			case pathContains(b, o):
+				// operator entry is equal or narrower — admit it.
+				admit(o)
+			case pathContains(o, b):
+				// backend entry is strictly narrower — admit it.
+				admit(b)
+			}
 		}
 	}
 	return filtered
+}
+
+// pathContains reports whether parent is an ancestor of (or equal to) child,
+// using the path separator as the boundary. Leading and trailing slashes
+// are normalized via path.Clean so "/var/log/" and "/var/log" compare equal.
+// Prefix-sibling strings like "/var/logger" do not count as contained in
+// "/var/log".
+func pathContains(parent, child string) bool {
+	parent = path.Clean(parent)
+	child = path.Clean(child)
+	if parent == child {
+		return true
+	}
+	// Ensure parent ends with exactly one separator before the prefix
+	// check, so "/var/log" tests as a prefix of "/var/log/nginx" but not
+	// of "/var/logger".
+	if !strings.HasSuffix(parent, "/") {
+		parent += "/"
+	}
+	return strings.HasPrefix(child, parent)
 }
 
 // RunCommandInputs defines the inputs for the runCommand action.

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -164,15 +164,16 @@ func (h *RunCommandHandler) filterAllowedPaths(backendAllowed []string) []string
 	return filtered
 }
 
-// pathContains reports whether parent is an ancestor of (or equal to) child,
-// using the path separator as the boundary. Both inputs are first
-// canonicalized to forward-slash form so the comparison works identically
-// on Linux and on Windows (where PAR also runs and rshell itself uses the
-// OS-native backslash). Prefix-sibling strings like "/var/logger" do not
-// count as contained in "/var/log".
+// pathContains reports whether parent is an ancestor of (or equal to) child.
+// Paths are assumed to be in forward-slash form — the operator-side
+// contract (see the datadog.yaml loader) rejects Windows-native backslash
+// paths up front, so this function does not deal with separator
+// normalization. Leading and trailing slashes are normalized via
+// path.Clean so "/var/log/" and "/var/log" compare equal. Prefix-sibling
+// strings like "/var/logger" do not count as contained in "/var/log".
 func pathContains(parent, child string) bool {
-	parent = normalizePath(parent)
-	child = normalizePath(child)
+	parent = path.Clean(parent)
+	child = path.Clean(child)
 	if parent == child {
 		return true
 	}
@@ -183,16 +184,6 @@ func pathContains(parent, child string) bool {
 		parent += "/"
 	}
 	return strings.HasPrefix(child, parent)
-}
-
-// normalizePath rewrites backslashes to forward slashes and runs path.Clean.
-// The backslash-to-slash step is what makes containment work for
-// Windows-native paths; path.Clean alone treats "\\" as an ordinary
-// character, which would make "C:\Data\logs" look like a prefix sibling of
-// "C:\Data" instead of a sub-path. We use path (not path/filepath) so the
-// comparison behaves identically regardless of build OS.
-func normalizePath(p string) string {
-	return path.Clean(strings.ReplaceAll(p, `\`, "/"))
 }
 
 // RunCommandInputs defines the inputs for the runCommand action.

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -268,8 +268,9 @@ func TestFilterAllowedCommandsMatrix(t *testing.T) {
 }
 
 // TestFilterAllowedPathsMatrix is the paths analogue of
-// TestFilterAllowedCommandsMatrix. Twelve scenarios with the same shape:
-// path intersection is plain string equality, identical to commands.
+// TestFilterAllowedCommandsMatrix. Path intersection is containment-aware
+// ("narrower wins") rather than plain set equality, so the non-empty x
+// non-empty cell has extra sub-cases for sub-path interplay.
 func TestFilterAllowedPathsMatrix(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -304,6 +305,24 @@ func TestFilterAllowedPathsMatrix(t *testing.T) {
 			[]string{"/var/log"}},
 		{"backend set, operator disjoint",
 			[]string{"/etc"}, []string{"/var/log"}, nil},
+
+		// Containment / "narrower wins" cases.
+		{"operator narrower than backend (sub-path wins)",
+			[]string{"/var/log"}, []string{"/var/log/nginx"},
+			[]string{"/var/log/nginx"}},
+		{"backend narrower than operator (backend wins)",
+			[]string{"/var/log/nginx"}, []string{"/var/log"},
+			[]string{"/var/log/nginx"}},
+		{"operator selects two siblings under one backend parent",
+			[]string{"/var/log"}, []string{"/var/log/nginx", "/var/log/apache"},
+			[]string{"/var/log/nginx", "/var/log/apache"}},
+		{"trailing slash on operator entry is normalized",
+			[]string{"/var/log"}, []string{"/var/log/"},
+			[]string{"/var/log/"}},
+		{"prefix sibling is not a sub-path (/var/logger vs /var/log)",
+			[]string{"/var/log"}, []string{"/var/logger"}, nil},
+		{"backend prefix sibling is not a sub-path",
+			[]string{"/var/logger"}, []string{"/var/log"}, nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -320,12 +339,23 @@ func TestFilterAllowedPathsMatrix(t *testing.T) {
 	}
 }
 
+func TestFilterAllowedCommandsRequiresNamespacedForm(t *testing.T) {
+	// The intersection is plain string equality: operator entries must be
+	// spelled in the backend's namespaced "rshell:<name>" form. A bare
+	// name like "cat" is silently ignored.
+	handler := NewRunCommandHandler(nil, []string{"cat", "rshell:echo"})
+
+	got := handler.filterAllowedCommands([]string{"rshell:cat", "rshell:echo", "rshell:ls"})
+
+	assert.Equal(t, []string{"rshell:echo"}, got)
+}
+
 func TestNewRunCommandHandlerStoresAllowedPaths(t *testing.T) {
 	paths := []string{"/var/log", "/tmp"}
 
 	handler := NewRunCommandHandler(paths, nil)
 
-	assert.Equal(t, map[string]struct{}{"/var/log": {}, "/tmp": {}}, handler.operatorAllowedPaths)
+	assert.Equal(t, []string{"/var/log", "/tmp"}, handler.operatorAllowedPaths)
 	assert.True(t, handler.operatorPathsFilterEnabled)
 }
 
@@ -337,7 +367,7 @@ func TestNewRshellBundleUsesConfiguredAllowedPaths(t *testing.T) {
 
 	handler, ok := action.(*RunCommandHandler)
 	require.True(t, ok)
-	assert.Equal(t, map[string]struct{}{"/var/log": {}, "/tmp": {}}, handler.operatorAllowedPaths)
+	assert.Equal(t, []string{"/var/log", "/tmp"}, handler.operatorAllowedPaths)
 }
 
 func mockStatFn(existing map[string]bool) func(string) (os.FileInfo, error) {

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -323,21 +323,6 @@ func TestFilterAllowedPathsMatrix(t *testing.T) {
 			[]string{"/var/log"}, []string{"/var/logger"}, nil},
 		{"backend prefix sibling is not a sub-path",
 			[]string{"/var/logger"}, []string{"/var/log"}, nil},
-
-		// Windows-native paths: PAR runs on Windows too and rshell itself
-		// uses OS-native separators. Containment must work regardless of
-		// whether entries use forward or backward slashes.
-		{"windows operator narrower than windows backend",
-			[]string{`C:\ProgramData\Datadog`}, []string{`C:\ProgramData\Datadog\logs`},
-			[]string{`C:\ProgramData\Datadog\logs`}},
-		{"windows backend narrower than windows operator",
-			[]string{`C:\ProgramData\Datadog\logs`}, []string{`C:\ProgramData\Datadog`},
-			[]string{`C:\ProgramData\Datadog\logs`}},
-		{"windows prefix sibling is not contained",
-			[]string{`C:\Data`}, []string{`C:\DataExtra`}, nil},
-		{"mixed separators still intersect",
-			[]string{`C:\ProgramData\Datadog`}, []string{"C:/ProgramData/Datadog/logs"},
-			[]string{"C:/ProgramData/Datadog/logs"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -323,6 +323,21 @@ func TestFilterAllowedPathsMatrix(t *testing.T) {
 			[]string{"/var/log"}, []string{"/var/logger"}, nil},
 		{"backend prefix sibling is not a sub-path",
 			[]string{"/var/logger"}, []string{"/var/log"}, nil},
+
+		// Windows-native paths: PAR runs on Windows too and rshell itself
+		// uses OS-native separators. Containment must work regardless of
+		// whether entries use forward or backward slashes.
+		{"windows operator narrower than windows backend",
+			[]string{`C:\ProgramData\Datadog`}, []string{`C:\ProgramData\Datadog\logs`},
+			[]string{`C:\ProgramData\Datadog\logs`}},
+		{"windows backend narrower than windows operator",
+			[]string{`C:\ProgramData\Datadog\logs`}, []string{`C:\ProgramData\Datadog`},
+			[]string{`C:\ProgramData\Datadog\logs`}},
+		{"windows prefix sibling is not contained",
+			[]string{`C:\Data`}, []string{`C:\DataExtra`}, nil},
+		{"mixed separators still intersect",
+			[]string{`C:\ProgramData\Datadog`}, []string{"C:/ProgramData/Datadog/logs"},
+			[]string{"C:/ProgramData/Datadog/logs"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/new-e2e/tests/privateactionrunner/README.md
+++ b/test/new-e2e/tests/privateactionrunner/README.md
@@ -37,6 +37,26 @@ permissive state so the outcome is attributable to the axis under test.
 `rshell_matrix_base_test.go` holds the shared `matrixSuite` base, PAR-readiness
 probe, and `enqueueAndWait` / `assertBlocked` / `assertAllowed` helpers.
 
+## CI workaround for the PAR sidecar's datadog.yaml
+
+The Datadog Helm chart (`agents.customAgentConfig` + `agents.useConfigMap:
+true`) mounts the generated `datadog.yaml` ConfigMap only on the main agent
+container — not on the `private-action-runner` sidecar. Without that mount,
+PAR reads the image's baked-in default `datadog.yaml` and any operator
+`private_action_runner.restricted_shell.*` config we set via customAgentConfig
+never reaches it.
+
+The proper fix is upstream in
+[DataDog/helm-charts#2601](https://github.com/DataDog/helm-charts/pull/2601),
+which adds the mirror mount on the PAR sidecar. Until that's released and the
+framework's default chart version catches up, `provisioner.go` applies a
+Pulumi `DaemonSetPatch` after the Helm install that injects the same mount.
+The patch is gated on operator config being set (so the
+`BothUnset` suite, which doesn't populate customAgentConfig, skips it).
+
+Once the chart fix is released, bump `minHelmChartVersion` and delete the
+patch (it's annotated with a `TODO(helm-charts#2601)` comment).
+
 ## Naming schema
 
 ```

--- a/test/new-e2e/tests/privateactionrunner/README.md
+++ b/test/new-e2e/tests/privateactionrunner/README.md
@@ -1,0 +1,53 @@
+# rshell permission-model E2E tests
+
+The `rshell_matrix_*_test.go` files exercise the rshell allow-list truth table
+from the [Confluence page](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/6608848267/Rshell+permission+model+allow+lists).
+
+## Truth table
+
+rshell has two independent allow-lists — `commands` and `paths` — each
+computed as the **intersection** of a backend-provided per-task list and an
+operator-provided datadog.yaml list. The expected effective list per cell:
+
+| Backend ↓ \ Operator → | unset   | `[]` | non-empty, disjoint | non-empty, overlap |
+|------------------------|---------|------|---------------------|--------------------|
+| nil / field absent     | ∅       | ∅    | ∅                   | ∅                  |
+| `[]`                   | ∅       | ∅    | ∅                   | ∅                  |
+| non-empty              | backend | ∅    | ∅                   | intersection       |
+
+- Backend is **authoritative**: when it's nil or `[]` the effective list is
+  always empty, regardless of what the operator says.
+- Operator can only **tighten**: an operator `[]` is the on-host kill-switch.
+- The commands matrix and paths matrix are independent — each has its own
+  12 cells.
+
+## Test layout
+
+Each test covers one cell on one axis. The non-tested axis is held in a
+permissive state so the outcome is attributable to the axis under test.
+
+| Suite file                                 | `operator.commands` | `operator.paths`       | Covers                               |
+|--------------------------------------------|---------------------|------------------------|--------------------------------------|
+| `rshell_matrix_both_unset_test.go`         | unset               | unset                  | commands col 1 + paths col 1         |
+| `rshell_matrix_commands_killswitch_test.go`| `[]`                | unset (permissive)     | commands col 2                       |
+| `rshell_matrix_commands_narrow_test.go`    | `["rshell:cat"]`    | unset (permissive)     | commands cols 3 & 4                  |
+| `rshell_matrix_paths_killswitch_test.go`   | unset (permissive)  | `[]`                   | paths col 2                          |
+| `rshell_matrix_paths_narrow_test.go`       | unset (permissive)  | `["/host/var/log"]`    | paths cols 3 & 4                     |
+
+`rshell_matrix_base_test.go` holds the shared `matrixSuite` base, PAR-readiness
+probe, and `enqueueAndWait` / `assertBlocked` / `assertAllowed` helpers.
+
+## Naming schema
+
+```
+Test<Axis>_Operator<State>_Backend<State>_<Outcome>
+```
+
+- `<Axis>` is `Commands` or `Paths` — needed because the `BothUnset` suite
+  covers both axes from one provisioner.
+- `<Operator state>` ∈ `Unset`, `Empty`, `NonEmptyDisjoint`, `NonEmptyOverlap`
+  (the four truth-table columns).
+- `<Backend state>` ∈ `Absent`, `Empty`, `NonEmpty` (the three rows).
+- `<Outcome>` ∈ `Allows`, `Blocks`.
+
+24 tests total (12 per axis, one per cell).

--- a/test/new-e2e/tests/privateactionrunner/provisioner.go
+++ b/test/new-e2e/tests/privateactionrunner/provisioner.go
@@ -8,6 +8,7 @@ package privateactionrunner
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -33,32 +34,65 @@ const (
 	minHelmChartVersion = "3.197.2"
 )
 
-// parHelmValuesTemplate configures the agent with PAR enabled.
-// Fakeintake URL wiring (DD_DD_URL, DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION) is handled
-// automatically by the e2e framework's configureFakeintake when fakeintake is present.
-// %s parameters: clusterName, runnerURN, privateKeyB64
-const parHelmValuesTemplate = `
-datadog:
-  kubelet:
-    tlsVerify: false
-  clusterName: "%s"
-  privateActionRunner:
-    enabled: true
-    selfEnroll: false
-    urn: "%s"
-    privateKey: "%s"
-agents:
-  useHostNetwork: true
-  containers:
-    privateActionRunner:
-      envDict:
-        DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST: "com.datadoghq.remoteaction.rshell.runCommand"
-`
+// rshellOperatorConfig models the operator-side `private_action_runner.restricted_shell.*`
+// allow-lists. It distinguishes "key absent" from "key present but empty list", because
+// that is the whole point of the truth-table matrix.
+type rshellOperatorConfig struct {
+	// commandsSet reports whether allowed_commands should appear in datadog.yaml at all.
+	// When false the key is omitted entirely (operator "unset"). When true the value of
+	// commands is written, including the empty-list case.
+	commandsSet bool
+	commands    []string
+
+	pathsSet bool
+	paths    []string
+}
+
+// rshellYAML renders the `restricted_shell` subtree with 6-space indent (i.e. as a child
+// of `private_action_runner`, which itself sits under `customAgentConfig` at 4 spaces).
+// Returns an empty string when neither axis is configured, so the caller can skip writing
+// the customAgentConfig block entirely.
+func (c rshellOperatorConfig) rshellYAML() string {
+	if !c.commandsSet && !c.pathsSet {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("      restricted_shell:\n")
+	if c.commandsSet {
+		sb.WriteString("        allowed_commands: ")
+		sb.WriteString(yamlList(c.commands))
+		sb.WriteString("\n")
+	}
+	if c.pathsSet {
+		sb.WriteString("        allowed_paths: ")
+		sb.WriteString(yamlList(c.paths))
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+// yamlList renders a string slice as a YAML flow sequence. An empty slice renders as `[]`,
+// which is deliberately different from omitting the key (see Confluence truth table).
+func yamlList(items []string) string {
+	if len(items) == 0 {
+		return "[]"
+	}
+	quoted := make([]string, len(items))
+	for i, s := range items {
+		quoted[i] = fmt.Sprintf("%q", s)
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}
 
 // parK8sProvisioner provisions a Kind-on-EC2 cluster with:
 //   - fakeintake deployed as ECS Fargate (HTTP, no load balancer) — PAR polls its OPMS endpoints
 //   - Datadog Agent with PAR enabled (custom image via --agent-image CLI flag)
-func parK8sProvisioner(runnerURN, privateKeyB64 string) provisioners.Provisioner {
+//
+// The rshellCfg controls the operator-side `private_action_runner.restricted_shell.*`
+// allow-lists as written to the agent's datadog.yaml. Each suite in the truth-matrix
+// coverage passes a different rshellCfg; the per-task backend lists are still set by
+// the tests themselves via fakeintake.EnqueuePARTask.
+func parK8sProvisioner(runnerURN, privateKeyB64 string, rshellCfg rshellOperatorConfig) provisioners.Provisioner {
 	p := provisioners.NewTypedPulumiProvisioner[environments.Kubernetes]("par-k8s",
 		func(ctx *pulumi.Context, env *environments.Kubernetes) error {
 			name := "kind"
@@ -115,14 +149,24 @@ func parK8sProvisioner(runnerURN, privateKeyB64 string) provisioners.Provisioner
 				return fmt.Errorf("kubernetes.NewProvider: %w", err)
 			}
 
-			// 4. Plant test data file on the Kind node (accessible to PAR at /host/var/log/)
+			// 4. Plant test fixtures on the Kind node (accessible to PAR at /host/...):
+			//   - /var/log/par-e2e-testdata.txt       — inside a backend-allowed dir
+			//   - /var/log/par-e2e-sibling.txt        — second file in the same dir, used
+			//     to exercise operator sub-path narrowing (Confluence: "narrower wins")
+			//   - /var/logger/par-e2e-prefix.txt      — prefix-sibling to /var/log, used
+			//     to confirm that a backend entry for /var/log does NOT admit /var/logger
+			plantScript := fmt.Sprintf(
+				`kind get nodes --name %%s | xargs -I{} docker exec {} bash -c '%s'`,
+				strings.Join([]string{
+					`echo "PAR_E2E_VALUE=hello_from_rshell" > /var/log/par-e2e-testdata.txt`,
+					`echo "PAR_E2E_SIBLING=file_in_same_dir" > /var/log/par-e2e-sibling.txt`,
+					`mkdir -p /var/logger && echo "PAR_E2E_PREFIX=sibling_dir" > /var/logger/par-e2e-prefix.txt`,
+				}, " && "),
+			)
 			_, err = host.OS.Runner().Command(
 				awsEnv.CommonNamer().ResourceName("plant-testdata"),
 				&command.Args{
-					Create: pulumi.Sprintf(
-						`kind get nodes --name %s | xargs -I{} docker exec {} bash -c "echo 'PAR_E2E_VALUE=hello_from_rshell' > /var/log/par-e2e-testdata.txt"`,
-						kindCluster.ClusterName,
-					),
+					Create: pulumi.Sprintf(plantScript, kindCluster.ClusterName),
 				},
 				utils.PulumiDependsOn(kindCluster),
 			)
@@ -133,9 +177,10 @@ func parK8sProvisioner(runnerURN, privateKeyB64 string) provisioners.Provisioner
 			// 5. Deploy Datadog agent via Helm with PAR enabled.
 			// DD_DD_URL and DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION for the PAR container are
 			// injected automatically by the e2e framework's configureFakeintake.
+			helmValues := buildPARHelmValues(ctx.Stack(), runnerURN, privateKeyB64, rshellCfg)
 			agent, err := helm.NewKubernetesAgent(&awsEnv, name, kubeProvider,
 				kubernetesagentparams.WithFakeintake(fi),
-				kubernetesagentparams.WithHelmValues(fmt.Sprintf(parHelmValuesTemplate, ctx.Stack(), runnerURN, privateKeyB64)),
+				kubernetesagentparams.WithHelmValues(helmValues),
 				kubernetesagentparams.WithClusterName(kindCluster.ClusterName),
 				kubernetesagentparams.WithTags([]string{"stackid:" + ctx.Stack()}),
 				kubernetesagentparams.WithHelmChartVersion(minHelmChartVersion),
@@ -152,4 +197,41 @@ func parK8sProvisioner(runnerURN, privateKeyB64 string) provisioners.Provisioner
 
 	p.SetDiagnoseFunc(awskubernetes.DiagnoseFunc)
 	return p
+}
+
+// buildPARHelmValues renders the Helm values YAML, conditionally attaching
+// `agents.customAgentConfig.private_action_runner.restricted_shell.*` when the operator
+// configures either axis. When both axes are unset, the `customAgentConfig` block is
+// omitted entirely so the default datadog.yaml is used verbatim.
+//
+// Fakeintake URL wiring (DD_DD_URL, DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION) is handled
+// automatically by the e2e framework's configureFakeintake when fakeintake is present.
+func buildPARHelmValues(clusterName, runnerURN, privateKeyB64 string, rshellCfg rshellOperatorConfig) string {
+	var customCfg string
+	if sub := rshellCfg.rshellYAML(); sub != "" {
+		// useConfigMap: true tells the chart to materialise customAgentConfig as a
+		// mounted datadog.yaml rather than translating it to env vars (which would
+		// lose the []/unset distinction we need to test).
+		customCfg = fmt.Sprintf(`  useConfigMap: true
+  customAgentConfig:
+    private_action_runner:
+%s`, sub)
+	}
+
+	return fmt.Sprintf(`datadog:
+  kubelet:
+    tlsVerify: false
+  clusterName: "%s"
+  privateActionRunner:
+    enabled: true
+    selfEnroll: false
+    urn: "%s"
+    privateKey: "%s"
+agents:
+  useHostNetwork: true
+%s  containers:
+    privateActionRunner:
+      envDict:
+        DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST: "com.datadoghq.remoteaction.rshell.runCommand"
+`, clusterName, runnerURN, privateKeyB64, customCfg)
 }

--- a/test/new-e2e/tests/privateactionrunner/provisioner.go
+++ b/test/new-e2e/tests/privateactionrunner/provisioner.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
@@ -189,6 +192,20 @@ func parK8sProvisioner(runnerURN, privateKeyB64 string, rshellCfg rshellOperator
 				return fmt.Errorf("agent.Export: %w", err)
 			}
 
+			// 6. Workaround for helm-charts#2601: mount the `datadog-yaml` ConfigMap on
+			// the private-action-runner sidecar so `agents.customAgentConfig` reaches PAR
+			// (the chart template currently only mounts it on the main agent container).
+			// Only needed when the operator axis is configured — otherwise useConfigMap=false
+			// and no ConfigMap exists to mount.
+			//
+			// TODO(helm-charts#2601): remove this patch and bump minHelmChartVersion once
+			// the PR lands in a released chart version.
+			if rshellCfg.commandsSet || rshellCfg.pathsSet {
+				if err = patchPARMountDatadogYAML(ctx, kubeProvider, agent); err != nil {
+					return fmt.Errorf("patchPARMountDatadogYAML: %w", err)
+				}
+			}
+
 			return nil
 		}, nil)
 
@@ -231,4 +248,56 @@ agents:
       envDict:
         DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST: "com.datadoghq.remoteaction.rshell.runCommand"
 `, clusterName, runnerURN, privateKeyB64, customCfg)
+}
+
+// patchPARMountDatadogYAML server-side-applies a strategic-merge patch to the
+// Datadog DaemonSet that adds the `datadog-yaml` ConfigMap mount (populated by
+// Helm when useConfigMap=true) to the private-action-runner container's
+// volumeMounts. This is a workaround for helm-charts#2601: the chart's
+// _container-private-action-runner.yaml template does not mount the
+// customAgentConfig ConfigMap, so PAR reads the image's baked-in datadog.yaml
+// instead of the operator-supplied content.
+//
+// The patch depends on the Helm agent install (the DaemonSet and the
+// `datadog-yaml` ConfigMap must already exist); K8s rolls out new pods that
+// pick up the new mount, and PAR then sees the operator config on startup.
+func patchPARMountDatadogYAML(ctx *pulumi.Context, kubeProvider *kubernetes.Provider, agent pulumi.Resource) error {
+	const (
+		daemonSetName   = "dda-linux-datadog" // matches linuxInstallName+"-datadog" from framework helm install
+		namespace       = "datadog"
+		parContainer    = "private-action-runner"
+		configMapVolume = "datadog-yaml"
+		confPath        = "/etc/datadog-agent/datadog.yaml"
+	)
+	_, err := appsv1.NewDaemonSetPatch(ctx, "par-mount-datadog-yaml", &appsv1.DaemonSetPatchArgs{
+		Metadata: &metav1.ObjectMetaPatchArgs{
+			Name:      pulumi.String(daemonSetName),
+			Namespace: pulumi.String(namespace),
+			Annotations: pulumi.StringMap{
+				// Force a rollout each time the patch is (re)applied so the mount
+				// actually takes effect on pods already running without it.
+				"kubectl.kubernetes.io/restartedAt": pulumi.String("par-operator-cfg"),
+			},
+		},
+		Spec: &appsv1.DaemonSetSpecPatchArgs{
+			Template: &corev1.PodTemplateSpecPatchArgs{
+				Spec: &corev1.PodSpecPatchArgs{
+					Containers: corev1.ContainerPatchArray{
+						&corev1.ContainerPatchArgs{
+							Name: pulumi.String(parContainer),
+							VolumeMounts: corev1.VolumeMountPatchArray{
+								&corev1.VolumeMountPatchArgs{
+									Name:      pulumi.String(configMapVolume),
+									MountPath: pulumi.String(confPath),
+									SubPath:   pulumi.String("datadog.yaml"),
+									ReadOnly:  pulumi.Bool(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, pulumi.Provider(kubeProvider), utils.PulumiDependsOn(agent))
+	return err
 }

--- a/test/new-e2e/tests/privateactionrunner/provisioner.go
+++ b/test/new-e2e/tests/privateactionrunner/provisioner.go
@@ -150,16 +150,13 @@ func parK8sProvisioner(runnerURN, privateKeyB64 string, rshellCfg rshellOperator
 			}
 
 			// 4. Plant test fixtures on the Kind node (accessible to PAR at /host/...):
-			//   - /var/log/par-e2e-testdata.txt       — inside a backend-allowed dir
-			//   - /var/log/par-e2e-sibling.txt        — second file in the same dir, used
-			//     to exercise operator sub-path narrowing (Confluence: "narrower wins")
-			//   - /var/logger/par-e2e-prefix.txt      — prefix-sibling to /var/log, used
-			//     to confirm that a backend entry for /var/log does NOT admit /var/logger
+			//   - /var/log/par-e2e-testdata.txt  — inside a backend-allowed dir
+			//   - /var/logger/par-e2e-prefix.txt — prefix-sibling to /var/log, used by
+			//     the paths narrow disjoint test to exercise operator narrowing
 			plantScript := fmt.Sprintf(
 				`kind get nodes --name %%s | xargs -I{} docker exec {} bash -c '%s'`,
 				strings.Join([]string{
 					`echo "PAR_E2E_VALUE=hello_from_rshell" > /var/log/par-e2e-testdata.txt`,
-					`echo "PAR_E2E_SIBLING=file_in_same_dir" > /var/log/par-e2e-sibling.txt`,
 					`mkdir -p /var/logger && echo "PAR_E2E_PREFIX=sibling_dir" > /var/logger/par-e2e-prefix.txt`,
 				}, " && "),
 			)
@@ -212,10 +209,10 @@ func buildPARHelmValues(clusterName, runnerURN, privateKeyB64 string, rshellCfg 
 		// useConfigMap: true tells the chart to materialise customAgentConfig as a
 		// mounted datadog.yaml rather than translating it to env vars (which would
 		// lose the []/unset distinction we need to test).
-		customCfg = fmt.Sprintf(`  useConfigMap: true
-  customAgentConfig:
-    private_action_runner:
-%s`, sub)
+		customCfg = "  useConfigMap: true\n" +
+			"  customAgentConfig:\n" +
+			"    private_action_runner:\n" +
+			sub
 	}
 
 	return fmt.Sprintf(`datadog:

--- a/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
@@ -31,6 +31,17 @@ const (
 	// accessible inside the PAR container at /host/var/log/ via the host volume mount.
 	testDataFile    = "/host/var/log/par-e2e-testdata.txt"
 	testDataContent = "PAR_E2E_VALUE=hello_from_rshell"
+
+	// testDataSibling is a second file planted alongside testDataFile. Used by the
+	// operator-narrowing matrix (Suite C) to tell "whole dir admitted" from "single
+	// file admitted" apart.
+	testDataSibling        = "/host/var/log/par-e2e-sibling.txt"
+	testDataSiblingContent = "PAR_E2E_SIBLING=file_in_same_dir"
+
+	// testDataPrefixSibling is planted at /var/logger/ — a prefix-sibling of /var/log.
+	// Used to confirm that a backend entry for /var/log does NOT admit /var/logger
+	// (see Confluence: "prefix siblings like /var/logger do not match /var/log").
+	testDataPrefixSibling = "/host/var/logger/par-e2e-prefix.txt"
 )
 
 type parK8sSuite struct {
@@ -42,7 +53,10 @@ func TestPARRshellK8sSuite(t *testing.T) {
 	t.Parallel()
 	urn, keyB64 := generateTestRunnerIdentity(t)
 	suite := &parK8sSuite{runnerURN: urn}
-	e2e.Run(t, suite, e2e.WithProvisioner(parK8sProvisioner(urn, keyB64)))
+	// Operator unset on both axes: rshell sees the backend list verbatim. These tests
+	// focus on the happy path and per-task (backend) blocking; full operator-matrix
+	// coverage lives in rshell_matrix_*_test.go.
+	e2e.Run(t, suite, e2e.WithProvisioner(parK8sProvisioner(urn, keyB64, rshellOperatorConfig{})))
 }
 
 // SetupSuite waits for PAR to be ready and actively polling fakeintake.

--- a/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
@@ -32,15 +32,10 @@ const (
 	testDataFile    = "/host/var/log/par-e2e-testdata.txt"
 	testDataContent = "PAR_E2E_VALUE=hello_from_rshell"
 
-	// testDataSibling is a second file planted alongside testDataFile. Used by the
-	// operator-narrowing matrix (Suite C) to tell "whole dir admitted" from "single
-	// file admitted" apart.
-	testDataSibling        = "/host/var/log/par-e2e-sibling.txt"
-	testDataSiblingContent = "PAR_E2E_SIBLING=file_in_same_dir"
-
 	// testDataPrefixSibling is planted at /var/logger/ — a prefix-sibling of /var/log.
-	// Used to confirm that a backend entry for /var/log does NOT admit /var/logger
-	// (see Confluence: "prefix siblings like /var/logger do not match /var/log").
+	// Used by the paths narrow disjoint test to exercise operator narrowing: the
+	// backend admits /host/var/logger (the parent of this file), but the operator
+	// list ["/host/var/log"] does not, so the intersection is empty.
 	testDataPrefixSibling = "/host/var/logger/par-e2e-prefix.txt"
 )
 

--- a/test/new-e2e/tests/privateactionrunner/rshell_matrix_base_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_matrix_base_test.go
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Helpers shared between the rshell matrix suites. The permission model has two
+// allow-lists (commands and paths) with two sources (backend per-task, operator
+// via datadog.yaml) intersected on each task execution. Each matrix suite fixes
+// the operator config at provision time and varies the backend lists per test.
+//
+// Truth table (Confluence: agent / Rshell permission model):
+//
+//	| Backend ↓ \ Operator → | unset | []     | disjoint | overlapping |
+//	| nil / []               | ∅     | ∅      | ∅        | ∅           |
+//	| non-empty              | backend | ∅    | ∅        | intersection|
+
+package privateactionrunner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+)
+
+// permissiveBackendPath is a path the provisioner plants on the Kind node and that
+// rshell's backend allowedPaths list should contain whenever the test wants the
+// paths axis to *pass* (so only the commands axis gates the outcome).
+const permissiveBackendPath = "/host/var/log"
+
+// permissiveBackendCommand is a command the test can run when it wants the commands
+// axis to *pass* (so only the paths axis gates the outcome). The backend's
+// allowedCommands list must include it for commands-axis to be permissive.
+const permissiveBackendCommand = "rshell:cat"
+
+// matrixSuite is the common base all rshell-matrix suites embed. It owns the
+// runner identity and the PAR-readiness probe. Per-suite overrides (SetupSuite,
+// BeforeTest) are not needed — the defaults suffice.
+type matrixSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+	runnerURN string
+}
+
+// SetupSuite waits for PAR to come up and start polling fakeintake before tests run.
+func (s *matrixSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure()
+	waitForPARReady(s.T(), s.Env(), s.Require())
+}
+
+// BeforeTest flushes fakeintake so each test starts from a clean queue/result state.
+func (s *matrixSuite) BeforeTest(suiteName, testName string) {
+	s.BaseSuite.BeforeTest(suiteName, testName)
+	if !s.IsDevMode() {
+		_ = s.Env().FakeIntake.Client().FlushPAR()
+	}
+}
+
+// pollResult is a thin wrapper around GetPARTaskResult with the standard timeout
+// and a failed-require on timeout. Returned result is never nil on success.
+func (s *matrixSuite) pollResult(taskID string) *api.PARTaskResult {
+	result, err := s.Env().FakeIntake.Client().GetPARTaskResult(taskID, 2*time.Minute)
+	s.Require().NoError(err, "timed out waiting for task result (taskID=%s)", taskID)
+	return result
+}
+
+// enqueueAndWait enqueues a runCommand task with the given inputs and blocks
+// until fakeintake receives the result. Shared by all matrix suites.
+func (s *matrixSuite) enqueueAndWait(inputs map[string]any) *api.PARTaskResult {
+	taskID := uuid.New().String()
+	s.Require().NoError(s.Env().FakeIntake.Client().EnqueuePARTask(taskID, runCommandAction, inputs))
+	return s.pollResult(taskID)
+}
+
+// requireInterface is a minimal stand-in for *require.Assertions so waitForPARReady
+// can be called from both the suite method and anywhere else without importing the
+// suite type. testify's Require() satisfies this.
+type requireInterface interface {
+	EventuallyWithT(condition func(*assert.CollectT), timeout, interval time.Duration, msgAndArgs ...any)
+}
+
+// waitForPARReady waits until the PAR sidecar is Ready and has polled fakeintake
+// at least once. Shared across matrix suites — each has its own provisioner but
+// the same readiness criteria.
+func waitForPARReady(t *testing.T, env *environments.Kubernetes, req requireInterface) {
+	t.Helper()
+
+	selector := env.Agent.LinuxNodeAgent.LabelSelectors["app"]
+	req.EventuallyWithT(func(c *assert.CollectT) {
+		pods, err := env.KubernetesCluster.Client().CoreV1().
+			Pods(agentNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=" + selector,
+		})
+		assert.NoError(c, err)
+		for _, pod := range pods.Items {
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.Name == parContainerName && cs.Ready {
+					return
+				}
+			}
+		}
+		assert.Fail(c, "private-action-runner container not ready")
+	}, 5*time.Minute, 10*time.Second, "PAR container should become ready")
+
+	// Confirm PAR is actively polling fakeintake by waiting for at least one dequeue call.
+	// Guards against a race where the container is Ready but the dequeue loop hasn't started.
+	req.EventuallyWithT(func(c *assert.CollectT) {
+		count, err := env.FakeIntake.Client().GetPARDequeueCount()
+		assert.NoError(c, err)
+		assert.Greater(c, count, 0, "PAR has not yet called the dequeue endpoint")
+	}, 2*time.Minute, 3*time.Second, "PAR should start polling fakeintake")
+}
+
+// assertBlocked asserts that a task result indicates rshell blocked the command.
+// rshell publishes blocked commands as successful PAR tasks with a non-zero exit
+// code, so we check exitCode rather than result.Success.
+func assertBlocked(t *testing.T, result *api.PARTaskResult, msgAndArgs ...any) {
+	t.Helper()
+	assert.NotEqual(t, 0, rshellExitCode(result), msgAndArgs...)
+}
+
+// assertAllowed asserts that a task executed successfully end-to-end.
+func assertAllowed(t *testing.T, result *api.PARTaskResult, msgAndArgs ...any) {
+	t.Helper()
+	assert.Equal(t, 0, rshellExitCode(result), msgAndArgs...)
+}

--- a/test/new-e2e/tests/privateactionrunner/rshell_matrix_both_unset_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_matrix_both_unset_test.go
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Matrix suite — BOTH operator axes UNSET.
+//
+// This suite covers column 1 (operator key unset) of BOTH the commands matrix
+// and the paths matrix. Commands-axis tests and paths-axis tests live together
+// here because they share the same operator-both-unset provisioner config.
+//
+// Each test isolates ONE axis: the non-tested axis is held in a permissive
+// state so the outcome is attributable to the axis under test.
+//   - For commands-axis tests: backend_paths = [permissiveBackendPath] so any
+//     file read from that path is admitted by the paths axis; only backend_commands
+//     varies.
+//   - For paths-axis tests: backend_commands = [permissiveBackendCommand] so
+//     the commands axis always passes; only backend_paths varies.
+
+package privateactionrunner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+)
+
+type parMatrixBothUnsetSuite struct {
+	matrixSuite
+}
+
+func TestPARRshellMatrixBothUnset(t *testing.T) {
+	t.Parallel()
+	urn, keyB64 := generateTestRunnerIdentity(t)
+	suite := &parMatrixBothUnsetSuite{matrixSuite: matrixSuite{runnerURN: urn}}
+	e2e.Run(t, suite,
+		e2e.WithProvisioner(parK8sProvisioner(urn, keyB64, rshellOperatorConfig{})),
+		e2e.WithStackName("par-rshell-matrix-both-unset"),
+	)
+}
+
+// ----- Commands axis — operator unset -----
+
+// TestCommands_OperatorUnset_BackendAbsent_Blocks: backend omits allowedCommands.
+// Paths axis is permissive, so the only reason to block is the commands axis.
+func (s *parMatrixBothUnsetSuite) TestCommands_OperatorUnset_BackendAbsent_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":      "cat " + testDataFile,
+		"allowedPaths": []string{permissiveBackendPath},
+		// allowedCommands absent → nil
+	})
+	assertBlocked(s.T(), result, "commands axis must block when backend commands is nil")
+}
+
+// TestCommands_OperatorUnset_BackendEmpty_Blocks: backend allowedCommands = [].
+func (s *parMatrixBothUnsetSuite) TestCommands_OperatorUnset_BackendEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{},
+		"allowedPaths":    []string{permissiveBackendPath},
+	})
+	assertBlocked(s.T(), result, "commands axis must block when backend commands is []")
+}
+
+// TestCommands_OperatorUnset_BackendNonEmpty_Allows: backend admits cat; operator
+// unset means pass-through; paths axis permissive → command executes.
+func (s *parMatrixBothUnsetSuite) TestCommands_OperatorUnset_BackendNonEmpty_Allows() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+		"allowedPaths":    []string{permissiveBackendPath},
+	})
+	assertAllowed(s.T(), result, "pass-through must admit cat; got exit=%d stderr=%v",
+		rshellExitCode(result), result.Outputs["stderr"])
+	assert.Contains(s.T(), result.Outputs["stdout"], testDataContent)
+}
+
+// ----- Paths axis — operator unset -----
+
+// TestPaths_OperatorUnset_BackendAbsent_Blocks: backend omits allowedPaths.
+// Commands axis is permissive, so the only reason to block is the paths axis.
+func (s *parMatrixBothUnsetSuite) TestPaths_OperatorUnset_BackendAbsent_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+		// allowedPaths absent → nil
+	})
+	assertBlocked(s.T(), result, "paths axis must block when backend paths is nil")
+}
+
+// TestPaths_OperatorUnset_BackendEmpty_Blocks: backend allowedPaths = [].
+func (s *parMatrixBothUnsetSuite) TestPaths_OperatorUnset_BackendEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+		"allowedPaths":    []string{},
+	})
+	assertBlocked(s.T(), result, "paths axis must block when backend paths is []")
+}
+
+// TestPaths_OperatorUnset_BackendNonEmpty_Allows: backend admits /host/var/log;
+// operator unset means pass-through; commands axis permissive → command executes.
+func (s *parMatrixBothUnsetSuite) TestPaths_OperatorUnset_BackendNonEmpty_Allows() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+		"allowedPaths":    []string{permissiveBackendPath},
+	})
+	assertAllowed(s.T(), result, "pass-through must admit path; got exit=%d stderr=%v",
+		rshellExitCode(result), result.Outputs["stderr"])
+	assert.Contains(s.T(), result.Outputs["stdout"], testDataContent)
+}

--- a/test/new-e2e/tests/privateactionrunner/rshell_matrix_commands_killswitch_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_matrix_commands_killswitch_test.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Matrix suite — commands axis only. operator.commands = [] (the kill-switch);
+// operator.paths = unset (permissive, so the paths axis never drives the outcome).
+//
+// Covers column 2 of the commands truth matrix:
+//
+//	| Backend commands ↓ | Effective (expected) |
+//	| absent             | ∅                    |
+//	| empty              | ∅                    |
+//	| non-empty          | ∅                    |
+//
+// Pre-fix (Bug #1): transform.go treats `[]` YAML as "unset", so the operator
+// kill-switch is silently disabled and the backend passes through.
+// Post-fix: all three cases block.
+
+package privateactionrunner
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+)
+
+type parMatrixCommandsKillSwitchSuite struct {
+	matrixSuite
+}
+
+func TestPARRshellMatrixCommandsKillSwitch(t *testing.T) {
+	t.Parallel()
+	urn, keyB64 := generateTestRunnerIdentity(t)
+	suite := &parMatrixCommandsKillSwitchSuite{matrixSuite: matrixSuite{runnerURN: urn}}
+	cfg := rshellOperatorConfig{
+		commandsSet: true, commands: []string{}, // kill-switch on commands
+		// pathsSet: false → operator.paths unset (permissive pass-through)
+	}
+	e2e.Run(t, suite,
+		e2e.WithProvisioner(parK8sProvisioner(urn, keyB64, cfg)),
+		e2e.WithStackName("par-rshell-matrix-commands-killswitch"),
+	)
+}
+
+// TestCommands_OperatorEmpty_BackendAbsent_Blocks: backend omits allowedCommands.
+// Outcome blocks either way (nil backend is authoritative), but we assert through
+// the commands axis with the paths axis permissive.
+func (s *parMatrixCommandsKillSwitchSuite) TestCommands_OperatorEmpty_BackendAbsent_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":      "cat " + testDataFile,
+		"allowedPaths": []string{permissiveBackendPath},
+	})
+	assertBlocked(s.T(), result, "kill-switch + nil backend commands → ∅")
+}
+
+// TestCommands_OperatorEmpty_BackendEmpty_Blocks: both sides [].
+func (s *parMatrixCommandsKillSwitchSuite) TestCommands_OperatorEmpty_BackendEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{},
+		"allowedPaths":    []string{permissiveBackendPath},
+	})
+	assertBlocked(s.T(), result, "kill-switch + [] backend commands → ∅")
+}
+
+// TestCommands_OperatorEmpty_BackendNonEmpty_Blocks: the interesting cell for
+// the kill-switch semantics — backend admits cat, operator = [] must override.
+// Pre-fix this test FAILS because bug #1 passes the backend through unchanged.
+func (s *parMatrixCommandsKillSwitchSuite) TestCommands_OperatorEmpty_BackendNonEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+		"allowedPaths":    []string{permissiveBackendPath},
+	})
+	assertBlocked(s.T(), result, "kill-switch must override non-empty backend commands; got exit=%d stdout=%v",
+		rshellExitCode(result), result.Outputs["stdout"])
+}

--- a/test/new-e2e/tests/privateactionrunner/rshell_matrix_commands_narrow_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_matrix_commands_narrow_test.go
@@ -69,13 +69,18 @@ func (s *parMatrixCommandsNarrowSuite) TestCommands_OperatorNonEmptyDisjoint_Bac
 }
 
 // Backend non-empty AND disjoint from operator ["rshell:cat"]: intersection empty.
+//
+// The probe runs `ls`, which the backend admits — so if operator narrowing were
+// ever bypassed, this test would pass unexpectedly. With narrowing applied,
+// ls is not in {"rshell:cat"} and the intersection is empty → blocked.
 func (s *parMatrixCommandsNarrowSuite) TestCommands_OperatorNonEmptyDisjoint_BackendNonEmpty_Blocks() {
 	result := s.enqueueAndWait(map[string]any{
-		"command":         "cat " + testDataFile,
-		"allowedCommands": []string{"rshell:ls", "rshell:find"}, // no rshell:cat
+		"command":         "ls " + permissiveBackendPath,
+		"allowedCommands": []string{"rshell:ls", "rshell:find"}, // backend admits ls
 		"allowedPaths":    []string{permissiveBackendPath},
 	})
-	assertBlocked(s.T(), result, "non-empty backend disjoint from operator → empty intersection → ∅")
+	assertBlocked(s.T(), result, "operator must narrow out ls; got exit=%d stdout=%v",
+		rshellExitCode(result), result.Outputs["stdout"])
 }
 
 // ----- Column 4: operator non-empty, overlapping backend -----

--- a/test/new-e2e/tests/privateactionrunner/rshell_matrix_commands_narrow_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_matrix_commands_narrow_test.go
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Matrix suite — commands axis only. operator.commands = ["rshell:cat"];
+// operator.paths = unset (permissive).
+//
+// Covers truth-matrix columns 3 (non-empty, disjoint-from-backend) and 4
+// (non-empty, overlapping-backend) for the commands axis. The operator
+// configuration is fixed at non-empty; tests vary the backend to hit each
+// (row, column) cell:
+//
+//	|                | col 3: Disjoint | col 4: Overlap |
+//	| Backend absent | ∅               | ∅ (vacuous)    |
+//	| Backend empty  | ∅               | ∅ (vacuous)    |
+//	| Backend set    | ∅               | intersection   |
+//
+// For the "vacuous" cells (backend nil/[] × operator.overlap), the "overlap"
+// semantics can't hold — there's nothing in the backend to overlap with. The
+// tests still exist to match the Confluence 12-cell grid one-for-one; their
+// bodies are identical to their disjoint counterparts on the same row.
+
+package privateactionrunner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+)
+
+type parMatrixCommandsNarrowSuite struct {
+	matrixSuite
+}
+
+func TestPARRshellMatrixCommandsNarrow(t *testing.T) {
+	t.Parallel()
+	urn, keyB64 := generateTestRunnerIdentity(t)
+	suite := &parMatrixCommandsNarrowSuite{matrixSuite: matrixSuite{runnerURN: urn}}
+	cfg := rshellOperatorConfig{
+		commandsSet: true, commands: []string{"rshell:cat"},
+		// operator.paths unset (permissive)
+	}
+	e2e.Run(t, suite,
+		e2e.WithProvisioner(parK8sProvisioner(urn, keyB64, cfg)),
+		e2e.WithStackName("par-rshell-matrix-commands-narrow"),
+	)
+}
+
+// ----- Column 3: operator non-empty, disjoint from backend -----
+
+func (s *parMatrixCommandsNarrowSuite) TestCommands_OperatorNonEmptyDisjoint_BackendAbsent_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":      "cat " + testDataFile,
+		"allowedPaths": []string{permissiveBackendPath},
+	})
+	assertBlocked(s.T(), result, "nil backend → ∅")
+}
+
+func (s *parMatrixCommandsNarrowSuite) TestCommands_OperatorNonEmptyDisjoint_BackendEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{},
+		"allowedPaths":    []string{permissiveBackendPath},
+	})
+	assertBlocked(s.T(), result, "[] backend → ∅")
+}
+
+// Backend non-empty AND disjoint from operator ["rshell:cat"]: intersection empty.
+func (s *parMatrixCommandsNarrowSuite) TestCommands_OperatorNonEmptyDisjoint_BackendNonEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{"rshell:ls", "rshell:find"}, // no rshell:cat
+		"allowedPaths":    []string{permissiveBackendPath},
+	})
+	assertBlocked(s.T(), result, "non-empty backend disjoint from operator → empty intersection → ∅")
+}
+
+// ----- Column 4: operator non-empty, overlapping backend -----
+
+// Vacuous cell: "overlap with nil" has no meaning, but the Confluence grid lists
+// it. The test body is identical to its disjoint counterpart on the same row.
+func (s *parMatrixCommandsNarrowSuite) TestCommands_OperatorNonEmptyOverlap_BackendAbsent_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":      "cat " + testDataFile,
+		"allowedPaths": []string{permissiveBackendPath},
+	})
+	assertBlocked(s.T(), result, "nil backend → ∅ regardless of how operator is labelled")
+}
+
+// Vacuous cell mirror for backend = [].
+func (s *parMatrixCommandsNarrowSuite) TestCommands_OperatorNonEmptyOverlap_BackendEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{},
+		"allowedPaths":    []string{permissiveBackendPath},
+	})
+	assertBlocked(s.T(), result, "[] backend → ∅ regardless of how operator is labelled")
+}
+
+// Backend non-empty AND overlapping operator ["rshell:cat"]: intersection admits cat.
+func (s *parMatrixCommandsNarrowSuite) TestCommands_OperatorNonEmptyOverlap_BackendNonEmpty_Allows() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{"rshell:cat", "rshell:ls"}, // overlaps operator on rshell:cat
+		"allowedPaths":    []string{permissiveBackendPath},
+	})
+	assertAllowed(s.T(), result, "overlap on cat must admit; got exit=%d stderr=%v",
+		rshellExitCode(result), result.Outputs["stderr"])
+	assert.Contains(s.T(), result.Outputs["stdout"], testDataContent)
+}

--- a/test/new-e2e/tests/privateactionrunner/rshell_matrix_paths_killswitch_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_matrix_paths_killswitch_test.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Matrix suite — paths axis only. operator.paths = [] (the kill-switch);
+// operator.commands = unset (permissive).
+//
+// Covers column 2 of the paths truth matrix. Mirrors commands-killswitch on the
+// other axis: the commands axis is pass-through (operator unset + backend
+// admits cat), so all blocking must come from the paths axis.
+
+package privateactionrunner
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+)
+
+type parMatrixPathsKillSwitchSuite struct {
+	matrixSuite
+}
+
+func TestPARRshellMatrixPathsKillSwitch(t *testing.T) {
+	t.Parallel()
+	urn, keyB64 := generateTestRunnerIdentity(t)
+	suite := &parMatrixPathsKillSwitchSuite{matrixSuite: matrixSuite{runnerURN: urn}}
+	cfg := rshellOperatorConfig{
+		pathsSet: true, paths: []string{}, // kill-switch on paths
+		// commandsSet: false → operator.commands unset (permissive)
+	}
+	e2e.Run(t, suite,
+		e2e.WithProvisioner(parK8sProvisioner(urn, keyB64, cfg)),
+		e2e.WithStackName("par-rshell-matrix-paths-killswitch"),
+	)
+}
+
+// TestPaths_OperatorEmpty_BackendAbsent_Blocks: backend omits allowedPaths.
+func (s *parMatrixPathsKillSwitchSuite) TestPaths_OperatorEmpty_BackendAbsent_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+	})
+	assertBlocked(s.T(), result, "kill-switch + nil backend paths → ∅")
+}
+
+// TestPaths_OperatorEmpty_BackendEmpty_Blocks: both sides [].
+func (s *parMatrixPathsKillSwitchSuite) TestPaths_OperatorEmpty_BackendEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+		"allowedPaths":    []string{},
+	})
+	assertBlocked(s.T(), result, "kill-switch + [] backend paths → ∅")
+}
+
+// TestPaths_OperatorEmpty_BackendNonEmpty_Blocks: the interesting cell. Backend
+// admits /host/var/log; operator = [] must override. Pre-fix: Bug #1 fails this.
+func (s *parMatrixPathsKillSwitchSuite) TestPaths_OperatorEmpty_BackendNonEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+		"allowedPaths":    []string{permissiveBackendPath},
+	})
+	assertBlocked(s.T(), result, "kill-switch must override non-empty backend paths; got exit=%d stdout=%v",
+		rshellExitCode(result), result.Outputs["stdout"])
+}

--- a/test/new-e2e/tests/privateactionrunner/rshell_matrix_paths_narrow_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_matrix_paths_narrow_test.go
@@ -61,13 +61,19 @@ func (s *parMatrixPathsNarrowSuite) TestPaths_OperatorNonEmptyDisjoint_BackendEm
 	assertBlocked(s.T(), result, "[] backend → ∅")
 }
 
+// The probe targets /host/var/logger/par-e2e-prefix.txt — a planted fixture
+// that the backend admits via /host/var/logger. The operator list
+// ["/host/var/log"] is a prefix-sibling (not a sub-path), so the intersection
+// is empty. If operator narrowing were ever bypassed the cat would succeed;
+// with narrowing applied it must block.
 func (s *parMatrixPathsNarrowSuite) TestPaths_OperatorNonEmptyDisjoint_BackendNonEmpty_Blocks() {
 	result := s.enqueueAndWait(map[string]any{
-		"command":         "cat " + testDataFile,
+		"command":         "cat " + testDataPrefixSibling,
 		"allowedCommands": []string{permissiveBackendCommand},
-		"allowedPaths":    []string{"/tmp", "/etc"}, // disjoint from ["/host/var/log"]
+		"allowedPaths":    []string{"/host/var/logger"}, // backend admits, operator does not
 	})
-	assertBlocked(s.T(), result, "non-empty backend disjoint from operator → empty intersection → ∅")
+	assertBlocked(s.T(), result, "operator must narrow out /host/var/logger; got exit=%d stdout=%v",
+		rshellExitCode(result), result.Outputs["stdout"])
 }
 
 // ----- Column 4: operator non-empty, overlapping backend -----

--- a/test/new-e2e/tests/privateactionrunner/rshell_matrix_paths_narrow_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_matrix_paths_narrow_test.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Matrix suite — paths axis only. operator.paths = ["/host/var/log"];
+// operator.commands = unset (permissive).
+//
+// Covers truth-matrix columns 3 (non-empty, disjoint-from-backend) and 4
+// (non-empty, overlapping-backend) for the paths axis:
+//
+//	|                | col 3: Disjoint | col 4: Overlap |
+//	| Backend absent | ∅               | ∅ (vacuous)    |
+//	| Backend empty  | ∅               | ∅ (vacuous)    |
+//	| Backend set    | ∅               | intersection   |
+
+package privateactionrunner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+)
+
+type parMatrixPathsNarrowSuite struct {
+	matrixSuite
+}
+
+func TestPARRshellMatrixPathsNarrow(t *testing.T) {
+	t.Parallel()
+	urn, keyB64 := generateTestRunnerIdentity(t)
+	suite := &parMatrixPathsNarrowSuite{matrixSuite: matrixSuite{runnerURN: urn}}
+	cfg := rshellOperatorConfig{
+		pathsSet: true, paths: []string{permissiveBackendPath},
+		// operator.commands unset (permissive)
+	}
+	e2e.Run(t, suite,
+		e2e.WithProvisioner(parK8sProvisioner(urn, keyB64, cfg)),
+		e2e.WithStackName("par-rshell-matrix-paths-narrow"),
+	)
+}
+
+// ----- Column 3: operator non-empty, disjoint from backend -----
+
+func (s *parMatrixPathsNarrowSuite) TestPaths_OperatorNonEmptyDisjoint_BackendAbsent_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+	})
+	assertBlocked(s.T(), result, "nil backend → ∅")
+}
+
+func (s *parMatrixPathsNarrowSuite) TestPaths_OperatorNonEmptyDisjoint_BackendEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+		"allowedPaths":    []string{},
+	})
+	assertBlocked(s.T(), result, "[] backend → ∅")
+}
+
+func (s *parMatrixPathsNarrowSuite) TestPaths_OperatorNonEmptyDisjoint_BackendNonEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+		"allowedPaths":    []string{"/tmp", "/etc"}, // disjoint from ["/host/var/log"]
+	})
+	assertBlocked(s.T(), result, "non-empty backend disjoint from operator → empty intersection → ∅")
+}
+
+// ----- Column 4: operator non-empty, overlapping backend -----
+
+// Vacuous cell: "overlap with nil" has no meaning, but the Confluence grid lists it.
+func (s *parMatrixPathsNarrowSuite) TestPaths_OperatorNonEmptyOverlap_BackendAbsent_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+	})
+	assertBlocked(s.T(), result, "nil backend → ∅ regardless of how operator is labelled")
+}
+
+// Vacuous cell mirror for backend = [].
+func (s *parMatrixPathsNarrowSuite) TestPaths_OperatorNonEmptyOverlap_BackendEmpty_Blocks() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+		"allowedPaths":    []string{},
+	})
+	assertBlocked(s.T(), result, "[] backend → ∅ regardless of how operator is labelled")
+}
+
+func (s *parMatrixPathsNarrowSuite) TestPaths_OperatorNonEmptyOverlap_BackendNonEmpty_Allows() {
+	result := s.enqueueAndWait(map[string]any{
+		"command":         "cat " + testDataFile,
+		"allowedCommands": []string{permissiveBackendCommand},
+		"allowedPaths":    []string{permissiveBackendPath, "/tmp"},
+	})
+	assertAllowed(s.T(), result, "overlap on /host/var/log must admit; got exit=%d stderr=%v",
+		rshellExitCode(result), result.Outputs["stderr"])
+	assert.Contains(s.T(), result.Outputs["stdout"], testDataContent)
+}


### PR DESCRIPTION
## Summary

Adds 24 E2E tests covering the rshell allow-list truth matrix (operator × backend intersection), one physical test per cell — 12 for the commands axis and 12 for the paths axis.

Stacked on top of [#fix-allow-list-bugs](https://github.com/DataDog/datadog-agent/compare/jules.macret/Q/rshell/fix-allow-list-bugs) so the tests exercise the fixed behavior end-to-end. Matrix reference: the [Confluence permission-model page](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/6608848267/Rshell+permission+model+allow+lists).

### What's new

- **5 test suites**, each with its own provisioner:
  - `rshell_matrix_both_unset_test.go` — both operator axes unset (column 1, both axes)
  - `rshell_matrix_commands_killswitch_test.go` — operator commands `[]`, paths permissive (column 2, commands)
  - `rshell_matrix_commands_narrow_test.go` — operator commands non-empty, paths permissive (columns 3-4, commands)
  - `rshell_matrix_paths_killswitch_test.go` — mirror for paths axis (column 2)
  - `rshell_matrix_paths_narrow_test.go` — mirror for paths axis (columns 3-4)
- **Single-axis isolation**: every test holds the non-tested axis permissive so the outcome is attributable to the axis under test.
- **Parametrized provisioner**: `provisioner.go` now takes an `rshellOperatorConfig` and injects `private_action_runner.restricted_shell.{allowed_commands,allowed_paths}` via Helm's `customAgentConfig` — needed to distinguish "key absent" from "key present but `[]`", which env vars can't express.
- **Naming schema**: `Test<Axis>_Operator<State>_Backend<State>_<Outcome>`. 4 operator states × 3 backend states × 2 axes = 24 tests.
- **README.md** with the truth table and test layout at `tests/privateactionrunner/README.md`.

## Test plan

- [ ] Run the full matrix locally: `dda inv new-e2e-tests.run --targets=./tests/privateactionrunner/...`
- [ ] Sanity-check each of the 6 `TestPAR*` entry points (`TestPARRshellK8sSuite` + 5 matrix suites) passes
- [ ] Verify the two vacuous cells per Narrow suite (`OperatorNonEmptyOverlap_Backend{Absent,Empty}`) block as expected
- [ ] CI runs on `main` merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)