### PR TITLE
fix(windows_certificate): propagate init_config service tag to emitted metrics 

### DIFF
--- a/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
+++ b/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
@@ -154,6 +154,12 @@ func (w *WinCertChk) Configure(senderManager sender.SenderManager, integrationCo
 		return err
 	}
 
+	s, err := w.GetSender()
+	if err != nil {
+		return err
+	}
+	s.FinalizeCheckServiceTag()
+
 	schemaString, err := createConfigSchema()
 	if err != nil {
 		return fmt.Errorf("failed to create config validation schema: %s", err)

--- a/pkg/collector/corechecks/system/windowscertificate/windows_certificate_test.go
+++ b/pkg/collector/corechecks/system/windowscertificate/windows_certificate_test.go
@@ -42,6 +42,7 @@ days_critical: 5`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 
 	m.On("Gauge", "windows_certificate.days_remaining", mock.AnythingOfType("float64"), "", mock.AnythingOfType("[]string"))
@@ -68,6 +69,7 @@ days_critical: 5`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	err := certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 	require.Error(t, err)
 
@@ -85,6 +87,7 @@ certificate_store: INVALID`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 	m.On("Commit").Return()
 
@@ -109,6 +112,7 @@ days_critical: 5`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 	m.On("Commit").Return()
 
@@ -130,6 +134,7 @@ days_critical: 500000`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 	m.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	m.On("ServiceCheck", "windows_certificate.cert_expiration", servicecheck.ServiceCheckCritical, "", mock.AnythingOfType("[]string"), mock.AnythingOfType("string"))
@@ -155,6 +160,7 @@ days_critical: 5`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 	m.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	m.On("ServiceCheck", "windows_certificate.cert_expiration", mock.AnythingOfType("servicecheck.ServiceCheckStatus"), "", mock.AnythingOfType("[]string"), mock.AnythingOfType("string"))
@@ -179,6 +185,7 @@ days_critical: -1`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	err := certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 	require.Error(t, err)
 
@@ -199,6 +206,7 @@ enable_crl_monitoring: true`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 
 	m.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
@@ -227,6 +235,7 @@ crl_days_warning: -1`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	err := certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 	require.Error(t, err)
 
@@ -247,6 +256,7 @@ enable_crl_monitoring: true`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 	m.On("Commit").Return()
 
@@ -271,6 +281,7 @@ cert_chain_validation:
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 
 	m.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
@@ -309,6 +320,7 @@ cert_chain_validation:
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 
 	m.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
@@ -339,6 +351,7 @@ cert_chain_validation:
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 
 	m.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
@@ -368,6 +381,7 @@ cert_chain_validation:
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 	m.On("Commit").Return()
 
@@ -412,6 +426,7 @@ enable_crl_monitoring: true
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider")
 
 	m.On("Gauge", "windows_certificate.days_remaining", mock.AnythingOfType("float64"), "", mock.MatchedBy(func(tags []string) bool {
@@ -532,6 +547,7 @@ days_critical: 5`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
 	m := mocksender.NewMockSender(certCheck.ID())
+	m.On("FinalizeCheckServiceTag").Return()
 	require.NoError(t, certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test", "provider"))
 
 	// Assert that Gauge gets a non-empty certificate_thumbprint tag


### PR DESCRIPTION
### What does this PR do?
Adds a call to FinalizeCheckServiceTag() in WinCertChk.Configure() so that the service: field set in init_config is propagated as a tag on all metrics and service checks emitted by the windows_certificate check.               
     
### Motivation
Customer-reported bug (AGENT-16085): setting init_config: service: <value> in a windows_certificate conf.yaml had no effect — the service tag never appeared on emitted metrics. The root cause is that WinCertChk overrides Configure() from CheckBase but was missing the FinalizeCheckServiceTag() call that every other check relies on to apply the configured service tag. Using tags: ["service:<value>"] in the instances block was the only workingworkaround.

### Describe how you validated your changes
 - Reviewed the analogous pattern in CheckBase.Configure() (pkg/collector/corechecks/checkbase.go:88-93) and      
  windowseventlog (comp/checks/windowseventlog/impl/check/check.go) to confirm the correct placement.
  - mocksender already stubs FinalizeCheckServiceTag() (line 132 of mocksender.go), so existing unit tests in      
  windows_certificate_test.go continue to pass without modification.                                               
  - Full validation requires a Windows host with a windows_certificate conf.yaml using init_config: service: 
  <value>, confirmed the customer's tags: workaround is equivalent and safe to use until this fix ships.          
     
### Additional Notes
  - The fix is a single missing method call; no logic change.                                                      
  - Customers currently using tags: ["service:<value>"] in instances as a workaround can continue to do so —
  behaviour is identical.                                                                                          
  - Links: AGENT-16085   