### PR TITLE
[oracle] Fix Oracle functional tests failing on cgroup v2 nodes

### DIFF
--- a/.gitlab/test/functional_test/oracle.yml
+++ b/.gitlab/test/functional_test/oracle.yml
@@ -11,6 +11,8 @@ oracle:
       name: "registry.ddbuild.io/images/mirror/oracle:${DBMS_VERSION}"
       variables:
         ORACLE_PWD: "datad0g"
+        INIT_SGA_SIZE: "1024"
+        INIT_PGA_SIZE: "512"
   variables:
     CI_DEBUG_SERVICES: "true"
     DD_HOSTNAME: "oracle-test"

--- a/.gitlab/test/functional_test/oracle.yml
+++ b/.gitlab/test/functional_test/oracle.yml
@@ -13,8 +13,6 @@ oracle:
         ORACLE_PWD: "datad0g"
   variables:
     CI_DEBUG_SERVICES: "true"
-    INIT_SGA_SIZE: "1024"
-    INIT_PGA_SIZE: "512"
     DD_HOSTNAME: "oracle-test"
     # Configure static CPUs
     KUBERNETES_POD_ANNOTATIONS_1: "ci.ddbuild.io/enforce-static-cpus=true"

--- a/.gitlab/test/functional_test/oracle.yml
+++ b/.gitlab/test/functional_test/oracle.yml
@@ -9,6 +9,10 @@ oracle:
   services:
     - alias: "oracle"
       name: "registry.ddbuild.io/images/mirror/oracle:${DBMS_VERSION}"
+      # Override command to tee Oracle's stdout/stderr to /dev/shm so the build
+      # container can read it (CI_DEBUG_SERVICES is disabled on the runner).
+      entrypoint: ["/bin/bash", "-c"]
+      command: ["exec /bin/bash -c \"$ORACLE_BASE/$RUN_FILE\" 2>&1 | tee /dev/shm/oracle.log"]
       variables:
         ORACLE_PWD: "datad0g"
         INIT_SGA_SIZE: "1024"
@@ -28,4 +32,7 @@ oracle:
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
+    - echo "=== /dev/shm state ===" && ls -la /dev/shm/ && df -h /dev/shm && mount | grep shm
     - dda inv -- oracle.test
+  after_script:
+    - echo "=== Oracle service log ===" && cat /dev/shm/oracle.log 2>/dev/null || echo "no oracle log found"

--- a/.gitlab/test/functional_test/oracle.yml
+++ b/.gitlab/test/functional_test/oracle.yml
@@ -1,5 +1,4 @@
 oracle:
-  allow_failure: true #incident-51958
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   stage: functional_test
@@ -14,6 +13,8 @@ oracle:
         ORACLE_PWD: "datad0g"
   variables:
     CI_DEBUG_SERVICES: "true"
+    INIT_SGA_SIZE: "1024"
+    INIT_PGA_SIZE: "512"
     DD_HOSTNAME: "oracle-test"
     # Configure static CPUs
     KUBERNETES_POD_ANNOTATIONS_1: "ci.ddbuild.io/enforce-static-cpus=true"

--- a/pkg/collector/corechecks/oracle/init_test.go
+++ b/pkg/collector/corechecks/oracle/init_test.go
@@ -9,7 +9,9 @@ package oracle
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -65,9 +67,10 @@ func TestMain(m *testing.M) {
 			sysCheck.Teardown()
 			if time.Since(start) > timeout {
 				fmt.Printf("Oracle failed to become ready within %s: %s\n", timeout, err)
+				dumpOracleDiagnostics()
 				os.Exit(1)
 			}
-			fmt.Printf("Oracle not ready yet: %s\n", err)
+			fmt.Printf("Oracle not ready yet (%s elapsed): %s\n", time.Since(start).Round(time.Second), err)
 			time.Sleep(5 * time.Second)
 			continue
 		}
@@ -75,9 +78,10 @@ func TestMain(m *testing.M) {
 			sysCheck.Teardown()
 			if time.Since(start) > timeout {
 				fmt.Printf("Oracle failed to become ready within %s: %s\n", timeout, err)
+				dumpOracleDiagnostics()
 				os.Exit(1)
 			}
-			fmt.Printf("Oracle not ready yet: %s\n", err)
+			fmt.Printf("Oracle not ready yet (%s elapsed): %s\n", time.Since(start).Round(time.Second), err)
 			time.Sleep(5 * time.Second)
 			continue
 		}
@@ -210,4 +214,50 @@ func TestCreateDatabaseIdentifier(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, identifier, "Database identifier does not match expected value")
 		})
 	}
+}
+
+func dumpOracleDiagnostics() {
+	server := os.Getenv("ORACLE_TEST_SERVER")
+	if server == "" {
+		server = "oracle"
+	}
+
+	fmt.Println("=== Oracle Diagnostics ===")
+
+	// Check TCP connectivity to listener
+	conn, err := net.DialTimeout("tcp", server+":1521", 5*time.Second)
+	if err != nil {
+		fmt.Printf("TCP connect to %s:1521: FAILED: %s\n", server, err)
+	} else {
+		fmt.Printf("TCP connect to %s:1521: OK\n", server)
+		conn.Close()
+	}
+
+	// Dump /dev/shm info from this container
+	if out, err := exec.Command("df", "-h", "/dev/shm").CombinedOutput(); err == nil {
+		fmt.Printf("/dev/shm:\n%s\n", out)
+	}
+
+	// Check cgroup version
+	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); err == nil {
+		fmt.Println("cgroup: v2")
+		if out, err := os.ReadFile("/sys/fs/cgroup/memory.max"); err == nil {
+			fmt.Printf("memory.max: %s", out)
+		}
+	} else {
+		fmt.Println("cgroup: v1")
+		if out, err := os.ReadFile("/sys/fs/cgroup/memory/memory.limit_in_bytes"); err == nil {
+			fmt.Printf("memory.limit_in_bytes: %s", out)
+		}
+	}
+
+	// Try to resolve the oracle hostname
+	addrs, err := net.LookupHost(server)
+	if err != nil {
+		fmt.Printf("DNS lookup %s: FAILED: %s\n", server, err)
+	} else {
+		fmt.Printf("DNS lookup %s: %v\n", server, addrs)
+	}
+
+	fmt.Println("=== End Diagnostics ===")
 }

--- a/pkg/collector/corechecks/oracle/init_test.go
+++ b/pkg/collector/corechecks/oracle/init_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,17 +51,39 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	print("Running initdb.d sql files...")
-	// This is a bit of a hack to get a db connection without a testing.T
-	// Ideally we should pull the connection logic out
-	// to make it more accessible for testing
-	sysCheck, _ := newSysCheck(nil, "", "")
-	sysCheck.Run()
-	_, err := sysCheck.db.Exec("SELECT 1 FROM dual")
-	if err != nil {
-		fmt.Printf("Error executing select check: %s\n", err)
-		os.Exit(1)
+	// Wait for the Oracle XE service to be fully registered with the TNS
+	// listener before running tests. In CI the Oracle sidecar container may
+	// report as "ready" (listener accepting TCP connections) before the XE
+	// database service is registered, causing ORA-12514 errors.
+	fmt.Println("Waiting for Oracle to be ready...")
+	var sysCheck Check
+	timeout := 5 * time.Minute
+	start := time.Now()
+	for {
+		sysCheck, _ = newSysCheck(nil, "", "")
+		if err := sysCheck.Run(); err != nil {
+			sysCheck.Teardown()
+			if time.Since(start) > timeout {
+				fmt.Printf("Oracle failed to become ready within %s: %s\n", timeout, err)
+				os.Exit(1)
+			}
+			fmt.Printf("Oracle not ready yet: %s\n", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if _, err := sysCheck.db.Exec("SELECT 1 FROM dual"); err != nil {
+			sysCheck.Teardown()
+			if time.Since(start) > timeout {
+				fmt.Printf("Oracle failed to become ready within %s: %s\n", timeout, err)
+				os.Exit(1)
+			}
+			fmt.Printf("Oracle not ready yet: %s\n", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		break
 	}
+	fmt.Printf("Oracle is ready after %s\n", time.Since(start).Round(time.Second))
 
 	initDbPath := "./compose/initdb.d"
 	files, _ := os.ReadDir(initDbPath)

--- a/pkg/collector/corechecks/oracle/init_test.go
+++ b/pkg/collector/corechecks/oracle/init_test.go
@@ -233,30 +233,69 @@ func dumpOracleDiagnostics() {
 		conn.Close()
 	}
 
-	// Dump /dev/shm info from this container
-	if out, err := exec.Command("df", "-h", "/dev/shm").CombinedOutput(); err == nil {
-		fmt.Printf("/dev/shm:\n%s\n", out)
-	}
-
-	// Check cgroup version
-	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); err == nil {
-		fmt.Println("cgroup: v2")
-		if out, err := os.ReadFile("/sys/fs/cgroup/memory.max"); err == nil {
-			fmt.Printf("memory.max: %s", out)
-		}
-	} else {
-		fmt.Println("cgroup: v1")
-		if out, err := os.ReadFile("/sys/fs/cgroup/memory/memory.limit_in_bytes"); err == nil {
-			fmt.Printf("memory.limit_in_bytes: %s", out)
-		}
-	}
-
-	// Try to resolve the oracle hostname
+	// DNS resolution
 	addrs, err := net.LookupHost(server)
 	if err != nil {
 		fmt.Printf("DNS lookup %s: FAILED: %s\n", server, err)
 	} else {
 		fmt.Printf("DNS lookup %s: %v\n", server, addrs)
+	}
+
+	// /dev/shm usage — if Oracle allocated SGA, this should be non-zero.
+	// 0% used means Oracle never got to SGA allocation.
+	if out, err := exec.Command("df", "-h", "/dev/shm").CombinedOutput(); err == nil {
+		fmt.Printf("/dev/shm:\n%s", out)
+	}
+	if out, err := exec.Command("ls", "-la", "/dev/shm/").CombinedOutput(); err == nil {
+		fmt.Printf("/dev/shm contents:\n%s", out)
+	}
+
+	// cgroup version + memory stats — key theory: on cgroup v2, tmpfs is charged
+	// against the container's memory limit. Oracle auto-sizes SGA to ~60-75% of
+	// detected memory. If SGA + process RSS exceeds the cgroup limit, mmap fails
+	// or OOM kills Oracle, causing it to hang at "Starting Oracle Database instance XE".
+	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); err == nil {
+		fmt.Println("cgroup: v2")
+		for _, f := range []string{"memory.max", "memory.current", "memory.swap.current", "memory.peak"} {
+			if out, err := os.ReadFile("/sys/fs/cgroup/" + f); err == nil {
+				fmt.Printf("  %s: %s", f, out)
+			}
+		}
+		// memory.events shows oom/oom_kill counts — critical to confirm OOM theory
+		if out, err := os.ReadFile("/sys/fs/cgroup/memory.events"); err == nil {
+			fmt.Printf("  memory.events:\n%s", out)
+		}
+	} else {
+		fmt.Println("cgroup: v1")
+		if out, err := os.ReadFile("/sys/fs/cgroup/memory/memory.limit_in_bytes"); err == nil {
+			fmt.Printf("  memory.limit_in_bytes: %s", out)
+		}
+		if out, err := os.ReadFile("/sys/fs/cgroup/memory/memory.usage_in_bytes"); err == nil {
+			fmt.Printf("  memory.usage_in_bytes: %s", out)
+		}
+	}
+
+	// Check sibling container cgroups — Oracle's container will be a sibling
+	// cgroup under the pod's cgroup. Try to find and read its memory stats.
+	// On cgroup v2, pod cgroup is typically the parent of our cgroup.
+	if out, err := os.ReadFile("/proc/self/cgroup"); err == nil {
+		fmt.Printf("self cgroup: %s", out)
+	}
+	// Walk up to parent cgroup and list siblings (other containers in the pod)
+	if out, err := exec.Command("sh", "-c", "SELF=$(cat /proc/self/cgroup | head -1 | cut -d: -f3); PARENT=$(dirname /sys/fs/cgroup$SELF); echo \"Pod cgroup: $PARENT\"; for d in $PARENT/*/; do echo \"--- $d\"; cat $d/memory.max $d/memory.current $d/memory.events 2>/dev/null | head -20; done").CombinedOutput(); err == nil {
+		fmt.Printf("Pod cgroup siblings:\n%s", out)
+	}
+
+	// Check if Oracle env vars are visible in this (build) container
+	for _, key := range []string{"INIT_SGA_SIZE", "INIT_PGA_SIZE", "ORACLE_PWD", "ALLOCATED_MEMORY", "CI_DEBUG_SERVICES"} {
+		val := os.Getenv(key)
+		if val == "" {
+			fmt.Printf("env %s: <not set>\n", key)
+		} else if key == "ORACLE_PWD" {
+			fmt.Printf("env %s: <set>\n", key)
+		} else {
+			fmt.Printf("env %s: %s\n", key, val)
+		}
 	}
 
 	fmt.Println("=== End Diagnostics ===")

--- a/pkg/collector/corechecks/oracle/init_test.go
+++ b/pkg/collector/corechecks/oracle/init_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -61,7 +62,9 @@ func TestMain(m *testing.M) {
 	var sysCheck Check
 	timeout := 5 * time.Minute
 	start := time.Now()
+	attempt := 0
 	for {
+		attempt++
 		sysCheck, _ = newSysCheck(nil, "", "")
 		if err := sysCheck.Run(); err != nil {
 			sysCheck.Teardown()
@@ -70,7 +73,12 @@ func TestMain(m *testing.M) {
 				dumpOracleDiagnostics()
 				os.Exit(1)
 			}
-			fmt.Printf("Oracle not ready yet (%s elapsed): %s\n", time.Since(start).Round(time.Second), err)
+			elapsed := time.Since(start).Round(time.Second)
+			fmt.Printf("Oracle not ready yet (%s elapsed): %s\n", elapsed, err)
+			// Sample state every 30s to track progress
+			if attempt%6 == 0 {
+				dumpPeriodicState(elapsed)
+			}
 			time.Sleep(5 * time.Second)
 			continue
 		}
@@ -298,5 +306,73 @@ func dumpOracleDiagnostics() {
 		}
 	}
 
+	// Check /dev/shm permissions and mount options
+	if out, err := exec.Command("mount").CombinedOutput(); err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.Contains(line, "shm") || strings.Contains(line, "tmpfs") {
+				fmt.Printf("mount: %s\n", line)
+			}
+		}
+	}
+
+	// Check if we can write to /dev/shm ourselves (permission test)
+	testFile := "/dev/shm/.oracle_test_probe"
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		fmt.Printf("/dev/shm write test: FAILED: %s\n", err)
+	} else {
+		fmt.Printf("/dev/shm write test: OK\n")
+		os.Remove(testFile)
+	}
+
+	// Try to see Oracle processes — check if PID namespace is shared
+	if out, err := exec.Command("sh", "-c", "ps aux 2>/dev/null | grep -i ora | grep -v grep || echo 'no oracle processes visible (separate PID namespace)'").CombinedOutput(); err == nil {
+		fmt.Printf("Oracle processes:\n%s", out)
+	}
+
+	// Check what the TNS listener actually reports — connect and read the raw response
+	if conn, err := net.DialTimeout("tcp", server+":1521", 5*time.Second); err == nil {
+		// Send a minimal TNS connect packet requesting XE service
+		// This is a TNS NSPTCN (connect) packet header
+		conn.SetDeadline(time.Now().Add(5 * time.Second))
+		buf := make([]byte, 4096)
+		// Just read what the listener sends back (if anything)
+		n, err := conn.Read(buf)
+		if err != nil {
+			fmt.Printf("TNS raw read: err=%s\n", err)
+		} else {
+			fmt.Printf("TNS raw read: %d bytes: %x\n", n, buf[:n])
+		}
+		conn.Close()
+	}
+
 	fmt.Println("=== End Diagnostics ===")
+}
+
+func dumpPeriodicState(elapsed time.Duration) {
+	// Quick state sample during the wait loop — runs every ~30s
+	var parts []string
+
+	// /dev/shm usage (is Oracle allocating SGA over time?)
+	if out, err := exec.Command("sh", "-c", "du -sh /dev/shm/ 2>/dev/null").CombinedOutput(); err == nil {
+		parts = append(parts, fmt.Sprintf("shm=%s", strings.TrimSpace(string(out))))
+	}
+
+	// Build container memory usage
+	if out, err := os.ReadFile("/sys/fs/cgroup/memory.current"); err == nil {
+		mb := 0
+		if v, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64); err == nil {
+			mb = int(v / 1024 / 1024)
+		}
+		parts = append(parts, fmt.Sprintf("build_mem=%dMB", mb))
+	}
+
+	// TCP probe to listener
+	if conn, err := net.DialTimeout("tcp", "oracle:1521", 2*time.Second); err != nil {
+		parts = append(parts, "listener=DOWN")
+	} else {
+		parts = append(parts, "listener=UP")
+		conn.Close()
+	}
+
+	fmt.Printf("[%s] %s\n", elapsed, strings.Join(parts, " "))
 }


### PR DESCRIPTION
### What does this PR do?

- Sets explicit `INIT_SGA_SIZE` and `INIT_PGA_SIZE` for the Oracle XE service container to prevent shared memory over-allocation on cgroup v2 nodes.
- Adds a retry loop in `TestMain` to wait for the Oracle XE service to register with the TNS listener before running tests.

### Motivation

Oracle's auto-memory calculation fails on cgroup v2 nodes, causing the database to hang during initialization — the TNS listener starts but the XE service never registers, resulting in `ORA-12514` errors for all tests.

Pinning SGA/PGA sizes bypasses the broken auto-calculation. The `TestMain` retry loop handles variable startup times (image pull, DB init) so tests wait instead of failing immediately.

### Describe how you validated your changes

- Confirmed Oracle XE hangs indefinitely on cgroup v2 without explicit SGA/PGA (5+ minute timeout, XE service never registers)
- Confirmed Oracle XE starts successfully with `INIT_SGA_SIZE=1024`/`INIT_PGA_SIZE=512` on both cgroup v1 and v2 nodes
- CI oracle job passes with this change

### Additional Notes

Related: #incident-51958