### PR TITLE
[DBMON-6491] Guard against nil pointer on db startup errors

### DIFF
--- a/pkg/collector/corechecks/oracle/oracle_integration_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_integration_test.go
@@ -305,10 +305,10 @@ func TestSQLXIn(t *testing.T) {
 	slice := []any{1}
 	result := 7
 	driver := common.GoOra
-	db, _ := connectToDB(driver)
+	db, err := connectToDB(driver)
+	require.NoError(t, err, "failed to connect to DB")
 
 	var rows *sql.Rows
-	var err error
 
 	rows, err = db.Query(fmt.Sprintf("SELECT %d FROM dual WHERE rownum IN (:1)", result), slice...)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?
Another case similar to #49801 . Fixes nil pointer panic in tests when the Oracle container fails to start by catching and raising a test failure.

### Motivation
When `connectToDB` fails, the returned `db` is `nil`. Calling `db.Prepare(...)` on a nil pointer causes a `SIGSEGV` (signal 11) instead of a clear test failure message, making the failure hard to diagnose.

### Describe how you validated your changes
CI

### Additional Notes
