### PR TITLE
[macOS] Add uninstall script for Agent 7.79.0+

### DIFF
--- a/cmd/agent/macos/install_mac_os.sh
+++ b/cmd/agent/macos/install_mac_os.sh
@@ -23,7 +23,10 @@ else
     BLUE=''
     NC=''
 fi
-install_log_file=/tmp/ddagent-install.log
+# Use mktemp so the log path is unpredictable (0600, random suffix). A fixed
+# /tmp path would let a local user pre-create it as a symlink and redirect
+# root-owned `tee` output into a privileged file.
+install_log_file=$(mktemp /tmp/ddagent-install.XXXXXX)
 exec > >(tee "$install_log_file") 2>&1
 dmg_file=/tmp/datadog-agent.dmg
 dmg_base_url="https://s3.amazonaws.com/dd-agent"
@@ -187,9 +190,9 @@ function on_error() {
 It looks like you hit an issue when trying to install the Agent.
 See the following log files for details:
 
-    - $install_log_file
     - /opt/datadog-agent/logs/preinstall.log
     - /opt/datadog-agent/logs/postinstall.log
+    - $install_log_file
 
 If you're still having problems, please send an email to support@datadoghq.com
 with the contents of the log files and we'll do our very best to help

--- a/cmd/agent/macos/uninstall_mac_os.sh
+++ b/cmd/agent/macos/uninstall_mac_os.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+# Datadog Agent uninstall script for macOS.
+# Paired with install_mac_os.sh (Agent 7.79.0+). Removes the system-wide
+# components installed by the DMG: LaunchDaemons (agent, sysprobe),
+# GUI LaunchAgent, /Applications app, /opt/datadog-agent tree, and symlinks.
+set -u
+
+if [ -t 1 ]; then
+    RED='\033[31m'
+    GREEN='\033[32m'
+    BLUE='\033[34m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    BLUE=''
+    NC=''
+fi
+uninstall_log_file=/tmp/ddagent-uninstall.log
+exec > >(tee "$uninstall_log_file") 2>&1
+
+if [ "$(echo "$UID")" = "0" ]; then
+    sudo_cmd=''
+else
+    sudo_cmd='sudo'
+fi
+
+function on_error() {
+    printf "${RED}
+An error occurred during uninstallation. Some components may still be
+present on the system. See the log at:
+
+    %s
+${NC}\n" "$uninstall_log_file"
+}
+trap on_error ERR
+
+printf "${BLUE}* Uninstalling Datadog Agent, you might be asked for your sudo password...\n${NC}"
+
+printf "${BLUE}\n    - Stopping system services...\n${NC}"
+$sudo_cmd launchctl bootout system/com.datadoghq.agent 2>/dev/null || true
+$sudo_cmd launchctl bootout system/com.datadoghq.sysprobe 2>/dev/null || true
+
+printf "${BLUE}\n    - Stopping GUI for logged-in users...\n${NC}"
+for logged_user in $(who | awk '{print $1}' | sort -u); do
+    logged_uid=$(id -u "$logged_user" 2>/dev/null) || continue
+    $sudo_cmd launchctl bootout "gui/$logged_uid/com.datadoghq.gui" 2>/dev/null || true
+done
+$sudo_cmd pkill -f 'Datadog Agent.app' 2>/dev/null || true
+
+printf "${BLUE}\n    - Removing launchd plists...\n${NC}"
+$sudo_cmd rm -f /Library/LaunchDaemons/com.datadoghq.agent.plist
+$sudo_cmd rm -f /Library/LaunchDaemons/com.datadoghq.sysprobe.plist
+$sudo_cmd rm -f /Library/LaunchAgents/com.datadoghq.gui.plist
+
+printf "${BLUE}\n    - Removing application and install directory...\n${NC}"
+$sudo_cmd rm -rf "/Applications/Datadog Agent.app"
+$sudo_cmd rm -rf /opt/datadog-agent
+
+printf "${BLUE}\n    - Removing symlinks and staging data...\n${NC}"
+$sudo_cmd rm -f /usr/local/bin/datadog-agent
+# /var/log/datadog is a symlink to /opt/datadog-agent/logs created by preinst.
+$sudo_cmd rm -f /var/log/datadog
+# Staging dir may be left behind by an interrupted install (normally cleaned
+# by postinst or install_mac_os.sh's EXIT trap).
+$sudo_cmd rm -rf /private/var/root/datadog-install
+
+printf "${GREEN}
+
+Datadog Agent has been uninstalled.
+${NC}\n"

--- a/cmd/agent/macos/uninstall_mac_os.sh
+++ b/cmd/agent/macos/uninstall_mac_os.sh
@@ -8,7 +8,7 @@
 # Paired with install_mac_os.sh (Agent 7.79.0+). Removes the system-wide
 # components installed by the DMG: LaunchDaemons (agent, sysprobe),
 # GUI LaunchAgent, /Applications app, /opt/datadog-agent tree, and symlinks.
-set -u
+set -eu
 
 if [ -t 1 ]; then
     RED='\033[31m'
@@ -21,7 +21,10 @@ else
     BLUE=''
     NC=''
 fi
-uninstall_log_file=/tmp/ddagent-uninstall.log
+# Use mktemp so the log path is unpredictable (0600, random suffix). A fixed
+# /tmp path would let a local user pre-create it as a symlink and redirect
+# root-owned `tee` output into a privileged file.
+uninstall_log_file=$(mktemp /tmp/ddagent-uninstall.XXXXXX)
 exec > >(tee "$uninstall_log_file") 2>&1
 
 if [ "$(echo "$UID")" = "0" ]; then


### PR DESCRIPTION
### What does this PR do?

Adds `cmd/agent/macos/uninstall_mac_os.sh`, a companion to the v2 `install_mac_os.sh`. It removes everything the DMG's `preinst`/`postinst` install on macOS:

- Boots out `system/com.datadoghq.agent` and `system/com.datadoghq.sysprobe` LaunchDaemons
- Boots out `gui/$uid/com.datadoghq.gui` for each logged-in user and kills any running `Datadog Agent.app` process
- Removes the three plists under `/Library/LaunchDaemons` and `/Library/LaunchAgents`
- Removes `/Applications/Datadog Agent.app` and the `/opt/datadog-agent` install tree
- Removes the `/usr/local/bin/datadog-agent` CLI symlink and the `/var/log/datadog` log symlink
- Removes the `/private/var/root/datadog-install` staging dir (normally cleaned by `postinst` but may persist if an install was interrupted)

Also hardens log-file creation in both the new uninstall script and the existing `install_mac_os.sh`:

- Both scripts now create the log file with `mktemp` instead of a fixed `/tmp` path, closing a symlink-clobber vector when the script is run under `sudo`.
- The uninstall script uses `set -eu` (instead of just `-u`) so unexpected failures trigger the `on_error` ERR trap that was already wired up.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2639

Agent 7.79.0 switched the macOS install from per-user LaunchAgents to a system-wide LaunchDaemon layout. We need a matching uninstall path so users on v2 have a single command to fully remove the Agent instead of tracking down daemons, plists, and directories by hand. The existing docs page (`.../osx/#uninstall-the-agent`) still describes the v1 layout and needs this script (or equivalent steps) to stay accurate.

### Describe how you validated your changes

- `bash -n` syntax check passes
- Cross-checked each removal against what `omnibus/package-scripts/agent-dmg/{preinst,postinst}` create
- Manual run on a macOS host with a v2 DMG install: confirmed `launchctl print` no longer shows the services, `/opt/datadog-agent` and `/Applications/Datadog Agent.app` are gone, `/usr/local/bin/datadog-agent` and `/var/log/datadog` symlinks are removed

### Additional Notes

- The `_dd-agent` system user and per-user GUI preferences (`~/Library/Preferences/com.datadoghq.agent.plist`) are intentionally left in place. Removing the user is disruptive if anything on the system still references it, and the UserDefaults are harmless when the app is absent. Can be added later if we want a `--purge` mode.
- The public docs page at `docs.datadoghq.com/agent/supported_platforms/osx/#uninstall-the-agent` should be updated to reference this script once shipped.