### PR TITLE
chore: register agent-data-plane team in pipeline config

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -18,6 +18,14 @@ github_team = "agent-metric-pipelines"
 github_labels = ["team/agent-metric-pipelines"]
 exclude_members = [""]
 
+[teams."Agent Data Plane"]
+jira_project = "DADP"
+jira_issue_type = "Task"
+jira_statuses = ["To Do", "In Progress", "Done"]
+github_team = "agent-data-plane"
+github_labels = ["team/agent-data-plane"]
+exclude_members = [""]
+
 [teams."Agent Runtimes"]
 jira_project = "AGENTRUN"
 jira_issue_type = "QA"

--- a/tasks/libs/pipeline/github_jira_map.yaml
+++ b/tasks/libs/pipeline/github_jira_map.yaml
@@ -17,6 +17,7 @@
 '@datadog/ecs-experiences': EXP
 '@datadog/agent-metrics-logs': AMLII
 '@datadog/agent-metric-pipelines': AGTMETRICS
+'@datadog/agent-data-plane': DADP
 '@datadog/agent-log-pipelines': AGNTLOG
 '@datadog/agent-runtimes': AGENTRUN
 '@datadog/agent-configuration': AGENTCFG

--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -46,6 +46,13 @@
   review:
     name: '#security-and-compliance-agent'
     id: 'CTNVD37T3'
+'@datadog/agent-data-plane':
+  notification:
+    name: '#agent-data-plane'
+    id: 'C070PQKLLP5'
+  review:
+    name: '#agent-data-plane'
+    id: 'C070PQKLLP5'
 '@datadog/agent-delivery':
   notification:
     name: '#agent-delivery-ops'


### PR DESCRIPTION
## Summary
- Register the newly created Agent Data Plane team (`agent-data-plane`) in the pipeline configuration.
- Adds `[teams."Agent Data Plane"]` section to `.ddqa/config.toml` (jira project `DADP`, label `team/agent-data-plane`).
- Adds `'@datadog/agent-data-plane': DADP` to `tasks/libs/pipeline/github_jira_map.yaml`.
- Adds `'@datadog/agent-data-plane'` notification and review channels (`#agent-data-plane` / `C070PQKLLP5`) to `tasks/libs/pipeline/github_slack_map.yaml`.
- Scope of existing dogstatsd-related CODEOWNERS entries is unchanged; those remain with `@DataDog/agent-metric-pipelines`.

## Test plan
- [x] YAML syntax is valid
- [x] TOML syntax is valid
- [x] CI passes any mapping validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)