### PR TITLE
[macOS] Fix system-probe launchd restart loop

### DIFF
--- a/packages/macos/app/launchd.sysprobe.plist.example.in
+++ b/packages/macos/app/launchd.sysprobe.plist.example.in
@@ -6,11 +6,6 @@
         <dict>
             <key>SuccessfulExit</key>
             <false/>
-            <key>PathState</key>
-            <dict>
-              <key>/opt/datadog-agent/etc/system-probe.yaml</key>
-              <true/>
-            </dict>
         </dict>
         <key>Label</key>
         <string>com.datadoghq.sysprobe</string>


### PR DESCRIPTION
## What does this PR do?

Removes the `PathState` condition from the `com.datadoghq.sysprobe` launchd plist, leaving only `SuccessfulExit=false` in `KeepAlive`.

https://datadoghq.atlassian.net/browse/WINA-2640

## Regression

Since PR #48932 ([ABLD-402] Copy etc/conf.d files as part of the bazel package build), the macOS DMG has been shipping `/opt/datadog-agent/etc/system-probe.yaml` (not just the `.example`). This was an unintended side effect of adding `//cmd/agent/dist:all_files` to the DMG's install_dir manifest — that filegroup transitively includes the generated `system-probe.yaml` config.

The sysprobe launchd plist gated the daemon on a `PathState` condition:

```xml
<key>KeepAlive</key>
<dict>
    <key>SuccessfulExit</key>
    <false/>
    <key>PathState</key>
    <dict>
      <key>/opt/datadog-agent/etc/system-probe.yaml</key>
      <true/>
    </dict>
</dict>
```

The original intent was "only run sysprobe if the user has opted in by creating `system-probe.yaml`." Since the DMG now ships that file by default, the gate is always satisfied.

Behavior on a fresh install with no system-probe modules enabled (no NPM/USM/CCM/EUDM):
1. launchd bootstraps the plist.
2. `PathState` is true → launchd starts system-probe.
3. system-probe loads, finds no modules to run at `pkg/system-probe/config/config.go:132`, exits cleanly (code 0).
4. `SuccessfulExit=false` wouldn't restart on code 0, but `PathState` (OR'd) still says "keep alive," so launchd restarts after the `minimum runtime = 10s` cooldown.
5. Loop. Observed via `launchctl print system/com.datadoghq.sysprobe` as `runs` climbing every 10 seconds.

## Fix

Drop the `PathState` block. The resulting plist matches the pattern already used by the main agent plist (`packages/macos/app/launchd.plist.example.in`):

```xml
<key>KeepAlive</key>
<dict>
    <key>SuccessfulExit</key>
    <false/>
</dict>
```

Resulting behavior:
- Daemon starts on `launchctl bootstrap` (a `KeepAlive` dict is enough — `SuccessfulExit=false` treats the never-run state as "not yet successful").
- Clean exit (no modules) → stays dead. No loop.
- Non-zero exit (crash) → restarts. Crash recovery preserved.
- When a module is enabled later (e.g., EUDM or NPM), `launchctl kickstart system/com.datadoghq.sysprobe` brings it up; with real work to do it stays in its run loop.

## Test plan

- [x] Fresh install of DMG without `infrastructure_mode: end_user_device` in `datadog.yaml`: `launchctl print system/com.datadoghq.sysprobe` reports low `runs` count that does not climb over time; no system-probe process in `ps aux`.
- [x] Fresh install with `infrastructure_mode: end_user_device`: system-probe starts once via the postinst bootstrap and stays running.
- [x] Kill the running system-probe with `sudo kill -9 <pid>` (non-zero exit): launchd restarts it within a few seconds.

[ABLD-402]: https://datadoghq.atlassian.net/browse/ABLD-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ